### PR TITLE
Attempt to get a passing CI build

### DIFF
--- a/.github/bin/install_chrome_deps_linux.sh
+++ b/.github/bin/install_chrome_deps_linux.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+sudo apt-get update -y
+sudo apt-get install -y libpangocairo-1.0-0 libx11-xcb1 libxcomposite1 \
+  libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 \
+  libgconf-2-4 libasound2 libatk1.0-0 libgtk-3-0
+sudo apt-get install -y libgbm-dev libxshmfence1

--- a/.github/workflows/all.yaml
+++ b/.github/workflows/all.yaml
@@ -72,10 +72,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Install chrome dependencies
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y libpangocairo-1.0-0 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 libgconf-2-4 libasound2 libatk1.0-0 libgtk-3-0
-          sudo apt-get install -y libgbm-dev libxshmfence1
+        run: "${GITHUB_WORKSPACE}/.github/bin/install_chrome_deps_linux.sh"
       - name: Setup chrome
         uses: browser-actions/setup-chrome@latest
         with:
@@ -109,10 +106,7 @@ jobs:
           echo "$HOME/sdk/gotip/bin" >> "$GITHUB_PATH"
       - name: Install chrome dependencies
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y libpangocairo-1.0-0 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 libgconf-2-4 libasound2 libatk1.0-0 libgtk-3-0
-          sudo apt-get install -y libgbm-dev libxshmfence1
+        run: "${GITHUB_WORKSPACE}/.github/bin/install_chrome_deps_linux.sh"
       - name: Setup chrome
         uses: browser-actions/setup-chrome@latest
         with:
@@ -144,10 +138,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Install chrome dependencies
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y libpangocairo-1.0-0 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 libgconf-2-4 libasound2 libatk1.0-0 libgtk-3-0
-          sudo apt-get install -y libgbm-dev libxshmfence1
+        run: "${GITHUB_WORKSPACE}/.github/bin/install_chrome_deps_linux.sh"
       - name: Setup chrome
         uses: browser-actions/setup-chrome@latest
         with:


### PR DESCRIPTION
As discussed, this disables running tests on macOS and Windows in CI since the GH Action VMs are much less stable than for Linux. We should re-enable them soon, but for now a passing build would allow us to iterate quicker.

And some other smaller changes, notably the removal of `-race`. See the commits.