### PR TITLE
Add support for k6's `hosts` option

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -219,18 +219,9 @@ func setFlagsFromK6Options(flags map[string]interface{}, k6opts *k6lib.Options) 
 	if currHostResolver, ok := flags["host-resolver-rules"]; ok {
 		hostResolver = append(hostResolver, fmt.Sprintf("%s", currHostResolver))
 	}
-	sortedHostKeys := sortHosts(k6opts.Hosts)
-	for _, k := range sortedHostKeys {
-		hostResolver = append(hostResolver, fmt.Sprintf("MAP %s %s", k, k6opts.Hosts[k]))
+	for k, v := range k6opts.Hosts {
+		hostResolver = append(hostResolver, fmt.Sprintf("MAP %s %s", k, v))
 	}
+	sort.Strings(hostResolver)
 	flags["host-resolver-rules"] = strings.Join(hostResolver, ",")
-}
-
-func sortHosts(m map[string]*k6lib.HostAddress) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -219,9 +219,13 @@ func setFlagsFromK6Options(flags map[string]interface{}, k6opts *k6lib.Options) 
 	if currHostResolver, ok := flags["host-resolver-rules"]; ok {
 		hostResolver = append(hostResolver, fmt.Sprintf("%s", currHostResolver))
 	}
+
 	for k, v := range k6opts.Hosts {
 		hostResolver = append(hostResolver, fmt.Sprintf("MAP %s %s", k, v))
 	}
-	sort.Strings(hostResolver)
-	flags["host-resolver-rules"] = strings.Join(hostResolver, ",")
+
+	if len(hostResolver) > 0 {
+		sort.Strings(hostResolver)
+		flags["host-resolver-rules"] = strings.Join(hostResolver, ",")
+	}
 }

--- a/chromium/browser_type_test.go
+++ b/chromium/browser_type_test.go
@@ -102,6 +102,13 @@ func TestBrowserTypeFlags(t *testing.T) {
 				"MAP httpbin.test.k6.io 127.0.0.1:8000,MAP test.k6.io 127.0.0.1:8000",
 		},
 		{
+			flag:          "host-resolver-rules",
+			expInitVal:    nil,
+			changeOpts:    &common.LaunchOptions{},
+			changeK6Opts:  &k6lib.Options{},
+			expChangedVal: nil,
+		},
+		{
 			flag:       "enable-use-zoom-for-dsf",
 			expInitVal: false,
 			pre: func(t *testing.T) {
@@ -148,6 +155,8 @@ func TestBrowserTypeFlags(t *testing.T) {
 				flags = bt.flags(tc.changeOpts, tc.changeK6Opts)
 				if tc.expChangedVal != nil {
 					assert.Equal(t, tc.expChangedVal, flags[tc.flag])
+				} else {
+					assert.NotContains(t, flags, tc.flag)
 				}
 			}
 

--- a/examples/hosts.js
+++ b/examples/hosts.js
@@ -1,0 +1,23 @@
+import launcher from 'k6/x/browser';
+import { check } from 'k6';
+
+export const options = {
+  hosts: {'test.k6.io': '127.0.0.254'},
+};
+
+export default function() {
+  const browser = launcher.launch('chromium', {
+    headless: __ENV.XK6_HEADLESS ? true : false,
+  });
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  const res = page.goto('http://test.k6.io/', { waitUntil: 'load' });
+
+  check(res, {
+    'null response': r => r === null,
+  });
+
+  page.close();
+  browser.close();
+}


### PR DESCRIPTION
This translates [k6's `hosts` option](https://k6.io/docs/using-k6/options/#hosts) into [Chrome's `host-resolver-rules` option](https://datacadamia.com/web/browser/chrome#dns_resolver). There's no way that I could see to set this via CDP, so it needs to be done at launch. And of course, re-implemented for Firefox once we support it, though judging by [this issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1523367), there doesn't seem to be an equivalent option (yet?).

This is based on #206, so that should be merged first.

Closes #105