### PR TITLE
More reliable response body size and `data_received` metric emission

### DIFF
--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -419,7 +419,8 @@ func (m *NetworkManager) onRequest(event *network.EventRequestWillBeSent, interc
 		frame = m.frameManager.getFrameByID(event.FrameID)
 	}
 	if frame == nil {
-		m.logger.Debugf("NetworkManager", "frame is nil")
+		m.logger.Debugf("NetworkManager:onRequest", "url:%s method:%s type:%s fid:%s frame is nil",
+			event.Request.URL, event.Request.Method, event.Initiator.Type, event.FrameID)
 	}
 
 	req, err := NewRequest(m.ctx, event, frame, redirectChain, interceptionID, m.userReqInterceptionEnabled)

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -391,6 +391,9 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 		}
 	}
 	req.responseEndTiming = float64(event.Timestamp.Time().Unix()-req.timestamp.Unix()) * 1000
+	if req.url.Scheme != "data" {
+		m.emitResponseMetrics(req.response)
+	}
 	m.deleteRequestByID(event.RequestID)
 	m.frameManager.requestFinished(req)
 }
@@ -528,9 +531,6 @@ func (m *NetworkManager) onResponseReceived(event *network.EventResponseReceived
 	}
 	resp := NewHTTPResponse(m.ctx, req, event.Response, event.Timestamp)
 	req.response = resp
-	if req.url.Scheme != "data" {
-		m.emitResponseMetrics(resp)
-	}
 	m.frameManager.requestReceivedResponse(resp)
 }
 

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -190,32 +190,57 @@ func (m *NetworkManager) emitRequestMetrics(req *Request) {
 	})
 }
 
-func (m *NetworkManager) emitResponseMetrics(resp *Response) {
+func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 	state := k6lib.GetState(m.ctx)
+
+	// In some scenarios we might not receive a ResponseReceived CDP event, in
+	// which case the response won't be created. So to emit as much metric data
+	// as possible we set some sensible defaults instead.
+	var (
+		status, bodySize                    int64
+		ipAddress, protocol                 string
+		fromCache, fromPreCache, fromSvcWrk bool
+		url                                 = req.url.String()
+		timestamp                           = time.Now()
+	)
+	if resp != nil {
+		status = resp.status
+		bodySize = resp.Size().Total()
+		ipAddress = resp.remoteAddress.IPAddress
+		protocol = resp.protocol
+		fromCache = resp.fromDiskCache
+		fromPreCache = resp.fromPrefetchCache
+		fromSvcWrk = resp.fromServiceWorker
+		timestamp = resp.timestamp
+		url = resp.url
+	} else {
+		m.logger.Debugf("NetworkManager:emitResponseMetrics",
+			"response is nil url:%s method:%s", req.url, req.method)
+	}
 
 	tags := state.CloneTags()
 	if state.Options.SystemTags.Has(k6stats.TagGroup) {
 		tags["group"] = state.Group.Path
 	}
 	if state.Options.SystemTags.Has(k6stats.TagMethod) {
-		tags["method"] = resp.request.method
+		tags["method"] = req.method
 	}
 	if state.Options.SystemTags.Has(k6stats.TagURL) {
-		tags["url"] = resp.url
+		tags["url"] = url
 	}
 	if state.Options.SystemTags.Has(k6stats.TagIP) {
-		tags["ip"] = resp.remoteAddress.IPAddress
+		tags["ip"] = ipAddress
 	}
 	if state.Options.SystemTags.Has(k6stats.TagStatus) {
-		tags["status"] = strconv.Itoa(int(resp.status))
+		tags["status"] = strconv.Itoa(int(status))
 	}
 	if state.Options.SystemTags.Has(k6stats.TagProto) {
-		tags["proto"] = resp.protocol
+		tags["proto"] = protocol
 	}
 
-	tags["from_cache"] = strconv.FormatBool(resp.fromDiskCache)
-	tags["from_prefetch_cache"] = strconv.FormatBool(resp.fromPrefetchCache)
-	tags["from_service_worker"] = strconv.FormatBool(resp.fromServiceWorker)
+	tags["from_cache"] = strconv.FormatBool(fromCache)
+	tags["from_prefetch_cache"] = strconv.FormatBool(fromPreCache)
+	tags["from_service_worker"] = strconv.FormatBool(fromSvcWrk)
 
 	sampleTags := k6stats.IntoSampleTags(&tags)
 	k6stats.PushIfNotDone(m.ctx, state.Samples, k6stats.ConnectedSamples{
@@ -224,7 +249,7 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response) {
 				Metric: state.BuiltinMetrics.HTTPReqs,
 				Tags:   sampleTags,
 				Value:  1,
-				Time:   resp.timestamp,
+				Time:   timestamp,
 			},
 			{
 				Metric: state.BuiltinMetrics.HTTPReqDuration,
@@ -235,18 +260,19 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response) {
 				// issues with the parsing and conversion to `time.Time`.
 				// Have not spent time looking for the root cause of this in the Chromium source to file a bug report, and neither
 				// Puppeteer nor Playwright seems to care about the `responseTime` value and don't use/expose it.
-				Value: k6stats.D(resp.timestamp.Sub(resp.request.timestamp)),
-				Time:  resp.timestamp,
+				Value: k6stats.D(timestamp.Sub(req.timestamp)),
+				Time:  timestamp,
 			},
 			{
 				Metric: state.BuiltinMetrics.DataReceived,
 				Tags:   sampleTags,
-				Value:  float64(resp.Size().Total()),
-				Time:   resp.timestamp,
+				Value:  float64(bodySize),
+				Time:   timestamp,
 			},
 		},
 	})
