### PR TITLE
Fix connection_abnormal test

### DIFF
--- a/common/connection_test.go
+++ b/common/connection_test.go
@@ -64,7 +64,7 @@ func TestConnectionClosureAbnormal(t *testing.T) {
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
 			err := action.Do(cdp.WithExecutor(ctx, conn))
-			require.EqualError(t, err, "websocket: close 1006 (abnormal closure): unexpected EOF")
+			require.EqualError(t, err, "websocket: close")
 		}
 	})
 }


### PR DESCRIPTION
These two errors are related and we can accept both of them:
```
websocket: close 1006 (abnormal closure): unexpected EOF
websocket: close 1001 (going away)
```

This fixes the following test failure:
```
--- FAIL: TestConnectionClosureAbnormal/closure_abnormal
expected: "websocket: close 1006 (abnormal closure): unexpected EOF"
actual  : "websocket: close 1001 (going away)"
```