### PR TITLE
Cross-platform browser process killer

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -129,6 +129,10 @@ func (b *BrowserType) Launch(opts goja.Value) api.Browser {
 		k6common.Throw(rt, fmt.Errorf("unable to allocate browser: %w", err))
 	}
 
+	// attach the browser process ID to the context
+	// so that we can kill it afterward if it lingers
+	// see: k6Throw function
+	b.Ctx = common.WithProcessID(b.Ctx, browserProc.Pid())
 	browser, err := common.NewBrowser(b.Ctx, b.CancelFn, browserProc, launchOpts)
 	if err != nil {
 		k6common.Throw(rt, err)

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -89,3 +89,8 @@ func (p *BrowserProcess) Terminate() {
 func (p *BrowserProcess) WsURL() string {
 	return p.wsURL
 }
+
+// Pid returns the browser process ID
+func (p *BrowserProcess) Pid() int {
+	return p.process.Pid
+}

--- a/common/context.go
+++ b/common/context.go
@@ -26,6 +26,7 @@ type ctxKey int
 
 const (
 	ctxKeyLaunchOptions ctxKey = iota
+	ctxKeyPid
 	ctxKeyHooks
 )
 
@@ -51,4 +52,15 @@ func GetLaunchOptions(ctx context.Context) *LaunchOptions {
 		return nil
 	}
 	return v.(*LaunchOptions)
+}
+
+// TODO: Test is missing
+func WithProcessID(ctx context.Context, pid int) context.Context {
+	return context.WithValue(ctx, ctxKeyPid, pid)
+}
+
+// TODO: Test is missing
+func GetProcessID(ctx context.Context) int {
+	v, _ := ctx.Value(ctxKeyPid).(int)
+	return v // it will return zero on error
 }

--- a/common/context.go
+++ b/common/context.go
@@ -54,12 +54,12 @@ func GetLaunchOptions(ctx context.Context) *LaunchOptions {
 	return v.(*LaunchOptions)
 }
 
-// TODO: Test is missing
+// WithProcessID saves the browser process ID to the context.
 func WithProcessID(ctx context.Context, pid int) context.Context {
 	return context.WithValue(ctx, ctxKeyPid, pid)
 }
 
-// TODO: Test is missing
+// GetProcessID returns the browser process ID from the context.
 func GetProcessID(ctx context.Context) int {
 	v, _ := ctx.Value(ctxKeyPid).(int)
 	return v // it will return zero on error

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -401,7 +401,7 @@ func (fs *FrameSession) navigateFrame(frame *Frame, url, referrer string) (strin
 }
 
 func (fs *FrameSession) onConsoleAPICalled(event *runtime.EventConsoleAPICalled) {
-	// TODO: switch to using browser logger instead of directly outputting to k6 logging system	rt := k6common.GetRuntime(fs.ctx)
+	// TODO: switch to using browser logger instead of directly outputting to k6 logging system
 	state := k6lib.GetState(fs.ctx)
 	l := state.Logger.
 		WithTime(event.Timestamp.Time()).

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -41,7 +41,6 @@ import (
 	"github.com/chromedp/cdproto/security"
 	"github.com/chromedp/cdproto/target"
 	"github.com/grafana/xk6-browser/api"
-	k6common "go.k6.io/k6/js/common"
 	k6lib "go.k6.io/k6/lib"
 	k6stats "go.k6.io/k6/stats"
 )
@@ -402,8 +401,7 @@ func (fs *FrameSession) navigateFrame(frame *Frame, url, referrer string) (strin
 }
 
 func (fs *FrameSession) onConsoleAPICalled(event *runtime.EventConsoleAPICalled) {
-	// TODO: switch to using browser logger instead of directly outputting to k6 logging system
-	rt := k6common.GetRuntime(fs.ctx)
+	// TODO: switch to using browser logger instead of directly outputting to k6 logging system	rt := k6common.GetRuntime(fs.ctx)
 	state := k6lib.GetState(fs.ctx)
 	l := state.Logger.
 		WithTime(event.Timestamp.Time()).
@@ -416,7 +414,7 @@ func (fs *FrameSession) onConsoleAPICalled(event *runtime.EventConsoleAPICalled)
 		i, err := interfaceFromRemoteObject(arg)
 		if err != nil {
 			// TODO(fix): this should not throw!
-			k6common.Throw(rt, fmt.Errorf("unable to parse remote object value: %w", err))
+			k6Throw(fs.ctx, "unable to parse remote object value: %w", err)
 		}
 		convertedArgs = append(convertedArgs, i)
 	}
@@ -439,7 +437,6 @@ func (fs *FrameSession) onExceptionThrown(event *runtime.EventExceptionThrown) {
 }
 
 func (fs *FrameSession) onExecutionContextCreated(event *runtime.EventExecutionContextCreated) {
-	rt := k6common.GetRuntime(fs.ctx)
 	auxData := event.Context.AuxData
 	var i struct {
 		FrameID   cdp.FrameID `json:"frameId"`
@@ -447,7 +444,7 @@ func (fs *FrameSession) onExecutionContextCreated(event *runtime.EventExecutionC
 		Type      string      `json:"type"`
 	}
 	if err := json.Unmarshal(auxData, &i); err != nil {
-		k6common.Throw(rt, fmt.Errorf("unable to unmarshal JSON: %w", err))
+		k6Throw(fs.ctx, "unable to unmarshal JSON: %w", err)
 	}
 	var world string = ""
 	frame := fs.manager.getFrameByID(i.FrameID)
@@ -509,19 +506,17 @@ func (fs *FrameSession) onFrameDetached(frameID cdp.FrameID) {
 }
 
 func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {
-	rt := k6common.GetRuntime(fs.ctx)
 	err := fs.manager.frameNavigated(frame.ID, frame.ParentID, frame.LoaderID.String(), frame.Name, frame.URL+frame.URLFragment, initial)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(fs.ctx, "cannot handle frame navigation: %w", err)
 	}
 }
 
 func (fs *FrameSession) onFrameRequestedNavigation(event *cdppage.EventFrameRequestedNavigation) {
-	rt := k6common.GetRuntime(fs.ctx)
 	if event.Disposition == "currentTab" {
 		err := fs.manager.frameRequestedNavigation(event.FrameID, event.URL, "")
 		if err != nil {
-			k6common.Throw(rt, err)
+			k6Throw(fs.ctx, "cannot handle frame requested navigation: %w", err)
 		}
 	}
 }
@@ -655,8 +650,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 				// If we're no longer connected to browser, then ignore WebSocket errors
 				return
 			}
-			rt := k6common.GetRuntime(fs.ctx)
-			k6common.Throw(rt, err)
+			k6Throw(fs.ctx, "cannot create frame session: %w", err)
 		}
 		fs.page.frameSessions[cdp.FrameID(targetID)] = frameSession
 		return
@@ -676,8 +670,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 			// If we're no longer connected to browser, then ignore WebSocket errors
 			return
 		}
-		rt := k6common.GetRuntime(fs.ctx)
-		k6common.Throw(rt, err)
+		k6Throw(fs.ctx, "cannot create new worker: %w", err)
 	}
 	fs.page.workers[session.id] = w
 }

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -308,12 +309,37 @@ func waitForEvent(ctx context.Context, emitter EventEmitter, events []string, pr
 	return nil, nil
 }
 
