### PR TITLE
Add metrics emission test

### DIFF
--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -1,0 +1,62 @@
+/*
+ *
+ * xk6-browser - a browser automation extension for k6
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k6stats "go.k6.io/k6/stats"
+)
+
+func assertMetricsEmitted(t *testing.T, samples []k6stats.SampleContainer,
+	expMetricTags map[string]map[string]string, callback func(sample k6stats.Sample)) {
+	t.Helper()
+
+	metricMap := make(map[string]bool, len(expMetricTags))
+	for m := range expMetricTags {
+		metricMap[m] = false
+	}
+
+	for _, container := range samples {
+		for _, sample := range container.GetSamples() {
+			tags := sample.Tags.CloneTags()
+			v, ok := metricMap[sample.Metric.Name]
+			assert.True(t, ok, "unexpected metric %s", sample.Metric.Name)
+			// Already seen this metric, skip it.
+			// TODO: Fail on repeated metrics?
+			if v {
+				continue
+			}
+			metricMap[sample.Metric.Name] = true
+			expTags := expMetricTags[sample.Metric.Name]
+			assert.EqualValues(t, expTags, tags,
+				"tags for metric %s don't match", sample.Metric.Name)
+			if callback != nil {
+				callback(sample)
+			}
+		}
+	}
+
+	for k, v := range metricMap {
+		assert.True(t, v, "didn't emit %s", k)
+	}
+}

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestDataURLSkipRequest(t *testing.T) {
+	t.Parallel()
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
@@ -42,6 +43,7 @@ func TestDataURLSkipRequest(t *testing.T) {
 }
 
 func TestMetricsEmission(t *testing.T) {
+	t.Parallel()
 	tb := newTestBrowser(t, withHTTPServer())
 
 	url := tb.URL("/get")

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -22,8 +22,13 @@ package tests
 
 import (
 	"testing"
+	"time"
 
+	"github.com/grafana/xk6-browser/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k6metrics "go.k6.io/k6/lib/metrics"
+	k6stats "go.k6.io/k6/stats"
 )
 
 func TestDataURLSkipRequest(t *testing.T) {
@@ -35,4 +40,73 @@ func TestDataURLSkipRequest(t *testing.T) {
 	p.Goto("data:text/html,hello", nil)
 
 	assert.True(t, lc.contains("skipped request handling of data URL"))
+}
+
+func TestMetricsEmission(t *testing.T) {
+	tb := newTestBrowser(t, withHTTPServer())
+
+	url := tb.URL("/get")
+	browserLoadedTags := map[string]string{
+		"group": "",
+		"url":   "about:blank",
+	}
+	browserTags := map[string]string{
+		"group": "",
+		"url":   url,
+	}
+	httpTags := map[string]string{
+		"method":              "GET",
+		"url":                 url,
+		"status":              "200",
+		"group":               "",
+		"proto":               "http/1.1",
+		"from_cache":          "false",
+		"from_prefetch_cache": "false",
+		"from_service_worker": "false",
+	}
+	expMetricTags := map[string]map[string]string{
+		common.BrowserDOMContentLoaded.Name:     browserLoadedTags,
+		common.BrowserLoaded.Name:               browserLoadedTags,
+		common.BrowserFirstPaint.Name:           browserTags,
+		common.BrowserFirstContentfulPaint.Name: browserTags,
+		k6metrics.DataSentName: map[string]string{
+			"group":  "",
+			"method": "GET",
+			"url":    url,
+		},
+		k6metrics.HTTPReqsName:              httpTags,
+		k6metrics.HTTPReqDurationName:       httpTags,
+		k6metrics.DataReceivedName:          httpTags,
+		k6metrics.HTTPReqConnectingName:     httpTags,
+		k6metrics.HTTPReqTLSHandshakingName: httpTags,
+		k6metrics.HTTPReqSendingName:        httpTags,
+		k6metrics.HTTPReqReceivingName:      httpTags,
+	}
+
+	p := tb.NewPage(nil)
+	resp := p.Goto(url, tb.rt.ToValue(struct {
+		WaitUntil string `js:"waitUntil"`
+	}{WaitUntil: "networkidle"}))
+	require.NotNil(t, resp)
+
+	// TODO: Remove this sleep. It's only needed to wait for all metrics to be
+	// emitted, but this should be synchronized with waitUntil
+	// load/networkidle/domcontentloaded. Without this the test would be flaky.
+	time.Sleep(100 * time.Millisecond)
+
+	bufSamples := k6stats.GetBufferedSamples(tb.samples)
+
+	var reqsCount int
+	cb := func(sample k6stats.Sample) {
+		switch sample.Metric.Name {
+		case k6metrics.HTTPReqsName:
+			reqsCount += int(sample.Value)
+		case k6metrics.DataSentName, k6metrics.DataReceivedName:
+			assert.Greaterf(t, int(sample.Value), 0,
+				"metric %s", sample.Metric.Name)
+		}
+	}
+
+	assertMetricsEmitted(t, bufSamples, expMetricTags, cb)
+	assert.Equal(t, 1, reqsCount)
 }


### PR DESCRIPTION
This adds a missing test for #40, and all other metrics emitted for `page.goto()`.

It uses a slightly modified version of the [`assertRequestMetricsEmittedSingle` helper from k6](https://github.com/grafana/k6/blob/804203bcf574da57cd05d67b39f03d05c54523ab/js/modules/k6/http/request_test.go#L109).