### PR TITLE
Feature/183 set os specific insets

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -998,6 +998,13 @@ func (fs *FrameSession) updateRequestInterception(initial bool) error {
 func (fs *FrameSession) updateViewport() error {
 	fs.logger.Debugf("NewFrameSession:updateViewport", "sid:%v tid:%v", fs.session.id, fs.targetID)
 
+	// other frames don't have viewports and,
+	// this method shouldn't be called for them.
+	// this is just a sanity check.
+	if !fs.isMainFrame() {
+		panic("updateViewport should be called only in the main frame")
+	}
+
 	opts := fs.page.browserCtx.opts
 	emulatedSize := fs.page.emulatedSize
 	if emulatedSize == nil {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -368,7 +368,6 @@ func (fs *FrameSession) initIsolatedWorld(name string) error {
 	return nil
 }
 
-// TODO: pass OS here? or hold it in the frame session
 func (fs *FrameSession) initOptions() error {
 	fs.logger.Debugf("NewFrameSession:initOptions",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
@@ -378,7 +377,6 @@ func (fs *FrameSession) initOptions() error {
 
 	if fs.isMainFrame() {
 		optActions = append(optActions, emulation.SetFocusEmulationEnabled(true))
-		// TODO: pass OS here? or hold it in the frame session
 		if err := fs.updateViewport(); err != nil {
 			fs.logger.Debugf("NewFrameSession:initOptions:updateViewport",
 				"sid:%v tid:%v, err:%v",
@@ -1036,8 +1034,7 @@ func (fs *FrameSession) updateViewport() error {
 
 	// add an inset to viewport depending on the operating system.
 	// this won't add an inset if we're running in headless mode.
-	addInsetToViewport(
-		viewport,
+	viewport.calculateInset(
 		fs.page.browserCtx.browser.launchOpts.Headless,
 		runtime.GOOS,
 	)
@@ -1050,29 +1047,4 @@ func (fs *FrameSession) updateViewport() error {
 	}
 
 	return nil
-}
-
-// addInsetToViewport calculates an inset depending on a given operating
-// system (os) and adds the inset width and height to Viewport.
-// It won't update the Viewport if headless is true.
-func addInsetToViewport(vp *Viewport, headless bool, os string) {
-	if headless {
-		return
-	}
-	// TODO: popup windows have their own insets.
-	var inset Viewport
-	switch os {
-	default:
-		inset = Viewport{Width: 24, Height: 88}
-	case "windows":
-		inset = Viewport{Width: 16, Height: 88}
-	case "linux":
-		inset = Viewport{Width: 8, Height: 85}
-	case "darwin":
-		// Playwright is using w:2 h:80 here but I checked it
-		// on my Mac and w:0 h:79 works best.
-		inset = Viewport{Width: 0, Height: 79}
-	}
-	vp.Width += inset.Width
-	vp.Height += inset.Height
 }

--- a/common/frame_session_test.go
+++ b/common/frame_session_test.go
@@ -1,0 +1,59 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// See: Issue #183 for details.
+func TestFrameSessionAddInsetToViewport(t *testing.T) {
+	t.Parallel()
+
+	// shouldn't change the viewport if headless is true.
+	t.Run("headless_true", func(t *testing.T) {
+		t.Parallel()
+
+		headless, vp := true, Viewport{}
+		addInsetToViewport(&vp, headless, "any os")
+		assert.Equal(t, vp, Viewport{})
+	})
+
+	// should add the default inset to viewport if the
+	// operating system is unrecognized.
+	t.Run("headless_false", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			headless bool
+			vp       Viewport
+		)
+		addInsetToViewport(&vp, headless, "any os")
+		assert.NotEqual(t, vp, Viewport{})
+	})
+
+	// should add a different inset to viewport than the default one
+	// if a recognized os is given.
+	for _, os := range []string{"windows", "linux", "darwin"} {
+		os := os
+		t.Run(os, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				headless bool
+				vp       Viewport
+			)
+			// add the default inset to the viewport
+			addInsetToViewport(&vp, headless, "any os")
+			defaultVp := vp
+			// add os specific inset to the viewport
+			addInsetToViewport(&vp, headless, os)
+
+			assert.NotEqual(t, vp, defaultVp, "inset for %q should exist", os)
+			assert.NotEqual(t, vp, Viewport{
+				Width:  defaultVp.Width * 2,
+				Height: defaultVp.Height * 2,
+			}, "inset for %q should not be the same as the default one", os)
+		})
+	}
+}

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -7,29 +7,29 @@ import (
 )
 
 // See: Issue #183 for details.
-func TestFrameSessionAddInsetToViewport(t *testing.T) {
+func TestViewportCalculateInset(t *testing.T) {
 	t.Parallel()
 
-	// shouldn't change the viewport if headless is true.
-	t.Run("headless_true", func(t *testing.T) {
+	t.Run("headless", func(t *testing.T) {
 		t.Parallel()
 
 		headless, vp := true, Viewport{}
-		addInsetToViewport(&vp, headless, "any os")
-		assert.Equal(t, vp, Viewport{})
+		vp.calculateInset(headless, "any os")
+		assert.Equal(t, vp, Viewport{},
+			"should not change the viewport if headless is true")
 	})
 
-	// should add the default inset to viewport if the
-	// operating system is unrecognized.
-	t.Run("headless_false", func(t *testing.T) {
+	t.Run("headful", func(t *testing.T) {
 		t.Parallel()
 
 		var (
 			headless bool
 			vp       Viewport
 		)
-		addInsetToViewport(&vp, headless, "any os")
-		assert.NotEqual(t, vp, Viewport{})
+		vp.calculateInset(headless, "any os")
+		assert.NotEqual(t, vp, Viewport{},
+			"should add the default inset to the viewport if the"+
+				" operating system is unrecognized by the addInset.")
 	})
 
 	// should add a different inset to viewport than the default one
@@ -44,12 +44,15 @@ func TestFrameSessionAddInsetToViewport(t *testing.T) {
 				vp       Viewport
 			)
 			// add the default inset to the viewport
-			addInsetToViewport(&vp, headless, "any os")
+			vp.calculateInset(headless, "any os")
 			defaultVp := vp
-			// add os specific inset to the viewport
-			addInsetToViewport(&vp, headless, os)
+			// add an os specific inset to the viewport
+			vp.calculateInset(headless, os)
 
 			assert.NotEqual(t, vp, defaultVp, "inset for %q should exist", os)
+			// we multiply the default viewport by two to detect
+			// whether an os specific inset is adding the default
+			// viewport, instead of its own.
 			assert.NotEqual(t, vp, Viewport{
 				Width:  defaultVp.Width * 2,
 				Height: defaultVp.Height * 2,


### PR DESCRIPTION
What a reviewer might review? Interesting parts are:

* [types_test.go](https://github.com/grafana/xk6-browser/blob/8d13a4e236e807bf52fc83ef4e26e51ef0c5d31a/common/types_test.go)
* [types.go@calculateInset](https://github.com/grafana/xk6-browser/blob/8d13a4e236e807bf52fc83ef4e26e51ef0c5d31a/common/types.go#L490-L513)
* [frame_session.go@updateViewPort](https://github.com/grafana/xk6-browser/blob/8d13a4e236e807bf52fc83ef4e26e51ef0c5d31a/common/frame_session.go#L1035-L1044)