### PR TITLE
Fix `Page/ElementHandle.screenshot()`, viewport, and screen emulation

### DIFF
--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -137,7 +137,7 @@ func (b *BrowserContextOptions) Parse(ctx context.Context, opts goja.Value) erro
 					b.ReducedMotion = ReducedMotionNoPreference
 				}
 			case "screen":
-				screen := NewScreen()
+				screen := &Screen{}
 				if err := screen.Parse(ctx, opts.Get(k).ToObject(rt)); err != nil {
 					return err
 				}
@@ -147,7 +147,7 @@ func (b *BrowserContextOptions) Parse(ctx context.Context, opts goja.Value) erro
 			case "userAgent":
 				b.UserAgent = opts.Get(k).String()
 			case "viewport":
-				viewport := NewViewport()
+				viewport := &Viewport{}
 				if err := viewport.Parse(ctx, opts.Get(k).ToObject(rt)); err != nil {
 					return err
 				}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -40,17 +40,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
-	"github.com/chromedp/cdproto/emulation"
 	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/dop251/goja"
 	"github.com/grafana/xk6-browser/api"
@@ -197,7 +193,7 @@ type ElementHandle struct {
 	frame *Frame
 }
 
-func (h *ElementHandle) boundingBox() (*api.Rect, error) {
+func (h *ElementHandle) boundingBox() (*Rect, error) {
 	var box *dom.BoxModel
 	var err error
 	action := dom.GetBoxModel().WithObjectID(h.remoteObject.ObjectID)
@@ -212,7 +208,7 @@ func (h *ElementHandle) boundingBox() (*api.Rect, error) {
 	height := math.Max(quad[1], math.Max(quad[3], math.Max(quad[5], quad[7]))) - y
 	position := h.frame.position()
 
-	return &api.Rect{X: x + position.X, Y: y + position.Y, Width: width, Height: height}, nil
+	return &Rect{X: x + position.X, Y: y + position.Y, Width: width, Height: height}, nil
 }
 
 func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, p Position) (bool, error) {
@@ -808,6 +804,23 @@ func (h *ElementHandle) typ(apiCtx context.Context, text string, opts *KeyboardO
 	return nil
 }
 
+func (h *ElementHandle) waitAndScrollIntoViewIfNeeded(apiCtx context.Context, force, noWaitAfter bool, timeout time.Duration) error {
+	rt := k6common.GetRuntime(apiCtx)
+	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
+		pageFn := rt.ToValue(`(element) => {
+			element.scrollIntoViewIfNeeded(true);
+			return [window.scrollX, window.scrollY];
+		}`)
+		return h.execCtx.evaluate(apiCtx, true, true, pageFn, rt.ToValue(h))
+	}
+	actFn := elementHandleActionFn(h, []string{"visible", "stable"}, fn, force, noWaitAfter, timeout)
+	_, err := callApiWithTimeout(h.ctx, actFn, timeout)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (h *ElementHandle) waitForElementState(apiCtx context.Context, states []string, timeout time.Duration) (bool, error) {
 	rt := k6common.GetRuntime(apiCtx)
 	injected, err := h.execCtx.getInjectedScript(apiCtx)
@@ -891,7 +904,7 @@ func (h *ElementHandle) BoundingBox() *api.Rect {
 	if err != nil {
 		return nil // Don't throw an exception here, just return nil
 	}
-	return bbox
+	return bbox.toApiRect()
 }
 
 // Check scrolls element into view and clicks in the center of the element
@@ -1284,110 +1297,18 @@ func (h *ElementHandle) QueryAll(selector string) []api.ElementHandle {
 }
 
 func (h *ElementHandle) Screenshot(opts goja.Value) goja.ArrayBuffer {
-	// TODO: https://github.com/microsoft/playwright/blob/master/src/server/screenshotter.ts#L92
 	rt := k6common.GetRuntime(h.ctx)
 	parsedOpts := NewElementHandleScreenshotOptions(h.defaultTimeout())
 	if err := parsedOpts.Parse(h.ctx, opts); err != nil {
 		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
 	}
 
-	var buf []byte
-	var clip cdppage.Viewport
-	format := parsedOpts.Format
-
-	bbox, err := h.boundingBox()
+	s := NewScreenshotter(h.ctx)
+	buf, err := s.screenshotElement(h, parsedOpts)
 	if err != nil {
-		k6common.Throw(rt, fmt.Errorf("node is either not visible or not an HTMLElement: %w", err))
+		k6common.Throw(rt, err)
 	}
-	if bbox.Width <= 0 {
-		k6common.Throw(rt, errors.New("node has 0 width"))
-	}
-	if bbox.Height <= 0 {
-		k6common.Throw(rt, errors.New("node has 0 height"))
-	}
-
-	// Infer file format by path
-	if parsedOpts.Path != "" && parsedOpts.Format != "png" && parsedOpts.Format != "jpeg" {
-		if strings.HasSuffix(parsedOpts.Path, ".jpg") || strings.HasSuffix(parsedOpts.Path, ".jpeg") {
-			format = "jpeg"
-		}
-	}
-
-	var capture *cdppage.CaptureScreenshotParams
-
-	// Setup viewport or full page screenshot capture based on options
-	_, _, contentSize, _, _, _, err := cdppage.GetLayoutMetrics().Do(cdp.WithExecutor(h.ctx, h.session))
-	if err != nil {
-		k6common.Throw(rt, fmt.Errorf("unable to get layout metrics: %w", err))
-	}
-	width, height := int64(math.Ceil(contentSize.Width)), int64(math.Ceil(contentSize.Height))
-	action := emulation.SetDeviceMetricsOverride(width, height, 1, false).
-		WithScreenOrientation(&emulation.ScreenOrientation{
-			Type:  emulation.OrientationTypePortraitPrimary,
-			Angle: 0,
-		})
-	if err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-		k6common.Throw(rt, fmt.Errorf("unable to set screen width and height: %w", err))
-	}
-	clip = cdppage.Viewport{
-		X:      contentSize.X,
-		Y:      contentSize.Y,
-		Width:  contentSize.Width,
-		Height: contentSize.Height,
-		Scale:  1,
-	}
-
-	if clip.Width > 0 && clip.Height > 0 {
-		capture = capture.WithClip(&clip)
-	}
-
-	// Add common options
-	capture.WithQuality(parsedOpts.Quality)
-	switch format {
-	case "jpeg":
-		capture.WithFormat(cdppage.CaptureScreenshotFormatJpeg)
-	default:
-		capture.WithFormat(cdppage.CaptureScreenshotFormatPng)
-	}
-
-	// Make background transparent for PNG captures if requested
-	if parsedOpts.OmitBackground && format == "png" {
-		action := emulation.SetDefaultBackgroundColorOverride().
-			WithColor(&cdp.RGBA{R: 0, G: 0, B: 0, A: 0})
-		if err := action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-			k6common.Throw(rt, fmt.Errorf("unable to set screenshot background transparency: %w", err))
-		}
-	}
-
-	// Capture screenshot
-	buf, err = capture.Do(cdp.WithExecutor(h.ctx, h.session))
-	if err != nil {
-		k6common.Throw(rt, fmt.Errorf("unable to capture screenshot of page '%s': %w", h.frame.manager.MainFrame().URL(), err))
-	}
-
-	// Reset background
-	if parsedOpts.OmitBackground && format == "png" {
-		action := emulation.SetDefaultBackgroundColorOverride()
-		if err := action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-			k6common.Throw(rt, fmt.Errorf("unable to reset screenshot background color: %w", err))
-		}
-	}
-
-	// TODO: Reset viewport
-
-	// Save screenshot capture to file
-	// TODO: we should not write to disk here but put it on some queue for async disk writes
-	if parsedOpts.Path != "" {
-		dir := filepath.Dir(parsedOpts.Path)
-		if err := os.MkdirAll(dir, 0775); err != nil {
-			k6common.Throw(rt, fmt.Errorf("unable to create directory for screenshot of page '%s': %w", h.frame.manager.MainFrame().URL(), err))
-		}
-		if err := ioutil.WriteFile(parsedOpts.Path, buf, 0664); err != nil {
-			k6common.Throw(rt, fmt.Errorf("unable to save screenshot of page '%s' to file: %w", h.frame.manager.MainFrame().URL(), err))
-		}
-	}
-
-	return rt.NewArrayBuffer(buf)
+	return rt.NewArrayBuffer(*buf)
 }
 
 func (h *ElementHandle) ScrollIntoViewIfNeeded(opts goja.Value) {
@@ -1396,15 +1317,7 @@ func (h *ElementHandle) ScrollIntoViewIfNeeded(opts goja.Value) {
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
 		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
 	}
-	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
-		pageFn := rt.ToValue(`(element) => {
-			element.scrollIntoViewIfNeeded(true);
-			return [window.scrollX, window.scrollY];
-		}`)
-		return h.execCtx.evaluate(apiCtx, true, true, pageFn, rt.ToValue(h))
-	}
-	actFn := elementHandleActionFn(h, []string{"visible", "stable"}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
-	_, err := callApiWithTimeout(h.ctx, actFn, actionOpts.Timeout)
+	err := h.waitAndScrollIntoViewIfNeeded(h.ctx, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
 	}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1303,7 +1303,7 @@ func (h *ElementHandle) Screenshot(opts goja.Value) goja.ArrayBuffer {
 		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
 	}
 
-	s := NewScreenshotter(h.ctx)
+	s := newScreenshotter(h.ctx)
 	buf, err := s.screenshotElement(h, parsedOpts)
 	if err != nil {
 		k6common.Throw(rt, err)

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -22,6 +22,7 @@ package common
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/dop251/goja"
@@ -72,7 +73,7 @@ type ElementHandlePressOptions struct {
 
 type ElementHandleScreenshotOptions struct {
 	Path           string        `json:"path"`
-	Format         string        `json:"format"`
+	Format         ImageFormat   `json:"format"`
 	OmitBackground bool          `json:"omitBackground"`
 	Quality        int64         `json:"quality"`
 	Timeout        time.Duration `json:"timeout"`
@@ -318,7 +319,7 @@ func (o *ElementHandlePressOptions) ToBaseOptions() *ElementHandleBaseOptions {
 func NewElementHandleScreenshotOptions(defaultTimeout time.Duration) *ElementHandleScreenshotOptions {
 	return &ElementHandleScreenshotOptions{
 		Path:           "",
-		Format:         "png",
+		Format:         ImageFormatPNG,
 		OmitBackground: false,
 		Quality:        100,
 		Timeout:        defaultTimeout,
@@ -328,6 +329,7 @@ func NewElementHandleScreenshotOptions(defaultTimeout time.Duration) *ElementHan
 func (o *ElementHandleScreenshotOptions) Parse(ctx context.Context, opts goja.Value) error {
 	rt := k6common.GetRuntime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
+		formatSpecified := false
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
@@ -338,9 +340,18 @@ func (o *ElementHandleScreenshotOptions) Parse(ctx context.Context, opts goja.Va
 			case "quality":
 				o.Quality = opts.Get(k).ToInteger()
 			case "type":
-				o.Format = opts.Get(k).String()
+				if f, ok := imageFormatToID[opts.Get(k).String()]; ok {
+					o.Format = f
+				}
 			case "timeout":
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
+			}
+		}
+
+		// Infer file format by path if format not explicitly specified (default is PNG)
+		if o.Path != "" && !formatSpecified {
+			if strings.HasSuffix(o.Path, ".jpg") || strings.HasSuffix(o.Path, ".jpeg") {
+				o.Format = ImageFormatJPEG
 			}
 		}
 	}

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -342,6 +342,7 @@ func (o *ElementHandleScreenshotOptions) Parse(ctx context.Context, opts goja.Va
 			case "type":
 				if f, ok := imageFormatToID[opts.Get(k).String()]; ok {
 					o.Format = f
+					formatSpecified = true
 				}
 			case "timeout":
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond

--- a/common/page.go
+++ b/common/page.go
@@ -575,7 +575,7 @@ func (p *Page) Screenshot(opts goja.Value) goja.ArrayBuffer {
 	if err := parsedOpts.Parse(p.ctx, opts); err != nil {
 		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
 	}
-	s := NewScreenshotter(p.ctx)
+	s := newScreenshotter(p.ctx)
 	buf, err := s.screenshotPage(p, parsedOpts)
 	if err != nil {
 		k6common.Throw(rt, fmt.Errorf("cannot capture screenshot: %w", err))

--- a/common/page.go
+++ b/common/page.go
@@ -24,10 +24,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"math"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -86,24 +82,23 @@ func NewPage(ctx context.Context, session *Session, browserCtx *BrowserContext, 
 		browserCtx:       browserCtx,
 		targetID:         targetID,
 		opener:           opener,
-		closed:           false,
 		backgroundPage:   backgroundPage,
 		mediaType:        MediaTypeScreen,
 		colorScheme:      browserCtx.opts.ColorScheme,
 		reducedMotion:    browserCtx.opts.ReducedMotion,
 		extraHTTPHeaders: browserCtx.opts.ExtraHTTPHeaders,
-		emulatedSize:     nil,
-		frameManager:     nil,
-		viewport:         nil,
 		timeoutSettings:  NewTimeoutSettings(browserCtx.timeoutSettings),
 		Keyboard:         NewKeyboard(ctx, session),
-		Mouse:            nil,
-		Touchscreen:      nil,
 		jsEnabled:        true,
-		mainFrameSession: nil,
 		frameSessions:    make(map[cdp.FrameID]*FrameSession),
 		workers:          make(map[target.SessionID]*Worker),
 		routes:           make([]api.Route, 0),
+	}
+
+	// We need to init viewport and screen size before initializing the main frame session,
+	// as that's where the emulation is activated.
+	if browserCtx.opts.Viewport != nil {
+		p.emulatedSize = NewEmulatedSize(browserCtx.opts.Viewport, browserCtx.opts.Screen)
 	}
 
 	var err error
@@ -115,10 +110,6 @@ func NewPage(ctx context.Context, session *Session, browserCtx *BrowserContext, 
 	p.frameSessions[cdp.FrameID(targetID)] = p.mainFrameSession
 	p.Mouse = NewMouse(ctx, session, p.frameManager.MainFrame(), browserCtx.timeoutSettings, p.Keyboard)
 	p.Touchscreen = NewTouchscreen(ctx, session, p.Keyboard)
-
-	if browserCtx.opts.Viewport != nil {
-		p.emulatedSize = NewEmulatedSize(browserCtx.opts.Viewport, browserCtx.opts.Screen)
-	}
 
 	if err := p.initEvents(); err != nil {
 		return nil, err
@@ -228,6 +219,28 @@ func (p *Page) hasRoutes() bool {
 	return len(p.routes) > 0
 }
 
+func (p *Page) resetViewport() error {
+	action := emulation.SetDeviceMetricsOverride(0, 0, 0, false)
+	return action.Do(cdp.WithExecutor(p.ctx, p.session))
+}
+
+func (p *Page) setEmulatedSize(emulatedSize *EmulatedSize) error {
+	p.emulatedSize = emulatedSize
+	return p.mainFrameSession.updateViewport()
+}
+
+func (p *Page) setViewportSize(viewportSize *Size) error {
+	viewport := &Viewport{
+		Width:  int64(viewportSize.Width),
+		Height: int64(viewportSize.Height),
+	}
+	screen := &Screen{
+		Width:  int64(viewportSize.Width),
+		Height: int64(viewportSize.Height),
+	}
+	return p.setEmulatedSize(NewEmulatedSize(viewport, screen))
+}
+
 func (p *Page) updateExtraHTTPHeaders() {
 	for _, fs := range p.frameSessions {
 		fs.updateExtraHTTPHeaders(false)
@@ -255,8 +268,11 @@ func (p *Page) updateHttpCredentials() {
 	}
 }
 
-func (p *Page) setEmulatedSize(emulatedSize *EmulatedSize) error {
-	return p.mainFrameSession.updateViewport()
+func (p *Page) viewportSize() Size {
+	return Size{
+		Width:  float64(p.emulatedSize.Viewport.Width),
+		Height: float64(p.emulatedSize.Viewport.Height),
+	}
 }
 
 // AddInitScript adds script to run in all new frames
@@ -559,96 +575,12 @@ func (p *Page) Screenshot(opts goja.Value) goja.ArrayBuffer {
 	if err := parsedOpts.Parse(p.ctx, opts); err != nil {
 		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
 	}
-
-	var buf []byte
-	clip := parsedOpts.Clip
-	format := parsedOpts.Format
-
-	// Infer file format by path
-	if parsedOpts.Path != "" && parsedOpts.Format != "png" && parsedOpts.Format != "jpeg" {
-		if strings.HasSuffix(parsedOpts.Path, ".jpg") || strings.HasSuffix(parsedOpts.Path, ".jpeg") {
-			format = "jpeg"
-		}
-	}
-
-	var capture *cdppage.CaptureScreenshotParams
-	capture = cdppage.CaptureScreenshot()
-
-	// Setup viewport or full page screenshot capture based on options
-	if parsedOpts.Clip.Width > 0 && parsedOpts.Clip.Height > 0 {
-		_, _, contentSize, _, _, _, err := cdppage.GetLayoutMetrics().Do(cdp.WithExecutor(p.ctx, p.session))
-		if err != nil {
-			k6common.Throw(rt, fmt.Errorf("unable to get layout metrics: %w", err))
-		}
-		width, height := int64(math.Ceil(contentSize.Width)), int64(math.Ceil(contentSize.Height))
-		action := emulation.SetDeviceMetricsOverride(width, height, 1, false).
-			WithScreenOrientation(&emulation.ScreenOrientation{
-				Type:  emulation.OrientationTypePortraitPrimary,
-				Angle: 0,
-			})
-		if err = action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
-			k6common.Throw(rt, fmt.Errorf("unable to set screen width and height: %w", err))
-		}
-		clip = cdppage.Viewport{
-			X:      contentSize.X,
-			Y:      contentSize.Y,
-			Width:  contentSize.Width,
-			Height: contentSize.Height,
-			Scale:  1,
-		}
-	}
-
-	if clip.Width > 0 && clip.Height > 0 {
-		capture = capture.WithClip(&clip)
-	}
-
-	// Add common options
-	capture.WithQuality(parsedOpts.Quality)
-	switch format {
-	case "jpeg":
-		capture.WithFormat(cdppage.CaptureScreenshotFormatJpeg)
-	default:
-		capture.WithFormat(cdppage.CaptureScreenshotFormatPng)
-	}
-
-	// Make background transparent for PNG captures if requested
-	if parsedOpts.OmitBackground && format == "png" {
-		action := emulation.SetDefaultBackgroundColorOverride().
-			WithColor(&cdp.RGBA{R: 0, G: 0, B: 0, A: 0})
-		if err := action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
-			k6common.Throw(rt, fmt.Errorf("unable to set screenshot background transparency: %w", err))
-		}
-	}
-
-	// Capture screenshot
-	buf, err := capture.Do(cdp.WithExecutor(p.ctx, p.session))
+	s := NewScreenshotter(p.ctx)
+	buf, err := s.screenshotPage(p, parsedOpts)
 	if err != nil {
-		k6common.Throw(rt, fmt.Errorf("unable to capture screenshot of page '%s': %w", p.frameManager.MainFrame().URL(), err))
+		k6common.Throw(rt, fmt.Errorf("cannot capture screenshot: %w", err))
 	}
-
-	// Reset background
-	if parsedOpts.OmitBackground && format == "png" {
-		action := emulation.SetDefaultBackgroundColorOverride()
-		if err := action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
-			k6common.Throw(rt, fmt.Errorf("unable to reset screenshot background color: %w", err))
-		}
-	}
-
-	// TODO: Reset viewport
-
-	// Save screenshot capture to file
-	// TODO: we should not write to disk here but put it on some queue for async disk writes
-	if parsedOpts.Path != "" {
-		dir := filepath.Dir(parsedOpts.Path)
-		if err := os.MkdirAll(dir, 0775); err != nil {
-			k6common.Throw(rt, fmt.Errorf("unable to create directory for screenshot of page '%s': %w", p.frameManager.MainFrame().URL(), err))
-		}
-		if err := ioutil.WriteFile(parsedOpts.Path, buf, 0664); err != nil {
-			k6common.Throw(rt, fmt.Errorf("unable to save screenshot of page '%s' to file: %w", p.frameManager.MainFrame().URL(), err))
-		}
-	}
-
-	return rt.NewArrayBuffer(buf)
+	return rt.NewArrayBuffer(*buf)
 }
 
 func (p *Page) SelectOption(selector string, values goja.Value, opts goja.Value) []string {
@@ -684,15 +616,11 @@ func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value)
 // SetViewportSize will update the viewport width and height
 func (p *Page) SetViewportSize(viewportSize goja.Value) {
 	rt := k6common.GetRuntime(p.ctx)
-	viewport := NewViewport()
-	if err := viewport.Parse(p.ctx, viewportSize); err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing viewport: %w", err))
+	s := &Size{}
+	if err := s.Parse(p.ctx, viewportSize); err != nil {
+		k6common.Throw(rt, fmt.Errorf("failed parsing size: %w", err))
 	}
-	screen := NewScreen()
-	if err := viewport.Parse(p.ctx, viewportSize); err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing screen: %w", err))
-	}
-	if err := p.setEmulatedSize(NewEmulatedSize(viewport, screen)); err != nil {
+	if err := p.setViewportSize(s); err != nil {
 		k6common.Throw(rt, err)
 	}
 	applySlowMo(p.ctx)
@@ -740,10 +668,11 @@ func (p *Page) Video() api.Video {
 
 // ViewportSize will return information on the viewport width and height
 func (p *Page) ViewportSize() map[string]float64 {
-	size := make(map[string]float64, 2)
-	size["width"] = float64(p.emulatedSize.Viewport.Width)
-	size["height"] = float64(p.emulatedSize.Viewport.Height)
-	return size
+	vps := p.viewportSize()
+	return map[string]float64{
+		"width":  vps.Width,
+		"height": vps.Height,
+	}
 }
 
 // WaitForEvent waits for the specified event to trigger

--- a/common/page_options.go
+++ b/common/page_options.go
@@ -23,6 +23,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/page"
@@ -44,7 +45,7 @@ type PageReloadOptions struct {
 type PageScreenshotOptions struct {
 	Clip           *page.Viewport `json:"clip"`
 	Path           string         `json:"path"`
-	Format         string         `json:"format"`
+	Format         ImageFormat    `json:"format"`
 	FullPage       bool           `json:"fullPage"`
 	OmitBackground bool           `json:"omitBackground"`
 	Quality        int64          `json:"quality"`
@@ -108,7 +109,7 @@ func NewPageScreenshotOptions() *PageScreenshotOptions {
 	return &PageScreenshotOptions{
 		Clip:           nil,
 		Path:           "",
-		Format:         "png",
+		Format:         ImageFormatPNG,
 		FullPage:       false,
 		OmitBackground: false,
 		Quality:        100,
@@ -118,6 +119,7 @@ func NewPageScreenshotOptions() *PageScreenshotOptions {
 func (o *PageScreenshotOptions) Parse(ctx context.Context, opts goja.Value) error {
 	rt := k6common.GetRuntime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
+		formatSpecified := false
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
@@ -141,7 +143,17 @@ func (o *PageScreenshotOptions) Parse(ctx context.Context, opts goja.Value) erro
 			case "quality":
 				o.Quality = opts.Get(k).ToInteger()
 			case "type":
-				o.Format = opts.Get(k).String()
+				if f, ok := imageFormatToID[opts.Get(k).String()]; ok {
+					o.Format = f
+					formatSpecified = true
+				}
+			}
+		}
+
+		// Infer file format by path if format not explicitly specified (default is PNG)
+		if o.Path != "" && !formatSpecified {
+			if strings.HasSuffix(o.Path, ".jpg") || strings.HasSuffix(o.Path, ".jpeg") {
+				o.Format = ImageFormatJPEG
 			}
 		}
 	}

--- a/common/page_options.go
+++ b/common/page_options.go
@@ -42,12 +42,12 @@ type PageReloadOptions struct {
 }
 
 type PageScreenshotOptions struct {
-	Clip           page.Viewport `json:"clip"`
-	Path           string        `json:"path"`
-	Format         string        `json:"format"`
-	FullPage       bool          `json:"fullPage"`
-	OmitBackground bool          `json:"omitBackground"`
-	Quality        int64         `json:"quality"`
+	Clip           *page.Viewport `json:"clip"`
+	Path           string         `json:"path"`
+	Format         string         `json:"format"`
+	FullPage       bool           `json:"fullPage"`
+	OmitBackground bool           `json:"omitBackground"`
+	Quality        int64          `json:"quality"`
 }
 
 func NewPageEmulateMediaOptions(defaultMedia MediaType, defaultColorScheme ColorScheme, defaultReducedMotion ReducedMotion) *PageEmulateMediaOptions {
@@ -106,7 +106,7 @@ func (o *PageReloadOptions) Parse(ctx context.Context, opts goja.Value) error {
 
 func NewPageScreenshotOptions() *PageScreenshotOptions {
 	return &PageScreenshotOptions{
-		Clip:           page.Viewport{X: 0, Y: 0, Width: 0, Height: 0, Scale: 1},
+		Clip:           nil,
 		Path:           "",
 		Format:         "png",
 		FullPage:       false,
@@ -124,10 +124,13 @@ func (o *PageScreenshotOptions) Parse(ctx context.Context, opts goja.Value) erro
 			case "clip":
 				var c map[string]float64
 				if rt.ExportTo(opts.Get(k), &c) != nil {
-					o.Clip.X = c["x"]
-					o.Clip.Y = c["y"]
-					o.Clip.Width = c["width"]
-					o.Clip.Height = c["height"]
+					o.Clip = &page.Viewport{
+						X:      c["x"],
+						Y:      c["y"],
+						Width:  c["width"],
+						Height: c["height"],
+						Scale:  1,
+					}
 				}
 			case "fullPage":
 				o.FullPage = opts.Get(k).ToBoolean()

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -1,0 +1,377 @@
+/*
+ *
+ * xk6-browser - a browser automation extension for k6
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/emulation"
+	cdppage "github.com/chromedp/cdproto/page"
+	"github.com/dop251/goja"
+	k6common "go.k6.io/k6/js/common"
+)
+
+type Screenshotter struct {
+	ctx context.Context
+}
+
+func NewScreenshotter(ctx context.Context) *Screenshotter {
+	s := Screenshotter{
+		ctx: ctx,
+	}
+	return &s
+}
+
+func (s *Screenshotter) fullPageSize(p *Page) (*Size, error) {
+	rt := k6common.GetRuntime(s.ctx)
+	result, err := p.frameManager.mainFrame.mainExecutionContext.evaluate(s.ctx, true, true, rt.ToValue(`
+        () => {
+            if (!document.body || !document.documentElement) {
+                return null;
+            }
+            return {
+                width: Math.max(
+                    document.body.scrollWidth, document.documentElement.scrollWidth,
+                    document.body.offsetWidth, document.documentElement.offsetWidth,
+                    document.body.clientWidth, document.documentElement.clientWidth
+                ),
+                height: Math.max(
+                    document.body.scrollHeight, document.documentElement.scrollHeight,
+                    document.body.offsetHeight, document.documentElement.offsetHeight,
+                    document.body.clientHeight, document.documentElement.clientHeight
+                ),
+            };
+        }`))
+	if err != nil {
+		return nil, err
+	}
+	r, ok := result.(goja.Value)
+	if !ok {
+		return nil, fmt.Errorf("cannot convert result to goja value")
+	}
+	o := r.ToObject(rt)
+	return &Size{
+		Width:  o.Get("width").ToFloat(),
+		Height: o.Get("height").ToFloat(),
+	}, nil
+}
+
+func (s *Screenshotter) originalViewportSize(p *Page) (*Size, *Size, error) {
+	rt := k6common.GetRuntime(s.ctx)
+	originalViewportSize := p.viewportSize()
+	viewportSize := originalViewportSize
+	if viewportSize.Width != 0 || viewportSize.Height != 0 {
+		return &viewportSize, &originalViewportSize, nil
+	}
+	result, err := p.frameManager.mainFrame.mainExecutionContext.evaluate(s.ctx, true, true, rt.ToValue(`
+	() => (
+		{ width: window.innerWidth, height: window.innerHeight }
+	)`))
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot evaluate page function: %w", err)
+	}
+	r, ok := result.(goja.Object)
+	if !ok {
+		return nil, nil, fmt.Errorf("cannot convert to goja object: %w", err)
+	}
+	viewportSize.Width = r.Get("width").ToFloat()
+	viewportSize.Height = r.Get("height").ToFloat()
+	return &viewportSize, &originalViewportSize, nil
+}
+
+func (s *Screenshotter) restoreViewport(p *Page, originalViewport *Size) error {
+	if originalViewport != nil {
+		return p.setViewportSize(originalViewport)
+	}
+	return p.resetViewport()
+}
+
+func (s *Screenshotter) screenshot(session *Session, documentRect *Rect, viewportRect *Rect, format string, omitBackground bool, quality int64, path string) (*[]byte, error) {
+	var (
+		buf     []byte
+		clip    *cdppage.Viewport
+		capture *cdppage.CaptureScreenshotParams
+	)
+	capture = cdppage.CaptureScreenshot()
+
+	shouldSetDefaultBackground := omitBackground && format == "png"
+	if shouldSetDefaultBackground {
+		action := emulation.SetDefaultBackgroundColorOverride().
+			WithColor(&cdp.RGBA{R: 0, G: 0, B: 0, A: 0})
+		if err := action.Do(cdp.WithExecutor(s.ctx, session)); err != nil {
+			return nil, fmt.Errorf("cannot set screenshot background transparency: %w", err)
+		}
+	}
+
+	// Add common options
+	capture.WithQuality(quality)
+	switch format {
+	case "jpeg":
+		capture.WithFormat(cdppage.CaptureScreenshotFormatJpeg)
+	default:
+		capture.WithFormat(cdppage.CaptureScreenshotFormatPng)
+	}
+
+	// Add clip region
+	_, visualViewport, _, _, _, _, err := cdppage.GetLayoutMetrics().Do(cdp.WithExecutor(s.ctx, session))
+	if err != nil {
+		return nil, fmt.Errorf("cannot get layout metrics for screenshot: %w", err)
+	}
+
+	if documentRect == nil {
+		s := Size{
+			Width:  viewportRect.Width / visualViewport.Scale,
+			Height: viewportRect.Height / visualViewport.Scale,
+		}.enclosingIntSize()
+		documentRect = &Rect{
+			X:      visualViewport.PageX + viewportRect.X,
+			Y:      visualViewport.PageY + viewportRect.Y,
+			Width:  s.Width,
+			Height: s.Height,
+		}
+	}
+
+	scale := 1.0
+	if viewportRect != nil {
+		scale = visualViewport.Scale
+	}
+	clip = &cdppage.Viewport{
+		X:      documentRect.X,
+		Y:      documentRect.Y,
+		Width:  documentRect.Width,
+		Height: documentRect.Height,
+		Scale:  scale,
+	}
+	if clip.Width > 0 && clip.Height > 0 {
+		capture = capture.WithClip(clip)
+	}
+
+	// Capture screenshot
+	buf, err = capture.Do(cdp.WithExecutor(s.ctx, session))
+	if err != nil {
+		return nil, fmt.Errorf("cannot capture screenshot: %w", err)
+	}
+
+	if shouldSetDefaultBackground {
+		action := emulation.SetDefaultBackgroundColorOverride()
+		if err := action.Do(cdp.WithExecutor(s.ctx, session)); err != nil {
+			return nil, fmt.Errorf("cannot reset screenshot background color: %w", err)
+		}
+	}
+
+	// Save screenshot capture to file
+	// TODO: we should not write to disk here but put it on some queue for async disk writes
+	if path != "" {
+		dir := filepath.Dir(path)
+		if err := os.MkdirAll(dir, 0775); err != nil {
+			return nil, fmt.Errorf("cannot create directory for screenshot: %w", err)
+		}
+		if err := ioutil.WriteFile(path, buf, 0664); err != nil {
+			return nil, fmt.Errorf("cannot save screenshot to file: %w", err)
+		}
+	}
+	return &buf, nil
+}
+
+func (s *Screenshotter) screenshotElement(h *ElementHandle, opts *ElementHandleScreenshotOptions) (*[]byte, error) {
+	format := opts.Format
+
+	// Infer file format by path
+	if opts.Path != "" && opts.Format != "png" && opts.Format != "jpeg" {
+		if strings.HasSuffix(opts.Path, ".jpg") || strings.HasSuffix(opts.Path, ".jpeg") {
+			format = "jpeg"
+		}
+	}
+
+	viewportSize, originalViewportSize, err := s.originalViewportSize(h.frame.page)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get original viewport size: %w", err)
+	}
+
+	err = h.waitAndScrollIntoViewIfNeeded(h.ctx, false, true, opts.Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scroll element into view: %w", err)
+	}
+
+	bbox, err := h.boundingBox()
+	if err != nil {
+		return nil, fmt.Errorf("node is either not visible or not an HTMLElement: %w", err)
+	}
+	if bbox.Width <= 0 {
+		return nil, fmt.Errorf("node has 0 width")
+	}
+	if bbox.Height <= 0 {
+		return nil, fmt.Errorf("node has 0 height")
+	}
+
+	var overriddenViewportSize *Size
+	fitsViewport := bbox.Width <= viewportSize.Width && bbox.Height <= viewportSize.Height
+	if !fitsViewport {
+		overriddenViewportSize = Size{
+			Width:  math.Max(viewportSize.Width, bbox.Width),
+			Height: math.Max(viewportSize.Height, bbox.Height),
+		}.enclosingIntSize()
+		if err := h.frame.page.setViewportSize(overriddenViewportSize); err != nil {
+			return nil, fmt.Errorf("cannot set viewport size: %w", err)
+		}
+		err = h.waitAndScrollIntoViewIfNeeded(h.ctx, false, true, opts.Timeout)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scroll element into view: %w", err)
+		}
+		bbox, err = h.boundingBox()
+		if err != nil {
+			return nil, fmt.Errorf("node is either not visible or not an HTMLElement: %w", err)
+		}
+		if bbox.Width <= 0 {
+			return nil, fmt.Errorf("node has 0 width")
+		}
+		if bbox.Height <= 0 {
+			return nil, fmt.Errorf("node has 0 height")
+		}
+	}
+
+	documentRect := bbox
+	rt := k6common.GetRuntime(s.ctx)
+	scrollOffset := h.Evaluate(rt.ToValue(`() => { return {x: window.scrollX, y: window.scrollY};}`))
+	switch s := scrollOffset.(type) {
+	case goja.Value:
+		documentRect.X += s.ToObject(rt).Get("x").ToFloat()
+		documentRect.Y += s.ToObject(rt).Get("y").ToFloat()
+	}
+
+	buf, err := s.screenshot(h.frame.page.session, documentRect.enclosingIntRect(), nil, format, opts.OmitBackground, opts.Quality, opts.Path)
+	if err != nil {
+		return nil, err
+	}
+	if overriddenViewportSize != nil {
+		if err := s.restoreViewport(h.frame.page, originalViewportSize); err != nil {
+			return nil, fmt.Errorf("cannot restore viewport: %w", err)
+		}
+	}
+	return buf, nil
+}
+
+func (s *Screenshotter) screenshotPage(p *Page, opts *PageScreenshotOptions) (*[]byte, error) {
+	format := opts.Format
+
+	// Infer file format by path
+	if opts.Path != "" && opts.Format != "png" && opts.Format != "jpeg" {
+		if strings.HasSuffix(opts.Path, ".jpg") || strings.HasSuffix(opts.Path, ".jpeg") {
+			format = "jpeg"
+		}
+	}
+
+	viewportSize, originalViewportSize, err := s.originalViewportSize(p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get original viewport size: %w", err)
+	}
+
+	if opts.FullPage {
+		fullPageSize, err := s.fullPageSize(p)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get full page size: %w", err)
+		}
+		documentRect := &Rect{
+			X:      0,
+			Y:      0,
+			Width:  fullPageSize.Width,
+			Height: fullPageSize.Height,
+		}
+		var overriddenViewportSize *Size
+		fitsViewport := fullPageSize.Width <= viewportSize.Width && fullPageSize.Height <= viewportSize.Height
+		if !fitsViewport {
+			overriddenViewportSize = fullPageSize
+			if err := p.setViewportSize(overriddenViewportSize); err != nil {
+				return nil, fmt.Errorf("cannot set viewport size: %w", err)
+			}
+		}
+		if opts.Clip != nil {
+			documentRect, err = s.trimClipToSize(&Rect{
+				X:      opts.Clip.X,
+				Y:      opts.Clip.Y,
+				Width:  opts.Clip.Width,
+				Height: opts.Clip.Height,
+			}, &Size{Width: documentRect.Width, Height: documentRect.Height})
+			if err != nil {
+				return nil, fmt.Errorf("cannot trim clip to size: %w", err)
+			}
+		}
+
+		buf, err := s.screenshot(p.session, documentRect, nil, format, opts.OmitBackground, opts.Quality, opts.Path)
+		if err != nil {
+			return nil, fmt.Errorf("cannot screenshot: %w", err)
+		}
+		if overriddenViewportSize != nil {
+			if err := s.restoreViewport(p, originalViewportSize); err != nil {
+				return nil, fmt.Errorf("cannot restore viewport: %w", err)
+			}
+		}
+		return buf, nil
+	}
+
+	viewportRect := &Rect{
+		X:      0,
+		Y:      0,
+		Width:  viewportSize.Width,
+		Height: viewportSize.Height,
+	}
+	if opts.Clip != nil {
+		viewportRect, err = s.trimClipToSize(&Rect{
+			X:      opts.Clip.X,
+			Y:      opts.Clip.Y,
+			Width:  opts.Clip.Width,
+			Height: opts.Clip.Height,
+		}, viewportSize)
+		if err != nil {
+			return nil, fmt.Errorf("cannot trim clip to size: %w", err)
+		}
+	}
+	return s.screenshot(p.session, nil, viewportRect, format, opts.OmitBackground, opts.Quality, opts.Path)
+}
+
+func (s *Screenshotter) trimClipToSize(clip *Rect, size *Size) (*Rect, error) {
+	p1 := Position{
+		X: math.Max(0, math.Min(clip.X, size.Width)),
+		Y: math.Max(0, math.Min(clip.Y, size.Height)),
+	}
+	p2 := Position{
+		X: math.Max(0, math.Min(clip.X+clip.Width, size.Width)),
+		Y: math.Max(0, math.Min(clip.Y+clip.Height, size.Height)),
+	}
+	result := Rect{
+		X:      p1.X,
+		Y:      p1.Y,
+		Width:  p2.X - p1.X,
+		Height: p2.Y - p1.Y,
+	}
+	if result.Width == 0 || result.Height == 0 {
+		return nil, errors.New("clip area is either empty or outside the viewport")
+	}
+	return &result, nil
+}

--- a/common/types.go
+++ b/common/types.go
@@ -25,8 +25,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/dop251/goja"
+	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
 )
 
@@ -242,6 +244,13 @@ type Position struct {
 	Y float64 `json:"y"`
 }
 
+type Rect struct {
+	X      float64 `js:"x"`
+	Y      float64 `js:"y"`
+	Width  float64 `js:"width"`
+	Height float64 `js:"height"`
+}
+
 // ReducedMotion represents a browser reduce-motion setting
 type ReducedMotion string
 
@@ -307,6 +316,11 @@ type SelectOption struct {
 	Value *string `json:"value"`
 	Label *string `json:"label"`
 	Index *int64  `json:"index"`
+}
+
+type Size struct {
+	Width  float64 `js:"width"`
+	Height float64 `js:"height"`
 }
 
 // Viewport represents a page viewport
@@ -382,8 +396,16 @@ func (g *Geolocation) Parse(ctx context.Context, opts goja.Value) error {
 	return nil
 }
 
-func NewScreen() *Screen {
-	return &Screen{}
+func (r *Rect) enclosingIntRect() *Rect {
+	x := math.Floor(r.X + 1e-3)
+	y := math.Floor(r.Y + 1e-3)
+	x2 := math.Ceil(r.X + r.Width - 1e-3)
+	y2 := math.Ceil(r.Y + r.Height - 1e-3)
+	return &Rect{X: x, Y: y, Width: x2 - x, Height: y2 - y}
+}
+
+func (r *Rect) toApiRect() *api.Rect {
+	return &api.Rect{X: r.X, Y: r.Y, Width: r.Width, Height: r.Height}
 }
 
 func (s *Screen) Parse(ctx context.Context, screen goja.Value) error {
@@ -402,8 +424,27 @@ func (s *Screen) Parse(ctx context.Context, screen goja.Value) error {
 	return nil
 }
 
-func NewViewport() *Viewport {
-	return &Viewport{}
+func (s Size) enclosingIntSize() *Size {
+	return &Size{
+		Width:  math.Floor(s.Width + 1e-3),
+		Height: math.Floor(s.Height + 1e-3),
+	}
+}
+
+func (s *Size) Parse(ctx context.Context, viewport goja.Value) error {
+	rt := k6common.GetRuntime(ctx)
+	if viewport != nil && !goja.IsUndefined(viewport) && !goja.IsNull(viewport) {
+		viewport := viewport.ToObject(rt)
+		for _, k := range viewport.Keys() {
+			switch k {
+			case "width":
+				s.Width = viewport.Get(k).ToFloat()
+			case "height":
+				s.Height = viewport.Get(k).ToFloat()
+			}
+		}
+	}
+	return nil
 }
 
 func (v *Viewport) Parse(ctx context.Context, viewport goja.Value) error {

--- a/common/types.go
+++ b/common/types.go
@@ -144,6 +144,49 @@ type Geolocation struct {
 	Accurracy float64 `js:"accurracy"`
 }
 
+// ImageFormat represents an image file format
+type ImageFormat string
+
+// Valid image format options
+const (
+	ImageFormatJPEG ImageFormat = "jpeg"
+	ImageFormatPNG  ImageFormat = "png"
+)
+
+func (f ImageFormat) String() string {
+	return imageFormatToString[f]
+}
+
+var imageFormatToString = map[ImageFormat]string{
+	ImageFormatJPEG: "jpeg",
+	ImageFormatPNG:  "png",
+}
+
+var imageFormatToID = map[string]ImageFormat{
+	"jpeg": ImageFormatJPEG,
+	"png":  ImageFormatPNG,
+}
+
+// MarshalJSON marshals the enum as a quoted JSON string
+func (f ImageFormat) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(imageFormatToString[f])
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON unmarshals a quoted JSON string to the enum value
+func (f *ImageFormat) UnmarshalJSON(b []byte) error {
+	var j string
+	err := json.Unmarshal(b, &j)
+	if err != nil {
+		return err
+	}
+	// Note that if the string cannot be found then it will be set to the zero value.
+	*f = imageFormatToID[j]
+	return nil
+}
+
 type LifecycleEvent int
 
 const (

--- a/tests/element_handle_screenshot_test.go
+++ b/tests/element_handle_screenshot_test.go
@@ -1,0 +1,86 @@
+/*
+ *
+ * xk6-browser - a browser automation extension for k6
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tests
+
+import (
+	"bytes"
+	_ "embed"
+	"image/png"
+	"testing"
+
+	"github.com/grafana/xk6-browser/testutils/browsertest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestElementHandleScreenshot(t *testing.T) {
+	bt := browsertest.NewBrowserTest(t)
+	defer bt.Browser.Close()
+
+	t.Run("ElementHandle.screenshot", func(t *testing.T) {
+		t.Run("should work", func(t *testing.T) { testElementHandleScreenshot(t, bt) })
+	})
+}
+
+func testElementHandleScreenshot(t *testing.T, bt *browsertest.BrowserTest) {
+	p := bt.Browser.NewPage(nil)
+	defer p.Close(nil)
+
+	p.SetViewportSize(bt.Runtime.ToValue(struct {
+		Width  float64 `js:"width"`
+		Height float64 `js:"height"`
+	}{Width: 800, Height: 600}))
+	p.Evaluate(bt.Runtime.ToValue(`
+         () => {
+             document.body.style.margin = '0';
+             document.body.style.padding = '0';
+             document.documentElement.style.margin = '0';
+             document.documentElement.style.padding = '0';
+             const div = document.createElement('div');
+             div.style.marginTop = '400px';
+             div.style.marginLeft = '100px';
+             div.style.width = '100px';
+             div.style.height = '100px';
+             div.style.background = 'red';
+             document.body.appendChild(div);
+         }
+    `))
+
+	elem := p.Query("div")
+	buf := elem.Screenshot(bt.Runtime.ToValue(struct {
+		Path string `js:"path"`
+	}{Path: "eh-screenshot.png"}))
+
+	reader := bytes.NewReader(buf.Bytes())
+	img, err := png.Decode(reader)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 100, img.Bounds().Max.X, "screenshot width is not 100px as expected, but %dpx", img.Bounds().Max.X)
+	assert.Equal(t, 100, img.Bounds().Max.Y, "screenshot height is not 100px as expected, but %dpx", img.Bounds().Max.Y)
+
+	r, g, b, _ := img.At(0, 0).RGBA()
+	assert.Equal(t, uint32(255), r>>8) // each color component has been scaled by alpha (<<8)
+	assert.Equal(t, uint32(0), g)
+	assert.Equal(t, uint32(0), b)
+	r, g, b, _ = img.At(99, 99).RGBA()
+	assert.Equal(t, uint32(255), r>>8) // each color component has been scaled by alpha (<<8)
+	assert.Equal(t, uint32(0), g)
+	assert.Equal(t, uint32(0), b)
+}

--- a/tests/element_handle_screenshot_test.go
+++ b/tests/element_handle_screenshot_test.go
@@ -64,9 +64,7 @@ func testElementHandleScreenshot(t *testing.T, bt *browsertest.BrowserTest) {
     `))
 
 	elem := p.Query("div")
-	buf := elem.Screenshot(bt.Runtime.ToValue(struct {
-		Path string `js:"path"`
-	}{Path: "eh-screenshot.png"}))
+	buf := elem.Screenshot(nil)
 
 	reader := bytes.NewReader(buf.Bytes())
 	img, err := png.Decode(reader)

--- a/tests/page_screenshot_test.go
+++ b/tests/page_screenshot_test.go
@@ -1,0 +1,81 @@
+/*
+ *
+ * xk6-browser - a browser automation extension for k6
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tests
+
+import (
+	"bytes"
+	_ "embed"
+	"image/png"
+	"testing"
+
+	"github.com/grafana/xk6-browser/testutils/browsertest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPageScreenshot(t *testing.T) {
+	bt := browsertest.NewBrowserTest(t)
+	defer bt.Browser.Close()
+
+	t.Run("Page.screenshot", func(t *testing.T) {
+		t.Run("should work with full page", func(t *testing.T) { testPageScreenshotFullpage(t, bt) })
+	})
+}
+
+func testPageScreenshotFullpage(t *testing.T, bt *browsertest.BrowserTest) {
+	p := bt.Browser.NewPage(nil)
+	defer p.Close(nil)
+
+	p.SetViewportSize(bt.Runtime.ToValue(struct {
+		Width  float64 `js:"width"`
+		Height float64 `js:"height"`
+	}{Width: 1280, Height: 800}))
+	p.Evaluate(bt.Runtime.ToValue(`
+        () => {
+            document.body.style.margin = '0';
+            document.body.style.padding = '0';
+            document.documentElement.style.margin = '0';
+            document.documentElement.style.padding = '0';
+            const div = document.createElement('div');
+            div.style.width = '1280px';
+            div.style.height = '8000px';
+            div.style.background = 'linear-gradient(red, blue)';
+            document.body.appendChild(div);
+        }
+    `))
+
+	buf := p.Screenshot(bt.Runtime.ToValue(struct {
+		FullPage bool `js:"fullPage"`
+	}{FullPage: true}))
+
+	reader := bytes.NewReader(buf.Bytes())
+	img, err := png.Decode(reader)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 1280, img.Bounds().Max.X, "screenshot width is not 1280px as expected, but %dpx", img.Bounds().Max.X)
+	assert.Equal(t, 8000, img.Bounds().Max.Y, "screenshot height is not 8000px as expected, but %dpx", img.Bounds().Max.Y)
+
+	r, _, b, _ := img.At(0, 0).RGBA()
+	assert.Greater(t, r, uint32(128))
+	assert.Less(t, b, uint32(128))
+	r, _, b, _ = img.At(0, 7999).RGBA()
+	assert.Less(t, r, uint32(128))
+	assert.Greater(t, b, uint32(128))
+}


### PR DESCRIPTION
Replaces https://github.com/grafana/xk6-browser/pull/63

Implementation based on: https://github.com/microsoft/playwright/blob/master/packages/playwright-core/src/server/screenshotter.ts