### PR TITLE
Fix getting response body if Frame is nil

### DIFF
--- a/common/response.go
+++ b/common/response.go
@@ -133,7 +133,7 @@ func NewHTTPResponse(ctx context.Context, req *Request, resp *network.Response, 
 }
 
 func (r *Response) fetchBody() error {
-	if r.body != nil {
+	if r.body != nil || r.request.frame == nil {
 		return nil
 	}
 	action := network.GetResponseBody(r.request.requestID)


### PR DESCRIPTION
This is a quick fix for #82, but the root cause is still unknown.

We added debugging information for when this happens in 0451efba, so it's the same issue that will need a deeper lifecycle fix. I'll create a new issue for it.