### PR TITLE
Fix minor problems within FrameSession and Page

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -430,7 +430,7 @@ func (fs *FrameSession) onExceptionThrown(event *runtime.EventExceptionThrown) {
 	fs.page.emit(EventPageError, event.ExceptionDetails)
 }
 
-func (fs FrameSession) onExecutionContextCreated(event *runtime.EventExecutionContextCreated) {
+func (fs *FrameSession) onExecutionContextCreated(event *runtime.EventExecutionContextCreated) {
 	rt := k6common.GetRuntime(fs.ctx)
 	auxData := event.Context.AuxData
 	var i struct {

--- a/common/page.go
+++ b/common/page.go
@@ -107,14 +107,14 @@ func NewPage(ctx context.Context, session *Session, browserCtx *BrowserContext, 
 	}
 
 	var err error
-	p.frameManager = NewFrameManager(p.ctx, session, &p, browserCtx.timeoutSettings)
+	p.frameManager = NewFrameManager(ctx, session, &p, browserCtx.timeoutSettings)
 	p.mainFrameSession, err = NewFrameSession(ctx, session, &p, nil, targetID)
 	if err != nil {
 		return nil, err
 	}
 	p.frameSessions[cdp.FrameID(targetID)] = p.mainFrameSession
-	p.Mouse = NewMouse(p.ctx, session, p.frameManager.MainFrame(), browserCtx.timeoutSettings, p.Keyboard)
-	p.Touchscreen = NewTouchscreen(p.ctx, session, p.Keyboard)
+	p.Mouse = NewMouse(ctx, session, p.frameManager.MainFrame(), browserCtx.timeoutSettings, p.Keyboard)
+	p.Touchscreen = NewTouchscreen(ctx, session, p.Keyboard)
 
 	if browserCtx.opts.Viewport != nil {
 		p.emulatedSize = NewEmulatedSize(browserCtx.opts.Viewport, browserCtx.opts.Screen)


### PR DESCRIPTION
* Use consistent method receiver types in `FrameSession`

* Use consistent `ctx` variables in `Page`