### PR TITLE
Fix/49 cannot find context with specified id

### DIFF
--- a/common/context.go
+++ b/common/context.go
@@ -64,3 +64,14 @@ func GetProcessID(ctx context.Context) int {
 	v, _ := ctx.Value(ctxKeyPid).(int)
 	return v // it will return zero on error
 }
+
+// contextWithDoneChan returns a new context that is canceled when the done channel
+// is closed. The context will leak if the done channel is never closed.
+func contextWithDoneChan(ctx context.Context, done chan struct{}) context.Context {
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		<-done
+		cancel()
+	}()
+	return ctx
+}

--- a/common/frame.go
+++ b/common/frame.go
@@ -542,7 +542,7 @@ func (f *Frame) waitForFunction(
 			rt.ToValue(polling),
 		}, args...)...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("frame cannot wait for function: %w", err)
 	}
 	return result, nil
 }
@@ -569,14 +569,14 @@ func (f *Frame) waitForSelector(selector string, opts *FrameWaitForSelectorOptio
 
 	ec := f.executionContexts[mainWorld]
 	if ec == nil {
-		return nil, fmt.Errorf("cannot find execution context: %q", mainWorld)
+		return nil, fmt.Errorf("wait for selector cannot find execution context: %q", mainWorld)
 	}
 	// an element should belong to the current execution context.
 	// otherwise, we should adopt it to this execution context.
 	if ec != handle.execCtx {
 		defer handle.Dispose()
 		if handle, err = ec.adoptElementHandle(handle); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("wait for selector cannot adopt element handle: %w", err)
 		}
 	}
 
