### PR TITLE
Fix WaitForFrameNavigation nil pointer bug

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -243,9 +243,9 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 			}
 			select {
 			case <-b.ctx.Done():
-				b.logger.Debugf("Browser:onAttachedToTarget:background_page:return",
-					"sid:%v tid:%v context canceled",
-					ev.SessionID, evti.TargetID)
+				b.logger.Debugf("Browser:onAttachedToTarget:background_page:return:<-ctx.Done",
+					"sid:%v tid:%v err:%v",
+					ev.SessionID, evti.TargetID, b.ctx.Err())
 				return // ignore
 			default:
 				k6Throw(b.ctx, "cannot create NewPage for background_page event: %w", err)
@@ -282,9 +282,9 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 			}
 			select {
 			case <-b.ctx.Done():
-				b.logger.Debugf("Browser:onAttachedToTarget:page:return",
-					"sid:%v tid:%v context canceled",
-					ev.SessionID, evti.TargetID)
+				b.logger.Debugf("Browser:onAttachedToTarget:page:return:<-ctx.Done",
+					"sid:%v tid:%v err:%v",
+					ev.SessionID, evti.TargetID, b.ctx.Err())
 				return // ignore
 			default:
 				k6Throw(b.ctx, "cannot create NewPage for page event: %w", err)
@@ -381,7 +381,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (page *Page, err err
 		page = b.pages[tid]
 		b.pagesMu.RUnlock()
 	case <-ctx.Done():
-		b.logger.Debugf("Browser:newPageInContext:<-ctx.Done", "tid:%v bctxid:%v", tid, id)
+		b.logger.Debugf("Browser:newPageInContext:<-ctx.Done", "tid:%v bctxid:%v err:%v", tid, id, ctx.Err())
 		err = ctx.Err()
 	}
 	return page, err

--- a/common/browser.go
+++ b/common/browser.go
@@ -335,7 +335,7 @@ func (b *Browser) onDetachedFromTarget(ev *target.EventDetachedFromTarget) {
 	}
 }
 
