### PR TITLE
Revert "Refactor ElementHandle evaluate calls"

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1363,6 +1363,7 @@ func (h *ElementHandle) QueryAll(selector string) []api.ElementHandle {
 	for _, property := range properties {
 		elementHandle := property.AsElement()
 		if elementHandle != nil {
+			//nolint
 			result = append(elements, elementHandle)
 		} else {
 			property.Dispose()

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -49,11 +49,11 @@ func (ew executionWorld) valid() bool {
 	return ew == mainWorld || ew == utilityWorld
 }
 
-type evalOptions struct {
+type evaluateOptions struct {
 	forceCallable, returnByValue bool
 }
 
-func (ea evalOptions) String() string {
+func (ea evaluateOptions) String() string {
 	return fmt.Sprintf("forceCallable:%t returnByValue:%t", ea.forceCallable, ea.returnByValue)
 }
 
@@ -162,10 +162,11 @@ func (e *ExecutionContext) adoptElementHandle(eh *ElementHandle) (*ElementHandle
 	return e.adoptBackendNodeID(node.BackendNodeID)
 }
 
-// eval will evaluate provided callable within this execution context and return by value or handle.
-func (e *ExecutionContext) eval(
+// evaluate will evaluate provided callable within this execution context
+// and return by value or handle
+func (e *ExecutionContext) evaluate(
 	apiCtx context.Context,
-	opts evalOptions, pageFunc goja.Value, args ...goja.Value,
+	opts evaluateOptions, pageFunc goja.Value, args ...goja.Value,
 ) (res interface{}, err error) {
 	e.logger.Debugf(
 		"ExecutionContext:evaluate",
@@ -289,11 +290,11 @@ func (e *ExecutionContext) getInjectedScript(apiCtx context.Context) (api.JSHand
 			expressionWithSourceURL = expression + "\n" + suffix
 		}
 
-		opts := evalOptions{
+		opts := evaluateOptions{
 			forceCallable: false,
 			returnByValue: false,
 		}
-		handle, err := e.eval(apiCtx, opts, rt.ToValue(expressionWithSourceURL))
+		handle, err := e.evaluate(apiCtx, opts, rt.ToValue(expressionWithSourceURL))
 		if handle == nil || err != nil {
 			return nil, fmt.Errorf("cannot get injected script (%q): %w", suffix, err)
 		}
@@ -302,28 +303,28 @@ func (e *ExecutionContext) getInjectedScript(apiCtx context.Context) (api.JSHand
 	return e.injectedScript, nil
 }
 
-// Eval will evaluate provided page function within this execution context
-func (e *ExecutionContext) Eval(
+// Evaluate will evaluate provided page function within this execution context
+func (e *ExecutionContext) Evaluate(
 	apiCtx context.Context,
 	pageFunc goja.Value, args ...goja.Value,
 ) (interface{}, error) {
-	opts := evalOptions{
+	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	return e.eval(apiCtx, opts, pageFunc, args...)
+	return e.evaluate(apiCtx, opts, pageFunc, args...)
 }
 
-// EvalHandle will evaluate provided page function within this execution context
-func (e *ExecutionContext) EvalHandle(
+// EvaluateHandle will evaluate provided page function within this execution context
+func (e *ExecutionContext) EvaluateHandle(
 	apiCtx context.Context,
 	pageFunc goja.Value, args ...goja.Value,
 ) (api.JSHandle, error) {
-	opts := evalOptions{
+	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	res, err := e.eval(apiCtx, opts, pageFunc, args...)
+	res, err := e.evaluate(apiCtx, opts, pageFunc, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -321,7 +321,7 @@ func (f *Frame) document() (*ElementHandle, error) {
 
 	f.waitForExecutionContext(mainWorld)
 
-	opts := evalOptions{
+	opts := evaluateOptions{
 		forceCallable: false,
 		returnByValue: false,
 	}
@@ -531,11 +531,11 @@ func (f *Frame) waitForFunction(
 	} else {
 		predicate = fmt.Sprintf("return (%s)(...args);", predicateFn.ToString().String())
 	}
-	opts := evalOptions{
+	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := execCtx.eval(
+	result, err := execCtx.evaluate(
 		apiCtx, opts, pageFn, append([]goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(predicate),
@@ -721,7 +721,7 @@ func (f *Frame) Evaluate(pageFunc goja.Value, args ...goja.Value) interface{} {
 
 	f.waitForExecutionContext(mainWorld)
 
-	opts := evalOptions{
+	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -750,7 +750,7 @@ func (f *Frame) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (handle 
 		if ec == nil {
 			k6common.Throw(rt, fmt.Errorf("cannot find execution context: %q", mainWorld))
 		}
-		handle, err = ec.EvalHandle(f.ctx, pageFunc, args...)
+		handle, err = ec.EvaluateHandle(f.ctx, pageFunc, args...)
 	}
 	f.executionContextMu.RUnlock()
 	if err != nil {
@@ -1245,7 +1245,7 @@ func (f *Frame) SetContent(html string, opts goja.Value) {
 
 	f.waitForExecutionContext(utilityWorld)
 
-	eopts := evalOptions{
+	eopts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -1474,7 +1474,7 @@ func (f *Frame) adoptBackendNodeID(world executionWorld, id cdp.BackendNodeID) (
 func (f *Frame) evaluate(
 	apiCtx context.Context,
 	world executionWorld,
-	opts evalOptions, pageFunc goja.Value, args ...goja.Value,
+	opts evaluateOptions, pageFunc goja.Value, args ...goja.Value,
 ) (interface{}, error) {
 	f.log.Debugf("Frame:evaluate", "fid:%s furl:%q world:%s opts:%s", f.ID(), f.URL(), world, opts)
 
@@ -1485,7 +1485,7 @@ func (f *Frame) evaluate(
 	if ec == nil {
 		return nil, fmt.Errorf("cannot find execution context: %q", world)
 	}
-	eh, err := ec.eval(apiCtx, opts, pageFunc, args...)
+	eh, err := ec.evaluate(apiCtx, opts, pageFunc, args...)
 	if err != nil {
 		return nil, fmt.Errorf("frame cannot evaluate: %w", err)
 	}
@@ -1502,11 +1502,11 @@ type frameExecutionContext interface {
 	// execution context from another execution context.
 	adoptElementHandle(elementHandle *ElementHandle) (*ElementHandle, error)
 
-	// eval will evaluate provided callable within this execution
+	// evaluate will evaluate provided callable within this execution
 	// context and return by value or handle.
-	eval(
+	evaluate(
 		apiCtx context.Context,
-		opts evalOptions,
+		opts evaluateOptions,
 		pageFunc goja.Value, args ...goja.Value,
 	) (res interface{}, err error)
 
@@ -1514,16 +1514,16 @@ type frameExecutionContext interface {
 	// functions.
 	getInjectedScript(apiCtx context.Context) (api.JSHandle, error)
 
-	// Eval will evaluate provided page function within this execution
+	// Evaluate will evaluate provided page function within this execution
 	// context.
-	Eval(
+	Evaluate(
 		apiCtx context.Context,
 		pageFunc goja.Value, args ...goja.Value,
 	) (interface{}, error)
 
-	// EvalHandle will evaluate provided page function within this
+	// EvaluateHandle will evaluate provided page function within this
 	// execution context.
-	EvalHandle(
+	EvaluateHandle(
 		apiCtx context.Context,
 		pageFunc goja.Value, args ...goja.Value,
 	) (api.JSHandle, error)

--- a/common/frame_test.go
+++ b/common/frame_test.go
@@ -43,7 +43,7 @@ func TestFrameNilDocument(t *testing.T) {
 
 	// frame should not panic with a nil document
 	stub := &executionContextTestStub{
-		evalFn: func(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+		evaluateFn: func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
 			// return nil to test for panic
 			return nil, nil
 		},
@@ -68,7 +68,7 @@ func TestFrameNilDocument(t *testing.T) {
 
 	// frame gets the document from the evaluate call
 	want := &ElementHandle{}
-	stub.evalFn = func(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+	stub.evaluateFn = func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
 		return want, nil
 	}
 	got, err := frame.document()
@@ -116,9 +116,9 @@ func TestFrameManagerFrameAbortedNavigationShouldEmitANonNilPendingDocument(t *t
 
 type executionContextTestStub struct {
 	ExecutionContext
-	evalFn func(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error)
+	evaluateFn func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error)
 }
 
-func (e executionContextTestStub) eval(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
-	return e.evalFn(apiCtx, opts, pageFunc, args...)
+func (e executionContextTestStub) evaluate(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+	return e.evaluateFn(apiCtx, opts, pageFunc, args...)
 }

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -95,7 +95,7 @@ func (h *BaseJSHandle) Dispose() {
 func (h *BaseJSHandle) Evaluate(pageFunc goja.Value, args ...goja.Value) interface{} {
 	rt := k6common.GetRuntime(h.ctx)
 	args = append([]goja.Value{rt.ToValue(h)}, args...)
-	res, err := h.execCtx.Eval(h.ctx, pageFunc, args...)
+	res, err := h.execCtx.Evaluate(h.ctx, pageFunc, args...)
 	if err != nil {
 		k6common.Throw(rt, err)
 	}
@@ -106,7 +106,7 @@ func (h *BaseJSHandle) Evaluate(pageFunc goja.Value, args ...goja.Value) interfa
 func (h *BaseJSHandle) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) api.JSHandle {
 	rt := k6common.GetRuntime(h.ctx)
 	args = append([]goja.Value{rt.ToValue(h)}, args...)
-	res, err := h.execCtx.EvalHandle(h.ctx, pageFunc, args...)
+	res, err := h.execCtx.EvaluateHandle(h.ctx, pageFunc, args...)
 	if err != nil {
 		k6common.Throw(rt, err)
 	}

--- a/common/page.go
+++ b/common/page.go
@@ -225,11 +225,11 @@ func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) cdp.Frame
 		}
 	`)
 
-	opts := evalOptions{
+	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.execCtx.eval(apiCtx, opts, pageFn, []goja.Value{rt.ToValue(h)}...)
+	result, err := h.execCtx.evaluate(apiCtx, opts, pageFn, []goja.Value{rt.ToValue(h)}...)
 	if err != nil {
 		p.logger.Debugf("Page:getOwnerFrame:return", "sid:%v err:%v", p.sessionID(), err)
 		return ""

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -47,7 +47,7 @@ func newScreenshotter(ctx context.Context) *screenshotter {
 
 func (s *screenshotter) fullPageSize(p *Page) (*Size, error) {
 	rt := k6common.GetRuntime(s.ctx)
-	opts := evalOptions{
+	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -91,7 +91,7 @@ func (s *screenshotter) originalViewportSize(p *Page) (*Size, *Size, error) {
 		return &viewportSize, &originalViewportSize, nil
 	}
 
-	opts := evalOptions{
+	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}

--- a/tests/element_handle_click_test.go
+++ b/tests/element_handle_click_test.go
@@ -140,5 +140,5 @@ func TestElementHandleClickWithDetachedNode(t *testing.T) {
 		}))
 	}
 	panicTestFn()
-	assert.Contains(t, errorMsg, "element is not attached to the DOM", "expected click to result in correct error to be thrown")
+	assert.Equal(t, "element is not attached to the DOM", errorMsg, "expected click to result in correct error to be thrown")
 }


### PR DESCRIPTION
I'd like to revert #196, remove the `QueryAll` fix and add it to the actual fix PR. I'll also put the other refactorings in #195 to another PR—leave it only with the fix. So we can better point it out in the release and have a better history.