### PR TITLE
Improve mainframe handling

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -174,6 +174,7 @@ func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*common.
 		reCategoryFilter, _ = regexp.Compile(launchOpts.LogCategoryFilter)
 		logger              = common.NewLogger(ctx, k6Logger, launchOpts.Debug, reCategoryFilter)
 	)
+
 	// set the log level from the launch options (usually from a script's options).
 	if launchOpts.Debug {
 		_ = logger.SetLevel("debug")

--- a/common/frame.go
+++ b/common/frame.go
@@ -166,7 +166,7 @@ func (f *Frame) clearLifecycle() {
 	}
 	f.lifecycleEventsMu.Unlock()
 
-	f.page.frameManager.mainFrame.recalculateLifecycle()
+	f.page.frameManager.MainFrame().recalculateLifecycle()
 
 	// keep the request related to the document if present
 	// in f.inflightRequests
@@ -419,7 +419,7 @@ func (f *Frame) position() *Position {
 	if frame == nil {
 		return nil
 	}
-	if frame == f.page.frameManager.mainFrame {
+	if frame == f.page.frameManager.MainFrame() {
 		return &Position{X: 0, Y: 0}
 	}
 	element := frame.FrameElement()
@@ -1107,6 +1107,10 @@ func (f *Frame) IsVisible(selector string, opts goja.Value) bool {
 
 // ID returns the frame id
 func (f *Frame) ID() string {
+	if f == nil {
+		return ""
+	}
+
 	f.propertiesMu.RLock()
 	defer f.propertiesMu.RUnlock()
 
@@ -1115,6 +1119,10 @@ func (f *Frame) ID() string {
 
 // LoaderID returns the ID of the frame that loaded this frame
 func (f *Frame) LoaderID() string {
+	if f == nil {
+		return ""
+	}
+
 	f.propertiesMu.RLock()
 	defer f.propertiesMu.RUnlock()
 
@@ -1123,6 +1131,10 @@ func (f *Frame) LoaderID() string {
 
 // Name returns the frame name
 func (f *Frame) Name() string {
+	if f == nil {
+		return ""
+	}
+
 	f.propertiesMu.RLock()
 	defer f.propertiesMu.RUnlock()
 
@@ -1358,6 +1370,10 @@ func (f *Frame) Uncheck(selector string, opts goja.Value) {
 
 // URL returns the frame URL.
 func (f *Frame) URL() string {
+	if f == nil {
+		return ""
+	}
+
 	f.propertiesMu.RLock()
 	defer f.propertiesMu.RUnlock()
 

--- a/common/frame.go
+++ b/common/frame.go
@@ -1107,10 +1107,6 @@ func (f *Frame) IsVisible(selector string, opts goja.Value) bool {
 
 // ID returns the frame id
 func (f *Frame) ID() string {
-	if f == nil {
-		return ""
-	}
-
 	f.propertiesMu.RLock()
 	defer f.propertiesMu.RUnlock()
 
@@ -1119,10 +1115,6 @@ func (f *Frame) ID() string {
 
 // LoaderID returns the ID of the frame that loaded this frame
 func (f *Frame) LoaderID() string {
-	if f == nil {
-		return ""
-	}
-
 	f.propertiesMu.RLock()
 	defer f.propertiesMu.RUnlock()
 
@@ -1131,10 +1123,6 @@ func (f *Frame) LoaderID() string {
 
 // Name returns the frame name
 func (f *Frame) Name() string {
-	if f == nil {
-		return ""
-	}
-
 	f.propertiesMu.RLock()
 	defer f.propertiesMu.RUnlock()
 

--- a/common/page.go
+++ b/common/page.go
@@ -693,7 +693,7 @@ func (p *Page) Reload(opts goja.Value) api.Response {
 		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
 	}
 
-	ch, evCancelFn := createWaitForEventHandler(p.ctx, p.frameManager.mainFrame, []string{EventFrameNavigation}, func(data interface{}) bool {
+	ch, evCancelFn := createWaitForEventHandler(p.ctx, p.frameManager.MainFrame(), []string{EventFrameNavigation}, func(data interface{}) bool {
 		return true // Both successful and failed navigations are considered
 	})
 	defer evCancelFn() // Remove event handler
@@ -713,7 +713,7 @@ func (p *Page) Reload(opts goja.Value) api.Response {
 	}
 
 	if p.frameManager.mainFrame.hasSubtreeLifecycleEventFired(parsedOpts.WaitUntil) {
-		waitForEvent(p.ctx, p.frameManager.mainFrame, []string{EventFrameAddLifecycle}, func(data interface{}) bool {
+		_, _ = waitForEvent(p.ctx, p.frameManager.MainFrame(), []string{EventFrameAddLifecycle}, func(data interface{}) bool {
 			return data.(LifecycleEvent) == parsedOpts.WaitUntil
 		}, parsedOpts.Timeout)
 	}

--- a/common/request.go
+++ b/common/request.go
@@ -264,8 +264,5 @@ func (r *Request) Timing() goja.Value {
 
 // URL returns the request URL
 func (r *Request) URL() string {
-	if r == nil {
-		return ""
-	}
 	return r.url.String()
 }

--- a/common/request.go
+++ b/common/request.go
@@ -264,5 +264,8 @@ func (r *Request) Timing() goja.Value {
 
 // URL returns the request URL
 func (r *Request) URL() string {
+	if r == nil {
+		return ""
+	}
 	return r.url.String()
 }

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -51,7 +51,7 @@ func (s *screenshotter) fullPageSize(p *Page) (*Size, error) {
 		forceCallable: true,
 		returnByValue: true,
 	}
-	result, err := p.frameManager.mainFrame.evaluate(s.ctx, mainWorld, opts, rt.ToValue(`
+	result, err := p.frameManager.MainFrame().evaluate(s.ctx, mainWorld, opts, rt.ToValue(`
         () => {
             if (!document.body || !document.documentElement) {
                 return null;
@@ -95,7 +95,7 @@ func (s *screenshotter) originalViewportSize(p *Page) (*Size, *Size, error) {
 		forceCallable: true,
 		returnByValue: true,
 	}
-	result, err := p.frameManager.mainFrame.evaluate(s.ctx, mainWorld, opts, rt.ToValue(`
+	result, err := p.frameManager.MainFrame().evaluate(s.ctx, mainWorld, opts, rt.ToValue(`
 	() => (
 		{ width: window.innerWidth, height: window.innerHeight }
 	)`))


### PR DESCRIPTION
This PR skips setting the mainframe if it is already the same.

It also adds some sanity checks and protects the mainframe field behind a mutex in places that forgot to use it.