### PR TITLE
Fixes for CI build and release jobs

### DIFF
--- a/.github/workflows/all.yaml
+++ b/.github/workflows/all.yaml
@@ -306,7 +306,7 @@ jobs:
       - name: Create MSI package
         run: |
           $env:VERSION = $env:VERSION -replace 'v(\d+\.\d+\.\d+).*','$1'
-          pandoc -s -f markdown -t rtf -o packaging\LICENSE.rtf LICENSE.md
+          pandoc -s -f markdown -t rtf -o packaging\LICENSE.rtf LICENSE
           cd .\packaging
           candle.exe -arch x64 "-dVERSION=$env:VERSION" xk6-browser.wxs
           light.exe -ext WixUIExtension xk6-browser.wixobj

--- a/packaging/xk6-browser.wxs
+++ b/packaging/xk6-browser.wxs
@@ -7,19 +7,20 @@
         <Icon Id="k6Icon" SourceFile="xk6-browser.ico"/>
         <Property Id="ARPPRODUCTICON" Value="k6Icon"/>
 
-        <Media Id="1" Cabinet="xk6-browser.cab" EmbedCab="yes" />
+        <Media Id="1" Cabinet="xk6browser.cab" EmbedCab="yes" />
 
         <!-- Step 1: Define the directory structure -->
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFiles64Folder">
-                <Directory Id="INSTALLDIR" Name="k6"/>
+                <Directory Id="INSTALLDIR" Name="xk6-browser"/>
             </Directory>
         </Directory>
 
         <!-- Step 2: Add files to your installer package -->
         <DirectoryRef Id="INSTALLDIR">
-            <Component Id="xk6-browser.exe" Guid="*">
-                <File Id="xk6-browser.exe" Source="xk6-browser.exe" KeyPath="yes" />
+            <!-- Ids can't contain dashes; only A-Z, a-z, digits, underscore or period. -->
+            <Component Id="xk6browser.exe" Guid="*">
+                <File Id="xk6browser.exe" Source="xk6-browser.exe" KeyPath="yes" />
             </Component>
             <Component Id="PathEnv" Guid="2DFDBB7D-292E-462c-A3E3-2FA14FFCD05D" >
               <Environment Id="Path" Name="PATH" Value="[INSTALLDIR]" Permanent="no" Part="last" Action="set" System="yes" Separator=";" />
@@ -29,7 +30,7 @@
 
         <!-- Step 3: Tell WiX to install the files -->
         <Feature Id="MainApplication" Title="Main Application" Level="1">
-            <ComponentRef Id="xk6-browser.exe" />
+            <ComponentRef Id="xk6browser.exe" />
             <ComponentRef Id="PathEnv" />
         </Feature>
 


### PR DESCRIPTION
I tested the release workflow in my fork and it seems to have worked fine after these fixes. See https://github.com/imiric/xk6-browser/releases/tag/v0.1.0-test (You should have access to this, let me know otherwise.)

What's left tomorrow for the official release is creating the release notes in `release notes/v0.1.0.md` and tagging the commit with `v0.1.0`. We don't need to bump the version since it's already [`v0.1.0` in main.go](https://github.com/grafana/xk6-browser/blob/5f6c8875d5203439491a5c3237d04cc47fc92b60/main.go#L33) (in the future we might want to inject this at build time and move it outside `main.go`).