### PR TITLE
Fix/54 proper logger

### DIFF
--- a/api/page.go
+++ b/api/page.go
@@ -27,7 +27,7 @@ type Page interface {
 	AddInitScript(script goja.Value, arg goja.Value)
 	AddScriptTag(opts goja.Value)
 	AddStyleTag(opts goja.Value)
-	BrintToFront()
+	BringToFront()
 	Check(selector string, opts goja.Value)
 	Click(selector string, opts goja.Value)
 	Close(opts goja.Value)

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -167,7 +167,7 @@ func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*common.
 	)
 	// set the log level from the launch options (usually from a script's options).
 	if launchOpts.Debug {
-		logger.SetLevel("debug")
+		_ = logger.SetLevel("debug")
 	}
 	if el, ok := os.LookupEnv("XK6_BROWSER_LOG"); ok {
 		if err := logger.SetLevel(el); err != nil {

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -24,12 +24,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 
 	"github.com/dop251/goja"
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/common"
-	"github.com/sirupsen/logrus"
 	k6common "go.k6.io/k6/js/common"
 	k6lib "go.k6.io/k6/lib"
 )
@@ -167,8 +167,15 @@ func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*common.
 	)
 	// set the log level from the launch options (usually from a script's options).
 	if launchOpts.Debug {
-		logger.SetLevel(logrus.DebugLevel)
+		logger.SetLevel("debug")
 	}
-	err := logger.SetLevelEnv("XK6_BROWSER_LOG")
-	return logger, err
+	if el, ok := os.LookupEnv("XK6_BROWSER_LOG"); ok {
+		if err := logger.SetLevel(el); err != nil {
+			return nil, err
+		}
+	}
+	if _, ok := os.LookupEnv("XK6_BROWSER_CALLER"); ok {
+		logger.ReportCaller()
+	}
+	return logger, nil
 }

