### PR TITLE
Fix for timeout bug in `ElementHandle.waitForSelector`

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -883,13 +883,17 @@ func (h *ElementHandle) waitForSelector(apiCtx context.Context, selector string,
 			rt.ToValue(h),
 			rt.ToValue(opts.Strict),
 			rt.ToValue(opts.State.String()),
-			rt.ToValue(opts.Timeout),
+			rt.ToValue(opts.Timeout.Milliseconds()),
 		}...)
 	if err != nil {
 		return nil, err
 	}
-
-	return result.(*ElementHandle), nil
+	switch r := result.(type) {
+	case *ElementHandle:
+		return r, nil
+	default:
+		return nil, nil
+	}
 }
 
 // AsElement returns this element handle

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -489,7 +489,7 @@ class InjectedScript {
             throw 'error:strictmodeviolation';
         }
         if (result.length == 0) {
-            return nil
+            return null
         }
         return result[0].capture || result[0].element;
     }

--- a/tests/element_handle_waitforselector_test.go
+++ b/tests/element_handle_waitforselector_test.go
@@ -1,0 +1,62 @@
+/*
+ *
+ * xk6-browser - a browser automation extension for k6
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tests
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/grafana/xk6-browser/testutils/browsertest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestElementHandleWaitForSelector(t *testing.T) {
+	bt := browsertest.NewBrowserTest(t)
+	defer bt.Browser.Close()
+
+	t.Run("ElementHandle.waitForSelector", func(t *testing.T) {
+		t.Run("should work", func(t *testing.T) { testElementHandleWaitForSelector(t, bt) })
+	})
+}
+
+func testElementHandleWaitForSelector(t *testing.T, bt *browsertest.BrowserTest) {
+	p := bt.Browser.NewPage(nil)
+	defer p.Close(nil)
+
+	p.SetContent(`<div class="root"></div>`, nil)
+	root := p.Query(".root")
+	p.Evaluate(bt.Runtime.ToValue(`
+        () => {
+            setTimeout(() => {
+                const div = document.createElement('div');
+                div.className = 'element-to-appear';
+                div.appendChild(document.createTextNode("Hello World"));
+                root = document.querySelector('.root');
+                root.appendChild(div);
+            }, 100);
+        }
+    `))
+	element := root.WaitForSelector(".element-to-appear", bt.Runtime.ToValue(struct {
+		Timeout int64 `js:"timeout"`
+	}{Timeout: 1000}))
+	require.NotNil(t, element, "expected element to have been found after wait")
+	element.Dispose()
+}


### PR DESCRIPTION
This fix makes sure timeout is actually respected when calling `ElementHandle.waitForSelector()`, without this fix the call returns immediately after first check of presence of element(s) matched by selector in DOM which in many situations will result in `null`.

Partial fix for #53.