-	if resp.timing != nil {
+
+	if resp != nil && resp.timing != nil {
 		k6stats.PushIfNotDone(m.ctx, state.Samples, k6stats.ConnectedSamples{
 			Samples: []k6stats.Sample{
 				{
@@ -283,8 +309,8 @@ func (m *NetworkManager) handleRequestRedirect(req *Request, redirectResponse *n
 	req.response = resp
 	req.redirectChain = append(req.redirectChain, req)
 
+	m.emitResponseMetrics(resp, req)
 	m.deleteRequestByID(req.requestID)
-	m.emitResponseMetrics(resp)
 
 	/*
 		delete(m.attemptedAuth, req.interceptionID);
@@ -392,7 +418,7 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 	}
 	req.responseEndTiming = float64(event.Timestamp.Time().Unix()-req.timestamp.Unix()) * 1000
 	if req.url.Scheme != "data" {
-		m.emitResponseMetrics(req.response)
+		m.emitResponseMetrics(req.response, req)
 	}
 	m.deleteRequestByID(event.RequestID)
 	m.frameManager.requestFinished(req)

--- a/common/response.go
+++ b/common/response.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -191,19 +190,7 @@ func (r *Response) Body() goja.ArrayBuffer {
 }
 
 // bodySize returns the size in bytes of the response body.
-// It first attempts to get the size specified in the content-length
-// header, and if unavailable falls back to the size as returned by CDP in
-// r.fetchBody(). This is because the CDP Network.getResponseBody call
-// is unreliable, see https://github.com/ChromeDevTools/devtools-protocol/issues/12#issuecomment-306947275 .
 func (r *Response) bodySize() int64 {
-	if v, ok := r.headers["content-length"]; ok && len(v) > 0 {
-		cl, err := strconv.ParseInt(v[0], 10, 64)
-		if err == nil {
-			return cl
-		}
-		r.logger.Warnf("cdp", "error parsing content-length header: %s", err)
-	}
-
 	if err := r.fetchBody(); err != nil {
 		r.logger.Warnf("cdp", "error fetching response body for '%s': %s", r.url, err)
 	}

--- a/common/response.go
+++ b/common/response.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -146,7 +147,7 @@ func (r *Response) fetchBody() error {
 	action := network.GetResponseBody(r.request.requestID)
 	body, err := action.Do(cdp.WithExecutor(r.ctx, r.request.frame.manager.session))
 	if err != nil {
-		return err
+		return fmt.Errorf("error fetching response body: %w", err)
 	}
 	r.bodyMu.Lock()
 	r.body = body
@@ -197,7 +198,8 @@ func (r *Response) bodySize() int64 {
 	}
 
 	if err := r.fetchBody(); err != nil {
-		r.logger.Warnf("cdp", "error fetching response body for '%s': %s", r.url, err)
+		r.logger.Warnf("Response:bodySize:fetchBody",
+			"url:%s method:%s err:%s", r.url, r.request.method, err)
 	}
 
 	r.bodyMu.RLock()

--- a/common/response.go
+++ b/common/response.go
@@ -191,6 +191,11 @@ func (r *Response) Body() goja.ArrayBuffer {
 
 // bodySize returns the size in bytes of the response body.
 func (r *Response) bodySize() int64 {
+	// Skip redirect responses
+	if r.status >= 300 && r.status <= 399 {
+		return 0
+	}
+
 	if err := r.fetchBody(); err != nil {
 		r.logger.Warnf("cdp", "error fetching response body for '%s': %s", r.url, err)
 	}

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -29,13 +29,17 @@ import (
 	k6types "go.k6.io/k6/lib/types"
 )
 
-func TestDataURLSkipRequest(t *testing.T) {
+func TestURLSkipRequest(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t, withLogCache())
 	p := tb.NewPage(nil)
 
 	p.Goto("data:text/html,hello", nil)
-
 	assert.True(t, tb.logCache.contains("skipped request handling of data URL"))
+
+	p.Goto("blob:something", nil)
+	assert.True(t, tb.logCache.contains("skipped request handling of blob URL"))
 }
 
 func TestBlockHostnames(t *testing.T) {


### PR DESCRIPTION
This is related to #90, but doesn't really fix the issue as the current behavior is correct. See [this comment](https://github.com/grafana/xk6-browser/issues/90#issuecomment-966477394).

Essentially `Frame` being nil is a valid state for responses to preflight/`OPTIONS` requests, so the fix in b2052bb is all we need to do for handling this case.

What this PR does is:
- move the `data_received` metric emission to the `LoadingFinished` event handler, which [according to this comment](https://github.com/ChromeDevTools/devtools-protocol/issues/44#issuecomment-320127404) is more reliable. This results in more accurate `data_received` metric values.
  
  Before, on `main` (54cd293) with the script from [this comment](https://github.com/grafana/xk6-browser/pull/117#issuecomment-1002521620):
  ```
  data_received....................: 17 MB  737 kB/s
  ```
  After, on a9d9868:
  ```
  data_received....................: 39 MB  754 kB/s
  ```

  I confirmed this is more accurate by comparing with the Chrome DevTools Network tab.
  
  This change also produces less `error fetching response body` warning events, though it doesn't eliminate them entirely, except when running the test suite.
- enhance the logging so that we can see the type of request when `Frame` is nil. In all cases I've seen with the script from Tom these are preflight/`OPTIONS` requests which don't have an associated `FrameID`.