### PR TITLE
Fix/e2e cannot talk to GitHub issue

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
           which go
           go version
 
-          GOPROXY="direct" xk6 build latest \
+          GOPRIVATE="go.k6.io/k6" xk6 build latest \
             --output ./k6ext \
             --with github.com/grafana/xk6-browser=.
           ./k6ext version


### PR DESCRIPTION
This PR is for resolving [this error](https://github.com/grafana/xk6-browser/runs/4324594157?check_suite_focus=true).

Thanks, @MStoykov for the heads up 🙇 

```
go: downloading go.k6.io/k6 v0.35.0
go: go.k6.io/k6@v0.35.0 requires
	gopkg.in/guregu/null.v2@v2.1.2: unrecognized import path "gopkg.in/guregu/null.v2": reading https://gopkg.in/guregu/null.v2?go-get=1: 502 Bad Gateway
	server response: Cannot obtain refs from GitHub: cannot talk to GitHub: Get https://github.com/guregu/null.git/info/refs?service=git-upload-pack: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```