### PR TITLE
Skip request handling of data: URLs

### DIFF
--- a/common/logger.go
+++ b/common/logger.go
@@ -93,7 +93,7 @@ func (l *Logger) Logf(level logrus.Level, category string, msg string, args ...i
 				"elapsed":   fmt.Sprintf("%d ms", elapsed),
 				"goroutine": goRoutineID(),
 			})
-			if l.logger.Level < level && l.debugOverride {
+			if l.logger.GetLevel() < level && l.debugOverride {
 				entry.Printf(msg, args...)
 			} else {
 				entry.Logf(level, msg, args...)

--- a/common/response.go
+++ b/common/response.go
@@ -193,7 +193,7 @@ func (r *Response) bodySize() int64 {
 	}
 
 	if err := r.fetchBody(); err != nil {
-		r.logger.Warnf("cdp", "error fetching response body: %s", err)
+		r.logger.Warnf("cdp", "error fetching response body for '%s': %s", r.url, err)
 	}
 
 	return int64(len(r.body))

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -1,0 +1,56 @@
+/*
+ *
+ * xk6-browser - a browser automation extension for k6
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tests
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/grafana/xk6-browser/testutils"
+	"github.com/grafana/xk6-browser/testutils/browsertest"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDataURLSkipRequest(t *testing.T) {
+	t.Parallel()
+	bt := browsertest.NewBrowserTest(t)
+	p := bt.Browser.NewPage(nil)
+	t.Cleanup(func() {
+		p.Close(nil)
+		bt.Browser.Close()
+	})
+
+	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
+	bt.State.Logger.SetLevel(logrus.DebugLevel)
+	bt.State.Logger.AddHook(logHook)
+	bt.State.Logger.SetOutput(ioutil.Discard)
+
+	p.Goto("data:text/html,hello", nil)
+
+	var gotMsg bool
+	for _, evt := range logHook.Drain() {
+		if evt.Message == "skipped request handling of data URL" {
+			gotMsg = true
+		}
+	}
+	assert.True(t, gotMsg)
+}

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -21,12 +21,9 @@
 package tests
 
 import (
-	"io/ioutil"
 	"testing"
 
-	"github.com/grafana/xk6-browser/testutils"
 	"github.com/grafana/xk6-browser/testutils/browsertest"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,10 +36,7 @@ func TestDataURLSkipRequest(t *testing.T) {
 		bt.Browser.Close()
 	})
 
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
-	bt.State.Logger.SetLevel(logrus.DebugLevel)
-	bt.State.Logger.AddHook(logHook)
-	bt.State.Logger.SetOutput(ioutil.Discard)
+	logHook := bt.LogHook()
 
 	p.Goto("data:text/html,hello", nil)
 

--- a/testutils/browsertest/browsertest.go
+++ b/testutils/browsertest/browsertest.go
@@ -125,8 +125,8 @@ func NewBrowserTest(t testing.TB) *BrowserTest {
 	}
 }
 
-func (bt *BrowserTest) LogHook() *testutils.SimpleLogrusHook {
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
+func (bt *BrowserTest) LogHook() *testutils.CacheLogrusHook {
+	logHook := &testutils.CacheLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
 	bt.State.Logger.SetLevel(logrus.DebugLevel)
 	bt.State.Logger.AddHook(logHook)
 	bt.State.Logger.SetOutput(ioutil.Discard)

--- a/testutils/browsertest/browsertest.go
+++ b/testutils/browsertest/browsertest.go
@@ -22,6 +22,7 @@ package browsertest
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -29,6 +30,7 @@ import (
 	"github.com/dop251/goja"
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/chromium"
+	"github.com/grafana/xk6-browser/testutils"
 	"github.com/oxtoacart/bpool"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -121,4 +123,12 @@ func NewBrowserTest(t testing.TB) *BrowserTest {
 		HTTPMultiBin: tb,
 		Samples:      samples,
 	}
+}
+
+func (bt *BrowserTest) LogHook() *testutils.SimpleLogrusHook {
+	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
+	bt.State.Logger.SetLevel(logrus.DebugLevel)
+	bt.State.Logger.AddHook(logHook)
+	bt.State.Logger.SetOutput(ioutil.Discard)
+	return logHook
 }

--- a/testutils/logrus_hook.go
+++ b/testutils/logrus_hook.go
@@ -26,21 +26,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// SimpleLogrusHook implements the logrus.Hook interface and could be used to check
+// CacheLogrusHook implements the logrus.Hook interface and could be used to check
 // if log messages were outputted
-type SimpleLogrusHook struct {
+type CacheLogrusHook struct {
 	HookedLevels []logrus.Level
 	mutex        sync.Mutex
 	messageCache []logrus.Entry
 }
 
 // Levels just returns whatever was stored in the HookedLevels slice
-func (smh *SimpleLogrusHook) Levels() []logrus.Level {
+func (smh *CacheLogrusHook) Levels() []logrus.Level {
 	return smh.HookedLevels
 }
 
 // Fire saves whatever message the logrus library passed in the cache
-func (smh *SimpleLogrusHook) Fire(e *logrus.Entry) error {
+func (smh *CacheLogrusHook) Fire(e *logrus.Entry) error {
 	smh.mutex.Lock()
 	defer smh.mutex.Unlock()
 	smh.messageCache = append(smh.messageCache, *e)
@@ -48,7 +48,7 @@ func (smh *SimpleLogrusHook) Fire(e *logrus.Entry) error {
 }
 
 // Drain returns the currently stored messages and deletes them from the cache
-func (smh *SimpleLogrusHook) Drain() []logrus.Entry {
+func (smh *CacheLogrusHook) Drain() []logrus.Entry {
 	smh.mutex.Lock()
 	defer smh.mutex.Unlock()
 	res := smh.messageCache
@@ -56,4 +56,4 @@ func (smh *SimpleLogrusHook) Drain() []logrus.Entry {
 	return res
 }
 
-var _ logrus.Hook = &SimpleLogrusHook{}
+var _ logrus.Hook = &CacheLogrusHook{}

--- a/testutils/logrus_hook.go
+++ b/testutils/logrus_hook.go
@@ -1,0 +1,59 @@
+/*
+ *
+ * xk6-browser - a browser automation extension for k6
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutils
+
+import (
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// SimpleLogrusHook implements the logrus.Hook interface and could be used to check
+// if log messages were outputted
+type SimpleLogrusHook struct {
+	HookedLevels []logrus.Level
+	mutex        sync.Mutex
+	messageCache []logrus.Entry
+}
+
+// Levels just returns whatever was stored in the HookedLevels slice
+func (smh *SimpleLogrusHook) Levels() []logrus.Level {
+	return smh.HookedLevels
+}
+
+// Fire saves whatever message the logrus library passed in the cache
+func (smh *SimpleLogrusHook) Fire(e *logrus.Entry) error {
+	smh.mutex.Lock()
+	defer smh.mutex.Unlock()
+	smh.messageCache = append(smh.messageCache, *e)
+	return nil
+}
+
+// Drain returns the currently stored messages and deletes them from the cache
+func (smh *SimpleLogrusHook) Drain() []logrus.Entry {
+	smh.mutex.Lock()
+	defer smh.mutex.Unlock()
+	res := smh.messageCache
+	smh.messageCache = []logrus.Entry{}
+	return res
+}
+
+var _ logrus.Hook = &SimpleLogrusHook{}


### PR DESCRIPTION
This skips handling of `data:` URLs as early as possible, so that we don't emit empty metrics for them.

These are typically found in CSS, e.g.: `background:url("data:image/svg+xml;base64,PHN2ZyB3...")`.