-func (b *Browser) newPageInContext(id cdp.BrowserContextID) (page *Page, err error) {
+func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 	b.contextsMu.RLock()
 	browserCtx, ok := b.contexts[id]
 	b.contextsMu.RUnlock()
@@ -374,6 +374,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (page *Page, err err
 	}
 	// let the event handler know about the new page.
 	targetID <- tid
+	var page *Page
 	select {
 	case <-waitForPage:
 		b.logger.Debugf("Browser:newPageInContext:<-waitForPage", "tid:%v bctxid:%v", tid, id)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -58,11 +58,10 @@ type BrowserContext struct {
 }
 
 // NewBrowserContext creates a new browser context.
-func NewBrowserContext(ctx context.Context, conn *Connection, browser *Browser, id cdp.BrowserContextID, opts *BrowserContextOptions, logger *Logger) *BrowserContext {
+func NewBrowserContext(ctx context.Context, browser *Browser, id cdp.BrowserContextID, opts *BrowserContextOptions, logger *Logger) *BrowserContext {
 	b := BrowserContext{
 		BaseEventEmitter: NewBaseEventEmitter(ctx),
 		ctx:              ctx,
-		conn:             conn,
 		browser:          browser,
 		id:               id,
 		opts:             opts,
@@ -219,7 +218,7 @@ func (b *BrowserContext) NewPage() api.Page {
 
 	p, err := b.browser.newPageInContext(b.id)
 	if err != nil {
-		k6Throw(b.ctx, "cannot create a new page: %w", err)
+		k6Throw(b.ctx, "newPageInContext: %w", err)
 	}
 
 	var (

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -47,7 +47,6 @@ type BrowserContext struct {
 	BaseEventEmitter
 
 	ctx             context.Context
-	conn            *Connection
 	browser         *Browser
 	id              cdp.BrowserContextID
 	opts            *BrowserContextOptions
@@ -406,4 +405,8 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 	}
 	b.logger.Debugf("BrowserContext:WaitForEvent:return nil", "bctxid:%v event:%q", b.id, event)
 	return nil
+}
+
+func (b *BrowserContext) getSession(id target.SessionID) *Session {
+	return b.browser.connSessions.getSession(id)
 }

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -1,0 +1,225 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/target"
+	"github.com/mailru/easyjson"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrowserNewPageInContext(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		b   *Browser
+		bc  *BrowserContext
+		got struct {
+			params easyjson.Marshaler
+			method string
+			page   *Page
+			err    error
+		}
+	}
+	newTestCase := func(id cdp.BrowserContextID) *testCase {
+		ctx := context.Background()
+		b := newBrowser(ctx, nil, nil, NewLaunchOptions(), NewNullLogger())
+		// set a new browser context in the browser with `id`, so that newPageInContext can find it.
+		b.contexts[id] = NewBrowserContext(ctx, b, id, nil, nil)
+
+		tc := testCase{
+			b:  b,
+			bc: b.contexts[id],
+		}
+
+		return &tc
+	}
+
+	const (
+		// default IDs to be used in tests.
+		browserContextID cdp.BrowserContextID = "42"
+		targetID         target.ID            = "84"
+
+		// each test should finish in testTimeoutThreshold.
+		testTimeoutThreshold = 100 * time.Millisecond
+	)
+
+	t.Run("happy_path", func(t *testing.T) {
+		t.Parallel()
+
+		// newPageInContext will look for this browser context.
+		tc := newTestCase(browserContextID)
+
+		// newPageInContext will return this page by searching it by its targetID in the wait event handler.
+		tc.b.pages[targetID] = &Page{targetID: targetID}
+
+		done := make(chan struct{})
+		go func() {
+			tc.b.conn = executorTestFunc(func(
+				ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler,
+			) error {
+				tc.got.params = params
+				tc.got.method = method
+				if method != target.CommandCreateTarget {
+					// no need to continue the test if the command is not a create target action.
+					return nil
+				}
+
+				// newPageInContext event handler will catch this target ID, and compare it to
+				// the new page's target ID to detect whether the page is loaded.
+				res.(*target.CreateTargetReturns).TargetID = targetID
+
+				// for the event handler to work, there needs to be an event called
+				// EventBrowserContextPage to be fired.
+				//
+				// this normally happens when the browser's onAttachedToTarget event is fired. here,
+				// we imitate as if the browser created a target for the page.
+				//
+				//  but it's challenging to do that in this
+				// unit test. besides, it's better to test lesser number of
+				// units.
+				tc.bc.emit(EventBrowserContextPage, &Page{targetID: targetID})
+
+				return nil
+			})
+			tc.got.page, tc.got.err = tc.b.newPageInContext(browserContextID)
+
+			done <- struct{}{}
+		}()
+		select {
+		case <-done:
+			require.NoError(t, tc.got.err)
+
+			require.Equal(t, target.CommandCreateTarget, tc.got.method)
+			params := tc.got.params.(*target.CreateTargetParams)
+			require.Equal(t, "about:blank", params.URL)
+			require.Equal(t, browserContextID, params.BrowserContextID)
+
+			require.NotNil(t, tc.got.page)
+			require.Equal(t, targetID, tc.got.page.targetID)
+		case <-time.After(testTimeoutThreshold):
+			// this may happen if the tc.b.conn above does not emit: EventBrowserContextPage.
+			require.FailNow(t, "test timed out")
+		}
+	})
+
+	// should return an error if it cannot find a browser context.
+	t.Run("missing_browser_context", func(t *testing.T) {
+		t.Parallel()
+
+		const missingBrowserContextID = "911"
+
+		// set an existing browser context,
+		_, err := newTestCase(browserContextID).
+			// but look for a different one.
+			b.newPageInContext(missingBrowserContextID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), missingBrowserContextID,
+			"should have returned the missing browser context ID in the error message")
+	})
+
+	// should return the error returned from the executor.
+	t.Run("error_in_create_target_action", func(t *testing.T) {
+		t.Parallel()
+
+		const wantErr = "anything"
+
+		var (
+			tc   = newTestCase(browserContextID)
+			done = make(chan struct{})
+		)
+		go func() {
+			tc.b.conn = executorTestFunc(
+				func(context.Context, string, easyjson.Marshaler, easyjson.Unmarshaler) error {
+					return errors.New(wantErr)
+				})
+			tc.got.page, tc.got.err = tc.b.newPageInContext(browserContextID)
+
+			done <- struct{}{}
+		}()
+		select {
+		case <-done:
+			require.NotNil(t, tc.got.err)
+			require.Contains(t, tc.got.err.Error(), wantErr)
+			require.Nil(t, tc.got.page)
+		case <-time.After(testTimeoutThreshold):
+			require.FailNow(t, "test timed out")
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		t.Parallel()
+
+		tc := newTestCase(browserContextID)
+
+		// set a lower timeout for catching the timeout error.
+		const timeout = 100 * time.Millisecond
+
+		done := make(chan struct{})
+		go func() {
+			tc.b.conn = executorTestFunc(
+				func(context.Context, string, easyjson.Marshaler, easyjson.Unmarshaler) error {
+					// executor takes more time than the timeout.
+					time.Sleep(2 * timeout)
+					return nil
+				})
+			// set the timeout for the browser value.
+			tc.b.launchOpts.Timeout = timeout
+			// it should timeout in 100ms because the executor will sleep double of the timeout time.
+			tc.got.page, tc.got.err = tc.b.newPageInContext(browserContextID)
+
+			done <- struct{}{}
+		}()
+		select {
+		case <-done:
+			require.Error(t, tc.got.err)
+			require.ErrorIs(t, tc.got.err, context.DeadlineExceeded)
+			require.Nil(t, tc.got.page)
+		case <-time.After(5 * timeout):
+			require.FailNow(t, "test timed out: expected newPageInContext to time out instead")
+		}
+	})
+
+	t.Run("context_done", func(t *testing.T) {
+		t.Parallel()
+
+		tc := newTestCase(browserContextID)
+
+		done := make(chan struct{})
+		go func() {
+			tc.b.conn = executorTestFunc(
+				func(context.Context, string, easyjson.Marshaler, easyjson.Unmarshaler) error {
+					return nil
+				})
+
+			var cancel func()
+			tc.b.ctx, cancel = context.WithCancel(tc.b.ctx)
+			// let newPageInContext return a context cancelation error by canceling the context before
+			// running the method.
+			cancel()
+			tc.got.page, tc.got.err = tc.b.newPageInContext(browserContextID)
+			done <- struct{}{}
+
+		}()
+		select {
+		case <-done:
+			require.Error(t, tc.got.err)
+			require.ErrorIs(t, tc.got.err, context.Canceled)
+			require.Nil(t, tc.got.page)
+		case <-time.After(testTimeoutThreshold):
+			require.FailNow(t, "test timed out")
+		}
+	})
+}
+
+type executorTestFunc func(context.Context, string, easyjson.Marshaler, easyjson.Unmarshaler) error
+
+func (f executorTestFunc) Execute(
+	ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler,
+) error {
+	return f(ctx, method, params, res)
+}

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -16,36 +16,24 @@ func TestBrowserNewPageInContext(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		b   *Browser
-		bc  *BrowserContext
-		got struct {
-			params easyjson.Marshaler
-			method string
-			page   *Page
-			err    error
-		}
+		b  *Browser
+		bc *BrowserContext
 	}
 	newTestCase := func(id cdp.BrowserContextID) *testCase {
 		ctx := context.Background()
 		b := newBrowser(ctx, nil, nil, NewLaunchOptions(), NewNullLogger())
 		// set a new browser context in the browser with `id`, so that newPageInContext can find it.
 		b.contexts[id] = NewBrowserContext(ctx, b, id, nil, nil)
-
-		tc := testCase{
+		return &testCase{
 			b:  b,
 			bc: b.contexts[id],
 		}
-
-		return &tc
 	}
 
 	const (
 		// default IDs to be used in tests.
 		browserContextID cdp.BrowserContextID = "42"
 		targetID         target.ID            = "84"
-
-		// each test should finish in testTimeoutThreshold.
-		testTimeoutThreshold = 100 * time.Millisecond
 	)
 
 	t.Run("happy_path", func(t *testing.T) {
@@ -57,54 +45,31 @@ func TestBrowserNewPageInContext(t *testing.T) {
 		// newPageInContext will return this page by searching it by its targetID in the wait event handler.
 		tc.b.pages[targetID] = &Page{targetID: targetID}
 
-		done := make(chan struct{})
-		go func() {
-			tc.b.conn = executorTestFunc(func(
-				ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler,
-			) error {
-				tc.got.params = params
-				tc.got.method = method
-				if method != target.CommandCreateTarget {
-					// no need to continue the test if the command is not a create target action.
-					return nil
-				}
+		tc.b.conn = executorTestFunc(func(
+			ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler,
+		) error {
+			require.Equal(t, target.CommandCreateTarget, method)
+			tp := params.(*target.CreateTargetParams)
+			require.Equal(t, "about:blank", tp.URL)
+			require.Equal(t, browserContextID, tp.BrowserContextID)
 
-				// newPageInContext event handler will catch this target ID, and compare it to
-				// the new page's target ID to detect whether the page is loaded.
-				res.(*target.CreateTargetReturns).TargetID = targetID
+			// newPageInContext event handler will catch this target ID, and compare it to
+			// the new page's target ID to detect whether the page is loaded.
+			res.(*target.CreateTargetReturns).TargetID = targetID
 
-				// for the event handler to work, there needs to be an event called
-				// EventBrowserContextPage to be fired.
-				//
-				// this normally happens when the browser's onAttachedToTarget event is fired. here,
-				// we imitate as if the browser created a target for the page.
-				//
-				//  but it's challenging to do that in this
-				// unit test. besides, it's better to test lesser number of
-				// units.
-				tc.bc.emit(EventBrowserContextPage, &Page{targetID: targetID})
+			// for the event handler to work, there needs to be an event called
+			// EventBrowserContextPage to be fired. this normally happens when the browser's
+			// onAttachedToTarget event is fired. here, we imitate as if the browser created a target for
+			// the page.
+			tc.bc.emit(EventBrowserContextPage, &Page{targetID: targetID})
 
-				return nil
-			})
-			tc.got.page, tc.got.err = tc.b.newPageInContext(browserContextID)
+			return nil
+		})
 
-			done <- struct{}{}
-		}()
-		select {
-		case <-done:
-			require.NoError(t, tc.got.err)
-
-			require.Equal(t, target.CommandCreateTarget, tc.got.method)
-			params := tc.got.params.(*target.CreateTargetParams)
-			require.Equal(t, "about:blank", params.URL)
-			require.Equal(t, browserContextID, params.BrowserContextID)
-
-			require.NotNil(t, tc.got.page)
-			require.Equal(t, targetID, tc.got.page.targetID)
-		case <-time.After(testTimeoutThreshold):
-			// this may happen if the tc.b.conn above does not emit: EventBrowserContextPage.
-			require.FailNow(t, "test timed out")
-		}
+		page, err := tc.b.newPageInContext(browserContextID)
+		require.NoError(t, err)
+		require.NotNil(t, page)
+		require.Equal(t, targetID, page.targetID)
 	})
 
 	// should return an error if it cannot find a browser context.
@@ -128,27 +93,16 @@ func TestBrowserNewPageInContext(t *testing.T) {
 
 		const wantErr = "anything"
 
-		var (
-			tc   = newTestCase(browserContextID)
-			done = make(chan struct{})
-		)
-		go func() {
-			tc.b.conn = executorTestFunc(
-				func(context.Context, string, easyjson.Marshaler, easyjson.Unmarshaler) error {
-					return errors.New(wantErr)
-				})
-			tc.got.page, tc.got.err = tc.b.newPageInContext(browserContextID)
+		tc := newTestCase(browserContextID)
+		tc.b.conn = executorTestFunc(
+			func(context.Context, string, easyjson.Marshaler, easyjson.Unmarshaler) error {
+				return errors.New(wantErr)
+			})
+		page, err := tc.b.newPageInContext(browserContextID)
 
-			done <- struct{}{}
-		}()
-		select {
-		case <-done:
-			require.NotNil(t, tc.got.err)
-			require.Contains(t, tc.got.err.Error(), wantErr)
-			require.Nil(t, tc.got.page)
-		case <-time.After(testTimeoutThreshold):
-			require.FailNow(t, "test timed out")
-		}
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), wantErr)
+		require.Nil(t, page)
 	})
 
 	t.Run("timeout", func(t *testing.T) {
@@ -158,27 +112,31 @@ func TestBrowserNewPageInContext(t *testing.T) {
 
 		// set a lower timeout for catching the timeout error.
 		const timeout = 100 * time.Millisecond
+		// set the timeout for the browser value.
+		tc.b.launchOpts.Timeout = timeout
+		tc.b.conn = executorTestFunc(
+			func(context.Context, string, easyjson.Marshaler, easyjson.Unmarshaler) error {
+				// executor takes more time than the timeout.
+				time.Sleep(2 * timeout)
+				return nil
+			})
 
-		done := make(chan struct{})
+		var (
+			page *Page
+			err  error
+
+			done = make(chan struct{})
+		)
 		go func() {
-			tc.b.conn = executorTestFunc(
-				func(context.Context, string, easyjson.Marshaler, easyjson.Unmarshaler) error {
-					// executor takes more time than the timeout.
-					time.Sleep(2 * timeout)
-					return nil
-				})
-			// set the timeout for the browser value.
-			tc.b.launchOpts.Timeout = timeout
 			// it should timeout in 100ms because the executor will sleep double of the timeout time.
-			tc.got.page, tc.got.err = tc.b.newPageInContext(browserContextID)
-
+			page, err = tc.b.newPageInContext(browserContextID)
 			done <- struct{}{}
 		}()
 		select {
 		case <-done:
-			require.Error(t, tc.got.err)
-			require.ErrorIs(t, tc.got.err, context.DeadlineExceeded)
-			require.Nil(t, tc.got.page)
+			require.Error(t, err)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			require.Nil(t, page)
 		case <-time.After(5 * timeout):
 			require.FailNow(t, "test timed out: expected newPageInContext to time out instead")
 		}
@@ -189,30 +147,20 @@ func TestBrowserNewPageInContext(t *testing.T) {
 
 		tc := newTestCase(browserContextID)
 
-		done := make(chan struct{})
-		go func() {
-			tc.b.conn = executorTestFunc(
-				func(context.Context, string, easyjson.Marshaler, easyjson.Unmarshaler) error {
-					return nil
-				})
+		tc.b.conn = executorTestFunc(
+			func(context.Context, string, easyjson.Marshaler, easyjson.Unmarshaler) error {
+				return nil
+			})
 
-			var cancel func()
-			tc.b.ctx, cancel = context.WithCancel(tc.b.ctx)
-			// let newPageInContext return a context cancelation error by canceling the context before
-			// running the method.
-			cancel()
-			tc.got.page, tc.got.err = tc.b.newPageInContext(browserContextID)
-			done <- struct{}{}
-
-		}()
-		select {
-		case <-done:
-			require.Error(t, tc.got.err)
-			require.ErrorIs(t, tc.got.err, context.Canceled)
-			require.Nil(t, tc.got.page)
-		case <-time.After(testTimeoutThreshold):
-			require.FailNow(t, "test timed out")
-		}
+		var cancel func()
+		tc.b.ctx, cancel = context.WithCancel(tc.b.ctx)
+		// let newPageInContext return a context cancelation error by canceling the context before
+		// running the method.
+		cancel()
+		page, err := tc.b.newPageInContext(browserContextID)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Nil(t, page)
 	})
 }
 

--- a/common/event_emitter.go
+++ b/common/event_emitter.go
@@ -112,10 +112,9 @@ type BaseEventEmitter struct {
 // NewBaseEventEmitter creates a new instance of a base event emitter
 func NewBaseEventEmitter(ctx context.Context) BaseEventEmitter {
 	bem := BaseEventEmitter{
-		handlers:    make(map[string][]eventHandler),
-		handlersAll: make([]eventHandler, 0),
-		syncCh:      make(chan syncFunc),
-		ctx:         ctx,
+		handlers: make(map[string][]eventHandler),
+		syncCh:   make(chan syncFunc),
+		ctx:      ctx,
 	}
 	go bem.syncAll(ctx)
 	return bem

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -703,6 +703,11 @@ func (m *FrameManager) WaitForFrameNavigation(frame *Frame, opts goja.Value) api
 	var event *NavigationEvent
 	select {
 	case <-m.ctx.Done():
+		// ignore: the extension is shutting down
+		m.logger.Warnf("FrameManager:WaitForFrameNavigation",
+			"fmid:%d furl:%s context canceled",
+			m.ID(), frame.URL())
+		return nil
 	case <-time.After(parsedOpts.Timeout):
 		k6common.Throw(rt, ErrTimedOut)
 	case data := <-ch:
@@ -719,14 +724,7 @@ func (m *FrameManager) WaitForFrameNavigation(frame *Frame, opts goja.Value) api
 		}, parsedOpts.Timeout)
 	}
 
-	var resp *Response
-	req := event.newDocument.request
-	if req != nil {
-		if req.response != nil {
-			resp = req.response
-		}
-	}
-	return resp
+	return event.newDocument.request.response
 }
 
 // ID returns the unique ID of a FrameManager value.

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -704,9 +704,9 @@ func (m *FrameManager) WaitForFrameNavigation(frame *Frame, opts goja.Value) api
 	select {
 	case <-m.ctx.Done():
 		// ignore: the extension is shutting down
-		m.logger.Warnf("FrameManager:WaitForFrameNavigation",
-			"fmid:%d furl:%s context canceled",
-			m.ID(), frame.URL())
+		m.logger.Warnf("FrameManager:WaitForFrameNavigation:<-ctx.Done",
+			"fmid:%d furl:%s err:%v",
+			m.ID(), frame.URL(), m.ctx.Err())
 		return nil
 	case <-time.After(parsedOpts.Timeout):
 		k6common.Throw(rt, ErrTimedOut)

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -790,7 +790,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 		event.TargetInfo.TargetID, event.TargetInfo.BrowserContextID,
 		event.TargetInfo.Type)
 
-	session := fs.page.browserCtx.conn.getSession(event.SessionID)
+	session := fs.page.browserCtx.getSession(event.SessionID)
 	if session == nil {
 		fs.logger.Debugf("FrameSession:onAttachedToTarget:NewFrameSession",
 			"sid:%v tid:%v esid:%v etid:%v ebctxid:%v type:%q err:nil session",
@@ -807,7 +807,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 		err = fs.attachWorkerToTarget(ti, sid)
 	default:
 		// Just unblock (debugger continue) these targets and detach from them.
-		s := fs.page.browserCtx.conn.getSession(sid)
+		s := fs.page.browserCtx.getSession(sid)
 		_ = s.ExecuteWithoutExpectationOnReply(fs.ctx, cdpruntime.CommandRunIfWaitingForDebugger, nil, nil)
 		_ = s.ExecuteWithoutExpectationOnReply(fs.ctx, target.CommandDetachFromTarget,
 			&target.DetachFromTargetParams{SessionID: s.id}, nil)
@@ -871,7 +871,7 @@ func (fs *FrameSession) attachIFrameToTarget(ti *target.Info, sid target.Session
 
 	nfs, err := NewFrameSession(
 		fs.ctx,
-		fs.page.browserCtx.conn.getSession(sid),
+		fs.page.browserCtx.getSession(sid),
 		fs.page, fs, ti.TargetID,
 		fs.logger)
 	if err != nil {
@@ -885,7 +885,7 @@ func (fs *FrameSession) attachIFrameToTarget(ti *target.Info, sid target.Session
 
 // attachWorkerToTarget attaches a Worker target to a given session.
 func (fs *FrameSession) attachWorkerToTarget(ti *target.Info, sid target.SessionID) error {
-	w, err := NewWorker(fs.ctx, fs.page.browserCtx.conn.getSession(sid), ti.TargetID, ti.URL)
+	w, err := NewWorker(fs.ctx, fs.page.browserCtx.getSession(sid), ti.TargetID, ti.URL)
 	if err != nil {
 		return fmt.Errorf("cannot attach worker target (%v) to session (%v): %w",
 			ti.TargetID, sid, err)

--- a/common/launch.go
+++ b/common/launch.go
@@ -59,16 +59,9 @@ type LaunchPersistentContextOptions struct {
 
 func NewLaunchOptions() *LaunchOptions {
 	launchOpts := LaunchOptions{
-		Args:              make([]string, 0),
-		Debug:             false,
-		Devtools:          false,
 		Env:               make(map[string]string),
-		ExecutablePath:    "",
 		Headless:          true,
-		IgnoreDefaultArgs: make([]string, 0),
 		LogCategoryFilter: ".*",
-		Proxy:             ProxyOptions{},
-		SlowMo:            0.0,
 		Timeout:           DefaultTimeout,
 	}
 	return &launchOpts

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -21,6 +21,7 @@
 package tests
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"testing"
@@ -100,4 +101,13 @@ func TestPageSetExtraHTTPHeaders(t *testing.T) {
 	h := body.Headers["Some-Header"]
 	require.NotEmpty(t, h)
 	assert.Equal(t, "Some-Value", h[0])
+}
+
+// See: The issue #187 for details.
+func TestPageWaitForNavigationShouldNotPanic(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := newTestBrowser(t, withContext(ctx)).NewPage(nil)
+	go cancel()
+	<-ctx.Done()
+	require.NotPanics(t, func() { p.WaitForNavigation(nil) })
 }


### PR DESCRIPTION
This PR fixes [the problem](https://github.com/grafana/xk6-browser/issues/187) and adds an [integration test](https://github.com/grafana/xk6-browser/blob/cde9f02d2012356e852e375a03cce2ecddab0285/tests/page_test.go#L106-L113) and [unit test](https://github.com/grafana/xk6-browser/blob/cde9f02d2012356e852e375a03cce2ecddab0285/common/browser_test.go). It also refactors related code for better maintainability.

**Explanation of the fixes:**
`FrameManager.WaitForFrameNavigation` wasn't returning when the context is canceled, and then it was trying to read a `nil` event, resulting in a `nil pointer` error. [Now it returns](https://github.com/grafana/xk6-browser/blob/cde9f02d2012356e852e375a03cce2ecddab0285/common/frame_manager.go#L705-L710) and prevents this problem. There is no need to throw an error because the extension is in the shutting down stage.

After I fixed the problem, `Browser` started to throw errors. Similarly, it was throwing an error when the context is canceled, but it shouldn't do so when the extension is in the shutting down stage. I fixed this behavior [here](https://github.com/grafana/xk6-browser/blob/cde9f02d2012356e852e375a03cce2ecddab0285/common/browser.go#L245-L249) and [here](https://github.com/grafana/xk6-browser/blob/cde9f02d2012356e852e375a03cce2ecddab0285/common/browser.go#L284-L288).

These problems popped up while trying to test the nil pointer error, and I needed to fix them all. While trying to fix things, I was working on the `newPageInContext` method (it is related to these issues) because it was causing some unexpected issues, and it wasn't correctly returning errors. So I also [refactored](https://github.com/grafana/xk6-browser/blob/cde9f02d2012356e852e375a03cce2ecddab0285/common/browser.go#L338-L388) it in the meanwhile.

**Others:**
* Added a new function named `newBrowser` that returns a new `Browser` value without an actual connection to a running browser. This helped me unit test the Browser without actually connecting to a running Browser.
* This commit removes the `conn` field from the `BrowserContext` because `BrowserContext` never actually uses it. It's better to localize value owners. In this case, the `Browser` is the actual owner of the connection.
* `Browser` now has three fields with three different responsibilities for the same connection value for ease of testing, better maintainability, etc.
* We incorrectly named `Browser.connMu` because it doesn't protect the conn field. Instead, it protects the connected state. So this commit changes its name from `connMu` to `connectedMu`.