### PR TITLE
Fix data races with `common.Frame`

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -190,11 +190,11 @@ func (f *Frame) hasInflightRequest(requestID network.RequestID) bool {
 }
 
 func (f *Frame) clearLifecycle() {
-	f.lifecycleEventsMu.RLock()
+	f.lifecycleEventsMu.Lock()
 	for k := range f.lifecycleEvents {
 		f.lifecycleEvents[k] = false
 	}
-	f.lifecycleEventsMu.RUnlock()
+	f.lifecycleEventsMu.Unlock()
 	f.page.frameManager.mainFrame.recalculateLifecycle()
 
 	f.inflightRequestsMu.Lock()
@@ -427,12 +427,12 @@ func (f *Frame) startNetworkIdleTimer() {
 }
 
 func (f *Frame) stopNetworkIdleTimer() {
+	f.networkIdleMu.Lock()
+	defer f.networkIdleMu.Unlock()
 	if f.networkIdleCancelFn != nil {
 		f.networkIdleCancelFn()
-		f.networkIdleMu.Lock()
 		f.networkIdleCtx = nil
 		f.networkIdleCancelFn = nil
-		f.networkIdleMu.Unlock()
 	}
 }
 


### PR DESCRIPTION
I used [this script](https://dave.cheney.net/2013/06/19/stress-test-your-go-packages) to stress test both `tests` and `common` packages with `-race` enabled, and didn't see any failures on `tests` for about 30 minutes, but `common` failed after 13m with the `TestConnectionClosureAbnormal/closure_abnormal` known flaky test (#33), which appears to happen under high load or overprovisioned VMs. I'll create an issue for that one, but I think we can leave `-race` enabled in CI now, and also set `GOMAXPROCS=2` and `-p 2`. :crossed_fingers:

Running `GOMAXPROCS=1 go test -race -v -count=100 -failfast ./...` did fail after about 10 minutes with `race: limit on 8128 simultaneously alive goroutines is exceeded, dying`, which probably means we're leaking goroutines. I'm suspecting it's because of the goroutine that's sending to `handler.ch`, but I'll create an issue and look further into it.