### PR TITLE
Add request blocking based on k6 `blockHostnames` option

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -230,9 +230,11 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 		return
 	}
 
+	session := b.connSessions.getSession(ev.SessionID)
+
 	switch evti.Type {
 	case "background_page":
-		p, err := NewPage(b.ctx, b.connSessions.getSession(ev.SessionID), browserCtx, evti.TargetID, nil, false, b.logger)
+		p, err := NewPage(b.ctx, session, browserCtx, evti.TargetID, nil, false, b.logger)
 		if err != nil {
 			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() //b.conn.isConnected()
 			if _, ok := err.(*websocket.CloseError); !ok && !isRunning {
@@ -272,7 +274,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 
 		b.logger.Debugf("Browser:onAttachedToTarget:page", "sid:%v tid:%v opener nil:%t", ev.SessionID, evti.TargetID, opener == nil)
 
-		p, err := NewPage(b.ctx, b.connSessions.getSession(ev.SessionID), browserCtx, evti.TargetID, opener, true, b.logger)
+		p, err := NewPage(b.ctx, session, browserCtx, evti.TargetID, opener, true, b.logger)
 		if err != nil {
 			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() //b.conn.isConnected()
 			if _, ok := err.(*websocket.CloseError); !ok && !isRunning {

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -157,7 +157,7 @@ func (b *BrowserContext) ExposeBinding(name string, callback goja.Callable, opts
 }
 
 func (b *BrowserContext) ExposeFunction(name string, callback goja.Callable) {
-	k6Throw(b.ctx, "BrowserContext.newCDPSession(name, callback) has not been implemented yet")
+	k6Throw(b.ctx, "BrowserContext.exposeFunction(name, callback) has not been implemented yet")
 }
 
 // GrantPermissions enables the specified permissions, all others will be disabled.
@@ -245,7 +245,7 @@ func (b *BrowserContext) Pages() []api.Page {
 }
 
 func (b *BrowserContext) Route(url goja.Value, handler goja.Callable) {
-	k6Throw(b.ctx, "BrowserContext.setHTTPCredentials(httpCredentials) has not been implemented yet")
+	k6Throw(b.ctx, "BrowserContext.route(url, handler) has not been implemented yet")
 }
 
 // SetDefaultNavigationTimeout sets the default navigation timeout in milliseconds.
@@ -263,7 +263,7 @@ func (b *BrowserContext) SetDefaultTimeout(timeout int64) {
 }
 
 func (b *BrowserContext) SetExtraHTTPHeaders(headers map[string]string) {
-	k6Throw(b.ctx, "BrowserContext.setHTTPCredentials(httpCredentials) has not been implemented yet")
+	k6Throw(b.ctx, "BrowserContext.setExtraHTTPHeaders(headers) has not been implemented yet")
 }
 
 // SetGeolocation overrides the geo location of the user.

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -361,8 +361,11 @@ func (fs *FrameSession) initOptions() error {
 	fs.logger.Debugf("NewFrameSession:initOptions",
 		"sid:%v tid:%v", fs.session.id, fs.targetID)
 
-	opts := fs.manager.page.browserCtx.opts
-	optActions := []Action{}
+	var (
+		opts       = fs.manager.page.browserCtx.opts
+		optActions = []Action{}
+		state      = k6lib.GetState(fs.ctx)
+	)
 
 	if fs.isMainFrame() {
 		optActions = append(optActions, emulation.SetFocusEmulationEnabled(true))
@@ -402,9 +405,15 @@ func (fs *FrameSession) initOptions() error {
 		return err
 	}
 	fs.updateExtraHTTPHeaders(true)
-	if err := fs.updateRequestInterception(true); err != nil {
+
+	var reqIntercept bool
+	if state.Options.BlockedHostnames.Trie != nil {
+		reqIntercept = true
+	}
+	if err := fs.updateRequestInterception(reqIntercept); err != nil {
 		return err
 	}
+
 	fs.updateOffline(true)
 	fs.updateHttpCredentials(true)
 	if err := fs.updateEmulateMedia(true); err != nil {
@@ -979,10 +988,9 @@ func (fs *FrameSession) updateOffline(initial bool) {
 	}
 }
 
-func (fs *FrameSession) updateRequestInterception(initial bool) error {
-	fs.logger.Debugf("NewFrameSession:updateRequestInterception", "sid:%v tid:%v", fs.session.id, fs.targetID)
-
-	return fs.networkManager.setRequestInterception(fs.page.hasRoutes())
+func (fs *FrameSession) updateRequestInterception(enable bool) error {
+	fs.logger.Debugf("NewFrameSession:updateRequestInterception", "sid:%v tid:%v on:%v", fs.session.id, fs.targetID, enable)
+	return fs.networkManager.setRequestInterception(enable || fs.page.hasRoutes())
 }
 
 func (fs *FrameSession) updateViewport() error {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -112,26 +112,15 @@ func NewFrameSession(
 		},
 	}
 
+	var parentNM *NetworkManager
 	if fs.parent != nil {
-		fs.networkManager, err = NewNetworkManager(ctx, session, fs.manager, fs.parent.networkManager)
-		if err != nil {
-			logger.Debugf(
-				"NewFrameSession:NewNetworkManager",
-				"sid:%v tid:%v err:%v",
-				session.id, targetID, err)
-
-			return nil, err
-		}
-	} else {
-		fs.networkManager, err = NewNetworkManager(ctx, session, fs.manager, nil)
-		if err != nil {
-			logger.Debugf(
-				"NewFrameSession:NewNetworkManager#2",
-				"sid:%v tid:%v err:%v",
-				session.id, targetID, err)
-
-			return nil, err
-		}
+		parentNM = fs.parent.networkManager
+	}
+	fs.networkManager, err = NewNetworkManager(ctx, session, fs.manager, parentNM)
+	if err != nil {
+		logger.Debugf("NewFrameSession:NewNetworkManager", "sid:%v tid:%v err:%v",
+			session.id, targetID, err)
+		return nil, err
 	}
 
 	action := browser.GetWindowForTarget().WithTargetID(fs.targetID)

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -1,0 +1,125 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chromedp/cdproto/fetch"
+	"github.com/chromedp/cdproto/network"
+	"github.com/mailru/easyjson"
+	"github.com/oxtoacart/bpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k6lib "go.k6.io/k6/lib"
+	k6metrics "go.k6.io/k6/lib/metrics"
+	k6test "go.k6.io/k6/lib/testutils"
+	k6types "go.k6.io/k6/lib/types"
+	k6stats "go.k6.io/k6/stats"
+)
+
+type testSession struct {
+	*Session
+	cdpCalls []string
+}
+
+// Execute implements the cdp.Executor interface to record calls made to it and
+// allow assertions in tests.
+func (s *testSession) Execute(ctx context.Context, method string,
+	params easyjson.Marshaler, res easyjson.Unmarshaler) error {
+	s.cdpCalls = append(s.cdpCalls, method)
+	return nil
+}
+
+func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager, *testSession) {
+	ctx := context.Background()
+
+	root, err := k6lib.NewGroup("", nil)
+	require.NoError(t, err)
+
+	state := &k6lib.State{
+		Options:        k6opts,
+		Logger:         k6test.NewLogger(t),
+		Group:          root,
+		BPool:          bpool.NewBufferPool(1),
+		Samples:        make(chan k6stats.SampleContainer, 1000),
+		Tags:           k6lib.NewTagMap(map[string]string{"group": root.Path}),
+		BuiltinMetrics: k6metrics.RegisterBuiltinMetrics(k6metrics.NewRegistry()),
+	}
+
+	ctx = k6lib.WithState(ctx, state)
+	logger := NewLogger(ctx, state.Logger, false, nil)
+
+	session := &testSession{
+		Session: &Session{
+			id: "1234",
+		},
+	}
+
+	nm := &NetworkManager{
+		ctx:     ctx,
+		logger:  logger,
+		session: session,
+	}
+
+	return nm, session
+}
+
+func TestOnRequestPaused(t *testing.T) {
+	testCases := []struct {
+		name, reqURL                  string
+		blockedHostnames, expCDPCalls []string
+	}{
+		{
+			name:             "ok_fail_simple",
+			blockedHostnames: []string{"*.test"},
+			reqURL:           "http://host.test/",
+			expCDPCalls:      []string{"Fetch.failRequest"},
+		},
+		{
+			name:             "ok_continue_simple",
+			blockedHostnames: []string{"*.test"},
+			reqURL:           "http://host.com/",
+			expCDPCalls:      []string{"Fetch.continueRequest"},
+		},
+		{
+			name:             "ok_continue_empty",
+			blockedHostnames: nil,
+			reqURL:           "http://host.com/",
+			expCDPCalls:      []string{"Fetch.continueRequest"},
+		},
+		{
+			name:             "ok_continue_ip",
+			blockedHostnames: []string{"*.test"},
+			reqURL:           "http://127.0.0.1/",
+			expCDPCalls:      []string{"Fetch.continueRequest"},
+		},
+		{
+			name:             "err_url_continue",
+			blockedHostnames: []string{"*.test"},
+			reqURL:           ":::",
+			expCDPCalls:      []string{"Fetch.continueRequest"},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			blocked, err := k6types.NewNullHostnameTrie(tc.blockedHostnames)
+			require.NoError(t, err)
+
+			k6opts := k6lib.Options{BlockedHostnames: blocked}
+			nm, session := newTestNetworkManager(t, k6opts)
+			ev := &fetch.EventRequestPaused{
+				RequestID: "1234",
+				Request: &network.Request{
+					Method: "GET",
+					URL:    tc.reqURL,
+				},
+			}
+
+			nm.onRequestPaused(ev)
+
+			assert.Equal(t, tc.expCDPCalls, session.cdpCalls)
+		})
+	}
+}

--- a/common/session.go
+++ b/common/session.go
@@ -32,9 +32,13 @@ import (
 	k6lib "go.k6.io/k6/lib"
 )
 
-// Ensure Session implements the EventEmitter and Executor interfaces
-var _ EventEmitter = &Session{}
-var _ cdp.Executor = &Session{}
+var _ session = &Session{}
+
+type session interface {
+	EventEmitter
+	cdp.Executor
+	ID() target.SessionID
+}
 
 // Session represents a CDP session to a target
 type Session struct {
@@ -67,6 +71,11 @@ func NewSession(ctx context.Context, conn *Connection, id target.SessionID, tid 
 	s.logger.Debugf("Session:NewSession", "sid:%v tid:%v", id, tid)
 	go s.readLoop()
 	return &s
+}
+
+// ID returns the session ID.
+func (s *Session) ID() target.SessionID {
+	return s.id
 }
 
 func (s *Session) close() {

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -27,12 +27,10 @@ import (
 )
 
 func TestDataURLSkipRequest(t *testing.T) {
-	tb := newTestBrowser(t)
+	tb := newTestBrowser(t, withLogCache())
 	p := tb.NewPage(nil)
-
-	lc := attachLogCache(tb.state.Logger)
 
 	p.Goto("data:text/html,hello", nil)
 
-	assert.True(t, lc.contains("skipped request handling of data URL"))
+	assert.True(t, tb.logCache.contains("skipped request handling of data URL"))
 }


### PR DESCRIPTION
Partially implements #105

I decided to leave most of the previous request interception code intact (`api.Route`, etc.), except for the non-functional parts (47b0121). This will be useful once we expose this API to JS, which seems to have been the original idea, and is [what Playwright and Puppeteer already do](https://github.com/grafana/xk6-browser/issues/105#issuecomment-1016655405). For now, the [`Fetch` CDP domain](https://chromedevtools.github.io/devtools-protocol/tot/Fetch/) is only enabled and used internally.