@@ -1481,7 +1481,11 @@ func (f *Frame) evaluate(
 	if ec == nil {
 		return nil, fmt.Errorf("cannot find execution context: %q", world)
 	}
-	return ec.evaluate(apiCtx, opts, pageFunc, args...)
+	eh, err := ec.evaluate(apiCtx, opts, pageFunc, args...)
+	if err != nil {
+		return nil, fmt.Errorf("frame cannot evaluate: %w", err)
+	}
+	return eh, nil
 }
 
 // frameExecutionContext represents a JS execution context that belongs to Frame.

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -243,11 +243,11 @@ func (fs *FrameSession) initEvents() {
 		for {
 			select {
 			case <-fs.session.done:
-				fs.logger.Debugf("NewFrameSession:initEvents:go:session.done",
+				fs.logger.Debugf("FrameSession:initEvents:go:session.done",
 					"sid:%v tid:%v", fs.session.id, fs.targetID)
 				return
 			case <-fs.ctx.Done():
-				fs.logger.Debugf("NewFrameSession:initEvents:go:ctx.Done",
+				fs.logger.Debugf("FrameSession:initEvents:go:ctx.Done",
 					"sid:%v tid:%v", fs.session.id, fs.targetID)
 
 				return
@@ -285,12 +285,8 @@ func (fs *FrameSession) initEvents() {
 				case *runtime.EventExecutionContextsCleared:
 					fs.onExecutionContextsCleared()
 				case *target.EventAttachedToTarget:
-					// handle target attachment in a new goroutine
-					// so that other frame events won't go stale.
 					fs.onAttachedToTarget(ev)
 				case *target.EventDetachedFromTarget:
-					// handle target detachment in a new goroutine
-					// so that other frame events won't go stale.
 					fs.onDetachedFromTarget(ev)
 				}
 			}
@@ -476,7 +472,7 @@ func (fs *FrameSession) isMainFrame() bool {
 }
 
 func (fs *FrameSession) handleFrameTree(frameTree *cdppage.FrameTree) {
-	fs.logger.Debugf("NewFrameSession:handleFrameTree",
+	fs.logger.Debugf("FrameSession:handleFrameTree",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	if frameTree.Frame.ParentID != "" {
@@ -492,7 +488,7 @@ func (fs *FrameSession) handleFrameTree(frameTree *cdppage.FrameTree) {
 }
 
 func (fs *FrameSession) navigateFrame(frame *Frame, url, referrer string) (string, error) {
-	fs.logger.Debugf("NewFrameSession:navigateFrame",
+	fs.logger.Debugf("FrameSession:navigateFrame",
 		"sid:%v tid:%v url:%q referrer:%q",
 		fs.session.id, fs.targetID, url, referrer)
 
@@ -541,7 +537,7 @@ func (fs *FrameSession) onExceptionThrown(event *runtime.EventExceptionThrown) {
 }
 
 func (fs *FrameSession) onExecutionContextCreated(event *runtime.EventExecutionContextCreated) {
-	fs.logger.Debugf("NewFrameSession:onExecutionContextCreated",
+	fs.logger.Debugf("FrameSession:onExecutionContextCreated",
 		"sid:%v tid:%v ectxid:%d",
 		fs.session.id, fs.targetID, event.Context.ID)
 
@@ -579,7 +575,7 @@ func (fs *FrameSession) onExecutionContextCreated(event *runtime.EventExecutionC
 }
 
 func (fs *FrameSession) onExecutionContextDestroyed(execCtxID runtime.ExecutionContextID) {
-	fs.logger.Debugf("NewFrameSession:onExecutionContextDestroyed",
+	fs.logger.Debugf("FrameSession:onExecutionContextDestroyed",
 		"sid:%v tid:%v ectxid:%d",
 		fs.session.id, fs.targetID, execCtxID)
 
@@ -596,7 +592,7 @@ func (fs *FrameSession) onExecutionContextDestroyed(execCtxID runtime.ExecutionC
 }
 
 func (fs *FrameSession) onExecutionContextsCleared() {
-	fs.logger.Debugf("NewFrameSession:onExecutionContextsCleared",
+	fs.logger.Debugf("FrameSession:onExecutionContextsCleared",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	fs.contextIDToContextMu.Lock()
@@ -613,7 +609,7 @@ func (fs *FrameSession) onExecutionContextsCleared() {
 }
 
 func (fs *FrameSession) onFrameAttached(frameID cdp.FrameID, parentFrameID cdp.FrameID) {
-	fs.logger.Debugf("NewFrameSession:onFrameAttached",
+	fs.logger.Debugf("FrameSession:onFrameAttached",
 		"sid:%v tid:%v fid:%v pfid:%v",
 		fs.session.id, fs.targetID, frameID, parentFrameID)
 
@@ -622,7 +618,7 @@ func (fs *FrameSession) onFrameAttached(frameID cdp.FrameID, parentFrameID cdp.F
 }
 
 func (fs *FrameSession) onFrameDetached(frameID cdp.FrameID, reason cdppage.FrameDetachedReason) {
-	fs.logger.Debugf("NewFrameSession:onFrameDetached",
+	fs.logger.Debugf("FrameSession:onFrameDetached",
 		"sid:%v tid:%v fid:%v reason:%s",
 		fs.session.id, fs.targetID, frameID, reason)
 
@@ -630,7 +626,7 @@ func (fs *FrameSession) onFrameDetached(frameID cdp.FrameID, reason cdppage.Fram
 }
 
 func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {
-	fs.logger.Debugf("NewFrameSession:onFrameNavigated",
+	fs.logger.Debugf("FrameSession:onFrameNavigated",
 		"sid:%v tid:%v fid:%v",
 		fs.session.id, fs.targetID, frame.ID)
 
@@ -641,7 +637,7 @@ func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {
 }
 
 func (fs *FrameSession) onFrameRequestedNavigation(event *cdppage.EventFrameRequestedNavigation) {
-	fs.logger.Debugf("NewFrameSession:onFrameRequestedNavigation",
+	fs.logger.Debugf("FrameSession:onFrameRequestedNavigation",
 		"sid:%v tid:%v fid:%v url:%q",
 		fs.session.id, fs.targetID, event.FrameID, event.URL)
 
@@ -654,7 +650,7 @@ func (fs *FrameSession) onFrameRequestedNavigation(event *cdppage.EventFrameRequ
 }
 
 func (fs *FrameSession) onFrameStartedLoading(frameID cdp.FrameID) {
-	fs.logger.Debugf("NewFrameSession:onFrameStartedLoading",
+	fs.logger.Debugf("FrameSession:onFrameStartedLoading",
 		"sid:%v tid:%v fid:%v",
 		fs.session.id, fs.targetID, frameID)
 
@@ -662,7 +658,7 @@ func (fs *FrameSession) onFrameStartedLoading(frameID cdp.FrameID) {
 }
 
 func (fs *FrameSession) onFrameStoppedLoading(frameID cdp.FrameID) {
-	fs.logger.Debugf("NewFrameSession:onFrameStoppedLoading",
+	fs.logger.Debugf("FrameSession:onFrameStoppedLoading",
 		"sid:%v tid:%v fid:%v",
 		fs.session.id, fs.targetID, frameID)
 
@@ -692,7 +688,7 @@ func (fs *FrameSession) onLogEntryAdded(event *log.EventEntryAdded) {
 }
 
 func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
-	fs.logger.Debugf("NewFrameSession:onPageLifecycle",
+	fs.logger.Debugf("FrameSession:onPageLifecycle",
 		"sid:%v tid:%v fid:%v event:%q",
 		fs.session.id, fs.targetID, event.FrameID, event.Name)
 
@@ -773,7 +769,7 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 }
 
 func (fs *FrameSession) onPageNavigatedWithinDocument(event *cdppage.EventNavigatedWithinDocument) {
-	fs.logger.Debugf("NewFrameSession:onPageNavigatedWithinDocument",
+	fs.logger.Debugf("FrameSession:onPageNavigatedWithinDocument",
 		"sid:%v tid:%v fid:%v",
 		fs.session.id, fs.targetID, event.FrameID)
 
@@ -787,7 +783,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 		err error
 	)
 
-	fs.logger.Debugf("NewFrameSession:onAttachedToTarget",
+	fs.logger.Debugf("FrameSession:onAttachedToTarget",
 		"sid:%v tid:%v esid:%v etid:%v ebctxid:%v type:%q",
 		fs.session.id, fs.targetID, event.SessionID,
 		event.TargetInfo.TargetID, event.TargetInfo.BrowserContextID,
@@ -819,21 +815,19 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 		return
 	}
 	// Handle or ignore errors.
-	defer fs.logger.Debugf("FrameSession:onAttachedToTarget:return",
-		"sid:%v tid:%v esid:%v etid:%v ebctxid:%v type:%q err:%v",
-		fs.session.id, fs.targetID, sid,
-		ti.TargetID, ti.BrowserContextID,
-		ti.Type, err)
+	var reason string
+	defer func() {
+		fs.logger.Debugf("FrameSession:onAttachedToTarget:return",
+			"sid:%v tid:%v esid:%v etid:%v ebctxid:%v type:%q reason:%s",
+			fs.session.id, fs.targetID, sid,
+			ti.TargetID, ti.BrowserContextID,
+			ti.Type, reason)
+	}()
 	// Ignore errors if we're no longer connected to browser.
 	// This happens when there is no browser but we still want to
 	// attach a frame/worker to it.
 	if !fs.page.browserCtx.browser.IsConnected() {
-		return // ignore
-	}
-	// Ignore context canceled error to gracefuly handle shutting down
-	// of the extension. This may happen because of generated events
-	// while a frame session is being created.
-	if errors.Is(err, context.Canceled) {
+		reason = "browser disconnected"
 		return // ignore
 	}
 	// Final chance:
@@ -841,10 +835,20 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 	// throw a k6 error.
 	select {
 	case <-fs.ctx.Done():
+		reason = "frame session context canceled"
 		return
 	case <-session.done:
+		reason = "session closed"
 		return
 	default:
+		// Ignore context canceled error to gracefuly handle shutting down
+		// of the extension. This may happen because of generated events
+		// while a frame session is being created.
+		if errors.Is(err, context.Canceled) {
+			reason = "context canceled"
+			return // ignore
+		}
+		reason = "fatal"
 		k6Throw(fs.ctx, "cannot attach %v: %w", ti.Type, err)
 	}
 }
@@ -855,6 +859,10 @@ func (fs *FrameSession) attachIFrameToTarget(ti *target.Info, sid target.Session
 	if fr == nil {
 		// IFrame should be attached to fs.page with EventFrameAttached
 		// event before.
+		fs.logger.Debugf("FrameSession:attachIFrameToTarget:return",
+			"sid:%v tid:%v esid:%v etid:%v ebctxid:%v type:%q, nil frame",
+			fs.session.id, fs.targetID,
+			sid, ti.TargetID, ti.BrowserContextID, ti.Type)
 		return nil
 	}
 	// Remove all children of the previously attached frame.
@@ -887,7 +895,7 @@ func (fs *FrameSession) attachWorkerToTarget(ti *target.Info, sid target.Session
 }
 
 func (fs *FrameSession) onDetachedFromTarget(event *target.EventDetachedFromTarget) {
-	fs.logger.Debugf("NewFrameSession:onDetachedFromTarget",
+	fs.logger.Debugf("FrameSession:onDetachedFromTarget",
 		"sid:%v tid:%v esid:%v",
 		fs.session.id, fs.targetID, event.SessionID)
 
@@ -895,7 +903,7 @@ func (fs *FrameSession) onDetachedFromTarget(event *target.EventDetachedFromTarg
 }
 
 func (fs *FrameSession) onTargetCrashed(event *inspector.EventTargetCrashed) {
-	fs.logger.Debugf("NewFrameSession:onTargetCrashed", "sid:%v tid:%v", fs.session.id, fs.targetID)
+	fs.logger.Debugf("FrameSession:onTargetCrashed", "sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	fs.session.markAsCrashed()
 	fs.page.didCrash()

--- a/common/page.go
+++ b/common/page.go
@@ -137,24 +137,12 @@ func NewPage(
 	p.Mouse = NewMouse(ctx, session, p.frameManager.MainFrame(), browserCtx.timeoutSettings, p.Keyboard)
 	p.Touchscreen = NewTouchscreen(ctx, session, p.Keyboard)
 
-	if err := p.initEvents(); err != nil {
-		p.logger.Debugf("Page:NewPage:initEvents:return", "sid:%v tid:%v err:%v",
-			p.sessionID(), targetID, err)
-
-		return nil, err
+	action := target.SetAutoAttach(true, true).WithFlatten(true)
+	if err := action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
+		return nil, fmt.Errorf("cannot execute %T: %w", action, err)
 	}
 
 	return &p, nil
-}
-
-func (p *Page) initEvents() error {
-	p.logger.Debugf("Page:initEvents", "sid:%v", p.sessionID())
-
-	action := target.SetAutoAttach(true, true).WithFlatten(true)
-	if err := action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
-		return fmt.Errorf("unable to execute %T: %w", action, err)
-	}
-	return nil
 }
 
 func (p *Page) closeWorker(sessionID target.SessionID) {


### PR DESCRIPTION
This PR fixes #49 for good 🎉

After long debugging sessions and trials, finally, I figured out the problem: `FrameSession` was blocking frame handling, and the rest of the system couldn't propagate execution contexts, causing the `context with specified id not found` error. This misbehavior happens because a `Session` can get closed while a `FrameSession` is in the initialization stage.

The only error we are receiving is different now: `wait for selector didn't result in any nodes` on the `Click Continue (Recommendations)` group. I tested this patch with Chromium 98.0.4753.0. I also tested this with other test runners, and they stuck on the same step. I'm going to create a new issue for it.

<details>
<summary>Here's the script I'm using. It's a more concise and faster (_pauseMin/Max_) version of Tom's original script.</summary>

```javascript
import { sleep, group } from 'k6';
import launcher from 'k6/x/browser';

import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';

export const options = {};

export default function () {
        const pauseMin = 1;
        const pauseMax = 2;

        let browser = launcher.launch('chromium', {
                args: [],
                debug: false,
                devtools: false,
                env: {},
                executablePath: null,
                headless: false,
                ignoreDefaultArgs: [],
                proxy: {},
                slowMo: '500ms',
                timeout: '30s',
        });

        let context = browser.newContext({
                ignoreHTTPSErrors: true,
                screen: { width: 1920, height: 1080 },
                viewport: { width: 1920, height: 1080 },
        });

        let page = context.newPage();

        group("Navigate to Homepage", () => {
                console.log('Starting navigateToHomepage...');
                // page.goto('https://vistaprint.ca', { waitUntil: 'networkidle' });
                page.goto('https://vistaprint.ca');
                sleep(randomIntBetween(pauseMin, pauseMax));
        });

        group("Click Business Cards", () => {
                console.log('Starting clickBusinessCards...');
                page.waitForSelector("//span[text()='Business Cards']").click();
                sleep(randomIntBetween(pauseMin, pauseMax));
        });

        group("Click Browse Designs", () => {
                console.log('Starting clickBrowseDesigns...');
                page.waitForSelector("//a[text()='Browse designs']").click();
                sleep(randomIntBetween(pauseMin, pauseMax));
        });

        group("Select Design Option", () => {
                console.log('Starting clickDesign...');

                // const designOptions = page.$$("li.design-tile");
                // console.log(`Found ${designOptions.length} design options.`);

                const designOption = page.waitForSelector(`li.design-tile:first-child`);
                console.log("Design options:", designOption.textContent());
                designOption.click();
                sleep(randomIntBetween(pauseMin, pauseMax));
        });

        group("Click Customize Design", () => {
                console.log('Starting clickCustomizeDesign...');
                page.waitForSelector("//a[text()='Customize this design']").click();
                sleep(randomIntBetween(pauseMin, pauseMax));
        });


        group("Click Next", () => {
                console.log('Starting clickNext...');
                page.waitForSelector("//button[text()='Next']").click();
                sleep(randomIntBetween(pauseMin, pauseMax));
        });

        group("Click Continue Without Back", () => {
                console.log('Starting continueWithoutBack...');
                page.waitForSelector("//button[text()='Continue without back']").click();
                sleep(randomIntBetween(pauseMin, pauseMax));
        });

        group("Click Customer Reviewed", () => {
                console.log('Starting customerReviewed...');

                page.waitForSelector("//input[@value='customerReviewed']").click();
                sleep(1);

                page.waitForSelector("//button[text()='Continue']").click();
                sleep(randomIntBetween(pauseMin, pauseMax));
        });

        group("Click Add to Cart", () => {
                console.log('Starting addToCart...');
                page.waitForSelector("//button[text()='Add to cart']").click();
                sleep(randomIntBetween(pauseMin, pauseMax));
        });

        group("Click Continue (Recommendations)", () => {
                console.log('Starting continuePastRecommendations...');
                page.waitForSelector("//button[text()='Add to cart']").click(); // works
                
                // const els = page.$$("//a[text()='Continue']");
                // els[0].click();
                page.waitForSelector("//a[text()='Continue']").click();
                sleep(randomIntBetween(pauseMin, pauseMax));
        });

        group("Click Continue to Cart", () => {
                console.log('Starting continueToCart...');

                page.waitForSelector(".slim-footer"); // works
                // const els = page.$$("//a[text()='Continue to cart']");
                // els[0].click();
                page.waitForSelector("//a[text()='Continue to cart']").click();

                sleep(randomIntBetween(pauseMin, pauseMax));
        });

        group("Click Checkout", () => {
                console.log('Starting goToCheckout...');
                page.waitForSelector("//a[text()='Checkout']").click();
                sleep(randomIntBetween(pauseMin, pauseMax));
        });
}
```

</details>

<details>
<summary>Here's Tom's original script that also runs without context errors. I just added a `waitForNavigation` call before `page.waitForSelector("//span[text()='Step 4']");`.</summary>

```javascript
import { sleep, group } from 'k6';
import launcher from 'k6/x/browser';

import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';

export const options = {};

let browser, context, page;

const pauseMin = 10;
const pauseMax = 10;

export default function () {
        initialize();

        navigateToHomepage();
        clickBusinessCards();
        clickBrowseDesigns();
        clickDesign();
        clickCustomizeDesign();
        clickNext();
        continueWithoutBack();
        customerReviewed();
        addToCart();
        continuePastRecommendations();
        continueToCart();
        goToCheckout();
}

function initialize() {
        browser = launcher.launch('chromium', {
                args: [],
                debug: false,
                devtools: false,
                env: {},
                executablePath: null,
                headless: false,
                ignoreDefaultArgs: [],
                proxy: {},
                slowMo: '500ms',
                timeout: '30s',
        });

        context = browser.newContext({
                ignoreHTTPSErrors: true,
                screen: { width: 1920, height: 1080 },
                viewport: { width: 1920, height: 1080 },
        });

        page = context.newPage();
}

function navigateToHomepage() {
        console.log('Starting navigateToHomepage...');

        group("Navigate to Homepage", () => {
                page.goto('https://vistaprint.ca', { waitUntil: 'networkidle' });

                // Wait for a specific element to appear
                page.waitForSelector(".fluid-image");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}

function clickBusinessCards() {
        console.log('Starting clickBusinessCards...');

        const elem = page.$("//span[text()='Business Cards']");

        group("Click Business Cards", () => {
                elem.click();

                page.waitForSelector("//a[text()='Browse designs']");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}

function clickBrowseDesigns() {
        console.log('Starting clickBrowseDesigns...');

        const elem = page.$("//a[text()='Browse designs']");

        group("Click Browse Designs", () => {
                elem.click();

                page.waitForSelector("li.design-tile");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}

function clickDesign() {
        console.log('Starting clickDesign...');

        // fetch all of the design options
        const designOptions = page.$$("li.design-tile");
        console.log(`Found ${designOptions.length} design options.`);

        /*
        designOptions.some((designOption) => {
          const designOptionName = designOption.textContent();
          console.log(`Design option: ${designOptionName}`);
      
          if (designOptionName === designName) {
            console.log(`Selecting "${designName}"...`);
      
            group("Select Design Option", () => {
              designOption.click();
      
              page.waitForSelector("//a[text()='Customize this design']");
            });
      
            return true;
          }
        });
        */ // no bueno

        /*
        page.$$("li.design-tile", (designOption) => {
          const designOptionName = designOption.textContent();
          console.log(`Design option: ${designOptionName}`);
      
          if (designOptionName === designName) {
            console.log(`Selecting "${designName}"...`);
      
            group("Select Design Option", () => {
              designOption.click();
      
              page.waitForSelector("//a[text()='Customize this design']");
            });
      
            return true;
          }
        });
        */ // also no bueno

        const designOption = page.$(`li.design-tile >> nth=0`);
        console.log(designOption.textContent());

        group("Select Design Option", () => {
                designOption.click();

                page.waitForSelector("//a[text()='Customize this design']");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}

function clickCustomizeDesign() {
        console.log('Starting clickCustomizeDesign...');

        const elem = page.$("//a[text()='Customize this design']");

        group("Click Customize Design", () => {
                elem.click();

                page.waitForSelector("//button[text()='Next']");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}

function clickNext() {
        console.log('Starting clickNext...');

        const elem = page.$("//button[text()='Next']");

        group("Click Next", () => {
                elem.click();

                page.waitForSelector("//button[text()='Continue without back']");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}

function continueWithoutBack() {
        console.log('Starting continueWithoutBack...');

        const elem = page.$("//button[text()='Continue without back']");

        group("Click Continue Without Back", () => {
                elem.click();

                page.waitForSelector("//input[@value='customerReviewed']");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}

function customerReviewed() {
        console.log('Starting customerReviewed...');

        let elem = page.$("//input[@value='customerReviewed']");
        elem.click();

        sleep(5);

        elem = page.$("//button[text()='Continue']");

        group("Click Customer Reviewed", () => {
                elem.click();

                page.waitForNavigation();
                page.waitForSelector("//span[text()='Step 4']");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}

function addToCart() {
        console.log('Starting addToCart...');

        const elem = page.$("//button[text()='Add to cart']");

        group("Click Add to Cart", () => {
                elem.click();

                page.waitForSelector("//a[text()='Continue']");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}

function continuePastRecommendations() {
        console.log('Starting continuePastRecommendations...');

        const elem = page.$("//a[text()='Continue']");

        group("Click Continue (Recommendations)", () => {
                elem.click();

                page.waitForSelector("//a[text()='Continue to cart']");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}

function continueToCart() {
        console.log('Starting continueToCart...');

        const elem = page.$("//a[text()='Continue to cart']");

        group("Click Continue to Cart", () => {
                elem.click();

                page.waitForSelector("//a[text()='Checkout']");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}

function goToCheckout() {
        console.log('Starting goToCheckout...');

        const elem = page.$("//a[text()='Checkout']");

        group("Click Checkout", () => {
                elem.click();

                page.waitForSelector("//button[text()='Sign in']");
        });

        sleep(randomIntBetween(pauseMin, pauseMax));
}
```

</details>

<details>
<summary>Here's another script Tom has shared on Jan 4th, 2022. I modified it a little bit to wait for navigation.</summary>

```javascript
import launcher from 'k6/x/browser';
import { check, group, sleep } from 'k6';

export default function () {
  const browser = launcher.launch('chromium', {
    headless: false,
    // slowMo: '500ms' // slow down by 500ms
  });
  
  let context = browser.newContext({    
    // hack:
    // Without setting viewport, the script cannot find the add-to-cart
    // element. We might want to improve this.

    // screen: { width: 1920, height: 1080 },
    // viewport: { width: 1920, height: 1080 },
  });

  const page = context.newPage();

  group("Navigate to Homepage", () => {
    page.goto('http://ecommerce.test.k6.io/', { waitUntil: 'networkidle' });
  });

  sleep(2);

  group("Click Product", () => {
    page.waitForSelector('.woocommerce-result-count');
    page.click('.woocommerce-loop-product__title');
  });
  
  sleep(2);

  group("Click Add to Cart", () => {
    console.log("Clicking Add to Cart...");

    // wait for the element to be attached
    let b = page.waitForSelector('button[name="add-to-cart"]');

    // hack: scroll the element into view
    page.evaluate(() => {
      const el = document.querySelector('button[name="add-to-cart"]');
      el.scrollIntoView();
    });
    b.click();

    // 💣 💣 💣
    // we wait for navigation to happen
    // before waiting for a selector.
    page.waitForNavigation();
	
    // page is properly navigated. let's
    // wait for the selector.
    console.log("Waiting for .woocommerce-message...");
    page.waitForSelector('.woocommerce-message'); 
  });

  sleep(2);

  group("View Cart", () => {
    page.click('.cart-contents');
    page.waitForSelector('.woocommerce-cart-form__cart-item');
  });
  
  sleep(2);

  page.close();
  browser.close();
}
```

</details>