### PR TITLE
Fix/125 cannot create frame session (context canceled)

### DIFF
--- a/common/barrier_test.go
+++ b/common/barrier_test.go
@@ -31,7 +31,7 @@ import (
 func TestBarrier(t *testing.T) {
 	ctx := context.Background()
 
-	log := NewLogger(ctx, NullLogger(), false, nil)
+	log := NewNullLogger()
 
 	timeoutSetings := NewTimeoutSettings(nil)
 	frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings, log)

--- a/common/connection.go
+++ b/common/connection.go
@@ -358,6 +358,9 @@ func (c *Connection) send(msg *cdproto.Message, recvCh chan *cdproto.Message, re
 	case <-c.done:
 		c.logger.Debugf("Connection:send:<-c.done", "wsURL:%q sid:%v", c.wsURL, msg.SessionID)
 		return nil
+	case <-c.ctx.Done():
+		c.logger.Errorf("Connection:send:<-c.ctx.Done()", "wsURL:%q sid:%v err:%v", c.wsURL, msg.SessionID, c.ctx.Err())
+		return nil
 	}
 
 	// Block waiting for response.

--- a/common/connection_test.go
+++ b/common/connection_test.go
@@ -43,7 +43,7 @@ func TestConnection(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/echo", url.Host)
-		conn, err := NewConnection(ctx, wsURL, NewLogger(ctx, NullLogger(), false, nil))
+		conn, err := NewConnection(ctx, wsURL, NewNullLogger())
 		conn.Close()
 
 		require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestConnectionClosureAbnormal(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/closure-abnormal", url.Host)
-		conn, err := NewConnection(ctx, wsURL, NewLogger(ctx, NullLogger(), false, nil))
+		conn, err := NewConnection(ctx, wsURL, NewNullLogger())
 
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
@@ -76,7 +76,7 @@ func TestConnectionSendRecv(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, NewLogger(ctx, NullLogger(), false, nil))
+		conn, err := NewConnection(ctx, wsURL, NewNullLogger())
 
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
@@ -140,7 +140,7 @@ func TestConnectionCreateSession(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, NewLogger(ctx, NullLogger(), false, nil))
+		conn, err := NewConnection(ctx, wsURL, NewNullLogger())
 
 		if assert.NoError(t, err) {
 			session, err := conn.createSession(&target.Info{

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -238,8 +238,12 @@ func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, p Position) (bo
 			return injected.checkHitTargetAt(node, point);
 		}
 	`)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
 	result, err := h.execCtx.evaluate(
-		apiCtx, true, true, pageFn, []goja.Value{
+		apiCtx, opts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(h),
 			rt.ToValue(p),
@@ -270,8 +274,12 @@ func (h *ElementHandle) checkElementState(apiCtx context.Context, state string) 
 			return injected.checkElementState(node, state);
 		}
 	`)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
 	result, err := h.execCtx.evaluate(
-		apiCtx, true, true, pageFn, []goja.Value{
+		apiCtx, opts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(h),
 			rt.ToValue(state),
@@ -397,8 +405,12 @@ func (h *ElementHandle) dispatchEvent(apiCtx context.Context, typ string, eventI
 			injected.dispatchEvent(node, type, eventInit);
 		}
 	`)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
 	_, err = h.execCtx.evaluate(
-		apiCtx, true, true, pageFn, []goja.Value{
+		apiCtx, opts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(h),
 			rt.ToValue(typ),
@@ -421,8 +433,12 @@ func (h *ElementHandle) fill(apiCtx context.Context, value string) (interface{},
 				return injected.fill(node, value);
 			}
 		`)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
 	result, err := h.execCtx.evaluate(
-		apiCtx, true, true, pageFn, []goja.Value{
+		apiCtx, opts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(h),
 			rt.ToValue(value),
@@ -450,8 +466,12 @@ func (h *ElementHandle) focus(apiCtx context.Context, resetSelectionIfNotFocused
 			return injected.focusNode(node, resetSelectionIfNotFocused);
 		}
 	`)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
 	result, err := h.execCtx.evaluate(
-		apiCtx, true, true, pageFn, []goja.Value{
+		apiCtx, opts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(h),
 			rt.ToValue(resetSelectionIfNotFocused),
@@ -473,7 +493,11 @@ func (h *ElementHandle) getAttribute(apiCtx context.Context, name string) (inter
 		return element.getAttribute('` + name + `');
 	}`
 	rt := k6common.GetRuntime(apiCtx)
-	return h.execCtx.evaluate(apiCtx, true, true, rt.ToValue(js), rt.ToValue(h))
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
+	return h.execCtx.evaluate(apiCtx, opts, rt.ToValue(js), rt.ToValue(h))
 }
 
 func (h *ElementHandle) hover(apiCtx context.Context, p *Position) error {
@@ -485,7 +509,11 @@ func (h *ElementHandle) innerHTML(apiCtx context.Context) (interface{}, error) {
 	js := `(element) => {
 		return element.innerHTML;
 	}`
-	return h.execCtx.evaluate(apiCtx, true, true, rt.ToValue(js), rt.ToValue(h))
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
+	return h.execCtx.evaluate(apiCtx, opts, rt.ToValue(js), rt.ToValue(h))
 }
 
 func (h *ElementHandle) innerText(apiCtx context.Context) (interface{}, error) {
@@ -493,7 +521,11 @@ func (h *ElementHandle) innerText(apiCtx context.Context) (interface{}, error) {
 	js := `(element) => {
 		return element.innerText;
 	}`
-	return h.execCtx.evaluate(apiCtx, true, true, rt.ToValue(js), rt.ToValue(h))
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
+	return h.execCtx.evaluate(apiCtx, opts, rt.ToValue(js), rt.ToValue(h))
 }
 
 func (h *ElementHandle) inputValue(apiCtx context.Context) (interface{}, error) {
@@ -504,7 +536,11 @@ func (h *ElementHandle) inputValue(apiCtx context.Context) (interface{}, error) 
 		}
 		return element.value;
 	}`
-	return h.execCtx.evaluate(apiCtx, true, true, rt.ToValue(js), rt.ToValue(h))
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
+	return h.execCtx.evaluate(apiCtx, opts, rt.ToValue(js), rt.ToValue(h))
 }
 
 func (h *ElementHandle) isChecked(apiCtx context.Context, timeout time.Duration) (bool, error) {
@@ -543,8 +579,12 @@ func (h *ElementHandle) offsetPosition(apiCtx context.Context, offset *Position)
 			return injected.getElementBorderWidth(node);
 		}
 	`)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
 	result, err := h.execCtx.evaluate(
-		apiCtx, true, true, pageFn, []goja.Value{
+		apiCtx, opts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(h),
 		}...)
@@ -709,8 +749,12 @@ func (h *ElementHandle) selectOption(apiCtx context.Context, values goja.Value) 
 				return injected.selectOptions(node, values);
 			}
 		`)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: false,
+	}
 	result, err := h.execCtx.evaluate(
-		apiCtx, true, false, pageFn, []goja.Value{
+		apiCtx, opts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(h),
 			rt.ToValue(convValues),
@@ -738,8 +782,12 @@ func (h *ElementHandle) selectText(apiCtx context.Context) error {
 				return injected.selectText(node);
 			}
 		`)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
 	result, err := h.execCtx.evaluate(
-		apiCtx, true, true, pageFn, []goja.Value{
+		apiCtx, opts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(h),
 		}...)
@@ -789,7 +837,11 @@ func (h *ElementHandle) textContent(apiCtx context.Context) (interface{}, error)
 	js := `(element) => {
 		return element.textContent;
 	}`
-	return h.execCtx.evaluate(apiCtx, true, true, rt.ToValue(js), rt.ToValue(h))
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
+	return h.execCtx.evaluate(apiCtx, opts, rt.ToValue(js), rt.ToValue(h))
 }
 
 func (h *ElementHandle) typ(apiCtx context.Context, text string, opts *KeyboardOptions) error {
@@ -811,7 +863,11 @@ func (h *ElementHandle) waitAndScrollIntoViewIfNeeded(apiCtx context.Context, fo
 			element.scrollIntoViewIfNeeded(true);
 			return [window.scrollX, window.scrollY];
 		}`)
-		return h.execCtx.evaluate(apiCtx, true, true, pageFn, rt.ToValue(h))
+		opts := evaluateOptions{
+			forceCallable: true,
+			returnByValue: true,
+		}
+		return h.execCtx.evaluate(apiCtx, opts, pageFn, rt.ToValue(h))
 	}
 	actFn := elementHandleActionFn(h, []string{"visible", "stable"}, fn, force, noWaitAfter, timeout)
 	_, err := callApiWithTimeout(h.ctx, actFn, timeout)
@@ -832,8 +888,12 @@ func (h *ElementHandle) waitForElementState(apiCtx context.Context, states []str
 			return injected.waitForElementStates(node, states, timeout);
 		}
 	`)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
 	result, err := h.execCtx.evaluate(
-		apiCtx, true, true, pageFn, []goja.Value{
+		apiCtx, opts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(h),
 			rt.ToValue(states),
@@ -873,8 +933,12 @@ func (h *ElementHandle) waitForSelector(apiCtx context.Context, selector string,
 			return injected.waitForSelector(selector, scope, strict, state, 'raf', timeout, ...args);
 		}
 	`)
+	eopts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: false,
+	}
 	result, err := h.execCtx.evaluate(
-		apiCtx, true, false, pageFn, []goja.Value{
+		apiCtx, eopts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(parsedSelector),
 			rt.ToValue(h),
@@ -1166,7 +1230,11 @@ func (h *ElementHandle) OwnerFrame() api.Frame {
 			return injected.getDocumentElement(node);
 		}
 	`)
-	res, err := h.execCtx.evaluate(h.ctx, true, false, pageFn, []goja.Value{rt.ToValue(injected), rt.ToValue(h)}...)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: false,
+	}
+	res, err := h.execCtx.evaluate(h.ctx, opts, pageFn, []goja.Value{rt.ToValue(injected), rt.ToValue(h)}...)
 	if err != nil {
 		k6common.Throw(rt, fmt.Errorf("failed getting document element: %w", err))
 	}
@@ -1226,8 +1294,12 @@ func (h *ElementHandle) Query(selector string) api.ElementHandle {
 			return injected.querySelector(selector, scope || document, false);
 		}
 	`)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: false,
+	}
 	result, err := h.execCtx.evaluate(
-		h.ctx, true, false, pageFn, []goja.Value{
+		h.ctx, opts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(parsedSelector),
 			rt.ToValue(h),
@@ -1267,8 +1339,12 @@ func (h *ElementHandle) QueryAll(selector string) []api.ElementHandle {
 			return injected.querySelectorAll(selector, scope || document, false);
 		}
 	`)
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: false,
+	}
 	result, err := h.execCtx.evaluate(
-		h.ctx, true, false, pageFn, []goja.Value{
+		h.ctx, opts, pageFn, []goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(parsedSelector),
 			rt.ToValue(h),

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -36,7 +36,12 @@ import (
 
 const evaluationScriptURL = "__xk6_browser_evaluation_script__"
 
-var /* const */ sourceURLRegex = regexp.MustCompile(`^(?s)[\040\t]*//[@#] sourceURL=\s*(\S*?)\s*$`)
+var sourceURLRegex = regexp.MustCompile(`^(?s)[\040\t]*//[@#] sourceURL=\s*(\S*?)\s*$`)
+
+const (
+	mainExecutionContext    = "main"
+	utilityExecutionContext = "utility"
+)
 
 // ExecutionContext represents a JS execution context
 type ExecutionContext struct {

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -45,6 +45,10 @@ const (
 	utilityWorld executionWorld = "utility"
 )
 
+func (ew executionWorld) valid() bool {
+	return ew == mainWorld || ew == utilityWorld
+}
+
 type evaluateOptions struct {
 	forceCallable, returnByValue bool
 }

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -39,8 +39,8 @@ const evaluationScriptURL = "__xk6_browser_evaluation_script__"
 var sourceURLRegex = regexp.MustCompile(`^(?s)[\040\t]*//[@#] sourceURL=\s*(\S*?)\s*$`)
 
 const (
-	mainExecutionContext    = "main"
-	utilityExecutionContext = "utility"
+	mainWorld    = "main"
+	utilityWorld = "utility"
 )
 
 // ExecutionContext represents a JS execution context

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -164,7 +164,10 @@ func (e *ExecutionContext) adoptElementHandle(eh *ElementHandle) (*ElementHandle
 
 // evaluate will evaluate provided callable within this execution context
 // and return by value or handle
-func (e *ExecutionContext) evaluate(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+func (e *ExecutionContext) evaluate(
+	apiCtx context.Context,
+	opts evaluateOptions, pageFunc goja.Value, args ...goja.Value,
+) (res interface{}, err error) {
 	e.logger.Debugf(
 		"ExecutionContext:evaluate",
 		"sid:%s stid:%s fid:%s ectxid:%d furl:%q %s",

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -38,9 +38,11 @@ const evaluationScriptURL = "__xk6_browser_evaluation_script__"
 
 var sourceURLRegex = regexp.MustCompile(`^(?s)[\040\t]*//[@#] sourceURL=\s*(\S*?)\s*$`)
 
+type executionWorld string
+
 const (
-	mainWorld    = "main"
-	utilityWorld = "utility"
+	mainWorld    executionWorld = "main"
+	utilityWorld executionWorld = "utility"
 )
 
 type evaluateOptions struct {

--- a/common/frame.go
+++ b/common/frame.go
@@ -226,7 +226,7 @@ func (f *Frame) recalculateLifecycle() {
 	f.childFramesMu.RUnlock()
 
 	// Check if any of the fired events should be considered fired when looking at the entire subtree.
-	mainFrame := f.manager.mainFrame
+	mainFrame := f.manager.MainFrame()
 	for k := range events {
 		if f.hasSubtreeLifecycleEventFired(k) {
 			continue

--- a/common/frame.go
+++ b/common/frame.go
@@ -337,7 +337,7 @@ func (f *Frame) document() (*ElementHandle, error) {
 	return f.documentHandle, err
 }
 
-func (f *Frame) hasContext(world string) bool {
+func (f *Frame) hasContext(world executionWorld) bool {
 	f.executionContextMu.RLock()
 	defer f.executionContextMu.RUnlock()
 
@@ -443,7 +443,7 @@ func (f *Frame) requestByID(reqID network.RequestID) *Request {
 	return frameSession.networkManager.requestFromID(reqID)
 }
 
-func (f *Frame) setContext(world string, execCtx frameExecutionContext) {
+func (f *Frame) setContext(world executionWorld, execCtx frameExecutionContext) {
 	f.executionContextMu.Lock()
 	defer f.executionContextMu.Unlock()
 
@@ -472,7 +472,7 @@ func (f *Frame) setID(id cdp.FrameID) {
 	f.id = id
 }
 
-func (f *Frame) waitForExecutionContext(world string) {
+func (f *Frame) waitForExecutionContext(world executionWorld) {
 	f.log.Debugf("Frame:waitForExecutionContext", "fid:%s furl:%q world:%s",
 		f.ID(), f.URL(), world)
 
@@ -490,7 +490,7 @@ func (f *Frame) waitForExecutionContext(world string) {
 	}
 }
 
-func (f *Frame) waitForFunction(apiCtx context.Context, world string, predicateFn goja.Value, polling PollingType, interval int64, timeout time.Duration, args ...goja.Value) (interface{}, error) {
+func (f *Frame) waitForFunction(apiCtx context.Context, world executionWorld, predicateFn goja.Value, polling PollingType, interval int64, timeout time.Duration, args ...goja.Value) (interface{}, error) {
 	f.log.Debugf(
 		"Frame:waitForFunction",
 		"fid:%s furl:%q world:%s pt:%s timeout:%s",
@@ -1434,7 +1434,7 @@ func (f *Frame) WaitForTimeout(timeout int64) {
 	}
 }
 
-func (f *Frame) adoptBackendNodeID(world string, id cdp.BackendNodeID) (*ElementHandle, error) {
+func (f *Frame) adoptBackendNodeID(world executionWorld, id cdp.BackendNodeID) (*ElementHandle, error) {
 	f.executionContextMu.RLock()
 	defer f.executionContextMu.RUnlock()
 
@@ -1442,7 +1442,7 @@ func (f *Frame) adoptBackendNodeID(world string, id cdp.BackendNodeID) (*Element
 	return ec.adoptBackendNodeID(id)
 }
 
-func (f *Frame) evaluate(world string, apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+func (f *Frame) evaluate(world executionWorld, apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
 	f.executionContextMu.RLock()
 	defer f.executionContextMu.RUnlock()
 
@@ -1452,7 +1452,7 @@ func (f *Frame) evaluate(world string, apiCtx context.Context, opts evaluateOpti
 
 // getExecCtx returns an execution context using a given world name.
 // Unsafe to use concurrently.
-func (f *Frame) getExecCtx(world string) frameExecutionContext {
+func (f *Frame) getExecCtx(world executionWorld) frameExecutionContext {
 	ec := f.mainExecutionContext
 	if world == utilityWorld {
 		ec = f.utilityExecutionContext

--- a/common/frame.go
+++ b/common/frame.go
@@ -319,7 +319,7 @@ func (f *Frame) document() (*ElementHandle, error) {
 		return f.documentHandle, nil
 	}
 
-	f.waitForExecutionContext(mainExecutionContext)
+	f.waitForExecutionContext(mainWorld)
 
 	var (
 		result interface{}
@@ -346,9 +346,9 @@ func (f *Frame) hasContext(world string) bool {
 	defer f.executionContextMu.RUnlock()
 
 	switch world {
-	case mainExecutionContext:
+	case mainWorld:
 		return f.mainExecutionContext != nil
-	case utilityExecutionContext:
+	case utilityWorld:
 		return f.utilityExecutionContext != nil
 	}
 	return false // Should never reach here!
@@ -461,11 +461,11 @@ func (f *Frame) setContext(world string, execCtx frameExecutionContext) {
 		f.ID(), f.URL(), execCtx.ID(), world)
 
 	switch world {
-	case mainExecutionContext:
+	case mainWorld:
 		if f.mainExecutionContext == nil {
 			f.mainExecutionContext = execCtx
 		}
-	case utilityExecutionContext:
+	case utilityWorld:
 		if f.utilityExecutionContext == nil {
 			f.utilityExecutionContext = execCtx
 		}
@@ -524,7 +524,7 @@ func (f *Frame) waitForFunction(apiCtx context.Context, world string, predicateF
 	defer f.executionContextMu.RUnlock()
 
 	execCtx := f.mainExecutionContext
-	if world == utilityExecutionContext {
+	if world == utilityWorld {
 		execCtx = f.utilityExecutionContext
 	}
 	injected, err := execCtx.getInjectedScript(apiCtx)
@@ -722,7 +722,7 @@ func (f *Frame) Evaluate(pageFunc goja.Value, args ...goja.Value) (result interf
 
 	rt := k6common.GetRuntime(f.ctx)
 
-	f.waitForExecutionContext(mainExecutionContext)
+	f.waitForExecutionContext(mainWorld)
 
 	var err error
 	f.executionContextMu.RLock()
@@ -744,7 +744,7 @@ func (f *Frame) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (handle 
 
 	rt := k6common.GetRuntime(f.ctx)
 
-	f.waitForExecutionContext(mainExecutionContext)
+	f.waitForExecutionContext(mainWorld)
 
 	var err error
 	f.executionContextMu.RLock()
@@ -1377,7 +1377,7 @@ func (f *Frame) WaitForFunction(pageFunc goja.Value, opts goja.Value, args ...go
 		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
 	}
 
-	handle, err := f.waitForFunction(f.ctx, utilityExecutionContext, pageFunc, parsedOpts.Polling, parsedOpts.Interval, parsedOpts.Timeout, args...)
+	handle, err := f.waitForFunction(f.ctx, utilityWorld, pageFunc, parsedOpts.Polling, parsedOpts.Interval, parsedOpts.Timeout, args...)
 	if err != nil {
 		k6common.Throw(rt, err)
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -39,54 +39,6 @@ import (
 // Ensure frame implements the Frame interface
 var _ api.Frame = &Frame{}
 
-func frameActionFn(f *Frame, selector string, state DOMElementState, strict bool, fn ElementHandleActionFn, states []string, force, noWaitAfter bool, timeout time.Duration) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
-	// We execute a frame action in the following steps:
-	// 1. Find element matching specified selector
-	// 2. Wait for it to reach specified DOM state
-	// 3. Run element handle action (incl. actionability checks)
-
-	return func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
-		waitOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
-		waitOpts.State = state
-		waitOpts.Strict = strict
-		handle, err := f.waitForSelector(selector, waitOpts)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		if handle == nil {
-			resultCh <- nil
-			return
-		}
-		actFn := elementHandleActionFn(handle, states, fn, false, false, timeout)
-		actFn(apiCtx, resultCh, errCh)
-	}
-}
-
-func framePointerActionFn(f *Frame, selector string, state DOMElementState, strict bool, fn ElementHandlePointerActionFn, opts *ElementHandleBasePointerOptions) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
-	// We execute a frame pointer action in the following steps:
-	// 1. Find element matching specified selector
-	// 2. Wait for it to reach specified DOM state
-	// 3. Run element handle action (incl. actionability checks)
-
-	return func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
-		waitOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
-		waitOpts.State = state
-		waitOpts.Strict = strict
-		handle, err := f.waitForSelector(selector, waitOpts)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		if handle == nil {
-			resultCh <- nil
-			return
-		}
-		pointerActFn := elementHandlePointerActionFn(handle, true, fn, opts)
-		pointerActFn(apiCtx, resultCh, errCh)
-	}
-}
-
 type DocumentInfo struct {
 	documentID string
 	request    *Request
@@ -1468,4 +1420,52 @@ type frameExecutionContext interface {
 
 	// id returns the CDP runtime ID of this execution context.
 	ID() runtime.ExecutionContextID
+}
+
+func frameActionFn(f *Frame, selector string, state DOMElementState, strict bool, fn ElementHandleActionFn, states []string, force, noWaitAfter bool, timeout time.Duration) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
+	// We execute a frame action in the following steps:
+	// 1. Find element matching specified selector
+	// 2. Wait for it to reach specified DOM state
+	// 3. Run element handle action (incl. actionability checks)
+
+	return func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
+		waitOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
+		waitOpts.State = state
+		waitOpts.Strict = strict
+		handle, err := f.waitForSelector(selector, waitOpts)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if handle == nil {
+			resultCh <- nil
+			return
+		}
+		actFn := elementHandleActionFn(handle, states, fn, false, false, timeout)
+		actFn(apiCtx, resultCh, errCh)
+	}
+}
+
+func framePointerActionFn(f *Frame, selector string, state DOMElementState, strict bool, fn ElementHandlePointerActionFn, opts *ElementHandleBasePointerOptions) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
+	// We execute a frame pointer action in the following steps:
+	// 1. Find element matching specified selector
+	// 2. Wait for it to reach specified DOM state
+	// 3. Run element handle action (incl. actionability checks)
+
+	return func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
+		waitOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
+		waitOpts.State = state
+		waitOpts.Strict = strict
+		handle, err := f.waitForSelector(selector, waitOpts)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if handle == nil {
+			resultCh <- nil
+			return
+		}
+		pointerActFn := elementHandlePointerActionFn(handle, true, fn, opts)
+		pointerActFn(apiCtx, resultCh, errCh)
+	}
 }

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -457,9 +457,7 @@ func (m *FrameManager) requestFailed(req *Request, canceled bool) {
 	}
 
 	if frame.pendingDocument == nil || frame.pendingDocument.request != req {
-		m.logger.Debugf("FrameManager:requestFailed:return",
-			"fmid:%d pdoc:nil pdoc.req!=req:%t",
-			m.ID(), frame.pendingDocument.request != req)
+		m.logger.Debugf("FrameManager:requestFailed:return", "fmid:%d pdoc:nil", m.ID())
 		return
 	}
 	errorText := req.errorText

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -41,7 +41,12 @@ type FrameManager struct {
 	session         *Session
 	page            *Page
 	timeoutSettings *TimeoutSettings
-	mainFrame       *Frame
+
+	// protects from the data race between:
+	// - Frame.startNetworkIdleTimer.frameLifecycleEvent.recalculateLifecycle
+	// - *FrameSession.initEvents.onFrameNavigated->FrameManager.frameNavigated
+	mainFrameMu sync.RWMutex
+	mainFrame   *Frame
 
 	// Needed as the frames map will be accessed from multiple Go routines,
 	// the main VU/JS go routine and the Go routine listening for CDP messages.
@@ -266,7 +271,7 @@ func (m *FrameManager) frameNavigated(frameID cdp.FrameID, parentFrameID cdp.Fra
 			frame = NewFrame(m.ctx, m, nil, frameID, m.logger)
 		}
 		m.frames[frameID] = frame
-		m.mainFrame = frame
+		m.setMainFrame(frame)
 	}
 
 	frame.navigated(name, url, documentID)
@@ -535,7 +540,17 @@ func (m *FrameManager) Frames() []api.Frame {
 
 // MainFrame returns the main frame of the page
 func (m *FrameManager) MainFrame() *Frame {
+	m.mainFrameMu.RLock()
+	defer m.mainFrameMu.RUnlock()
+
 	return m.mainFrame
+}
+
+// setMainFrame sets the main frame of the page
+func (m *FrameManager) setMainFrame(f *Frame) {
+	m.mainFrameMu.Lock()
+	defer m.mainFrameMu.Unlock()
+	m.mainFrame = f
 }
 
 // NavigateFrame will navigate specified frame to specifed URL

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -848,7 +848,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 		// ignore errors if we're no longer connected to browser
 		// this happens when there is no browser but we still want to
 		// attach a worker to it.
-		if !fs.page.browserCtx.browser.connected {
+		if !fs.page.browserCtx.browser.IsConnected() {
 			return
 		}
 		select {
@@ -860,9 +860,8 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 				event.TargetInfo.Type)
 			return
 		default:
-			k6Throw(fs.ctx, "cannot create frame session (worker): %w", err)
+			k6Throw(fs.ctx, "cannot create new worker: %w", err)
 		}
-		k6Throw(fs.ctx, "cannot create new worker: %w", err)
 	}
 	fs.page.workers[session.id] = w
 }

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -553,12 +553,12 @@ func (fs *FrameSession) onExecutionContextCreated(event *runtime.EventExecutionC
 	frame := fs.manager.getFrameByID(i.FrameID)
 	if frame != nil {
 		if i.IsDefault {
-			world = mainExecutionContext
-		} else if event.Context.Name == utilityWorldName && !frame.hasContext(utilityExecutionContext) {
+			world = mainWorld
+		} else if event.Context.Name == utilityWorldName && !frame.hasContext(utilityWorld) {
 			// In case of multiple sessions to the same target, there's a race between
 			// connections so we might end up creating multiple isolated worlds.
 			// We can use either.
-			world = utilityExecutionContext
+			world = utilityWorld
 		}
 	}
 	if i.Type == "isolated" {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -805,8 +805,10 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 			fs.session.id, fs.targetID, event.SessionID,
 			event.TargetInfo.TargetID, event.TargetInfo.BrowserContextID,
 			event.TargetInfo.Type, err)
-		// If we're no longer connected to browser, then ignore WebSocket errors
-		if !fs.page.browserCtx.browser.connected && strings.Contains(err.Error(), "websocket: close 1006 (abnormal closure)") {
+		// ignore errors if we're no longer connected to browser
+		// this happens when there is no browser but we still want to
+		// attach a frame to it.
+		if !fs.page.browserCtx.browser.IsConnected() {
 			return
 		}
 		// Ignore context canceled error to gracefuly handle shutting down
@@ -843,8 +845,10 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 	// Handle new worker
 	w, err := NewWorker(fs.ctx, session, targetID, event.TargetInfo.URL)
 	if err != nil {
-		if !fs.page.browserCtx.browser.connected && strings.Contains(err.Error(), "websocket: close 1006 (abnormal closure)") {
-			// If we're no longer connected to browser, then ignore WebSocket errors
+		// ignore errors if we're no longer connected to browser
+		// this happens when there is no browser but we still want to
+		// attach a worker to it.
+		if !fs.page.browserCtx.browser.connected {
 			return
 		}
 		select {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -801,7 +801,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 		}
 		// Erroneous cases
 		defer fs.logger.Debugf("FrameSession:onAttachedToTarget:NewFrameSession",
-			"sid:%v tid:%v esid:%v etid:%v ebctxid:%v type:%q err:%t",
+			"sid:%v tid:%v esid:%v etid:%v ebctxid:%v type:%q err:%v",
 			fs.session.id, fs.targetID, event.SessionID,
 			event.TargetInfo.TargetID, event.TargetInfo.BrowserContextID,
 			event.TargetInfo.Type, err)

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -785,7 +785,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 	session := fs.page.browserCtx.conn.getSession(event.SessionID)
 	targetID := event.TargetInfo.TargetID
 
-	if eti := event.TargetInfo; eti.Type == "iframe" && eti.URL != "" {
+	if event.TargetInfo.Type == "iframe" {
 		frame := fs.manager.getFrameByID(cdp.FrameID(targetID))
 		if frame == nil {
 			return

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -549,7 +549,7 @@ func (fs *FrameSession) onExecutionContextCreated(event *runtime.EventExecutionC
 	if err := json.Unmarshal(auxData, &i); err != nil {
 		k6Throw(fs.ctx, "unable to unmarshal JSON: %w", err)
 	}
-	var world string = ""
+	var world executionWorld
 	frame := fs.manager.getFrameByID(i.FrameID)
 	if frame != nil {
 		if i.IsDefault {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -796,7 +796,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 		// Successful case
 		frameSession, err := NewFrameSession(fs.ctx, session, fs.page, fs, targetID, fs.logger)
 		if err == nil {
-			fs.page.frameSessions[cdp.FrameID(targetID)] = frameSession
+			fs.page.attachFrameSession(cdp.FrameID(targetID), frameSession)
 			return
 		}
 		// Erroneous cases

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -553,12 +553,12 @@ func (fs *FrameSession) onExecutionContextCreated(event *runtime.EventExecutionC
 	frame := fs.manager.getFrameByID(i.FrameID)
 	if frame != nil {
 		if i.IsDefault {
-			world = "main"
-		} else if event.Context.Name == utilityWorldName && !frame.hasContext("utility") {
+			world = mainExecutionContext
+		} else if event.Context.Name == utilityWorldName && !frame.hasContext(utilityExecutionContext) {
 			// In case of multiple sessions to the same target, there's a race between
 			// connections so we might end up creating multiple isolated worlds.
 			// We can use either.
-			world = "utility"
+			world = utilityExecutionContext
 		}
 	}
 	if i.Type == "isolated" {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -785,7 +785,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 	session := fs.page.browserCtx.conn.getSession(event.SessionID)
 	targetID := event.TargetInfo.TargetID
 
-	if event.TargetInfo.Type == "iframe" {
+	if eti := event.TargetInfo; eti.Type == "iframe" && eti.URL != "" {
 		frame := fs.manager.getFrameByID(cdp.FrameID(targetID))
 		if frame == nil {
 			return

--- a/common/frame_test.go
+++ b/common/frame_test.go
@@ -36,10 +36,10 @@ func TestFrameNilDocument(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	logger := NewLogger(ctx, NullLogger(), false, nil)
+	log := NewNullLogger()
 
-	fm := NewFrameManager(ctx, nil, nil, nil, logger)
-	frame := NewFrame(ctx, fm, nil, cdp.FrameID("42"), logger)
+	fm := NewFrameManager(ctx, nil, nil, nil, log)
+	frame := NewFrame(ctx, fm, nil, cdp.FrameID("42"), log)
 
 	// frame should not panic with a nil document
 	stub := &executionContextTestStub{

--- a/common/frame_test.go
+++ b/common/frame_test.go
@@ -52,7 +52,7 @@ func TestFrameNilDocument(t *testing.T) {
 	// document() waits for the main execution context
 	ok := make(chan struct{}, 1)
 	go func() {
-		frame.setContext(mainExecutionContext, stub)
+		frame.setContext(mainWorld, stub)
 		ok <- struct{}{}
 	}()
 	select {

--- a/common/frame_test.go
+++ b/common/frame_test.go
@@ -52,7 +52,7 @@ func TestFrameNilDocument(t *testing.T) {
 	// document() waits for the main execution context
 	ok := make(chan struct{}, 1)
 	go func() {
-		frame.setContext("main", stub)
+		frame.setContext(mainExecutionContext, stub)
 		ok <- struct{}{}
 	}()
 	select {

--- a/common/frame_test.go
+++ b/common/frame_test.go
@@ -43,7 +43,7 @@ func TestFrameNilDocument(t *testing.T) {
 
 	// frame should not panic with a nil document
 	stub := &executionContextTestStub{
-		evaluateFn: func(apiCtx context.Context, forceCallable bool, returnByValue bool, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+		evaluateFn: func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
 			// return nil to test for panic
 			return nil, nil
 		},
@@ -68,7 +68,7 @@ func TestFrameNilDocument(t *testing.T) {
 
 	// frame gets the document from the evaluate call
 	want := &ElementHandle{}
-	stub.evaluateFn = func(apiCtx context.Context, forceCallable bool, returnByValue bool, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+	stub.evaluateFn = func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
 		return want, nil
 	}
 	got, err := frame.document()
@@ -82,9 +82,9 @@ func TestFrameNilDocument(t *testing.T) {
 
 type executionContextTestStub struct {
 	ExecutionContext
-	evaluateFn func(apiCtx context.Context, forceCallable bool, returnByValue bool, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error)
+	evaluateFn func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error)
 }
 
-func (e executionContextTestStub) evaluate(apiCtx context.Context, forceCallable bool, returnByValue bool, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
-	return e.evaluateFn(apiCtx, forceCallable, returnByValue, pageFunc, args...)
+func (e executionContextTestStub) evaluate(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+	return e.evaluateFn(apiCtx, opts, pageFunc, args...)
 }

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -143,7 +143,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := NewLogger(ctx, NullLogger(), false, nil)
+		log := NewNullLogger()
 
 		timeoutSetings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings, log)
@@ -166,7 +166,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle wrong context", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := NewLogger(ctx, NullLogger(), false, nil)
+		log := NewNullLogger()
 
 		timeoutSetings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings, log)
@@ -188,7 +188,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle is disposed", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := NewLogger(ctx, NullLogger(), false, nil)
+		log := NewNullLogger()
 
 		timeoutSetings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings, log)
@@ -210,7 +210,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle as *ElementHandle", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := NewLogger(ctx, NullLogger(), false, nil)
+		log := NewNullLogger()
 
 		timeoutSetings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings, log)

--- a/common/logger.go
+++ b/common/logger.go
@@ -51,6 +51,10 @@ func NullLogger() *logrus.Logger {
 	return log
 }
 
+func NewNullLogger() *Logger {
+	return NewLogger(context.TODO(), NullLogger(), false, nil)
+}
+
 func NewLogger(ctx context.Context, logger *logrus.Logger, debugOverride bool, categoryFilter *regexp.Regexp) *Logger {
 	return &Logger{
 		ctx:            ctx,

--- a/common/page.go
+++ b/common/page.go
@@ -193,7 +193,7 @@ func (p *Page) evaluateOnNewDocument(source string) {
 	// TODO: implement
 }
 
-func (p *Page) getFrameElement(f *Frame) (*ElementHandle, error) {
+func (p *Page) getFrameElement(f *Frame) (handle *ElementHandle, _ error) {
 	if f == nil {
 		p.logger.Debugf("Page:getFrameElement", "sid:%v frame:nil", p.sessionID())
 	} else {
@@ -220,8 +220,7 @@ func (p *Page) getFrameElement(f *Frame) (*ElementHandle, error) {
 	if parent == nil {
 		return nil, errors.New("frame has been detached 2")
 	}
-	handle, err := parent.mainExecutionContext.adoptBackendNodeID(backendNodeId)
-	return handle, err
+	return parent.adoptBackendNodeID(mainWorld, backendNodeId)
 }
 
 func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) cdp.FrameID {

--- a/common/page.go
+++ b/common/page.go
@@ -236,7 +236,12 @@ func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) cdp.Frame
       		return node.ownerDocument ? node.ownerDocument.documentElement : null;
 		}
 	`)
-	result, err := h.execCtx.evaluate(apiCtx, true, false, pageFn, []goja.Value{rt.ToValue(h)}...)
+
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: false,
+	}
+	result, err := h.execCtx.evaluate(apiCtx, opts, pageFn, []goja.Value{rt.ToValue(h)}...)
 	if err != nil {
 		p.logger.Debugf("Page:getOwnerFrame:return", "sid:%v err:%v", p.sessionID(), err)
 		return ""

--- a/common/page.go
+++ b/common/page.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/chromedp/cdproto/cdp"
@@ -57,19 +58,28 @@ type Page struct {
 	frameManager    *FrameManager
 	timeoutSettings *TimeoutSettings
 
-	jsEnabled        bool
-	closed           bool
-	backgroundPage   bool
+	jsEnabled bool
+
+	// protects from race between:
+	// - Browser.initEvents.onDetachedFromTarget->Page.didClose
+	// - FrameSession.initEvents.onFrameDetached->FrameManager.frameDetached.removeFramesRecursively->Page.IsClosed
+	closedMu sync.RWMutex
+	closed   bool
+
+	// TODO: setter change these fields (mutex?)
+	emulatedSize     *EmulatedSize
 	mediaType        MediaType
 	colorScheme      ColorScheme
 	reducedMotion    ReducedMotion
 	extraHTTPHeaders map[string]string
-	emulatedSize     *EmulatedSize
+
+	backgroundPage bool
 
 	mainFrameSession *FrameSession
-	frameSessions    map[cdp.FrameID]*FrameSession
-	workers          map[target.SessionID]*Worker
-	routes           []api.Route
+	// TODO: FrameSession changes by attachFrameSession (mutex?)
+	frameSessions map[cdp.FrameID]*FrameSession
+	workers       map[target.SessionID]*Worker
+	routes        []api.Route
 
 	logger *Logger
 }
@@ -163,7 +173,12 @@ func (p *Page) defaultTimeout() time.Duration {
 func (p *Page) didClose() {
 	p.logger.Debugf("Page:didClose", "sid:%v", p.sessionID())
 
-	p.closed = true
+	p.closedMu.Lock()
+	{
+		p.closed = true
+	}
+	p.closedMu.Unlock()
+
 	p.emit(EventPageClose, p)
 }
 
@@ -253,6 +268,11 @@ func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) cdp.Frame
 	frameID := node.FrameID
 	documentElement.Dispose()
 	return frameID
+}
+
+func (p *Page) attachFrameSession(fid cdp.FrameID, fs *FrameSession) {
+	p.logger.Debugf("Page:attachFrameSession", "sid:%v fid=%v", p.session.id, fid)
+	fs.page.frameSessions[fid] = fs
 }
 
 func (p *Page) getFrameSession(frameID cdp.FrameID) *FrameSession {
@@ -573,6 +593,9 @@ func (p *Page) IsChecked(selector string, opts goja.Value) bool {
 }
 
 func (p *Page) IsClosed() bool {
+	p.closedMu.RLock()
+	defer p.closedMu.RUnlock()
+
 	return p.closed
 }
 

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -47,7 +47,7 @@ func newScreenshotter(ctx context.Context) *screenshotter {
 
 func (s *screenshotter) fullPageSize(p *Page) (*Size, error) {
 	rt := k6common.GetRuntime(s.ctx)
-	result, err := p.frameManager.mainFrame.mainExecutionContext.evaluate(s.ctx, true, true, rt.ToValue(`
+	result, err := p.frameManager.mainFrame.evaluate(mainWorld, s.ctx, true, true, rt.ToValue(`
         () => {
             if (!document.body || !document.documentElement) {
                 return null;

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -51,7 +51,7 @@ func (s *screenshotter) fullPageSize(p *Page) (*Size, error) {
 		forceCallable: true,
 		returnByValue: true,
 	}
-	result, err := p.frameManager.mainFrame.evaluate(mainWorld, s.ctx, opts, rt.ToValue(`
+	result, err := p.frameManager.mainFrame.evaluate(s.ctx, mainWorld, opts, rt.ToValue(`
         () => {
             if (!document.body || !document.documentElement) {
                 return null;
@@ -95,7 +95,7 @@ func (s *screenshotter) originalViewportSize(p *Page) (*Size, *Size, error) {
 		forceCallable: true,
 		returnByValue: true,
 	}
-	result, err := p.frameManager.mainFrame.evaluate(mainWorld, s.ctx, opts, rt.ToValue(`
+	result, err := p.frameManager.mainFrame.evaluate(s.ctx, mainWorld, opts, rt.ToValue(`
 	() => (
 		{ width: window.innerWidth, height: window.innerHeight }
 	)`))

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -47,7 +47,11 @@ func newScreenshotter(ctx context.Context) *screenshotter {
 
 func (s *screenshotter) fullPageSize(p *Page) (*Size, error) {
 	rt := k6common.GetRuntime(s.ctx)
-	result, err := p.frameManager.mainFrame.evaluate(mainWorld, s.ctx, true, true, rt.ToValue(`
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
+	result, err := p.frameManager.mainFrame.evaluate(mainWorld, s.ctx, opts, rt.ToValue(`
         () => {
             if (!document.body || !document.documentElement) {
                 return null;
@@ -86,7 +90,12 @@ func (s *screenshotter) originalViewportSize(p *Page) (*Size, *Size, error) {
 	if viewportSize.Width != 0 || viewportSize.Height != 0 {
 		return &viewportSize, &originalViewportSize, nil
 	}
-	result, err := p.frameManager.mainFrame.mainExecutionContext.evaluate(s.ctx, true, true, rt.ToValue(`
+
+	opts := evaluateOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
+	result, err := p.frameManager.mainFrame.evaluate(mainWorld, s.ctx, opts, rt.ToValue(`
 	() => (
 		{ width: window.innerWidth, height: window.innerHeight }
 	)`))

--- a/common/session_test.go
+++ b/common/session_test.go
@@ -77,7 +77,7 @@ func TestSessionCreateSession(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, NewLogger(ctx, NullLogger(), false, nil))
+		conn, err := NewConnection(ctx, wsURL, NewNullLogger())
 
 		if assert.NoError(t, err) {
 			session, err := conn.createSession(&target.Info{


### PR DESCRIPTION
### Update (2021-12-23)

I added a few more bug fixes after [receiving another script that fails with this error](https://community.k6.io/t/unable-to-properly-navigate-to-url/2567/4) (_from a user in our community_). Now we no longer try to attach a frame or worker if the browser is already closed. These commits solved the user's issues: 77949eb and a3aea00.

### Update (2021-12-20)

This PR only focuses on fixing and gracefully handling _"cannot create frame session"_ problem in #125 with this afe4550c commit. Later on, within other commits, it fixes related data race issues, makes some refactorings, and cleans things up.

The problem was about the propagation of #49 into this one. We throw an error when we cannot find a context with a given id while a new `FrameSession` is trying to boot up. So the extension is already in a terminating state but `FrameSession` doesn't know about it. This PR prevents `FrameSession` to rethrow if the context was canceled and instead log.

However, it's not focusing on fixing #49 as it's a whole world of a different problem, and we don't have a good fix for it yet (see: 6382e42 and d4e3900).

### First Update

**In this PR:**
* I changed the handling of execution contexts.
* Fixed most of the data races.
* Refactored some parts of the code.
* Fixed _cannot create frame session (context canceled)_ problem.
* ~Skipped creating frame sessions for frames with empty URLs (such as _about:blank_)~

**With these, this PR seemed to fix the problems to some extent:**
* Tom's script was failing on the 2nd group before, `clickBusinessCards`—**16% of the whole script**
* Now it works until the `customerReviewed` group—**%67 of the whole script**

I discovered some reasons why it still fails.

**I noticed we receive [deprecated events](https://github.com/chromium/chromium/commit/4005fcf1c724629b63ac6fc390d40a2f8f40be3d) like**:
* `Page.frameScheduledNavigation`
* `Page.frameClearedScheduledNavigation`

So, I believe the last steps don't work because of these and we can create new issues for handling them. So I let them return as errors:

```
ERRO[0094] unknown command or event "Page.frameScheduledNavigation"
ERRO[0094] unknown command or event "Page.frameClearedScheduledNavigation"
```