### PR TITLE
Fix panic setting extra HTTP headers

### DIFF
--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -100,7 +100,7 @@ func (b *BrowserContextOptions) Parse(ctx context.Context, opts goja.Value) erro
 			case "extraHTTPHeaders":
 				headers := opts.Get(k).ToObject(rt)
 				for _, k := range headers.Keys() {
-					b.ExtraHTTPHeaders[k] = opts.Get(k).String()
+					b.ExtraHTTPHeaders[k] = headers.Get(k).String()
 				}
 			case "geolocation":
 				geolocation := NewGeolocation()

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -715,7 +715,7 @@ func (fs *FrameSession) updateEmulateMedia(initial bool) error {
 func (fs *FrameSession) updateExtraHTTPHeaders(initial bool) {
 	// Merge extra headers from browser context and page, where page specific headers ake precedence.
 	mergedHeaders := make(network.Headers)
-	for v, k := range fs.page.browserCtx.opts.ExtraHTTPHeaders {
+	for k, v := range fs.page.browserCtx.opts.ExtraHTTPHeaders {
 		mergedHeaders[k] = v
 	}
 	for v, k := range fs.page.extraHTTPHeaders {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -718,7 +718,7 @@ func (fs *FrameSession) updateExtraHTTPHeaders(initial bool) {
 	for k, v := range fs.page.browserCtx.opts.ExtraHTTPHeaders {
 		mergedHeaders[k] = v
 	}
-	for v, k := range fs.page.extraHTTPHeaders {
+	for k, v := range fs.page.extraHTTPHeaders {
 		mergedHeaders[k] = v
 	}
 	if !initial || len(mergedHeaders) > 0 {

--- a/common/page.go
+++ b/common/page.go
@@ -604,7 +604,7 @@ func (p *Page) SetDefaultTimeout(timeout int64) {
 // SetExtraHTTPHeaders sets default HTTP headers for page and whole frame hierarchy
 func (p *Page) SetExtraHTTPHeaders(headers map[string]string) {
 	p.extraHTTPHeaders = headers
-	p.updateHttpCredentials()
+	p.updateExtraHTTPHeaders()
 }
 
 func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value) {

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestBrowserContextOptions(t *testing.T) {
 	bt := browsertest.NewBrowserTest(t)
-	defer bt.Browser.Close()
+	t.Cleanup(bt.Browser.Close)
 
 	t.Run("BrowserContextOptions", func(t *testing.T) {
 		t.Run("should have correct default values", func(t *testing.T) { testBrowserContextOptionsDefaultValues(t, bt) })
@@ -84,7 +84,7 @@ func testBrowserContextOptionsSetViewport(t *testing.T, bt *browsertest.BrowserT
 			Height: 600,
 		},
 	}))
-	t.Cleanup(func() { bctx.Close() })
+	t.Cleanup(bctx.Close)
 	p := bctx.NewPage()
 
 	viewportSize := p.ViewportSize()


### PR DESCRIPTION
Closes #111

Also fixes it for `Page.SetExtraHTTPHeaders()`.