### PR TITLE
Refactor ElementHandle evaluate calls

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1414,7 +1414,7 @@ func (h *ElementHandle) evalWithScript(
 	return h.eval(ctx, opts, js, args...)
 }
 
-// eval evaluates a given js function in the scope of this ElementHandle.
+// eval evaluates the given js code in the scope of this ElementHandle and returns the result.
 func (h *ElementHandle) eval(
 	ctx context.Context,
 	opts evaluateOptions, js string, args ...interface{},

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -231,7 +231,7 @@ func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, point Position)
 			return injected.checkHitTargetAt(node, point);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -257,7 +257,7 @@ func (h *ElementHandle) checkElementState(apiCtx context.Context, state string) 
 			return injected.checkElementState(node, state);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -378,7 +378,7 @@ func (h *ElementHandle) dispatchEvent(apiCtx context.Context, typ string, eventI
 			injected.dispatchEvent(node, type, eventInit);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -392,7 +392,7 @@ func (h *ElementHandle) fill(apiCtx context.Context, value string) (interface{},
 			return injected.fill(node, value);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -415,7 +415,7 @@ func (h *ElementHandle) focus(apiCtx context.Context, resetSelectionIfNotFocused
 			return injected.focusNode(node, resetSelectionIfNotFocused);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -438,7 +438,7 @@ func (h *ElementHandle) getAttribute(apiCtx context.Context, name string) (inter
 			return element.getAttribute('` + name + `');
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -455,7 +455,7 @@ func (h *ElementHandle) innerHTML(apiCtx context.Context) (interface{}, error) {
 			return element.innerHTML;
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -468,7 +468,7 @@ func (h *ElementHandle) innerText(apiCtx context.Context) (interface{}, error) {
 			return element.innerText;
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -484,7 +484,7 @@ func (h *ElementHandle) inputValue(apiCtx context.Context) (interface{}, error) 
 			return element.value;
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -521,7 +521,7 @@ func (h *ElementHandle) offsetPosition(apiCtx context.Context, offset *Position)
 			return injected.getElementBorderWidth(node);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -685,7 +685,7 @@ func (h *ElementHandle) selectOption(apiCtx context.Context, values goja.Value) 
 			return injected.selectOptions(node, values);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
@@ -708,7 +708,7 @@ func (h *ElementHandle) selectText(apiCtx context.Context) error {
 			return injected.selectText(node);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -760,7 +760,7 @@ func (h *ElementHandle) textContent(apiCtx context.Context) (interface{}, error)
 			return element.textContent;
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -787,7 +787,7 @@ func (h *ElementHandle) waitAndScrollIntoViewIfNeeded(apiCtx context.Context, fo
 				return [window.scrollX, window.scrollY];
 			}
 		`
-		opts := evaluateOptions{
+		opts := evalOptions{
 			forceCallable: true,
 			returnByValue: true,
 		}
@@ -807,7 +807,7 @@ func (h *ElementHandle) waitForElementState(apiCtx context.Context, states []str
 			return injected.waitForElementStates(node, states, timeout);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -839,7 +839,7 @@ func (h *ElementHandle) waitForSelector(apiCtx context.Context, selector string,
 			return injected.waitForSelector(selector, node, strict, state, 'raf', timeout, ...args);
 		}
 	`
-	eopts := evaluateOptions{
+	eopts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
@@ -1111,7 +1111,7 @@ func (h *ElementHandle) OwnerFrame() api.Frame {
 			return injected.getDocumentElement(node);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
@@ -1167,7 +1167,7 @@ func (h *ElementHandle) Query(selector string) api.ElementHandle {
 			return injected.querySelector(selector, node || document, false);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
@@ -1203,7 +1203,7 @@ func (h *ElementHandle) QueryAll(selector string) []api.ElementHandle {
 			return injected.querySelectorAll(selector, node || document, false);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
@@ -1402,7 +1402,7 @@ func (h *ElementHandle) WaitForSelector(selector string, opts goja.Value) api.El
 // The js code can call helper functions from injected_script.js.
 func (h *ElementHandle) evalWithScript(
 	ctx context.Context,
-	opts evaluateOptions, js string, args ...interface{},
+	opts evalOptions, js string, args ...interface{},
 ) (interface{}, error) {
 	script, err := h.execCtx.getInjectedScript(h.ctx)
 	if err != nil {
@@ -1415,7 +1415,7 @@ func (h *ElementHandle) evalWithScript(
 // eval evaluates the given js code in the scope of this ElementHandle and returns the result.
 func (h *ElementHandle) eval(
 	ctx context.Context,
-	opts evaluateOptions, js string, args ...interface{},
+	opts evalOptions, js string, args ...interface{},
 ) (interface{}, error) {
 	// passing `h` makes it evaluate js code in the element handle's scope.
 	args = append([]interface{}{h}, args...)
@@ -1424,7 +1424,7 @@ func (h *ElementHandle) eval(
 	for i, arg := range args {
 		gargs[i] = rt.ToValue(arg)
 	}
-	result, err := h.execCtx.evaluate(ctx, opts, rt.ToValue(js), gargs...)
+	result, err := h.execCtx.eval(ctx, opts, rt.ToValue(js), gargs...)
 	if err != nil {
 		err = fmt.Errorf("element handle cannot evaluate: %w", err)
 	}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1404,12 +1404,10 @@ func (h *ElementHandle) evalWithScript(
 	ctx context.Context,
 	opts evaluateOptions, js string, args ...interface{},
 ) (interface{}, error) {
-	// get the injected script's handle so that js function can call its functions.
 	script, err := h.execCtx.getInjectedScript(h.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get injected script: %w", err)
 	}
-	// passing `script` allows `js` to use `script`'s functions.
 	args = append([]interface{}{script}, args...)
 	return h.eval(ctx, opts, js, args...)
 }
@@ -1421,13 +1419,11 @@ func (h *ElementHandle) eval(
 ) (interface{}, error) {
 	// passing `h` makes it evaluate js code in the element handle's scope.
 	args = append([]interface{}{h}, args...)
-	// convert the arguments to goja values.
 	rt := k6common.GetRuntime(ctx)
 	gargs := make([]goja.Value, len(args))
 	for i, arg := range args {
 		gargs[i] = rt.ToValue(arg)
 	}
-	// call the javascript function.
 	result, err := h.execCtx.evaluate(ctx, opts, rt.ToValue(js), gargs...)
 	if err != nil {
 		err = fmt.Errorf("element handle cannot evaluate: %w", err)

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1398,8 +1398,8 @@ func (h *ElementHandle) WaitForSelector(selector string, opts goja.Value) api.El
 	return handle
 }
 
-// evalWithScript evaluates a given js function in the scope of this ElementHandle and allows to call the injected
-// script's functions.
+// evalWithScript evaluates the given js code in the scope of this ElementHandle and returns the result.
+// The js code can call helper functions from injected_script.js.
 func (h *ElementHandle) evalWithScript(
 	ctx context.Context,
 	opts evaluateOptions, js string, args ...interface{},

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1410,7 +1410,7 @@ func (h *ElementHandle) evalWithScript(
 		return nil, fmt.Errorf("cannot get injected script: %w", err)
 	}
 	// passing `script` allows `js` to use `script`'s functions.
-	args = append(append([]interface{}(nil), script), args...)
+	args = append([]interface{}{script}, args...)
 	return h.eval(ctx, opts, js, args...)
 }
 
@@ -1420,7 +1420,7 @@ func (h *ElementHandle) eval(
 	opts evaluateOptions, js string, args ...interface{},
 ) (interface{}, error) {
 	// passing `h` makes it evaluate js code in the element handle's scope.
-	args = append(append([]interface{}(nil), h), args...)
+	args = append([]interface{}{h}, args...)
 	// convert the arguments to goja values.
 	rt := k6common.GetRuntime(ctx)
 	gargs := make([]goja.Value, len(args))

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1054,7 +1054,7 @@ func (h *ElementHandle) InputValue(opts goja.Value) string {
 func (h *ElementHandle) IsChecked() bool {
 	result, err := h.isChecked(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6Throw(h.ctx, "cannot handle element is check: %w", err)
+		k6Throw(h.ctx, "cannot handle element is checked: %w", err)
 	}
 	return result
 }
@@ -1235,7 +1235,7 @@ func (h *ElementHandle) Screenshot(opts goja.Value) goja.ArrayBuffer {
 	rt := k6common.GetRuntime(h.ctx)
 	parsedOpts := NewElementHandleScreenshotOptions(h.defaultTimeout())
 	if err := parsedOpts.Parse(h.ctx, opts); err != nil {
-		k6Throw(h.ctx, "cannot parse element screenshoot options: %w", err)
+		k6Throw(h.ctx, "cannot parse element screenshot options: %w", err)
 	}
 
 	s := newScreenshotter(h.ctx)
@@ -1376,7 +1376,7 @@ func (h *ElementHandle) WaitForElementState(state string, opts goja.Value) {
 	parsedOpts := NewElementHandleWaitForElementStateOptions(time.Duration(h.frame.manager.timeoutSettings.timeout()) * time.Second)
 	err := parsedOpts.Parse(h.ctx, opts)
 	if err != nil {
-		k6Throw(h.ctx, "cannt parse element wait for state options: %w", err)
+		k6Throw(h.ctx, "cannot parse element wait for state options: %w", err)
 	}
 	_, err = h.waitForElementState(h.ctx, []string{state}, parsedOpts.Timeout)
 	if err != nil {

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -49,11 +49,11 @@ func (ew executionWorld) valid() bool {
 	return ew == mainWorld || ew == utilityWorld
 }
 
-type evaluateOptions struct {
+type evalOptions struct {
 	forceCallable, returnByValue bool
 }
 
-func (ea evaluateOptions) String() string {
+func (ea evalOptions) String() string {
 	return fmt.Sprintf("forceCallable:%t returnByValue:%t", ea.forceCallable, ea.returnByValue)
 }
 
@@ -162,11 +162,10 @@ func (e *ExecutionContext) adoptElementHandle(eh *ElementHandle) (*ElementHandle
 	return e.adoptBackendNodeID(node.BackendNodeID)
 }
 
-// evaluate will evaluate provided callable within this execution context
-// and return by value or handle
-func (e *ExecutionContext) evaluate(
+// eval will evaluate provided callable within this execution context and return by value or handle.
+func (e *ExecutionContext) eval(
 	apiCtx context.Context,
-	opts evaluateOptions, pageFunc goja.Value, args ...goja.Value,
+	opts evalOptions, pageFunc goja.Value, args ...goja.Value,
 ) (res interface{}, err error) {
 	e.logger.Debugf(
 		"ExecutionContext:evaluate",
@@ -290,11 +289,11 @@ func (e *ExecutionContext) getInjectedScript(apiCtx context.Context) (api.JSHand
 			expressionWithSourceURL = expression + "\n" + suffix
 		}
 
-		opts := evaluateOptions{
+		opts := evalOptions{
 			forceCallable: false,
 			returnByValue: false,
 		}
-		handle, err := e.evaluate(apiCtx, opts, rt.ToValue(expressionWithSourceURL))
+		handle, err := e.eval(apiCtx, opts, rt.ToValue(expressionWithSourceURL))
 		if handle == nil || err != nil {
 			return nil, fmt.Errorf("cannot get injected script (%q): %w", suffix, err)
 		}
@@ -303,28 +302,28 @@ func (e *ExecutionContext) getInjectedScript(apiCtx context.Context) (api.JSHand
 	return e.injectedScript, nil
 }
 
-// Evaluate will evaluate provided page function within this execution context
-func (e *ExecutionContext) Evaluate(
+// Eval will evaluate provided page function within this execution context
+func (e *ExecutionContext) Eval(
 	apiCtx context.Context,
 	pageFunc goja.Value, args ...goja.Value,
 ) (interface{}, error) {
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	return e.evaluate(apiCtx, opts, pageFunc, args...)
+	return e.eval(apiCtx, opts, pageFunc, args...)
 }
 
-// EvaluateHandle will evaluate provided page function within this execution context
-func (e *ExecutionContext) EvaluateHandle(
+// EvalHandle will evaluate provided page function within this execution context
+func (e *ExecutionContext) EvalHandle(
 	apiCtx context.Context,
 	pageFunc goja.Value, args ...goja.Value,
 ) (api.JSHandle, error) {
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	res, err := e.evaluate(apiCtx, opts, pageFunc, args...)
+	res, err := e.eval(apiCtx, opts, pageFunc, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -321,7 +321,7 @@ func (f *Frame) document() (*ElementHandle, error) {
 
 	f.waitForExecutionContext(mainWorld)
 
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: false,
 		returnByValue: false,
 	}
@@ -531,11 +531,11 @@ func (f *Frame) waitForFunction(
 	} else {
 		predicate = fmt.Sprintf("return (%s)(...args);", predicateFn.ToString().String())
 	}
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := execCtx.evaluate(
+	result, err := execCtx.eval(
 		apiCtx, opts, pageFn, append([]goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(predicate),
@@ -721,7 +721,7 @@ func (f *Frame) Evaluate(pageFunc goja.Value, args ...goja.Value) interface{} {
 
 	f.waitForExecutionContext(mainWorld)
 
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -750,7 +750,7 @@ func (f *Frame) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (handle 
 		if ec == nil {
 			k6common.Throw(rt, fmt.Errorf("cannot find execution context: %q", mainWorld))
 		}
-		handle, err = ec.EvaluateHandle(f.ctx, pageFunc, args...)
+		handle, err = ec.EvalHandle(f.ctx, pageFunc, args...)
 	}
 	f.executionContextMu.RUnlock()
 	if err != nil {
@@ -1245,7 +1245,7 @@ func (f *Frame) SetContent(html string, opts goja.Value) {
 
 	f.waitForExecutionContext(utilityWorld)
 
-	eopts := evaluateOptions{
+	eopts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -1474,7 +1474,7 @@ func (f *Frame) adoptBackendNodeID(world executionWorld, id cdp.BackendNodeID) (
 func (f *Frame) evaluate(
 	apiCtx context.Context,
 	world executionWorld,
-	opts evaluateOptions, pageFunc goja.Value, args ...goja.Value,
+	opts evalOptions, pageFunc goja.Value, args ...goja.Value,
 ) (interface{}, error) {
 	f.log.Debugf("Frame:evaluate", "fid:%s furl:%q world:%s opts:%s", f.ID(), f.URL(), world, opts)
 
@@ -1485,7 +1485,7 @@ func (f *Frame) evaluate(
 	if ec == nil {
 		return nil, fmt.Errorf("cannot find execution context: %q", world)
 	}
-	eh, err := ec.evaluate(apiCtx, opts, pageFunc, args...)
+	eh, err := ec.eval(apiCtx, opts, pageFunc, args...)
 	if err != nil {
 		return nil, fmt.Errorf("frame cannot evaluate: %w", err)
 	}
@@ -1502,11 +1502,11 @@ type frameExecutionContext interface {
 	// execution context from another execution context.
 	adoptElementHandle(elementHandle *ElementHandle) (*ElementHandle, error)
 
-	// evaluate will evaluate provided callable within this execution
+	// eval will evaluate provided callable within this execution
 	// context and return by value or handle.
-	evaluate(
+	eval(
 		apiCtx context.Context,
-		opts evaluateOptions,
+		opts evalOptions,
 		pageFunc goja.Value, args ...goja.Value,
 	) (res interface{}, err error)
 
@@ -1514,16 +1514,16 @@ type frameExecutionContext interface {
 	// functions.
 	getInjectedScript(apiCtx context.Context) (api.JSHandle, error)
 
-	// Evaluate will evaluate provided page function within this execution
+	// Eval will evaluate provided page function within this execution
 	// context.
-	Evaluate(
+	Eval(
 		apiCtx context.Context,
 		pageFunc goja.Value, args ...goja.Value,
 	) (interface{}, error)
 
-	// EvaluateHandle will evaluate provided page function within this
+	// EvalHandle will evaluate provided page function within this
 	// execution context.
-	EvaluateHandle(
+	EvalHandle(
 		apiCtx context.Context,
 		pageFunc goja.Value, args ...goja.Value,
 	) (api.JSHandle, error)

--- a/common/frame_test.go
+++ b/common/frame_test.go
@@ -43,7 +43,7 @@ func TestFrameNilDocument(t *testing.T) {
 
 	// frame should not panic with a nil document
 	stub := &executionContextTestStub{
-		evaluateFn: func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+		evalFn: func(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
 			// return nil to test for panic
 			return nil, nil
 		},
@@ -68,7 +68,7 @@ func TestFrameNilDocument(t *testing.T) {
 
 	// frame gets the document from the evaluate call
 	want := &ElementHandle{}
-	stub.evaluateFn = func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+	stub.evalFn = func(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
 		return want, nil
 	}
 	got, err := frame.document()
@@ -116,9 +116,9 @@ func TestFrameManagerFrameAbortedNavigationShouldEmitANonNilPendingDocument(t *t
 
 type executionContextTestStub struct {
 	ExecutionContext
-	evaluateFn func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error)
+	evalFn func(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error)
 }
 
-func (e executionContextTestStub) evaluate(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
-	return e.evaluateFn(apiCtx, opts, pageFunc, args...)
+func (e executionContextTestStub) eval(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+	return e.evalFn(apiCtx, opts, pageFunc, args...)
 }

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -95,7 +95,7 @@ func (h *BaseJSHandle) Dispose() {
 func (h *BaseJSHandle) Evaluate(pageFunc goja.Value, args ...goja.Value) interface{} {
 	rt := k6common.GetRuntime(h.ctx)
 	args = append([]goja.Value{rt.ToValue(h)}, args...)
-	res, err := h.execCtx.Evaluate(h.ctx, pageFunc, args...)
+	res, err := h.execCtx.Eval(h.ctx, pageFunc, args...)
 	if err != nil {
 		k6common.Throw(rt, err)
 	}
@@ -106,7 +106,7 @@ func (h *BaseJSHandle) Evaluate(pageFunc goja.Value, args ...goja.Value) interfa
 func (h *BaseJSHandle) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) api.JSHandle {
 	rt := k6common.GetRuntime(h.ctx)
 	args = append([]goja.Value{rt.ToValue(h)}, args...)
-	res, err := h.execCtx.EvaluateHandle(h.ctx, pageFunc, args...)
+	res, err := h.execCtx.EvalHandle(h.ctx, pageFunc, args...)
 	if err != nil {
 		k6common.Throw(rt, err)
 	}

--- a/common/page.go
+++ b/common/page.go
@@ -225,11 +225,11 @@ func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) cdp.Frame
 		}
 	`)
 
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.execCtx.evaluate(apiCtx, opts, pageFn, []goja.Value{rt.ToValue(h)}...)
+	result, err := h.execCtx.eval(apiCtx, opts, pageFn, []goja.Value{rt.ToValue(h)}...)
 	if err != nil {
 		p.logger.Debugf("Page:getOwnerFrame:return", "sid:%v err:%v", p.sessionID(), err)
 		return ""

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -47,7 +47,7 @@ func newScreenshotter(ctx context.Context) *screenshotter {
 
 func (s *screenshotter) fullPageSize(p *Page) (*Size, error) {
 	rt := k6common.GetRuntime(s.ctx)
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -91,7 +91,7 @@ func (s *screenshotter) originalViewportSize(p *Page) (*Size, *Size, error) {
 		return &viewportSize, &originalViewportSize, nil
 	}
 
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}

--- a/tests/element_handle_click_test.go
+++ b/tests/element_handle_click_test.go
@@ -140,5 +140,5 @@ func TestElementHandleClickWithDetachedNode(t *testing.T) {
 		}))
 	}
 	panicTestFn()
-	assert.Equal(t, "element is not attached to the DOM", errorMsg, "expected click to result in correct error to be thrown")
+	assert.Contains(t, errorMsg, "element is not attached to the DOM", "expected click to result in correct error to be thrown")
 }


### PR DESCRIPTION
This PR refactors `ElementHandle`'s evaluate calls that happen through the `ExecutionContext,` which are repetitive. This is not a critical change, but I worked on it while fixing #170 and wanted to create a separate PR.

We now provide two new unexported methods:
* [`evalWithScript`](https://github.com/grafana/xk6-browser/blob/9b773bffd96c063363e3897d06b687ec79f1d64f/common/element_handle.go#L1428-L1442): Runs a javascript code in the current `ElementHandle` scope and provides an ability to use the injected script's functions. In the previous code version, each `ElementHandle` function needs to pass the current `ElementHandle` and call `getInjectedScript` and then pass it to the `ExecutionContext`'s `evaluate` call. This function makes this easier.
* [`eval`](https://github.com/grafana/xk6-browser/blob/9b773bffd96c063363e3897d06b687ec79f1d64f/common/element_handle.go#L1444-L1463): Similar to `evalWithScript` but it runs the given javascript code without the injected script.

Another advantage of doing this is that the methods don't need to call `rt.ToValue` everywhere. However, there is a disadvantage (IDK how critical it is), though: We need to [convert the arguments to `goja.Value`s](https://github.com/grafana/xk6-browser/blob/9b773bffd96c063363e3897d06b687ec79f1d64f/common/element_handle.go#L1451-L1456) in the `eval` functions I explained above.

Naming changes:
* ExecutionContext:
  * Evaluate -> Eval
  * EvaluateHandle -> EvalHandle
  * evaluate -> eval
* evaluateOptions -> evalOptions