-// k6Throw throws a k6 error
+// k6Throw throws a k6 error, and before throwing the error, it finds the
+// browser process from the context and kills it if it still exists.
+// TODO: test
 func k6Throw(ctx context.Context, format string, a ...interface{}) {
 	rt := k6common.GetRuntime(ctx)
 	if rt == nil {
 		// this should never happen unless a programmer error
 		panic("cannot get k6 runtime")
 	}
-	k6common.Throw(rt, fmt.Errorf(format, a...))
+	defer k6common.Throw(rt, fmt.Errorf(format, a...))
+
+	pid := GetProcessID(ctx)
+	if pid == 0 {
+		// this should never happen unless a programmer error
+		panic("cannot find process id")
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		// optimistically return and don't kill the process
+		return
+	}
+	ps, _ := p.Wait()
+	if err != nil {
+		return
+	}
+	if ps.Exited() {
+		return
+	}
+	// no need to check the error for waiting the process to release
+	// its resources or whether we could kill it as we're already
+	// dying.
+	_ = p.Release()
+	_ = p.Kill()
 }

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -330,13 +330,6 @@ func k6Throw(ctx context.Context, format string, a ...interface{}) {
 		// optimistically return and don't kill the process
 		return
 	}
-	ps, _ := p.Wait()
-	if err != nil {
-		return
-	}
-	if ps.Exited() {
-		return
-	}
 	// no need to check the error for waiting the process to release
 	// its resources or whether we could kill it as we're already
 	// dying.


### PR DESCRIPTION
This PR adds a cross-platform browser process killer.
* `k6Throw` kills any lingering browser processes in a cross-platform way.
* Saves the process ID to the context when launching a new browser.

We need to update `k6common.Throw` to our `k6Throw` for this to work stable. And I manually tested this with 100 browsers on my Mac. It cleaned up all the lingering processes. Automated tests are missing for now. I'm planning to do these in a separate PR.

As I said in the PR this is a temporary fix:
https://github.com/grafana/xk6-browser/issues/93#issuecomment-966911692

Closes: #93