### PR TITLE
Fix `Page.screenshot()`, viewport, and screen emulation

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -28,6 +28,7 @@ import (
 	"math"
 
 	"github.com/dop251/goja"
+	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
 )
 
@@ -207,6 +208,13 @@ type Position struct {
 	Y float64 `json:"y"`
 }
 
+type Rect struct {
+	X      float64 `js:"x"`
+	Y      float64 `js:"y"`
+	Width  float64 `js:"width"`
+	Height float64 `js:"height"`
+}
+
 // ReducedMotion represents a browser reduce-motion setting
 type ReducedMotion string
 
@@ -316,6 +324,18 @@ func (g *Geolocation) Parse(ctx context.Context, opts goja.Value) error {
 	g.Latitude = latitude
 	g.Longitude = longitude
 	return nil
+}
+
+func (r *Rect) enclosingIntRect() *Rect {
+	x := math.Floor(r.X + 1e-3)
+	y := math.Floor(r.Y + 1e-3)
+	x2 := math.Ceil(r.X + r.Width - 1e-3)
+	y2 := math.Ceil(r.Y + r.Height - 1e-3)
+	return &Rect{X: x, Y: y, Width: x2 - x, Height: y2 - y}
+}
+
+func (r *Rect) toApiRect() *api.Rect {
+	return &api.Rect{X: r.X, Y: r.Y, Width: r.Width, Height: r.Height}
 }
 
 func (s *Screen) Parse(ctx context.Context, screen goja.Value) error {

--- a/tests/element_handle_screenshot_test.go
+++ b/tests/element_handle_screenshot_test.go
@@ -1,0 +1,86 @@
+/*
+ *
+ * xk6-browser - a browser automation extension for k6
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tests
+
+import (
+	"bytes"
+	_ "embed"
+	"image/png"
+	"testing"
+
+	"github.com/grafana/xk6-browser/testutils/browsertest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestElementHandleScreenshot(t *testing.T) {
+	bt := browsertest.NewBrowserTest(t)
+	defer bt.Browser.Close()
+
+	t.Run("ElementHandle.screenshot", func(t *testing.T) {
+		t.Run("should work", func(t *testing.T) { testElementHandleScreenshot(t, bt) })
+	})
+}
+
+func testElementHandleScreenshot(t *testing.T, bt *browsertest.BrowserTest) {
+	p := bt.Browser.NewPage(nil)
+	defer p.Close(nil)
+
+	p.SetViewportSize(bt.Runtime.ToValue(struct {
+		Width  float64 `js:"width"`
+		Height float64 `js:"height"`
+	}{Width: 800, Height: 600}))
+	p.Evaluate(bt.Runtime.ToValue(`
+         () => {
+             document.body.style.margin = '0';
+             document.body.style.padding = '0';
+             document.documentElement.style.margin = '0';
+             document.documentElement.style.padding = '0';
+             const div = document.createElement('div');
+             div.style.marginTop = '400px';
+             div.style.marginLeft = '100px';
+             div.style.width = '100px';
+             div.style.height = '100px';
+             div.style.background = 'red';
+             document.body.appendChild(div);
+         }
+    `))
+
+	elem := p.Query("div")
+	buf := elem.Screenshot(bt.Runtime.ToValue(struct {
+		Path string `js:"path"`
+	}{Path: "eh-screenshot.png"}))
+
+	reader := bytes.NewReader(buf.Bytes())
+	img, err := png.Decode(reader)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 100, img.Bounds().Max.X, "screenshot width is not 100px as expected, but %dpx", img.Bounds().Max.X)
+	assert.Equal(t, 100, img.Bounds().Max.Y, "screenshot height is not 100px as expected, but %dpx", img.Bounds().Max.Y)
+
+	r, g, b, _ := img.At(0, 0).RGBA()
+	assert.Equal(t, uint32(255), r>>8) // each color component has been scaled by alpha (<<8)
+	assert.Equal(t, uint32(0), g)
+	assert.Equal(t, uint32(0), b)
+	r, g, b, _ = img.At(99, 99).RGBA()
+	assert.Equal(t, uint32(255), r>>8) // each color component has been scaled by alpha (<<8)
+	assert.Equal(t, uint32(0), g)
+	assert.Equal(t, uint32(0), b)
+}


### PR DESCRIPTION
This PR fixes issues with viewport and screen emulation affecting screenshotting. It's now been fixed and follows how Playwright takes screenshots.