--- a/common/barrier_test.go
+++ b/common/barrier_test.go
@@ -32,7 +32,7 @@ func TestBarrier(t *testing.T) {
 	t.Run("should work", func(t *testing.T) {
 		ctx := context.Background()
 		timeoutSetings := NewTimeoutSettings(nil)
-		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings)
+		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings, NewLogger(ctx, NullLogger(), false, nil))
 		frame := NewFrame(ctx, frameManager, nil, cdp.FrameID("frame_id_0123456789"))
 
 		barrier := NewBarrier()

--- a/common/browser.go
+++ b/common/browser.go
@@ -207,7 +207,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 	if ok {
 		browserCtx = bctx
 	}
-	b.logger.Debugf("Browser:onAttachedToTarget", "sid:%v tid:%v bcid:%v btx nil=%t", ev.SessionID, ev.TargetInfo.TargetID, ev.TargetInfo.BrowserContextID, bctx == nil)
+	b.logger.Debugf("Browser:onAttachedToTarget", "sid:%v tid:%v bcid:%v bctx nil=%t", ev.SessionID, ev.TargetInfo.TargetID, ev.TargetInfo.BrowserContextID, bctx == nil)
 	b.contextsMu.RUnlock()
 
 	// We're not interested in the top-level browser target, other targets or DevTools targets right now.

--- a/common/browser.go
+++ b/common/browser.go
@@ -112,7 +112,7 @@ func NewBrowser(ctx context.Context, cancelFn context.CancelFunc, browserProc *B
 }
 
 func (b *Browser) connect() error {
-	b.logger.Infof("Browser:connect", "wsURL=%v", b.browserProc.WsURL())
+	b.logger.Debugf("Browser:connect", "wsURL:%v", b.browserProc.WsURL())
 	var err error
 	b.conn, err = NewConnection(b.ctx, b.browserProc.WsURL(), b.logger)
 	if err != nil {
@@ -127,7 +127,7 @@ func (b *Browser) connect() error {
 }
 
 func (b *Browser) disposeContext(id cdp.BrowserContextID) error {
-	b.logger.Infof("Browser:disposeContext", "bctxid=%v", id)
+	b.logger.Debugf("Browser:disposeContext", "bctxid:%v", id)
 	action := target.DisposeBrowserContext(id)
 	if err := action.Do(cdp.WithExecutor(b.ctx, b.conn)); err != nil {
 		return fmt.Errorf("unable to dispose browser context %T: %w", action, err)
@@ -166,13 +166,13 @@ func (b *Browser) initEvents() error {
 				return
 			case event := <-chHandler:
 				if ev, ok := event.data.(*target.EventAttachedToTarget); ok {
-					b.logger.Infof("Browser:initEvents:onAttachedToTarget", "sid=%v tid=%v", ev.SessionID, ev.TargetInfo.TargetID)
+					b.logger.Debugf("Browser:initEvents:onAttachedToTarget", "sid:%v tid:%v", ev.SessionID, ev.TargetInfo.TargetID)
 					go b.onAttachedToTarget(ev)
 				} else if ev, ok := event.data.(*target.EventDetachedFromTarget); ok {
-					b.logger.Infof("Browser:initEvents:onDetachedFromTarget", "sid=%v", ev.SessionID)
+					b.logger.Debugf("Browser:initEvents:onDetachedFromTarget", "sid:%v", ev.SessionID)
 					go b.onDetachedFromTarget(ev)
 				} else if event.typ == EventConnectionClose {
-					b.logger.Infof("Browser:initEvents:EventConnectionClose", "")
+					b.logger.Debugf("Browser:initEvents:EventConnectionClose", "")
 
 					b.connMu.Lock()
 					b.connected = false
@@ -207,13 +207,13 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 	if ok {
 		browserCtx = bctx
 	}
-	b.logger.Infof("Browser:onAttachedToTarget", "sid=%v tid=%v bcid=%v btx nil=%t", ev.SessionID, ev.TargetInfo.TargetID, ev.TargetInfo.BrowserContextID, bctx == nil)
+	b.logger.Debugf("Browser:onAttachedToTarget", "sid:%v tid:%v bcid:%v btx nil=%t", ev.SessionID, ev.TargetInfo.TargetID, ev.TargetInfo.BrowserContextID, bctx == nil)
 	b.contextsMu.RUnlock()
 
 	// We're not interested in the top-level browser target, other targets or DevTools targets right now.
 	isDevTools := strings.HasPrefix(ev.TargetInfo.URL, "devtools://devtools")
 	if ev.TargetInfo.Type == "browser" || ev.TargetInfo.Type == "other" || isDevTools {
-		b.logger.Infof("Browser:onAttachedToTarget", "sid=%v tid=%v, returns: devtools", ev.SessionID, ev.TargetInfo.TargetID)
+		b.logger.Debugf("Browser:onAttachedToTarget", "sid:%v tid:%v, returns: devtools", ev.SessionID, ev.TargetInfo.TargetID)
 		return
 	}
 
@@ -223,17 +223,17 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() //b.conn.isConnected()
 			if _, ok := err.(*websocket.CloseError); !ok && !isRunning {
 				// If we're no longer connected to browser, then ignore WebSocket errors
-				b.logger.Infof("Browser:onAttachedToTarget:background_page", "sid=%v tid=%v, returns: websocket error", ev.SessionID, ev.TargetInfo.TargetID)
+				b.logger.Debugf("Browser:onAttachedToTarget:background_page", "sid:%v tid:%v, returns: websocket error", ev.SessionID, ev.TargetInfo.TargetID)
 				return
 			}
 			k6Throw(b.ctx, "cannot create NewPage for background_page event: %w", err)
 		}
 		b.pagesMu.Lock()
-		b.logger.Infof("Browser:onAttachedToTarget:background_page", "sid=%v tid=%v, adding tid", ev.SessionID, ev.TargetInfo.TargetID)
+		b.logger.Debugf("Browser:onAttachedToTarget:background_page", "sid:%v tid:%v, adding tid", ev.SessionID, ev.TargetInfo.TargetID)
 		b.pages[ev.TargetInfo.TargetID] = p
 		b.pagesMu.Unlock()
 		b.sessionIDtoTargetIDMu.Lock()
-		b.logger.Infof("Browser:onAttachedToTarget:background_page", "sid=%v tid=%v, adding sid", ev.SessionID, ev.TargetInfo.TargetID)
+		b.logger.Debugf("Browser:onAttachedToTarget:background_page", "sid:%v tid:%v, adding sid", ev.SessionID, ev.TargetInfo.TargetID)
 		b.sessionIDtoTargetID[ev.SessionID] = ev.TargetInfo.TargetID
 		b.sessionIDtoTargetIDMu.Unlock()
 	} else if ev.TargetInfo.Type == "page" {
@@ -242,24 +242,24 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 		if t, ok := b.pages[ev.TargetInfo.OpenerID]; ok {
 			opener = t
 		}
-		b.logger.Infof("Browser:onAttachedToTarget:page", "sid=%v tid=%v opener nil:%t", ev.SessionID, ev.TargetInfo.TargetID, opener == nil)
+		b.logger.Debugf("Browser:onAttachedToTarget:page", "sid:%v tid:%v opener nil:%t", ev.SessionID, ev.TargetInfo.TargetID, opener == nil)
 		b.pagesMu.RUnlock()
 		p, err := NewPage(b.ctx, b.conn.getSession(ev.SessionID), browserCtx, ev.TargetInfo.TargetID, opener, true)
 		if err != nil {
 			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() //b.conn.isConnected()
 			if _, ok := err.(*websocket.CloseError); !ok && !isRunning {
 				// If we're no longer connected to browser, then ignore WebSocket errors
-				b.logger.Infof("Browser:onAttachedToTarget:page", "sid=%v tid=%v, returns: websocket error", ev.SessionID, ev.TargetInfo.TargetID)
+				b.logger.Debugf("Browser:onAttachedToTarget:page", "sid:%v tid:%v, returns: websocket error", ev.SessionID, ev.TargetInfo.TargetID)
 				return
 			}
 			k6Throw(b.ctx, "cannot create NewPage for page event: %w", err)
 		}
 		b.pagesMu.Lock()
-		b.logger.Infof("Browser:onAttachedToTarget:page", "sid=%v tid=%v, adding page as a target", ev.SessionID, ev.TargetInfo.TargetID)
+		b.logger.Debugf("Browser:onAttachedToTarget:page", "sid:%v tid:%v, adding page as a target", ev.SessionID, ev.TargetInfo.TargetID)
 		b.pages[ev.TargetInfo.TargetID] = p
 		b.pagesMu.Unlock()
 		b.sessionIDtoTargetIDMu.Lock()
-		b.logger.Infof("Browser:onAttachedToTarget:page", "sid=%v tid=%v, changing sid to tid", ev.SessionID, ev.TargetInfo.TargetID)
+		b.logger.Debugf("Browser:onAttachedToTarget:page", "sid:%v tid:%v, changing sid to tid", ev.SessionID, ev.TargetInfo.TargetID)
 		b.sessionIDtoTargetID[ev.SessionID] = ev.TargetInfo.TargetID
 		b.sessionIDtoTargetIDMu.Unlock()
 		browserCtx.emit(EventBrowserContextPage, p)
@@ -269,10 +269,10 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 func (b *Browser) onDetachedFromTarget(ev *target.EventDetachedFromTarget) {
 	b.sessionIDtoTargetIDMu.RLock()
 	targetID, ok := b.sessionIDtoTargetID[ev.SessionID]
-	b.logger.Infof("Browser:onDetachedFromTarget", "sid=%v tid=%v", ev.SessionID, targetID)
+	b.logger.Debugf("Browser:onDetachedFromTarget", "sid:%v tid:%v", ev.SessionID, targetID)
 	b.sessionIDtoTargetIDMu.RUnlock()
 	if !ok {
-		b.logger.Infof("Browser:onDetachedFromTarget", "sid=%v tid=%v, returns", ev.SessionID, targetID)
+		b.logger.Debugf("Browser:onDetachedFromTarget", "sid:%v tid:%v, returns", ev.SessionID, targetID)
 		// We don't track targets of type "browser", "other" and "devtools", so ignore if we don't recognize target.
 		return
 	}
@@ -280,7 +280,7 @@ func (b *Browser) onDetachedFromTarget(ev *target.EventDetachedFromTarget) {
 	b.pagesMu.Lock()
 	defer b.pagesMu.Unlock()
 	if t, ok := b.pages[targetID]; ok {
-		b.logger.Infof("Browser:onDetachedFromTarget", "tid=%v, delete page", targetID)
+		b.logger.Debugf("Browser:onDetachedFromTarget", "tid:%v, delete page", targetID)
 		delete(b.pages, targetID)
 		t.didClose()
 	}
@@ -306,7 +306,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 		func(data interface{}) bool {
 			mu.RLock()
 			defer mu.RUnlock()
-			b.logger.Infof("Browser:newPageInContext", "tid:%v bcid=%v, createWaitForEventHandler", targetID, id)
+			b.logger.Debugf("Browser:newPageInContext", "tid:%v bcid:%v, createWaitForEventHandler", targetID, id)
 			return data.(*Page).targetID == targetID
 		},
 	)
@@ -317,20 +317,20 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		localTargetID = targetID
-		b.logger.Infof("Browser:newPageInContext", "tid=%v bcid=%v, CreateTarget(blank)", localTargetID, id)
+		b.logger.Debugf("Browser:newPageInContext", "tid:%v bcid:%v, CreateTarget(blank)", localTargetID, id)
 		if targetID, err = action.Do(cdp.WithExecutor(b.ctx, b.conn)); err != nil {
 			errCh <- fmt.Errorf("unable to execute %T: %w", action, err)
 		}
 	}()
 	select {
 	case <-b.ctx.Done():
-		b.logger.Infof("Browser:newPageInContext:<-b.ctx.Done", "tid=%v bcid=%v", localTargetID, id)
+		b.logger.Debugf("Browser:newPageInContext:<-b.ctx.Done", "tid:%v bcid:%v", localTargetID, id)
 	case <-time.After(b.launchOpts.Timeout):
-		b.logger.Infof("Browser:newPageInContext:timeout", "tid=%v bcid=%v", localTargetID, id)
+		b.logger.Debugf("Browser:newPageInContext:timeout", "tid:%v bcid:%v", localTargetID, id)
 	case c := <-ch:
-		b.logger.Infof("Browser:newPageInContext:<-ch", "tid=%v bcid=%v, ch:%v", localTargetID, id, c)
+		b.logger.Debugf("Browser:newPageInContext:<-ch", "tid:%v bcid:%v, ch:%v", localTargetID, id, c)
 	case err := <-errCh:
-		b.logger.Infof("Browser:newPageInContext:<-errCh", "tid=%v bcid=%v, ch:%v", localTargetID, id, err)
+		b.logger.Debugf("Browser:newPageInContext:<-errCh", "tid:%v bcid:%v, ch:%v", localTargetID, id, err)
 		return nil, err
 	}
 	b.pagesMu.RLock()
@@ -340,16 +340,16 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 
 // Close shuts down the browser
 func (b *Browser) Close() {
-	b.logger.Infof("Browser:Close", "")
+	b.logger.Debugf("Browser:Close", "")
 	if !atomic.CompareAndSwapInt64(&b.state, b.state, BrowserStateClosing) {
 		// If we're already in a closing state then no need to continue.
-		b.logger.Infof("Browser:Close", "already in a closing state")
+		b.logger.Debugf("Browser:Close", "already in a closing state")
 		return
 	}
-	b.logger.Infof("Browser:Close", "graceful terminate")
+	b.logger.Debugf("Browser:Close", "graceful terminate")
 	b.browserProc.GracefulClose()
 	defer func() {
-		b.logger.Infof("Browser:Close", "browserProc terminate")
+		b.logger.Debugf("Browser:Close", "browserProc terminate")
 		b.browserProc.Terminate()
 	}()
 
@@ -383,7 +383,7 @@ func (b *Browser) IsConnected() bool {
 func (b *Browser) NewContext(opts goja.Value) api.BrowserContext {
 	action := target.CreateBrowserContext().WithDisposeOnDetach(true)
 	browserContextID, err := action.Do(cdp.WithExecutor(b.ctx, b.conn))
-	b.logger.Infof("Browser:NewContext", "browserContextID: %v", browserContextID)
+	b.logger.Debugf("Browser:NewContext", "browserContextID: %v", browserContextID)
 	if err != nil {
 		k6Throw(b.ctx, "unable to execute %T: %w", action, err)
 	}
@@ -395,7 +395,7 @@ func (b *Browser) NewContext(opts goja.Value) api.BrowserContext {
 
 	b.contextsMu.Lock()
 	defer b.contextsMu.Unlock()
-	b.logger.Infof("Browser:NewContext", "NewBrowserContext: %v", browserContextID)
+	b.logger.Debugf("Browser:NewContext", "NewBrowserContext: %v", browserContextID)
 	browserCtx := NewBrowserContext(b.ctx, b.conn, b, browserContextID, browserCtxOpts, b.logger)
 	b.contexts[browserContextID] = browserCtx
 
@@ -405,7 +405,7 @@ func (b *Browser) NewContext(opts goja.Value) api.BrowserContext {
 // NewPage creates a new tab in the browser window
 func (b *Browser) NewPage(opts goja.Value) api.Page {
 	browserCtx := b.NewContext(opts)
-	b.logger.Infof("Browser:NewContext", "NewPage")
+	b.logger.Debugf("Browser:NewContext", "NewPage")
 	return browserCtx.NewPage()
 }
 

--- a/common/browser.go
+++ b/common/browser.go
@@ -218,7 +218,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 	}
 
 	if ev.TargetInfo.Type == "background_page" {
-		p, err := NewPage(b.ctx, b.conn.getSession(ev.SessionID), browserCtx, ev.TargetInfo.TargetID, nil, false)
+		p, err := NewPage(b.ctx, b.conn.getSession(ev.SessionID), browserCtx, ev.TargetInfo.TargetID, nil, false, b.logger)
 		if err != nil {
 			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() //b.conn.isConnected()
 			if _, ok := err.(*websocket.CloseError); !ok && !isRunning {
@@ -244,7 +244,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 		}
 		b.logger.Debugf("Browser:onAttachedToTarget:page", "sid:%v tid:%v opener nil:%t", ev.SessionID, ev.TargetInfo.TargetID, opener == nil)
 		b.pagesMu.RUnlock()
-		p, err := NewPage(b.ctx, b.conn.getSession(ev.SessionID), browserCtx, ev.TargetInfo.TargetID, opener, true)
+		p, err := NewPage(b.ctx, b.conn.getSession(ev.SessionID), browserCtx, ev.TargetInfo.TargetID, opener, true, b.logger)
 		if err != nil {
 			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() //b.conn.isConnected()
 			if _, ok := err.(*websocket.CloseError); !ok && !isRunning {

--- a/common/browser.go
+++ b/common/browser.go
@@ -112,7 +112,7 @@ func NewBrowser(ctx context.Context, cancelFn context.CancelFunc, browserProc *B
 }
 
 func (b *Browser) connect() error {
-	b.logger.Infof("Browser:connect", "wsurl=%v", b.browserProc.WsURL())
+	b.logger.Infof("Browser:connect", "wsURL=%v", b.browserProc.WsURL())
 	var err error
 	b.conn, err = NewConnection(b.ctx, b.browserProc.WsURL(), b.logger)
 	if err != nil {
@@ -172,7 +172,7 @@ func (b *Browser) initEvents() error {
 					b.logger.Infof("Browser:initEvents:onDetachedFromTarget", "sid=%v", ev.SessionID)
 					go b.onDetachedFromTarget(ev)
 				} else if event.typ == EventConnectionClose {
-					b.logger.Infof("Browser:initEvents:EventConnectionClose", "sid=%v", ev.SessionID)
+					b.logger.Infof("Browser:initEvents:EventConnectionClose", "")
 
 					b.connMu.Lock()
 					b.connected = false
@@ -207,13 +207,13 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 	if ok {
 		browserCtx = bctx
 	}
-	b.logger.Infof("Browser:onAttachedToTarget", "id=%v, btx nil=%t", ev.TargetInfo.BrowserContextID, bctx == nil)
+	b.logger.Infof("Browser:onAttachedToTarget", "sid=%v tid=%v bcid=%v btx nil=%t", ev.SessionID, ev.TargetInfo.TargetID, ev.TargetInfo.BrowserContextID, bctx == nil)
 	b.contextsMu.RUnlock()
 
 	// We're not interested in the top-level browser target, other targets or DevTools targets right now.
 	isDevTools := strings.HasPrefix(ev.TargetInfo.URL, "devtools://devtools")
 	if ev.TargetInfo.Type == "browser" || ev.TargetInfo.Type == "other" || isDevTools {
-		b.logger.Infof("Browser:onAttachedToTarget", "returns: devtools")
+		b.logger.Infof("Browser:onAttachedToTarget", "sid=%v tid=%v, returns: devtools", ev.SessionID, ev.TargetInfo.TargetID)
 		return
 	}
 
@@ -223,17 +223,17 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() //b.conn.isConnected()
 			if _, ok := err.(*websocket.CloseError); !ok && !isRunning {
 				// If we're no longer connected to browser, then ignore WebSocket errors
-				b.logger.Infof("Browser:onAttachedToTarget:background_page", "returns: websocket error")
+				b.logger.Infof("Browser:onAttachedToTarget:background_page", "sid=%v tid=%v, returns: websocket error", ev.SessionID, ev.TargetInfo.TargetID)
 				return
 			}
 			k6Throw(b.ctx, "cannot create NewPage for background_page event: %w", err)
 		}
 		b.pagesMu.Lock()
-		b.logger.Infof("Browser:onAttachedToTarget:background_page", "adding target id:%v", ev.TargetInfo.TargetID)
+		b.logger.Infof("Browser:onAttachedToTarget:background_page", "sid=%v tid=%v, adding tid", ev.SessionID, ev.TargetInfo.TargetID)
 		b.pages[ev.TargetInfo.TargetID] = p
 		b.pagesMu.Unlock()
 		b.sessionIDtoTargetIDMu.Lock()
-		b.logger.Infof("Browser:onAttachedToTarget:background_page", "adding session id:%v", ev.TargetInfo.TargetID)
+		b.logger.Infof("Browser:onAttachedToTarget:background_page", "sid=%v tid=%v, adding sid", ev.SessionID, ev.TargetInfo.TargetID)
 		b.sessionIDtoTargetID[ev.SessionID] = ev.TargetInfo.TargetID
 		b.sessionIDtoTargetIDMu.Unlock()
 	} else if ev.TargetInfo.Type == "page" {
@@ -242,24 +242,24 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 		if t, ok := b.pages[ev.TargetInfo.OpenerID]; ok {
 			opener = t
 		}
-		b.logger.Infof("Browser:onAttachedToTarget:page", "opener nil:%t", opener == nil)
+		b.logger.Infof("Browser:onAttachedToTarget:page", "sid=%v tid=%v opener nil:%t", ev.SessionID, ev.TargetInfo.TargetID, opener == nil)
 		b.pagesMu.RUnlock()
 		p, err := NewPage(b.ctx, b.conn.getSession(ev.SessionID), browserCtx, ev.TargetInfo.TargetID, opener, true)
 		if err != nil {
 			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() //b.conn.isConnected()
 			if _, ok := err.(*websocket.CloseError); !ok && !isRunning {
 				// If we're no longer connected to browser, then ignore WebSocket errors
-				b.logger.Infof("Browser:onAttachedToTarget:page", "returns: websocket error")
+				b.logger.Infof("Browser:onAttachedToTarget:page", "sid=%v tid=%v, returns: websocket error", ev.SessionID, ev.TargetInfo.TargetID)
 				return
 			}
 			k6Throw(b.ctx, "cannot create NewPage for page event: %w", err)
 		}
 		b.pagesMu.Lock()
-		b.logger.Infof("Browser:onAttachedToTarget:page", "adding page as a target id:%v", ev.TargetInfo.TargetID)
+		b.logger.Infof("Browser:onAttachedToTarget:page", "sid=%v tid=%v, adding page as a target", ev.SessionID, ev.TargetInfo.TargetID)
 		b.pages[ev.TargetInfo.TargetID] = p
 		b.pagesMu.Unlock()
 		b.sessionIDtoTargetIDMu.Lock()
-		b.logger.Infof("Browser:onAttachedToTarget:page", "changing session id (%v) to target id (%v)", ev.SessionID, ev.TargetInfo.TargetID)
+		b.logger.Infof("Browser:onAttachedToTarget:page", "sid=%v tid=%v, changing sid to tid", ev.SessionID, ev.TargetInfo.TargetID)
 		b.sessionIDtoTargetID[ev.SessionID] = ev.TargetInfo.TargetID
 		b.sessionIDtoTargetIDMu.Unlock()
 		browserCtx.emit(EventBrowserContextPage, p)
@@ -269,10 +269,10 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 func (b *Browser) onDetachedFromTarget(ev *target.EventDetachedFromTarget) {
 	b.sessionIDtoTargetIDMu.RLock()
 	targetID, ok := b.sessionIDtoTargetID[ev.SessionID]
-	b.logger.Infof("Browser:onDetachedFromTarget", "sid=%v, tid=%v", ev.SessionID, targetID)
+	b.logger.Infof("Browser:onDetachedFromTarget", "sid=%v tid=%v", ev.SessionID, targetID)
 	b.sessionIDtoTargetIDMu.RUnlock()
 	if !ok {
-		b.logger.Infof("Browser:onDetachedFromTarget", "returns")
+		b.logger.Infof("Browser:onDetachedFromTarget", "sid=%v tid=%v, returns", ev.SessionID, targetID)
 		// We don't track targets of type "browser", "other" and "devtools", so ignore if we don't recognize target.
 		return
 	}
@@ -280,10 +280,9 @@ func (b *Browser) onDetachedFromTarget(ev *target.EventDetachedFromTarget) {
 	b.pagesMu.Lock()
 	defer b.pagesMu.Unlock()
 	if t, ok := b.pages[targetID]; ok {
-		b.logger.Infof("Browser:onDetachedFromTarget", "deletes")
+		b.logger.Infof("Browser:onDetachedFromTarget", "tid=%v, delete page", targetID)
 		delete(b.pages, targetID)
 		t.didClose()
-		b.logger.Infof("Browser:onDetachedFromTarget", "deleted")
 	}
 }
 
@@ -296,8 +295,9 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 	}
 
 	var (
-		mu       sync.RWMutex // protects targetID
-		targetID target.ID
+		mu            sync.RWMutex // protects targetID
+		targetID      target.ID
+		localTargetID target.ID // sync free access for logging
 
 		err error
 	)
@@ -306,30 +306,31 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 		func(data interface{}) bool {
 			mu.RLock()
 			defer mu.RUnlock()
-			b.logger.Infof("Browser:newPageInContext", "createWaitForEventHandler page targetID: %v, targetID: %v", data.(*Page).targetID, targetID)
+			b.logger.Infof("Browser:newPageInContext", "tid:%v bcid=%v, createWaitForEventHandler", targetID, id)
 			return data.(*Page).targetID == targetID
 		},
 	)
 	defer evCancelFn() // Remove event handler
 	errCh := make(chan error)
 	func() {
-		b.logger.Infof("Browser:newPageInContext", "CreateTarget(blank) target id: %v", id)
 		action := target.CreateTarget("about:blank").WithBrowserContextID(id)
 		mu.Lock()
 		defer mu.Unlock()
+		localTargetID = targetID
+		b.logger.Infof("Browser:newPageInContext", "tid=%v bcid=%v, CreateTarget(blank)", localTargetID, id)
 		if targetID, err = action.Do(cdp.WithExecutor(b.ctx, b.conn)); err != nil {
 			errCh <- fmt.Errorf("unable to execute %T: %w", action, err)
 		}
 	}()
 	select {
 	case <-b.ctx.Done():
-		b.logger.Infof("Browser:newPageInContext", "ctx done")
+		b.logger.Infof("Browser:newPageInContext:<-b.ctx.Done", "tid=%v bcid=%v", localTargetID, id)
 	case <-time.After(b.launchOpts.Timeout):
-		b.logger.Infof("Browser:newPageInContext", "timed out")
+		b.logger.Infof("Browser:newPageInContext:timeout", "tid=%v bcid=%v", localTargetID, id)
 	case c := <-ch:
-		b.logger.Infof("Browser:newPageInContext", "ch: %v", c)
+		b.logger.Infof("Browser:newPageInContext:<-ch", "tid=%v bcid=%v, ch:%v", localTargetID, id, c)
 	case err := <-errCh:
-		b.logger.Infof("Browser:newPageInContext", "err: %v", err)
+		b.logger.Infof("Browser:newPageInContext:<-errCh", "tid=%v bcid=%v, ch:%v", localTargetID, id, err)
 		return nil, err
 	}
 	b.pagesMu.RLock()

--- a/common/browser.go
+++ b/common/browser.go
@@ -166,7 +166,7 @@ func (b *Browser) initEvents() error {
 				return
 			case event := <-chHandler:
 				if ev, ok := event.data.(*target.EventAttachedToTarget); ok {
-					b.logger.Infof("Browser:initEvents:onAttachedToTarget", "sid=%v, tid=%v", ev.SessionID, ev.TargetInfo.TargetID)
+					b.logger.Infof("Browser:initEvents:onAttachedToTarget", "sid=%v tid=%v", ev.SessionID, ev.TargetInfo.TargetID)
 					go b.onAttachedToTarget(ev)
 				} else if ev, ok := event.data.(*target.EventDetachedFromTarget); ok {
 					b.logger.Infof("Browser:initEvents:onDetachedFromTarget", "sid=%v", ev.SessionID)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -79,7 +79,7 @@ func (b *BrowserContext) AddCookies(cookies goja.Value) {
 
 // AddInitScript adds a script that will be initialized on all new pages.
 func (b *BrowserContext) AddInitScript(script goja.Value, arg goja.Value) {
-	b.logger.Infof("BrowserContext:AddInitScript", "")
+	b.logger.Debugf("BrowserContext:AddInitScript", "")
 
 	rt := k6common.GetRuntime(b.ctx)
 
@@ -165,7 +165,7 @@ func (b *BrowserContext) ExposeFunction(name string, callback goja.Callable) {
 
 // GrantPermissions enables the specified permissions, all others will be disabled.
 func (b *BrowserContext) GrantPermissions(permissions []string, opts goja.Value) {
-	b.logger.Infof("BrowserContext:GrantPermissions", "")
+	b.logger.Debugf("BrowserContext:GrantPermissions", "")
 	rt := k6common.GetRuntime(b.ctx)
 	permsToProtocol := map[string]cdpbrowser.PermissionType{
 		"geolocation":          cdpbrowser.PermissionTypeGeolocation,
@@ -216,7 +216,7 @@ func (b *BrowserContext) NewCDPSession() api.CDPSession {
 
 // NewPage creates a new page inside this browser context.
 func (b *BrowserContext) NewPage() api.Page {
-	b.logger.Infof("BrowserContext:NewPage", "b.id:%v", b.id)
+	b.logger.Debugf("BrowserContext:NewPage", "b.id:%v", b.id)
 	p, err := b.browser.newPageInContext(b.id)
 	if err != nil {
 		rt := k6common.GetRuntime(b.ctx)
@@ -303,7 +303,7 @@ func (b *BrowserContext) Unroute(url goja.Value, handler goja.Callable) {
 }
 
 func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) interface{} {
-	b.logger.Infof("BrowserContext:WaitForEvent", "event:%q", event)
+	b.logger.Debugf("BrowserContext:WaitForEvent", "event:%q", event)
 	// TODO: This public API needs Promise support (as return value) to be useful in JS!
 
 	rt := k6common.GetRuntime(b.ctx)
@@ -340,16 +340,16 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 	ch := make(chan interface{})
 
 	go func() {
-		b.logger.Infof("BrowserContext:WaitForEvent:go()", "starts")
-		defer b.logger.Infof("BrowserContext:WaitForEvent:go()", "returns")
+		b.logger.Debugf("BrowserContext:WaitForEvent:go()", "starts")
+		defer b.logger.Debugf("BrowserContext:WaitForEvent:go()", "returns")
 		for {
 			select {
 			case <-evCancelCtx.Done():
-				b.logger.Infof("BrowserContext:WaitForEvent:go()", "evCancelCtx done")
+				b.logger.Debugf("BrowserContext:WaitForEvent:go()", "evCancelCtx done")
 				return
 			case ev := <-chEvHandler:
 				if ev.typ == EventBrowserContextClose {
-					b.logger.Infof("BrowserContext:WaitForEvent:go()", "EventBrowserContextClose returns")
+					b.logger.Debugf("BrowserContext:WaitForEvent:go()", "EventBrowserContextClose returns")
 					ch <- nil
 					close(ch)
 
@@ -359,11 +359,11 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 					return
 				}
 				if ev.typ == EventBrowserContextPage {
-					b.logger.Infof("BrowserContext:WaitForEvent:go()", "EventBrowserContextPage")
+					b.logger.Debugf("BrowserContext:WaitForEvent:go()", "EventBrowserContextPage")
 					p := ev.data.(*Page)
 					exported := k6common.Bind(rt, p, &b.ctx)
 					if retVal, err := predicateFn(rt.ToValue(exported)); err == nil && retVal.ToBoolean() {
-						b.logger.Infof("BrowserContext:WaitForEvent:go()", "EventBrowserContextPage returns")
+						b.logger.Debugf("BrowserContext:WaitForEvent:go()", "EventBrowserContextPage returns")
 						ch <- p
 						close(ch)
 
@@ -382,13 +382,13 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 
 	select {
 	case <-b.ctx.Done():
-		b.logger.Infof("BrowserContext:WaitForEvent", "b.ctx Done")
+		b.logger.Debugf("BrowserContext:WaitForEvent", "b.ctx Done")
 	case <-time.After(timeout):
-		b.logger.Infof("BrowserContext:WaitForEvent", "timeout")
+		b.logger.Debugf("BrowserContext:WaitForEvent", "timeout")
 	case evData := <-ch:
-		b.logger.Infof("BrowserContext:WaitForEvent", "evData")
+		b.logger.Debugf("BrowserContext:WaitForEvent", "evData")
 		return evData
 	}
-	b.logger.Infof("BrowserContext:WaitForEvent", "nil return")
+	b.logger.Debugf("BrowserContext:WaitForEvent", "nil return")
 	return nil
 }

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -74,7 +74,7 @@ func NewBrowserContext(ctx context.Context, conn *Connection, browser *Browser, 
 
 func (b *BrowserContext) AddCookies(cookies goja.Value) {
 	rt := k6common.GetRuntime(b.ctx)
-	k6common.Throw(rt, errors.New("BrowserContext.addCookies(cookies) has not been implemented yet!"))
+	k6common.Throw(rt, errors.New("BrowserContext.addCookies(cookies) has not been implemented yet"))
 }
 
 // AddInitScript adds a script that will be initialized on all new pages.
@@ -149,18 +149,18 @@ func (b *BrowserContext) Close() {
 
 func (b *BrowserContext) Cookies() []goja.Object {
 	rt := k6common.GetRuntime(b.ctx)
-	k6common.Throw(rt, errors.New("BrowserContext.cookies() has not been implemented yet!"))
+	k6common.Throw(rt, errors.New("BrowserContext.cookies() has not been implemented yet"))
 	return nil
 }
 
 func (b *BrowserContext) ExposeBinding(name string, callback goja.Callable, opts goja.Value) {
 	rt := k6common.GetRuntime(b.ctx)
-	k6common.Throw(rt, errors.New("BrowserContext.exposeBinding(name, callback, opts) has not been implemented yet!"))
+	k6common.Throw(rt, errors.New("BrowserContext.exposeBinding(name, callback, opts) has not been implemented yet"))
 }
 
 func (b *BrowserContext) ExposeFunction(name string, callback goja.Callable) {
 	rt := k6common.GetRuntime(b.ctx)
-	k6common.Throw(rt, errors.New("BrowserContext.newCDPSession(name, callback) has not been implemented yet!"))
+	k6common.Throw(rt, errors.New("BrowserContext.newCDPSession(name, callback) has not been implemented yet"))
 }
 
 // GrantPermissions enables the specified permissions, all others will be disabled.
@@ -210,7 +210,7 @@ func (b *BrowserContext) GrantPermissions(permissions []string, opts goja.Value)
 // NewCDPSession returns a new CDP session attached to this target
 func (b *BrowserContext) NewCDPSession() api.CDPSession {
 	rt := k6common.GetRuntime(b.ctx)
-	k6common.Throw(rt, errors.New("BrowserContext.newCDPSession() has not been implemented yet!"))
+	k6common.Throw(rt, errors.New("BrowserContext.newCDPSession() has not been implemented yet"))
 	return nil
 }
 
@@ -236,7 +236,7 @@ func (b *BrowserContext) Pages() []api.Page {
 
 func (b *BrowserContext) Route(url goja.Value, handler goja.Callable) {
 	rt := k6common.GetRuntime(b.ctx)
-	k6common.Throw(rt, errors.New("BrowserContext.setHTTPCredentials(httpCredentials) has not been implemented yet!"))
+	k6common.Throw(rt, errors.New("BrowserContext.setHTTPCredentials(httpCredentials) has not been implemented yet"))
 }
 
 // SetDefaultNavigationTimeout sets the default navigation timeout in milliseconds.
@@ -251,7 +251,7 @@ func (b *BrowserContext) SetDefaultTimeout(timeout int64) {
 
 func (b *BrowserContext) SetExtraHTTPHeaders(headers map[string]string) {
 	rt := k6common.GetRuntime(b.ctx)
-	k6common.Throw(rt, errors.New("BrowserContext.setHTTPCredentials(httpCredentials) has not been implemented yet!"))
+	k6common.Throw(rt, errors.New("BrowserContext.setHTTPCredentials(httpCredentials) has not been implemented yet"))
 }
 
 // SetGeolocation overrides the geo location of the user.
@@ -294,12 +294,12 @@ func (b *BrowserContext) SetOffline(offline bool) {
 
 func (b *BrowserContext) StorageState(opts goja.Value) {
 	rt := k6common.GetRuntime(b.ctx)
-	k6common.Throw(rt, errors.New("BrowserContext.storageState(opts) has not been implemented yet!"))
+	k6common.Throw(rt, errors.New("BrowserContext.storageState(opts) has not been implemented yet"))
 }
 
 func (b *BrowserContext) Unroute(url goja.Value, handler goja.Callable) {
 	rt := k6common.GetRuntime(b.ctx)
-	k6common.Throw(rt, errors.New("BrowserContext.unroute(url, handler) has not been implemented yet!"))
+	k6common.Throw(rt, errors.New("BrowserContext.unroute(url, handler) has not been implemented yet"))
 }
 
 func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) interface{} {

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -41,6 +41,8 @@ type BrowserProcess struct {
 
 	// The directory where user data for the browser is stored.
 	userDataDir string
+
+	logger *Logger
 }
 
 func NewBrowserProcess(
@@ -77,11 +79,13 @@ func (p *BrowserProcess) didLoseConnection() {
 
 // GracefulClose triggers a graceful closing of the browser process
 func (p *BrowserProcess) GracefulClose() {
+	p.logger.Debugf("Browser:GracefulClose", "")
 	close(p.processIsGracefullyClosing)
 }
 
 // Terminate triggers the termination of the browser process
 func (p *BrowserProcess) Terminate() {
+	p.logger.Debugf("Browser:Close", "browserProc terminate")
 	p.cancel()
 }
 
@@ -93,4 +97,9 @@ func (p *BrowserProcess) WsURL() string {
 // Pid returns the browser process ID
 func (p *BrowserProcess) Pid() int {
 	return p.process.Pid
+}
+
+// WithLogger attaches a logger to the browser process
+func (p *BrowserProcess) AttachLogger(logger *Logger) {
+	p.logger = logger
 }

--- a/common/connection.go
+++ b/common/connection.go
@@ -280,7 +280,7 @@ func (c *Connection) recvLoop() {
 			eva := ev.(*target.EventAttachedToTarget)
 			sid, tid := eva.SessionID, eva.TargetInfo.TargetID
 			c.sessionsMu.Lock()
-			session := NewSession(c.ctx, c, sid, tid)
+			session := NewSession(c.ctx, c, sid, tid, c.logger)
 			c.logger.Debugf("Connection:recvLoop:EventAttachedToTarget", "sid:%v tid:%v wsURL:%q, NewSession", sid, tid, c.wsURL)
 			c.sessions[sid] = session
 			c.sessionsMu.Unlock()

--- a/common/connection.go
+++ b/common/connection.go
@@ -270,7 +270,7 @@ func (c *Connection) recvLoop() {
 				sessionID := ev.(*target.EventAttachedToTarget).SessionID
 				c.sessionsMu.Lock()
 				session := NewSession(c.ctx, c, sessionID)
-				c.logger.Infof("Connection:recvLoop", "sid:%v wsURL:%q, NewSession(%v)", sessionID, c.wsURL)
+				c.logger.Infof("Connection:recvLoop", "sid:%v wsURL:%q, NewSession", sessionID, c.wsURL)
 				c.sessions[sessionID] = session
 				c.sessionsMu.Unlock()
 			} else if msg.Method == cdproto.EventTargetDetachedFromTarget {
@@ -297,10 +297,10 @@ func (c *Connection) recvLoop() {
 				select {
 				case session.readCh <- &msg:
 				case code := <-c.closeCh:
-					c.logger.Errorf("Connection:recvLoop:<-c.closeCh", "sid=%v wsURL=%v scrashed:%t", session.id, c.wsURL, session.crashed)
+					c.logger.Errorf("Connection:recvLoop:<-c.closeCh", "sid=%v wsURL=%v crashed:%t", session.id, c.wsURL, session.crashed)
 					_ = c.closeConnection(code)
 				case <-c.done:
-					c.logger.Errorf("Connection:recvLoop:<-c.done", "sid=%v wsURL=%v scrashed:%t", session.id, c.wsURL, session.crashed)
+					c.logger.Errorf("Connection:recvLoop:<-c.done", "sid=%v wsURL=%v crashed:%t", session.id, c.wsURL, session.crashed)
 					return
 				}
 			}

--- a/common/connection.go
+++ b/common/connection.go
@@ -207,6 +207,7 @@ func (c *Connection) createSession(info *target.Info) (*Session, error) {
 
 func (c *Connection) handleIOError(err error) {
 	c.logger.Errorf("Connection:handleIOError", "err:%v", err)
+
 	if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 		// Report an unexpected closure
 		select {
@@ -269,7 +270,7 @@ func (c *Connection) recvLoop() {
 			sessionID := ev.(*target.EventAttachedToTarget).SessionID
 			c.sessionsMu.Lock()
 			session := NewSession(c.ctx, c, sessionID)
-			c.logger.Infof("Connection:recvLoop", "sid:%v wsURL:%q, NewSession", sessionID, c.wsURL)
+			c.logger.Infof("Connection:recvLoop:EventAttachedToTarget", "sid:%v wsURL:%q, NewSession", sessionID, c.wsURL)
 			c.sessions[sessionID] = session
 			c.sessionsMu.Unlock()
 		} else if msg.Method == cdproto.EventTargetDetachedFromTarget {
@@ -279,7 +280,7 @@ func (c *Connection) recvLoop() {
 				continue
 			}
 			sessionID := ev.(*target.EventDetachedFromTarget).SessionID
-			c.logger.Errorf("Connection:recvLoop", "sid:%v wsURL:%q, closeSession", sessionID, c.wsURL)
+			c.logger.Errorf("Connection:recvLoop:EventDetachedFromTarget", "sid:%v wsURL:%q, closeSession", sessionID, c.wsURL)
 			c.closeSession(sessionID)
 		}
 

--- a/common/connection.go
+++ b/common/connection.go
@@ -260,7 +260,7 @@ func (c *Connection) recvLoop() {
 			return
 		}
 
-		c.logger.Debugf("cdp:recv", "<- %s", buf)
+		c.logger.Tracef("cdp:recv", "<- %s", buf)
 
 		var msg cdproto.Message
 		c.decoder = jlexer.Lexer{Data: buf}
@@ -423,7 +423,7 @@ func (c *Connection) sendLoop() {
 			}
 
 			buf, _ := c.encoder.BuildBytes()
-			c.logger.Debugf("cdp:send", "-> %s", buf)
+			c.logger.Tracef("cdp:send", "-> %s", buf)
 			writer, err := c.conn.NextWriter(websocket.TextMessage)
 			if err != nil {
 				c.handleIOError(err)

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -51,10 +51,12 @@ type FrameManager struct {
 
 	barriersMu sync.RWMutex
 	barriers   []*Barrier
+
+	logger *Logger
 }
 
 // NewFrameManager creates a new HTML document frame manager.
-func NewFrameManager(ctx context.Context, session *Session, page *Page, timeoutSettings *TimeoutSettings) *FrameManager {
+func NewFrameManager(ctx context.Context, session *Session, page *Page, timeoutSettings *TimeoutSettings, logger *Logger) *FrameManager {
 	m := FrameManager{
 		ctx:              ctx,
 		session:          session,
@@ -66,6 +68,7 @@ func NewFrameManager(ctx context.Context, session *Session, page *Page, timeoutS
 		inflightRequests: make(map[network.RequestID]bool),
 		barriers:         make([]*Barrier, 0),
 		barriersMu:       sync.RWMutex{},
+		logger:           logger,
 	}
 	return &m
 }
@@ -306,7 +309,7 @@ func (m *FrameManager) requestFailed(req *Request, canceled bool) {
 
 	frame := req.getFrame()
 	if frame == nil {
-		debugLog("<framemanager:requestFailed> frame is nil")
+		m.logger.Debugf("FrameManager:requestFailed", "frame is nil")
 		return
 	}
 	frame.deleteRequest(req.getID())
@@ -317,7 +320,7 @@ func (m *FrameManager) requestFailed(req *Request, canceled bool) {
 	case rc <= 10:
 		for reqID := range frame.inflightRequests {
 			req := frame.requestByID(reqID)
-			debugLog("<framemanager:requestFailed> reqID=%s inflightURL=%s, frameID=%s", reqID, req.url, frame.id)
+			m.logger.Debugf("FrameManager:requestFailed", "reqID:%s inflightURL:%s frameID:%s", reqID, req.url, frame.id)
 		}
 	}
 

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -78,7 +78,7 @@ type FrameSession struct {
 }
 
 func NewFrameSession(ctx context.Context, session *Session, page *Page, parent *FrameSession, targetID target.ID) (*FrameSession, error) {
-	session.conn.logger.Infof("NewFrameSession", "sid:%v tid:%v", session.id, targetID)
+	session.conn.logger.Debugf("NewFrameSession", "sid:%v tid:%v", session.id, targetID)
 	fs := FrameSession{
 		ctx:                  ctx, // TODO: create cancelable context that can be used to cancel and close all child sessions
 		session:              session,
@@ -98,41 +98,41 @@ func NewFrameSession(ctx context.Context, session *Session, page *Page, parent *
 	if fs.parent != nil {
 		fs.networkManager, err = NewNetworkManager(ctx, session, fs.manager, fs.parent.networkManager)
 		if err != nil {
-			session.conn.logger.Infof("NewFrameSession:NewNetworkManager", "sid:%v tid:%v err:%v", session.id, targetID, err)
+			session.conn.logger.Debugf("NewFrameSession:NewNetworkManager", "sid:%v tid:%v err:%v", session.id, targetID, err)
 			return nil, err
 		}
 	} else {
 		fs.networkManager, err = NewNetworkManager(ctx, session, fs.manager, nil)
 		if err != nil {
-			session.conn.logger.Infof("NewFrameSession:NewNetworkManager#2", "sid:%v tid:%v err:%v", session.id, targetID, err)
+			session.conn.logger.Debugf("NewFrameSession:NewNetworkManager#2", "sid:%v tid:%v err:%v", session.id, targetID, err)
 			return nil, err
 		}
 	}
 
 	action := browser.GetWindowForTarget().WithTargetID(fs.targetID)
 	if fs.windowID, _, err = action.Do(cdp.WithExecutor(fs.ctx, fs.session)); err != nil {
-		session.conn.logger.Infof("NewFrameSession:GetWindowForTarget", "sid:%v tid:%v err:%v", session.id, targetID, err)
+		session.conn.logger.Debugf("NewFrameSession:GetWindowForTarget", "sid:%v tid:%v err:%v", session.id, targetID, err)
 		return nil, fmt.Errorf(`unable to get window ID: %w`, err)
 	}
 
 	fs.initEvents()
 	if err = fs.initFrameTree(); err != nil {
-		session.conn.logger.Infof("NewFrameSession:initFrameTree", "sid:%v tid:%v err:%v", session.id, targetID, err)
+		session.conn.logger.Debugf("NewFrameSession:initFrameTree", "sid:%v tid:%v err:%v", session.id, targetID, err)
 		return nil, err
 	}
 	if err = fs.initIsolatedWorld(utilityWorldName); err != nil {
-		session.conn.logger.Infof("NewFrameSession:initIsolatedWorld", "sid:%v tid:%v err:%v", session.id, targetID, err)
+		session.conn.logger.Debugf("NewFrameSession:initIsolatedWorld", "sid:%v tid:%v err:%v", session.id, targetID, err)
 		return nil, err
 	}
 	if err = fs.initDomains(); err != nil {
-		session.conn.logger.Infof("NewFrameSession:initDomains", "sid:%v tid:%v err:%v", session.id, targetID, err)
+		session.conn.logger.Debugf("NewFrameSession:initDomains", "sid:%v tid:%v err:%v", session.id, targetID, err)
 		return nil, err
 	}
 	if err = fs.initOptions(); err != nil {
-		session.conn.logger.Infof("NewFrameSession:initOptions", "sid:%v tid:%v err:%v", session.id, targetID, err)
+		session.conn.logger.Debugf("NewFrameSession:initOptions", "sid:%v tid:%v err:%v", session.id, targetID, err)
 		return nil, err
 	}
-	session.conn.logger.Infof("NewFrameSession", "sid:%v tid:%v wid:%v err:%v", session.id, targetID, fs.windowID, err)
+	session.conn.logger.Debugf("NewFrameSession", "sid:%v tid:%v wid:%v err:%v", session.id, targetID, fs.windowID, err)
 	return &fs, nil
 }
 
@@ -178,7 +178,7 @@ func (fs *FrameSession) initDomains() error {
 }
 
 func (fs *FrameSession) initEvents() {
-	fs.session.conn.logger.Infof("NewFrameSession:initEvents",
+	fs.session.conn.logger.Debugf("NewFrameSession:initEvents",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	events := []string{
@@ -190,15 +190,15 @@ func (fs *FrameSession) initEvents() {
 	}
 
 	go func() {
-		fs.session.conn.logger.Infof("NewFrameSession:initEvents:go",
+		fs.session.conn.logger.Debugf("NewFrameSession:initEvents:go",
 			"sid:%v tid:%v", fs.session.id, fs.targetID)
-		defer fs.session.conn.logger.Infof("NewFrameSession:initEvents:go",
+		defer fs.session.conn.logger.Debugf("NewFrameSession:initEvents:go",
 			"sid:%v tid:%v, returns", fs.session.id, fs.targetID)
 
 		for {
 			select {
 			case <-fs.ctx.Done():
-				fs.session.conn.logger.Infof(
+				fs.session.conn.logger.Debugf(
 					"NewFrameSession:initEvents:go:ctx.Done",
 					"sid:%v tid:%v",
 					fs.session.id, fs.targetID)
@@ -245,7 +245,7 @@ func (fs *FrameSession) initEvents() {
 }
 
 func (fs *FrameSession) initFrameTree() error {
-	fs.session.conn.logger.Infof("NewFrameSession:initFrameTree",
+	fs.session.conn.logger.Debugf("NewFrameSession:initFrameTree",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	action := cdppage.Enable()
@@ -274,7 +274,7 @@ func (fs *FrameSession) initFrameTree() error {
 }
 
 func (fs *FrameSession) initIsolatedWorld(name string) error {
-	fs.session.conn.logger.Infof("NewFrameSession:initIsolatedWorld",
+	fs.session.conn.logger.Debugf("NewFrameSession:initIsolatedWorld",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	action := cdppage.SetLifecycleEventsEnabled(true)
@@ -283,7 +283,7 @@ func (fs *FrameSession) initIsolatedWorld(name string) error {
 	}
 
 	if _, ok := fs.isolatedWorlds[name]; ok {
-		fs.session.conn.logger.Infof("NewFrameSession:initIsolatedWorld",
+		fs.session.conn.logger.Debugf("NewFrameSession:initIsolatedWorld",
 			"sid:%v tid:%v, not found: %q", fs.session.id, fs.targetID, name)
 		return nil
 	}
@@ -304,7 +304,7 @@ func (fs *FrameSession) initIsolatedWorld(name string) error {
 		}, nil)
 	}
 
-	fs.session.conn.logger.Infof(
+	fs.session.conn.logger.Debugf(
 		"NewFrameSession:initIsolatedWorld:AddScriptToEvaluateOnNewDocument",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
 
@@ -317,7 +317,7 @@ func (fs *FrameSession) initIsolatedWorld(name string) error {
 }
 
 func (fs *FrameSession) initOptions() error {
-	fs.session.conn.logger.Infof("NewFrameSession:initOptions",
+	fs.session.conn.logger.Debugf("NewFrameSession:initOptions",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	opts := fs.manager.page.browserCtx.opts
@@ -326,7 +326,7 @@ func (fs *FrameSession) initOptions() error {
 	if fs.isMainFrame() {
 		optActions = append(optActions, emulation.SetFocusEmulationEnabled(true))
 		if err := fs.updateViewport(); err != nil {
-			fs.session.conn.logger.Infof(
+			fs.session.conn.logger.Debugf(
 				"NewFrameSession:initOptions:updateViewport",
 				"sid:%v tid:%v, err:%v",
 				fs.session.id, fs.targetID, err)
@@ -391,7 +391,7 @@ func (fs *FrameSession) initOptions() error {
 }
 
 func (fs *FrameSession) initRendererEvents() {
-	fs.session.conn.logger.Infof("NewFrameSession:initEvents:initRendererEvents",
+	fs.session.conn.logger.Debugf("NewFrameSession:initEvents:initRendererEvents",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	events := []string{
@@ -422,7 +422,7 @@ func (fs *FrameSession) isMainFrame() bool {
 }
 
 func (fs *FrameSession) handleFrameTree(frameTree *cdppage.FrameTree) {
-	fs.session.conn.logger.Infof("NewFrameSession:handleFrameTree",
+	fs.session.conn.logger.Debugf("NewFrameSession:handleFrameTree",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	if frameTree.Frame.ParentID != "" {
@@ -438,7 +438,7 @@ func (fs *FrameSession) handleFrameTree(frameTree *cdppage.FrameTree) {
 }
 
 func (fs *FrameSession) navigateFrame(frame *Frame, url, referrer string) (string, error) {
-	fs.session.conn.logger.Infof("NewFrameSession:navigateFrame",
+	fs.session.conn.logger.Debugf("NewFrameSession:navigateFrame",
 		"sid:%v tid:%v url:%q referrer:%q",
 		fs.session.id, fs.targetID, url, referrer)
 
@@ -487,7 +487,7 @@ func (fs *FrameSession) onExceptionThrown(event *runtime.EventExceptionThrown) {
 }
 
 func (fs *FrameSession) onExecutionContextCreated(event *runtime.EventExecutionContextCreated) {
-	fs.session.conn.logger.Infof("NewFrameSession:onExecutionContextCreated",
+	fs.session.conn.logger.Debugf("NewFrameSession:onExecutionContextCreated",
 		"sid:%v tid:%v ectxid:%v", fs.session.id, fs.targetID, event.Context.ID)
 
 	auxData := event.Context.AuxData
@@ -524,7 +524,7 @@ func (fs *FrameSession) onExecutionContextCreated(event *runtime.EventExecutionC
 }
 
 func (fs *FrameSession) onExecutionContextDestroyed(execCtxID runtime.ExecutionContextID) {
-	fs.session.conn.logger.Infof("NewFrameSession:onExecutionContextDestroyed",
+	fs.session.conn.logger.Debugf("NewFrameSession:onExecutionContextDestroyed",
 		"sid:%v tid:%v ectxid:%v", fs.session.id, fs.targetID, execCtxID)
 
 	fs.contextIDToContextMu.Lock()
@@ -540,7 +540,7 @@ func (fs *FrameSession) onExecutionContextDestroyed(execCtxID runtime.ExecutionC
 }
 
 func (fs *FrameSession) onExecutionContextsCleared() {
-	fs.session.conn.logger.Infof("NewFrameSession:onExecutionContextsCleared",
+	fs.session.conn.logger.Debugf("NewFrameSession:onExecutionContextsCleared",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	fs.contextIDToContextMu.Lock()
@@ -556,7 +556,7 @@ func (fs *FrameSession) onExecutionContextsCleared() {
 }
 
 func (fs *FrameSession) onFrameAttached(frameID cdp.FrameID, parentFrameID cdp.FrameID) {
-	fs.session.conn.logger.Infof("NewFrameSession:onFrameAttached",
+	fs.session.conn.logger.Debugf("NewFrameSession:onFrameAttached",
 		"sid:%v tid:%v fid:%v pfid:%v",
 		fs.session.id, fs.targetID, frameID, parentFrameID)
 
@@ -565,14 +565,14 @@ func (fs *FrameSession) onFrameAttached(frameID cdp.FrameID, parentFrameID cdp.F
 }
 
 func (fs *FrameSession) onFrameDetached(frameID cdp.FrameID) {
-	fs.session.conn.logger.Infof("NewFrameSession:onFrameDetached",
+	fs.session.conn.logger.Debugf("NewFrameSession:onFrameDetached",
 		"sid:%v tid:%v fid:%v", fs.session.id, fs.targetID, frameID)
 
 	fs.manager.frameDetached(frameID)
 }
 
 func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {
-	fs.session.conn.logger.Infof("NewFrameSession:onFrameNavigated",
+	fs.session.conn.logger.Debugf("NewFrameSession:onFrameNavigated",
 		"sid:%v tid:%v fid:%v", fs.session.id, fs.targetID, frame.ID)
 
 	err := fs.manager.frameNavigated(frame.ID, frame.ParentID, frame.LoaderID.String(), frame.Name, frame.URL+frame.URLFragment, initial)
@@ -582,7 +582,7 @@ func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {
 }
 
 func (fs *FrameSession) onFrameRequestedNavigation(event *cdppage.EventFrameRequestedNavigation) {
-	fs.session.conn.logger.Infof("NewFrameSession:onFrameRequestedNavigation",
+	fs.session.conn.logger.Debugf("NewFrameSession:onFrameRequestedNavigation",
 		"sid:%v tid:%v fid:%v url:%q",
 		fs.session.id, fs.targetID, event.FrameID, event.URL)
 
@@ -595,14 +595,14 @@ func (fs *FrameSession) onFrameRequestedNavigation(event *cdppage.EventFrameRequ
 }
 
 func (fs *FrameSession) onFrameStartedLoading(frameID cdp.FrameID) {
-	fs.session.conn.logger.Infof("NewFrameSession:onFrameStartedLoading",
+	fs.session.conn.logger.Debugf("NewFrameSession:onFrameStartedLoading",
 		"sid:%v tid:%v fid:%v", fs.session.id, fs.targetID, frameID)
 
 	fs.manager.frameLoadingStarted(frameID)
 }
 
 func (fs *FrameSession) onFrameStoppedLoading(frameID cdp.FrameID) {
-	fs.session.conn.logger.Infof("NewFrameSession:onFrameStoppedLoading",
+	fs.session.conn.logger.Debugf("NewFrameSession:onFrameStoppedLoading",
 		"sid:%v tid:%v fid:%v", fs.session.id, fs.targetID, frameID)
 
 	fs.manager.frameLoadingStopped(frameID)
@@ -633,7 +633,7 @@ func (fs *FrameSession) onLogEntryAdded(event *log.EventEntryAdded) {
 }
 
 func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
-	fs.session.conn.logger.Infof("NewFrameSession:onPageLifecycle",
+	fs.session.conn.logger.Debugf("NewFrameSession:onPageLifecycle",
 		"sid:%v tid:%v fid:%v event:%q",
 		fs.session.id, fs.targetID, event.FrameID, event.Name)
 
@@ -714,14 +714,14 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 }
 
 func (fs *FrameSession) onPageNavigatedWithinDocument(event *cdppage.EventNavigatedWithinDocument) {
-	fs.session.conn.logger.Infof("NewFrameSession:onPageNavigatedWithinDocument",
+	fs.session.conn.logger.Debugf("NewFrameSession:onPageNavigatedWithinDocument",
 		"sid:%v tid:%v fid:%v", fs.session.id, fs.targetID, event.FrameID)
 
 	fs.manager.frameNavigatedWithinDocument(event.FrameID, event.URL)
 }
 
 func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) {
-	fs.session.conn.logger.Infof("NewFrameSession:onAttachedToTarget",
+	fs.session.conn.logger.Debugf("NewFrameSession:onAttachedToTarget",
 		"sid:%v tid:%v esid:%v etid:%v ebctxid:%v type:%q",
 		fs.session.id, fs.targetID, event.SessionID,
 		event.TargetInfo.TargetID, event.TargetInfo.BrowserContextID,
@@ -768,19 +768,19 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 }
 
 func (fs *FrameSession) onDetachedFromTarget(event *target.EventDetachedFromTarget) {
-	fs.session.conn.logger.Infof("NewFrameSession:onDetachedFromTarget", "sid:%v tid:%v esid:%v", fs.session.id, fs.targetID, event.SessionID)
+	fs.session.conn.logger.Debugf("NewFrameSession:onDetachedFromTarget", "sid:%v tid:%v esid:%v", fs.session.id, fs.targetID, event.SessionID)
 
 	fs.page.closeWorker(event.SessionID)
 }
 
 func (fs *FrameSession) onTargetCrashed(event *inspector.EventTargetCrashed) {
-	fs.session.conn.logger.Infof("NewFrameSession:onTargetCrashed", "sid:%v tid:%v", fs.session.id, fs.targetID)
+	fs.session.conn.logger.Debugf("NewFrameSession:onTargetCrashed", "sid:%v tid:%v", fs.session.id, fs.targetID)
 	fs.session.markAsCrashed()
 	fs.page.didCrash()
 }
 
 func (fs *FrameSession) updateEmulateMedia(initial bool) error {
-	fs.session.conn.logger.Infof("NewFrameSession:updateEmulateMedia", "sid:%v tid:%v", fs.session.id, fs.targetID)
+	fs.session.conn.logger.Debugf("NewFrameSession:updateEmulateMedia", "sid:%v tid:%v", fs.session.id, fs.targetID)
 	features := make([]*emulation.MediaFeature, 0)
 
 	switch fs.page.colorScheme {
@@ -809,7 +809,7 @@ func (fs *FrameSession) updateEmulateMedia(initial bool) error {
 }
 
 func (fs *FrameSession) updateExtraHTTPHeaders(initial bool) {
-	fs.session.conn.logger.Infof("NewFrameSession:updateExtraHTTPHeaders", "sid:%v tid:%v", fs.session.id, fs.targetID)
+	fs.session.conn.logger.Debugf("NewFrameSession:updateExtraHTTPHeaders", "sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	// Merge extra headers from browser context and page, where page specific headers ake precedence.
 	mergedHeaders := make(network.Headers)
@@ -825,7 +825,7 @@ func (fs *FrameSession) updateExtraHTTPHeaders(initial bool) {
 }
 
 func (fs *FrameSession) updateGeolocation(initial bool) error {
-	fs.session.conn.logger.Infof("NewFrameSession:updateGeolocation", "sid:%v tid:%v", fs.session.id, fs.targetID)
+	fs.session.conn.logger.Debugf("NewFrameSession:updateGeolocation", "sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	geolocation := fs.page.browserCtx.opts.Geolocation
 	if !initial || geolocation != nil {
@@ -841,7 +841,7 @@ func (fs *FrameSession) updateGeolocation(initial bool) error {
 }
 
 func (fs *FrameSession) updateHttpCredentials(initial bool) {
-	fs.session.conn.logger.Infof("NewFrameSession:updateHttpCredentials", "sid:%v tid:%v", fs.session.id, fs.targetID)
+	fs.session.conn.logger.Debugf("NewFrameSession:updateHttpCredentials", "sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	credentials := fs.page.browserCtx.opts.HttpCredentials
 	if !initial || credentials != nil {
@@ -850,7 +850,7 @@ func (fs *FrameSession) updateHttpCredentials(initial bool) {
 }
 
 func (fs *FrameSession) updateOffline(initial bool) {
-	fs.session.conn.logger.Infof("NewFrameSession:updateOffline", "sid:%v tid:%v", fs.session.id, fs.targetID)
+	fs.session.conn.logger.Debugf("NewFrameSession:updateOffline", "sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	offline := fs.page.browserCtx.opts.Offline
 	if !initial || offline {
@@ -859,13 +859,13 @@ func (fs *FrameSession) updateOffline(initial bool) {
 }
 
 func (fs *FrameSession) updateRequestInterception(initial bool) error {
-	fs.session.conn.logger.Infof("NewFrameSession:updateRequestInterception", "sid:%v tid:%v", fs.session.id, fs.targetID)
+	fs.session.conn.logger.Debugf("NewFrameSession:updateRequestInterception", "sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	return fs.networkManager.setRequestInterception(fs.page.hasRoutes())
 }
 
 func (fs *FrameSession) updateViewport() error {
-	fs.session.conn.logger.Infof("NewFrameSession:updateViewport", "sid:%v tid:%v", fs.session.id, fs.targetID)
+	fs.session.conn.logger.Debugf("NewFrameSession:updateViewport", "sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	opts := fs.page.browserCtx.opts
 	emulatedSize := fs.page.emulatedSize

--- a/common/helper_test.go
+++ b/common/helper_test.go
@@ -153,7 +153,7 @@ func TestHelpersConvertArgument(t *testing.T) {
 		execCtx := NewExecutionContext(ctx, nil, nil, runtime.ExecutionContextID(123456789))
 		rt := goja.New()
 		timeoutSetings := NewTimeoutSettings(nil)
-		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings)
+		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings, NewLogger(ctx, NullLogger(), false, nil))
 		frame := NewFrame(ctx, frameManager, nil, cdp.FrameID("frame_id_0123456789"))
 		remoteObjValue := "hellow world"
 		result, _ := json.Marshal(remoteObjValue)
@@ -176,7 +176,7 @@ func TestHelpersConvertArgument(t *testing.T) {
 		execCtx := NewExecutionContext(ctx, nil, nil, runtime.ExecutionContextID(123456789))
 		rt := goja.New()
 		timeoutSetings := NewTimeoutSettings(nil)
-		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings)
+		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings, NewLogger(ctx, NullLogger(), false, nil))
 		frame := NewFrame(ctx, frameManager, nil, cdp.FrameID("frame_id_0123456789"))
 		remoteObjectID := runtime.RemoteObjectID("object_id_0123456789")
 		remoteObject := &runtime.RemoteObject{
@@ -198,7 +198,7 @@ func TestHelpersConvertArgument(t *testing.T) {
 		execCtx := NewExecutionContext(ctx, nil, nil, runtime.ExecutionContextID(123456789))
 		rt := goja.New()
 		timeoutSetings := NewTimeoutSettings(nil)
-		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings)
+		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings, NewLogger(ctx, NullLogger(), false, nil))
 		frame := NewFrame(ctx, frameManager, nil, cdp.FrameID("frame_id_0123456789"))
 		remoteObjectID := runtime.RemoteObjectID("object_id_0123456789")
 		remoteObject := &runtime.RemoteObject{
@@ -220,7 +220,7 @@ func TestHelpersConvertArgument(t *testing.T) {
 		execCtx := NewExecutionContext(ctx, nil, nil, runtime.ExecutionContextID(123456789))
 		rt := goja.New()
 		timeoutSetings := NewTimeoutSettings(nil)
-		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings)
+		frameManager := NewFrameManager(ctx, nil, nil, timeoutSetings, NewLogger(ctx, NullLogger(), false, nil))
 		frame := NewFrame(ctx, frameManager, nil, cdp.FrameID("frame_id_0123456789"))
 		remoteObjectID := runtime.RemoteObjectID("object_id_0123456789")
 		remoteObject := &runtime.RemoteObject{

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -28,7 +28,6 @@ import (
 	"math"
 	"os"
 	"reflect"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -167,17 +166,6 @@ func errorFromDOMError(domErr string) error {
 		}
 	}
 	return fmt.Errorf(domErr)
-}
-
-func goRoutineID() int {
-	var buf [64]byte
-	n := runtime.Stack(buf[:], false)
-	idField := strings.Fields(strings.TrimPrefix(string(buf[:n]), "goroutine "))[0]
-	id, err := strconv.Atoi(idField)
-	if err != nil {
-		panic(fmt.Sprintf("cannot get goroutine id: %v", err))
-	}
-	return id
 }
 
 func interfaceFromRemoteObject(remoteObject *cdpruntime.RemoteObject) (interface{}, error) {

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -31,32 +31,12 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
-	"github.com/fatih/color"
 	k6common "go.k6.io/k6/js/common"
 )
-
-var debugMu = sync.Mutex{}
-var debugLastCall int64 = 0
-
-func debugLog(msg string, args ...interface{}) {
-	debugMu.Lock()
-	defer debugMu.Unlock()
-	now := time.Now().UnixNano() / 1000000
-	elapsed := now - debugLastCall
-	if now == elapsed {
-		elapsed = 0
-	}
-	magenta := color.New(color.FgMagenta).SprintFunc()
-	args = []interface{}{fmt.Sprintf("[%d] %s", goRoutineID(), fmt.Sprintf(msg, args...))}
-	args = append(args, fmt.Sprintf("%s ms", magenta(elapsed)))
-	fmt.Println(args...)
-	debugLastCall = now
-}
 
 func convertBaseJSHandleTypes(ctx context.Context, execCtx *ExecutionContext, objHandle *BaseJSHandle) (*cdpruntime.CallArgument, error) {
 	if objHandle.execCtx != execCtx {

--- a/common/logger.go
+++ b/common/logger.go
@@ -39,6 +39,9 @@ type Logger struct {
 	lastLogCall    int64
 	debugOverride  bool
 	categoryFilter *regexp.Regexp
+
+	// debug is true if debug mode is enabled in the browser launch options.
+	debug bool
 }
 
 func NullLogger() *logrus.Logger {
@@ -106,4 +109,12 @@ func (l *Logger) Logf(level logrus.Level, category string, msg string, args ...i
 		return
 	}
 	entry.Logf(level, msg, args...)
+}
+
+func (l *Logger) EnableDebugMode() {
+	l.debug = true
+}
+
+func (l *Logger) DebugMode() bool {
+	return l.debug
 }

--- a/common/logger.go
+++ b/common/logger.go
@@ -57,6 +57,10 @@ func NewLogger(ctx context.Context, logger *logrus.Logger, debugOverride bool, c
 	}
 }
 
+func (l *Logger) Tracef(category string, msg string, args ...interface{}) {
+	l.Logf(logrus.TraceLevel, category, msg, args...)
+}
+
 func (l *Logger) Debugf(category string, msg string, args ...interface{}) {
 	l.Logf(logrus.DebugLevel, category, msg, args...)
 }

--- a/common/logger.go
+++ b/common/logger.go
@@ -26,6 +26,9 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -138,4 +141,15 @@ func (l *Logger) SetLevelEnv(level string) error {
 // DebugMode returns true if the logger level is set to Debug or higher.
 func (l *Logger) DebugMode() bool {
 	return l.log.GetLevel() >= logrus.DebugLevel
+}
+
+func goRoutineID() int {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	idField := strings.Fields(strings.TrimPrefix(string(buf[:n]), "goroutine "))[0]
+	id, err := strconv.Atoi(idField)
+	if err != nil {
+		panic(fmt.Sprintf("cannot get goroutine id: %v", err))
+	}
+	return id
 }

--- a/common/page.go
+++ b/common/page.go
@@ -127,7 +127,7 @@ func (p *Page) initEvents() error {
 }
 
 func (p *Page) closeWorker(sessionID target.SessionID) {
-	p.browserCtx.logger.Infof("Page:closeWorker", "sid=%v", sessionID)
+	p.browserCtx.logger.Debugf("Page:closeWorker", "sid:%v", sessionID)
 	if worker, ok := p.workers[sessionID]; ok {
 		worker.didClose()
 		delete(p.workers, sessionID)
@@ -139,13 +139,13 @@ func (p *Page) defaultTimeout() time.Duration {
 }
 
 func (p *Page) didClose() {
-	p.browserCtx.logger.Infof("Page:didClose", "sid=%v", p.session.id)
+	p.browserCtx.logger.Debugf("Page:didClose", "sid:%v", p.session.id)
 	p.closed = true
 	p.emit(EventPageClose, p)
 }
 
 func (p *Page) didCrash() {
-	p.browserCtx.logger.Infof("Page:didCrash", "sid=%v", p.session.id)
+	p.browserCtx.logger.Debugf("Page:didCrash", "sid:%v", p.session.id)
 	p.frameManager.dispose()
 	p.emit(EventPageCrash, p)
 }
@@ -155,7 +155,7 @@ func (p *Page) evaluateOnNewDocument(source string) {
 }
 
 func (p *Page) getFrameElement(f *Frame) (*ElementHandle, error) {
-	p.browserCtx.logger.Infof("Page:getFrameElement", "sid=%v", p.session.id)
+	p.browserCtx.logger.Debugf("Page:getFrameElement", "sid:%v", p.session.id)
 	parent := f.parentFrame
 	if parent == nil {
 		return nil, errors.New("frame has been detached 1")
@@ -180,7 +180,7 @@ func (p *Page) getFrameElement(f *Frame) (*ElementHandle, error) {
 }
 
 func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) cdp.FrameID {
-	p.browserCtx.logger.Infof("Page:getOwnerFrame", "sid=%v", p.session.id)
+	p.browserCtx.logger.Debugf("Page:getOwnerFrame", "sid:%v", p.session.id)
 	// document.documentElement has frameId of the owner frame
 	rt := k6common.GetRuntime(p.ctx)
 	pageFn := rt.ToValue(`
@@ -217,7 +217,7 @@ func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) cdp.Frame
 }
 
 func (p *Page) getFrameSession(frameID cdp.FrameID) *FrameSession {
-	p.browserCtx.logger.Infof("Page:getFrameSession", "sid=%v fid=%v", p.session.id, frameID)
+	p.browserCtx.logger.Debugf("Page:getFrameSession", "sid:%v fid=%v", p.session.id, frameID)
 	return p.frameSessions[frameID]
 }
 
@@ -299,7 +299,7 @@ func (p *Page) AddStyleTag(opts goja.Value) {
 
 // BrintToFront activates the browser tab for this page
 func (p *Page) BrintToFront() {
-	p.browserCtx.logger.Infof("Page:BrintToFront", "sid=%v", p.session.id)
+	p.browserCtx.logger.Debugf("Page:BrintToFront", "sid:%v", p.session.id)
 	rt := k6common.GetRuntime(p.ctx)
 	action := cdppage.BringToFront()
 	if err := action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
@@ -338,7 +338,7 @@ func (p *Page) Dblclick(selector string, opts goja.Value) {
 }
 
 func (p *Page) DispatchEvent(selector string, typ string, eventInit goja.Value, opts goja.Value) {
-	p.browserCtx.logger.Infof("Page:DispatchEvent", "sid=%v selector=%q", p.session.id, selector)
+	p.browserCtx.logger.Debugf("Page:DispatchEvent", "sid:%v selector:%q", p.session.id, selector)
 	p.MainFrame().DispatchEvent(selector, typ, eventInit, opts)
 }
 
@@ -447,7 +447,7 @@ func (p *Page) GoForward(opts goja.Value) api.Response {
 
 // Goto will navigate the page to the specified URL and return a HTTP response object
 func (p *Page) Goto(url string, opts goja.Value) api.Response {
-	p.browserCtx.logger.Infof("Page:Goto", "sid=%v url=%q", p.session.id, url)
+	p.browserCtx.logger.Debugf("Page:Goto", "sid:%v url:%q", p.session.id, url)
 	return p.MainFrame().Goto(url, opts)
 }
 
@@ -521,18 +521,18 @@ func (p *Page) Press(selector string, key string, opts goja.Value) {
 }
 
 func (p *Page) Query(selector string) api.ElementHandle {
-	p.browserCtx.logger.Infof("Page:Query", "sid=%v selector=%q", p.session.id, selector)
+	p.browserCtx.logger.Debugf("Page:Query", "sid:%v selector:%q", p.session.id, selector)
 	return p.frameManager.MainFrame().Query(selector)
 }
 
 func (p *Page) QueryAll(selector string) []api.ElementHandle {
-	p.browserCtx.logger.Infof("Page:QueryAll", "sid=%v selector=%q", p.session.id, selector)
+	p.browserCtx.logger.Debugf("Page:QueryAll", "sid:%v selector:%q", p.session.id, selector)
 	return p.frameManager.MainFrame().QueryAll(selector)
 }
 
 // Reload will reload the current page
 func (p *Page) Reload(opts goja.Value) api.Response {
-	p.browserCtx.logger.Infof("Page:Reload", "sid=%v", p.session.id)
+	p.browserCtx.logger.Debugf("Page:Reload", "sid:%v", p.session.id)
 	rt := k6common.GetRuntime(p.ctx)
 	parsedOpts := NewPageReloadOptions(LifecycleEventLoad, p.defaultTimeout())
 	if err := parsedOpts.Parse(p.ctx, opts); err != nil {
@@ -605,13 +605,13 @@ func (p *Page) SetContent(html string, opts goja.Value) {
 
 // SetDefaultNavigationTimeout sets the default navigation timeout in milliseconds
 func (p *Page) SetDefaultNavigationTimeout(timeout int64) {
-	p.browserCtx.logger.Infof("Page:SetDefaultNavigationTimeout", "sid=%v timeout=%d", p.session.id, timeout)
+	p.browserCtx.logger.Debugf("Page:SetDefaultNavigationTimeout", "sid:%v timeout=%d", p.session.id, timeout)
 	p.timeoutSettings.setDefaultNavigationTimeout(timeout)
 }
 
 // SetDefaultTimeout sets the default maximum timeout in milliseconds
 func (p *Page) SetDefaultTimeout(timeout int64) {
-	p.browserCtx.logger.Infof("Page:SetDefaultTimeout", "sid=%v timeout=%d", p.session.id, timeout)
+	p.browserCtx.logger.Debugf("Page:SetDefaultTimeout", "sid:%v timeout=%d", p.session.id, timeout)
 	p.timeoutSettings.setDefaultTimeout(timeout)
 }
 
@@ -629,7 +629,7 @@ func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value)
 
 // SetViewportSize will update the viewport width and height
 func (p *Page) SetViewportSize(viewportSize goja.Value) {
-	p.browserCtx.logger.Infof("Page:SetViewportSize", "sid=%v", p.session.id)
+	p.browserCtx.logger.Debugf("Page:SetViewportSize", "sid:%v", p.session.id)
 	rt := k6common.GetRuntime(p.ctx)
 	s := &Size{}
 	if err := s.Parse(p.ctx, viewportSize); err != nil {
@@ -699,19 +699,19 @@ func (p *Page) WaitForEvent(event string, optsOrPredicate goja.Value) interface{
 
 // WaitForFunction waits for the given predicate to return a truthy value
 func (p *Page) WaitForFunction(pageFunc goja.Value, arg goja.Value, opts goja.Value) api.JSHandle {
-	p.browserCtx.logger.Infof("Page:WaitForFunction", "sid=%v", p.session.id)
+	p.browserCtx.logger.Debugf("Page:WaitForFunction", "sid:%v", p.session.id)
 	return p.frameManager.MainFrame().WaitForFunction(pageFunc, opts, arg)
 }
 
 // WaitForLoadState waits for the specified page life cycle event
 func (p *Page) WaitForLoadState(state string, opts goja.Value) {
-	p.browserCtx.logger.Infof("Page:WaitForLoadState", "sid=%v state=%q", p.session.id, state)
+	p.browserCtx.logger.Debugf("Page:WaitForLoadState", "sid:%v state=%q", p.session.id, state)
 	p.frameManager.MainFrame().WaitForLoadState(state, opts)
 }
 
 // WaitForNavigation waits for the given navigation lifecycle event to happen
 func (p *Page) WaitForNavigation(opts goja.Value) api.Response {
-	p.browserCtx.logger.Infof("Page:WaitForNavigation", "sid=%v", p.session.id)
+	p.browserCtx.logger.Debugf("Page:WaitForNavigation", "sid:%v", p.session.id)
 	return p.frameManager.MainFrame().WaitForNavigation(opts)
 }
 
@@ -729,13 +729,13 @@ func (p *Page) WaitForResponse(urlOrPredicate, opts goja.Value) api.Response {
 
 // WaitForSelector waits for the given selector to match the waiting criteria
 func (p *Page) WaitForSelector(selector string, opts goja.Value) api.ElementHandle {
-	p.browserCtx.logger.Infof("Page:WaitForSelector", "sid=%v selector=%q", p.session.id, selector)
+	p.browserCtx.logger.Debugf("Page:WaitForSelector", "sid:%v stid:%v ptid:%v selector:%q", p.session.id, p.session.targetID, p.targetID, selector)
 	return p.frameManager.MainFrame().WaitForSelector(selector, opts)
 }
 
 // WaitForTimeout waits the specified number of milliseconds
 func (p *Page) WaitForTimeout(timeout int64) {
-	p.browserCtx.logger.Infof("Page:WaitForTimeout", "sid=%v timeout=%d", p.session.id, timeout)
+	p.browserCtx.logger.Debugf("Page:WaitForTimeout", "sid:%v timeout=%d", p.session.id, timeout)
 	p.frameManager.MainFrame().WaitForTimeout(timeout)
 }
 

--- a/common/page.go
+++ b/common/page.go
@@ -308,9 +308,9 @@ func (p *Page) AddStyleTag(opts goja.Value) {
 	k6common.Throw(rt, errors.New("Page.addStyleTag(opts) has not been implemented yet!"))
 }
 
-// BrintToFront activates the browser tab for this page
-func (p *Page) BrintToFront() {
-	p.logger.Debugf("Page:BrintToFront", "sid:%v", p.session.id)
+// BringToFront activates the browser tab for this page
+func (p *Page) BringToFront() {
+	p.logger.Debugf("Page:BringToFront", "sid:%v", p.session.id)
 	rt := k6common.GetRuntime(p.ctx)
 	action := cdppage.BringToFront()
 	if err := action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {

--- a/common/page.go
+++ b/common/page.go
@@ -127,6 +127,7 @@ func (p *Page) initEvents() error {
 }
 
 func (p *Page) closeWorker(sessionID target.SessionID) {
+	p.browserCtx.logger.Infof("Page:closeWorker", "sid=%v", sessionID)
 	if worker, ok := p.workers[sessionID]; ok {
 		worker.didClose()
 		delete(p.workers, sessionID)
@@ -138,11 +139,13 @@ func (p *Page) defaultTimeout() time.Duration {
 }
 
 func (p *Page) didClose() {
+	p.browserCtx.logger.Infof("Page:didClose", "sid=%v", p.session.id)
 	p.closed = true
 	p.emit(EventPageClose, p)
 }
 
 func (p *Page) didCrash() {
+	p.browserCtx.logger.Infof("Page:didCrash", "sid=%v", p.session.id)
 	p.frameManager.dispose()
 	p.emit(EventPageCrash, p)
 }
@@ -152,6 +155,7 @@ func (p *Page) evaluateOnNewDocument(source string) {
 }
 
 func (p *Page) getFrameElement(f *Frame) (*ElementHandle, error) {
+	p.browserCtx.logger.Infof("Page:getFrameElement", "sid=%v", p.session.id)
 	parent := f.parentFrame
 	if parent == nil {
 		return nil, errors.New("frame has been detached 1")
@@ -176,6 +180,7 @@ func (p *Page) getFrameElement(f *Frame) (*ElementHandle, error) {
 }
 
 func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) cdp.FrameID {
+	p.browserCtx.logger.Infof("Page:getOwnerFrame", "sid=%v", p.session.id)
 	// document.documentElement has frameId of the owner frame
 	rt := k6common.GetRuntime(p.ctx)
 	pageFn := rt.ToValue(`
@@ -212,6 +217,7 @@ func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) cdp.Frame
 }
 
 func (p *Page) getFrameSession(frameID cdp.FrameID) *FrameSession {
+	p.browserCtx.logger.Infof("Page:getFrameSession", "sid=%v fid=%v", p.session.id, frameID)
 	return p.frameSessions[frameID]
 }
 
@@ -293,6 +299,7 @@ func (p *Page) AddStyleTag(opts goja.Value) {
 
 // BrintToFront activates the browser tab for this page
 func (p *Page) BrintToFront() {
+	p.browserCtx.logger.Infof("Page:BrintToFront", "sid=%v", p.session.id)
 	rt := k6common.GetRuntime(p.ctx)
 	action := cdppage.BringToFront()
 	if err := action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
@@ -331,6 +338,7 @@ func (p *Page) Dblclick(selector string, opts goja.Value) {
 }
 
 func (p *Page) DispatchEvent(selector string, typ string, eventInit goja.Value, opts goja.Value) {
+	p.browserCtx.logger.Infof("Page:DispatchEvent", "sid=%v selector=%q", p.session.id, selector)
 	p.MainFrame().DispatchEvent(selector, typ, eventInit, opts)
 }
 
@@ -439,6 +447,7 @@ func (p *Page) GoForward(opts goja.Value) api.Response {
 
 // Goto will navigate the page to the specified URL and return a HTTP response object
 func (p *Page) Goto(url string, opts goja.Value) api.Response {
+	p.browserCtx.logger.Infof("Page:Goto", "sid=%v url=%q", p.session.id, url)
 	return p.MainFrame().Goto(url, opts)
 }
 
@@ -512,15 +521,18 @@ func (p *Page) Press(selector string, key string, opts goja.Value) {
 }
 
 func (p *Page) Query(selector string) api.ElementHandle {
+	p.browserCtx.logger.Infof("Page:Query", "sid=%v selector=%q", p.session.id, selector)
 	return p.frameManager.MainFrame().Query(selector)
 }
 
 func (p *Page) QueryAll(selector string) []api.ElementHandle {
+	p.browserCtx.logger.Infof("Page:QueryAll", "sid=%v selector=%q", p.session.id, selector)
 	return p.frameManager.MainFrame().QueryAll(selector)
 }
 
 // Reload will reload the current page
 func (p *Page) Reload(opts goja.Value) api.Response {
+	p.browserCtx.logger.Infof("Page:Reload", "sid=%v", p.session.id)
 	rt := k6common.GetRuntime(p.ctx)
 	parsedOpts := NewPageReloadOptions(LifecycleEventLoad, p.defaultTimeout())
 	if err := parsedOpts.Parse(p.ctx, opts); err != nil {
@@ -593,11 +605,13 @@ func (p *Page) SetContent(html string, opts goja.Value) {
 
 // SetDefaultNavigationTimeout sets the default navigation timeout in milliseconds
 func (p *Page) SetDefaultNavigationTimeout(timeout int64) {
+	p.browserCtx.logger.Infof("Page:SetDefaultNavigationTimeout", "sid=%v timeout=%d", p.session.id, timeout)
 	p.timeoutSettings.setDefaultNavigationTimeout(timeout)
 }
 
 // SetDefaultTimeout sets the default maximum timeout in milliseconds
 func (p *Page) SetDefaultTimeout(timeout int64) {
+	p.browserCtx.logger.Infof("Page:SetDefaultTimeout", "sid=%v timeout=%d", p.session.id, timeout)
 	p.timeoutSettings.setDefaultTimeout(timeout)
 }
 
@@ -615,6 +629,7 @@ func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value)
 
 // SetViewportSize will update the viewport width and height
 func (p *Page) SetViewportSize(viewportSize goja.Value) {
+	p.browserCtx.logger.Infof("Page:SetViewportSize", "sid=%v", p.session.id)
 	rt := k6common.GetRuntime(p.ctx)
 	s := &Size{}
 	if err := s.Parse(p.ctx, viewportSize); err != nil {
@@ -684,16 +699,19 @@ func (p *Page) WaitForEvent(event string, optsOrPredicate goja.Value) interface{
 
 // WaitForFunction waits for the given predicate to return a truthy value
 func (p *Page) WaitForFunction(pageFunc goja.Value, arg goja.Value, opts goja.Value) api.JSHandle {
+	p.browserCtx.logger.Infof("Page:WaitForFunction", "sid=%v", p.session.id)
 	return p.frameManager.MainFrame().WaitForFunction(pageFunc, opts, arg)
 }
 
 // WaitForLoadState waits for the specified page life cycle event
 func (p *Page) WaitForLoadState(state string, opts goja.Value) {
+	p.browserCtx.logger.Infof("Page:WaitForLoadState", "sid=%v state=%q", p.session.id, state)
 	p.frameManager.MainFrame().WaitForLoadState(state, opts)
 }
 
 // WaitForNavigation waits for the given navigation lifecycle event to happen
 func (p *Page) WaitForNavigation(opts goja.Value) api.Response {
+	p.browserCtx.logger.Infof("Page:WaitForNavigation", "sid=%v", p.session.id)
 	return p.frameManager.MainFrame().WaitForNavigation(opts)
 }
 
@@ -711,11 +729,13 @@ func (p *Page) WaitForResponse(urlOrPredicate, opts goja.Value) api.Response {
 
 // WaitForSelector waits for the given selector to match the waiting criteria
 func (p *Page) WaitForSelector(selector string, opts goja.Value) api.ElementHandle {
+	p.browserCtx.logger.Infof("Page:WaitForSelector", "sid=%v selector=%q", p.session.id, selector)
 	return p.frameManager.MainFrame().WaitForSelector(selector, opts)
 }
 
 // WaitForTimeout waits the specified number of milliseconds
 func (p *Page) WaitForTimeout(timeout int64) {
+	p.browserCtx.logger.Infof("Page:WaitForTimeout", "sid=%v timeout=%d", p.session.id, timeout)
 	p.frameManager.MainFrame().WaitForTimeout(timeout)
 }
 

--- a/common/response.go
+++ b/common/response.go
@@ -217,7 +217,7 @@ func (r *Response) bodySize() int64 {
 func (r *Response) Finished() bool {
 	// TODO: should return nil|Error
 	rt := k6common.GetRuntime(r.ctx)
-	k6common.Throw(rt, errors.New("Response.finished() has not been implemented yet!"))
+	k6common.Throw(rt, errors.New("Response.finished() has not been implemented yet"))
 	return false
 }
 

--- a/common/session.go
+++ b/common/session.go
@@ -96,7 +96,6 @@ func (s *Session) readLoop() {
 			if err != nil {
 				s.conn.logger.Infof("Session:readLoop:<-s.readCh", "sid=%v cannot unmarshal: %v", s.id, err)
 				if _, ok := err.(cdp.ErrUnknownCommandOrEvent); ok {
-					s.conn.logger.Infof("Session:readLoop:<-s.readCh", "sid=%v unknown command", s.id)
 					// This is most likely an event received from an older
 					// Chrome which a newer cdproto doesn't have, as it is
 					// deprecated. Ignore that error, and emit raw cdproto.Message.
@@ -220,6 +219,5 @@ func (s *Session) ExecuteWithoutExpectationOnReply(ctx context.Context, method s
 		Method:    cdproto.MethodType(method),
 		Params:    buf,
 	}
-	s.conn.logger.Infof("Session:ExecuteWithoutExpectationOnReply:s.conn.send", "sid=%v method=%q err=%v", s.id, method)
 	return s.conn.send(msg, nil, res)
 }

--- a/common/session.go
+++ b/common/session.go
@@ -112,7 +112,7 @@ func (s *Session) readLoop() {
 			}
 			s.emit(string(msg.Method), ev)
 		case <-s.done:
-			s.conn.logger.Errorf("Session:readLoop:<-s.done", "sid:%v tid:%v", s.id, s.targetID)
+			s.logger.Debugf("Session:readLoop:<-s.done", "sid:%v tid:%v", s.id, s.targetID)
 			return
 		}
 	}
@@ -140,14 +140,14 @@ func (s *Session) Execute(ctx context.Context, method string, params easyjson.Ma
 		for {
 			select {
 			case <-evCancelCtx.Done():
-				s.conn.logger.Errorf("Session:Execute:<-evCancelCtx.Done()", "sid:%v tid:%v method:%q, returns", s.id, s.targetID, method)
+				s.logger.Debugf("Session:Execute:<-evCancelCtx.Done()", "sid:%v tid:%v method:%q, returns", s.id, s.targetID, method)
 				return
 			case ev := <-chEvHandler:
 				// s.logger.Debugf("Session:Execute:<-chEvHandler", "sid:%v method:%q", s.id, method)
 				if msg, ok := ev.data.(*cdproto.Message); ok && msg.ID == id {
 					select {
 					case <-evCancelCtx.Done():
-						s.conn.logger.Errorf("Session:Execute:<-evCancelCtx.Done():2", "sid:%v tid:%v method:%q, returns", s.id, s.targetID, method)
+						s.logger.Debugf("Session:Execute:<-evCancelCtx.Done():2", "sid:%v tid:%v method:%q, returns", s.id, s.targetID, method)
 					case ch <- msg:
 						// s.logger.Debugf("Session:Execute:<-chEvHandler:ch <- msg", "sid:%v method:%q", s.id, method)
 						// We expect only one response with the matching message ID,

--- a/common/session.go
+++ b/common/session.go
@@ -143,13 +143,11 @@ func (s *Session) Execute(ctx context.Context, method string, params easyjson.Ma
 				s.logger.Debugf("Session:Execute:<-evCancelCtx.Done()", "sid:%v tid:%v method:%q, returns", s.id, s.targetID, method)
 				return
 			case ev := <-chEvHandler:
-				// s.logger.Debugf("Session:Execute:<-chEvHandler", "sid:%v method:%q", s.id, method)
 				if msg, ok := ev.data.(*cdproto.Message); ok && msg.ID == id {
 					select {
 					case <-evCancelCtx.Done():
 						s.logger.Debugf("Session:Execute:<-evCancelCtx.Done():2", "sid:%v tid:%v method:%q, returns", s.id, s.targetID, method)
 					case ch <- msg:
-						// s.logger.Debugf("Session:Execute:<-chEvHandler:ch <- msg", "sid:%v method:%q", s.id, method)
 						// We expect only one response with the matching message ID,
 						// then remove event handler by cancelling context and stopping goroutine.
 						evCancelFn()

--- a/common/session.go
+++ b/common/session.go
@@ -49,10 +49,12 @@ type Session struct {
 	done     chan struct{}
 	closed   bool
 	crashed  bool
+
+	logger *Logger
 }
 
 // NewSession creates a new session
-func NewSession(ctx context.Context, conn *Connection, id target.SessionID, tid target.ID) *Session {
+func NewSession(ctx context.Context, conn *Connection, id target.SessionID, tid target.ID, logger *Logger) *Session {
 	s := Session{
 		BaseEventEmitter: NewBaseEventEmitter(ctx),
 		ctx:              ctx,
@@ -61,16 +63,18 @@ func NewSession(ctx context.Context, conn *Connection, id target.SessionID, tid 
 		targetID:         tid,
 		readCh:           make(chan *cdproto.Message),
 		done:             make(chan struct{}),
+
+		logger: logger,
 	}
-	s.conn.logger.Debugf("Session:NewSession", "sid:%v tid:%v", id, tid)
+	s.logger.Debugf("Session:NewSession", "sid:%v tid:%v", id, tid)
 	go s.readLoop()
 	return &s
 }
 
 func (s *Session) close() {
-	s.conn.logger.Debugf("Session:close", "sid:%v tid:%v", s.id, s.targetID)
+	s.logger.Debugf("Session:close", "sid:%v tid:%v", s.id, s.targetID)
 	if s.closed {
-		s.conn.logger.Debugf("Session:close", "already closed, sid:%v tid:%v", s.id, s.targetID)
+		s.logger.Debugf("Session:close", "already closed, sid:%v tid:%v", s.id, s.targetID)
 		return
 	}
 
@@ -82,7 +86,7 @@ func (s *Session) close() {
 }
 
 func (s *Session) markAsCrashed() {
-	s.conn.logger.Debugf("Session:markAsCrashed", "sid:%v tid:%v", s.id, s.targetID)
+	s.logger.Debugf("Session:markAsCrashed", "sid:%v tid:%v", s.id, s.targetID)
 	s.crashed = true
 }
 
@@ -95,7 +99,7 @@ func (s *Session) readLoop() {
 		case msg := <-s.readCh:
 			ev, err := cdproto.UnmarshalMessage(msg)
 			if err != nil {
-				s.conn.logger.Debugf("Session:readLoop:<-s.readCh", "sid:%v tid:%v cannot unmarshal: %v", s.id, s.targetID, err)
+				s.logger.Debugf("Session:readLoop:<-s.readCh", "sid:%v tid:%v cannot unmarshal: %v", s.id, s.targetID, err)
 				if _, ok := err.(cdp.ErrUnknownCommandOrEvent); ok {
 					// This is most likely an event received from an older
 					// Chrome which a newer cdproto doesn't have, as it is
@@ -116,13 +120,13 @@ func (s *Session) readLoop() {
 
 // Execute implements the cdp.Executor interface
 func (s *Session) Execute(ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler) error {
-	s.conn.logger.Debugf("Session:Execute", "sid:%v tid:%v method:%q", s.id, s.targetID, method)
+	s.logger.Debugf("Session:Execute", "sid:%v tid:%v method:%q", s.id, s.targetID, method)
 	// Certain methods aren't available to the user directly.
 	if method == target.CommandCloseTarget {
 		return errors.New("to close the target, cancel its context")
 	}
 	if s.crashed {
-		s.conn.logger.Debugf("Session:Execute", "sid:%v tid:%v method:%q, returns: crashed", s.id, s.targetID, method)
+		s.logger.Debugf("Session:Execute", "sid:%v tid:%v method:%q, returns: crashed", s.id, s.targetID, method)
 		return ErrTargetCrashed
 	}
 
@@ -139,13 +143,13 @@ func (s *Session) Execute(ctx context.Context, method string, params easyjson.Ma
 				s.conn.logger.Errorf("Session:Execute:<-evCancelCtx.Done()", "sid:%v tid:%v method:%q, returns", s.id, s.targetID, method)
 				return
 			case ev := <-chEvHandler:
-				// s.conn.logger.Debugf("Session:Execute:<-chEvHandler", "sid:%v method:%q", s.id, method)
+				// s.logger.Debugf("Session:Execute:<-chEvHandler", "sid:%v method:%q", s.id, method)
 				if msg, ok := ev.data.(*cdproto.Message); ok && msg.ID == id {
 					select {
 					case <-evCancelCtx.Done():
 						s.conn.logger.Errorf("Session:Execute:<-evCancelCtx.Done():2", "sid:%v tid:%v method:%q, returns", s.id, s.targetID, method)
 					case ch <- msg:
-						// s.conn.logger.Debugf("Session:Execute:<-chEvHandler:ch <- msg", "sid:%v method:%q", s.id, method)
+						// s.logger.Debugf("Session:Execute:<-chEvHandler:ch <- msg", "sid:%v method:%q", s.id, method)
 						// We expect only one response with the matching message ID,
 						// then remove event handler by cancelling context and stopping goroutine.
 						evCancelFn()
@@ -173,18 +177,18 @@ func (s *Session) Execute(ctx context.Context, method string, params easyjson.Ma
 		Method:    cdproto.MethodType(method),
 		Params:    buf,
 	}
-	s.conn.logger.Debugf("Session:Execute:s.conn.send", "sid:%v tid:%v method:%q", s.id, s.targetID, method)
+	s.logger.Debugf("Session:Execute:s.conn.send", "sid:%v tid:%v method:%q", s.id, s.targetID, method)
 	return s.conn.send(msg, ch, res)
 }
 
 func (s *Session) ExecuteWithoutExpectationOnReply(ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler) error {
-	s.conn.logger.Debugf("Session:ExecuteWithoutExpectationOnReply", "sid:%v tid:%v method:%q", s.id, s.targetID, method)
+	s.logger.Debugf("Session:ExecuteWithoutExpectationOnReply", "sid:%v tid:%v method:%q", s.id, s.targetID, method)
 	// Certain methods aren't available to the user directly.
 	if method == target.CommandCloseTarget {
 		return errors.New("to close the target, cancel its context")
 	}
 	if s.crashed {
-		s.conn.logger.Debugf("Session:ExecuteWithoutExpectationOnReply", "sid:%v tid:%v method:%q, ErrTargetCrashed", s.id, s.targetID, method)
+		s.logger.Debugf("Session:ExecuteWithoutExpectationOnReply", "sid:%v tid:%v method:%q, ErrTargetCrashed", s.id, s.targetID, method)
 		return ErrTargetCrashed
 	}
 
@@ -196,7 +200,7 @@ func (s *Session) ExecuteWithoutExpectationOnReply(ctx context.Context, method s
 		var err error
 		buf, err = easyjson.Marshal(params)
 		if err != nil {
-			s.conn.logger.Debugf("Session:ExecuteWithoutExpectationOnReply:Marshal", "sid:%v tid:%v method:%q err=%v", s.id, s.targetID, method, err)
+			s.logger.Debugf("Session:ExecuteWithoutExpectationOnReply:Marshal", "sid:%v tid:%v method:%q err=%v", s.id, s.targetID, method, err)
 			return err
 		}
 	}


### PR DESCRIPTION
This PR is for #54 (Proper logger):
* Passes the same logger extension-wide
* Adds `Debugf` to the entities in the extension
* Updates tests to use a null logger when needed

With this, I'm able to see the problems in #125 and #49.

So I think they are helpful for us to diagnose issues in the future as well.

Closes #54 