### PR TITLE
Refactor/elementhandle evaluate calls after revert

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1054,7 +1054,7 @@ func (h *ElementHandle) InputValue(opts goja.Value) string {
 func (h *ElementHandle) IsChecked() bool {
 	result, err := h.isChecked(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6Throw(h.ctx, "cannot handle element is check: %w", err)
+		k6Throw(h.ctx, "cannot handle element is checked: %w", err)
 	}
 	return result
 }
@@ -1236,7 +1236,7 @@ func (h *ElementHandle) Screenshot(opts goja.Value) goja.ArrayBuffer {
 	rt := k6common.GetRuntime(h.ctx)
 	parsedOpts := NewElementHandleScreenshotOptions(h.defaultTimeout())
 	if err := parsedOpts.Parse(h.ctx, opts); err != nil {
-		k6Throw(h.ctx, "cannot parse element screenshoot options: %w", err)
+		k6Throw(h.ctx, "cannot parse element screenshot options: %w", err)
 	}
 
 	s := newScreenshotter(h.ctx)
@@ -1377,7 +1377,7 @@ func (h *ElementHandle) WaitForElementState(state string, opts goja.Value) {
 	parsedOpts := NewElementHandleWaitForElementStateOptions(time.Duration(h.frame.manager.timeoutSettings.timeout()) * time.Second)
 	err := parsedOpts.Parse(h.ctx, opts)
 	if err != nil {
-		k6Throw(h.ctx, "cannt parse element wait for state options: %w", err)
+		k6Throw(h.ctx, "cannot parse element wait for state options: %w", err)
 	}
 	_, err = h.waitForElementState(h.ctx, []string{state}, parsedOpts.Timeout)
 	if err != nil {

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1399,8 +1399,8 @@ func (h *ElementHandle) WaitForSelector(selector string, opts goja.Value) api.El
 	return handle
 }
 
-// evalWithScript evaluates a given js function in the scope of this ElementHandle and allows to call the injected
-// script's functions.
+// evalWithScript evaluates the given js code in the scope of this ElementHandle and returns the result.
+// The js code can call helper functions from injected_script.js.
 func (h *ElementHandle) evalWithScript(
 	ctx context.Context,
 	opts evaluateOptions, js string, args ...interface{},

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1415,7 +1415,7 @@ func (h *ElementHandle) evalWithScript(
 	return h.eval(ctx, opts, js, args...)
 }
 
-// eval evaluates a given js function in the scope of this ElementHandle.
+// eval evaluates the given js code in the scope of this ElementHandle and returns the result.
 func (h *ElementHandle) eval(
 	ctx context.Context,
 	opts evaluateOptions, js string, args ...interface{},

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -231,7 +231,7 @@ func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, point Position)
 			return injected.checkHitTargetAt(node, point);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -257,7 +257,7 @@ func (h *ElementHandle) checkElementState(apiCtx context.Context, state string) 
 			return injected.checkElementState(node, state);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -378,7 +378,7 @@ func (h *ElementHandle) dispatchEvent(apiCtx context.Context, typ string, eventI
 			injected.dispatchEvent(node, type, eventInit);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -392,7 +392,7 @@ func (h *ElementHandle) fill(apiCtx context.Context, value string) (interface{},
 			return injected.fill(node, value);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -415,7 +415,7 @@ func (h *ElementHandle) focus(apiCtx context.Context, resetSelectionIfNotFocused
 			return injected.focusNode(node, resetSelectionIfNotFocused);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -438,7 +438,7 @@ func (h *ElementHandle) getAttribute(apiCtx context.Context, name string) (inter
 			return element.getAttribute('` + name + `');
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -455,7 +455,7 @@ func (h *ElementHandle) innerHTML(apiCtx context.Context) (interface{}, error) {
 			return element.innerHTML;
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -468,7 +468,7 @@ func (h *ElementHandle) innerText(apiCtx context.Context) (interface{}, error) {
 			return element.innerText;
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -484,7 +484,7 @@ func (h *ElementHandle) inputValue(apiCtx context.Context) (interface{}, error) 
 			return element.value;
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -521,7 +521,7 @@ func (h *ElementHandle) offsetPosition(apiCtx context.Context, offset *Position)
 			return injected.getElementBorderWidth(node);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -685,7 +685,7 @@ func (h *ElementHandle) selectOption(apiCtx context.Context, values goja.Value) 
 			return injected.selectOptions(node, values);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
@@ -708,7 +708,7 @@ func (h *ElementHandle) selectText(apiCtx context.Context) error {
 			return injected.selectText(node);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -760,7 +760,7 @@ func (h *ElementHandle) textContent(apiCtx context.Context) (interface{}, error)
 			return element.textContent;
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -787,7 +787,7 @@ func (h *ElementHandle) waitAndScrollIntoViewIfNeeded(apiCtx context.Context, fo
 				return [window.scrollX, window.scrollY];
 			}
 		`
-		opts := evaluateOptions{
+		opts := evalOptions{
 			forceCallable: true,
 			returnByValue: true,
 		}
@@ -807,7 +807,7 @@ func (h *ElementHandle) waitForElementState(apiCtx context.Context, states []str
 			return injected.waitForElementStates(node, states, timeout);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -839,7 +839,7 @@ func (h *ElementHandle) waitForSelector(apiCtx context.Context, selector string,
 			return injected.waitForSelector(selector, node, strict, state, 'raf', timeout, ...args);
 		}
 	`
-	eopts := evaluateOptions{
+	eopts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
@@ -1111,7 +1111,7 @@ func (h *ElementHandle) OwnerFrame() api.Frame {
 			return injected.getDocumentElement(node);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
@@ -1167,7 +1167,7 @@ func (h *ElementHandle) Query(selector string) api.ElementHandle {
 			return injected.querySelector(selector, node || document, false);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
@@ -1203,7 +1203,7 @@ func (h *ElementHandle) QueryAll(selector string) []api.ElementHandle {
 			return injected.querySelectorAll(selector, node || document, false);
 		}
 	`
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
@@ -1403,7 +1403,7 @@ func (h *ElementHandle) WaitForSelector(selector string, opts goja.Value) api.El
 // The js code can call helper functions from injected_script.js.
 func (h *ElementHandle) evalWithScript(
 	ctx context.Context,
-	opts evaluateOptions, js string, args ...interface{},
+	opts evalOptions, js string, args ...interface{},
 ) (interface{}, error) {
 	script, err := h.execCtx.getInjectedScript(h.ctx)
 	if err != nil {
@@ -1416,7 +1416,7 @@ func (h *ElementHandle) evalWithScript(
 // eval evaluates the given js code in the scope of this ElementHandle and returns the result.
 func (h *ElementHandle) eval(
 	ctx context.Context,
-	opts evaluateOptions, js string, args ...interface{},
+	opts evalOptions, js string, args ...interface{},
 ) (interface{}, error) {
 	// passing `h` makes it evaluate js code in the element handle's scope.
 	args = append([]interface{}{h}, args...)
@@ -1425,7 +1425,7 @@ func (h *ElementHandle) eval(
 	for i, arg := range args {
 		gargs[i] = rt.ToValue(arg)
 	}
-	result, err := h.execCtx.evaluate(ctx, opts, rt.ToValue(js), gargs...)
+	result, err := h.execCtx.eval(ctx, opts, rt.ToValue(js), gargs...)
 	if err != nil {
 		err = fmt.Errorf("element handle cannot evaluate: %w", err)
 	}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1411,7 +1411,7 @@ func (h *ElementHandle) evalWithScript(
 		return nil, fmt.Errorf("cannot get injected script: %w", err)
 	}
 	// passing `script` allows `js` to use `script`'s functions.
-	args = append(append([]interface{}(nil), script), args...)
+	args = append([]interface{}{script}, args...)
 	return h.eval(ctx, opts, js, args...)
 }
 
@@ -1421,7 +1421,7 @@ func (h *ElementHandle) eval(
 	opts evaluateOptions, js string, args ...interface{},
 ) (interface{}, error) {
 	// passing `h` makes it evaluate js code in the element handle's scope.
-	args = append(append([]interface{}(nil), h), args...)
+	args = append([]interface{}{h}, args...)
 	// convert the arguments to goja values.
 	rt := k6common.GetRuntime(ctx)
 	gargs := make([]goja.Value, len(args))

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -211,7 +211,7 @@ func (h *ElementHandle) boundingBox() (*Rect, error) {
 	return &Rect{X: x + position.X, Y: y + position.Y, Width: width, Height: height}, nil
 }
 
-func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, p Position) (bool, error) {
+func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, point Position) (bool, error) {
 	frame := h.ownerFrame(apiCtx)
 	if frame != nil && frame.parentFrame != nil {
 		element := h.frame.FrameElement().(*ElementHandle)
@@ -222,32 +222,20 @@ func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, p Position) (bo
 		if box == nil {
 			return false, errors.New("unable to get bounding box of element")
 		}
-
 		// Translate from viewport coordinates to frame coordinates.
-		p.X = p.X - box.X
-		p.Y = p.Y - box.Y
+		point.X = point.X - box.X
+		point.Y = point.Y - box.Y
 	}
-
-	rt := k6common.GetRuntime(h.ctx)
-	injected, err := h.execCtx.getInjectedScript(apiCtx)
-	if err != nil {
-		return false, err
-	}
-	pageFn := rt.ToValue(`
-		(injected, node, point) => {
+	fn := `
+		(node, injected, point) => {
 			return injected.checkHitTargetAt(node, point);
 		}
-	`)
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	result, err := h.execCtx.evaluate(
-		apiCtx, opts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(h),
-			rt.ToValue(p),
-		}...)
+	result, err := h.evalWithScript(h.ctx, opts, fn, point)
 	if err != nil {
 		return false, err
 	}
@@ -264,26 +252,16 @@ func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, p Position) (bo
 }
 
 func (h *ElementHandle) checkElementState(apiCtx context.Context, state string) (*bool, error) {
-	rt := k6common.GetRuntime(apiCtx)
-	injected, err := h.execCtx.getInjectedScript(apiCtx)
-	if err != nil {
-		return nil, err
-	}
-	pageFn := rt.ToValue(`
-		(injected, node, state) => {
+	fn := `
+		(node, injected, state) => {
 			return injected.checkElementState(node, state);
 		}
-	`)
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	result, err := h.execCtx.evaluate(
-		apiCtx, opts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(h),
-			rt.ToValue(state),
-		}...)
+	result, err := h.evalWithScript(h.ctx, opts, fn, state)
 	if err != nil {
 		return nil, err
 	}
@@ -395,54 +373,30 @@ func (h *ElementHandle) defaultTimeout() time.Duration {
 }
 
 func (h *ElementHandle) dispatchEvent(apiCtx context.Context, typ string, eventInit goja.Value) (interface{}, error) {
-	rt := k6common.GetRuntime(apiCtx)
-	injected, err := h.execCtx.getInjectedScript(apiCtx)
-	if err != nil {
-		return nil, err
-	}
-	pageFn := rt.ToValue(`
-		(injected, node, type, eventInit) => {
+	fn := `
+		(node, injected, type, eventInit) => {
 			injected.dispatchEvent(node, type, eventInit);
 		}
-	`)
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	_, err = h.execCtx.evaluate(
-		apiCtx, opts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(h),
-			rt.ToValue(typ),
-			eventInit,
-		}...)
-	if err != nil {
-		return nil, err
-	}
-	return nil, nil
+	_, err := h.evalWithScript(h.ctx, opts, fn, typ, eventInit)
+	return nil, err
 }
 
 func (h *ElementHandle) fill(apiCtx context.Context, value string) (interface{}, error) {
-	rt := k6common.GetRuntime(apiCtx)
-	injected, err := h.execCtx.getInjectedScript(apiCtx)
-	if err != nil {
-		return nil, err
-	}
-	pageFn := rt.ToValue(`
-			(injected, node, value) => {
-				return injected.fill(node, value);
-			}
-		`)
+	fn := `
+		(node, injected, value) => {
+			return injected.fill(node, value);
+		}
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	result, err := h.execCtx.evaluate(
-		apiCtx, opts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(h),
-			rt.ToValue(value),
-		}...)
+	result, err := h.evalWithScript(h.ctx, opts, fn, value)
 	if err != nil {
 		return nil, err
 	}
@@ -456,26 +410,16 @@ func (h *ElementHandle) fill(apiCtx context.Context, value string) (interface{},
 }
 
 func (h *ElementHandle) focus(apiCtx context.Context, resetSelectionIfNotFocused bool) error {
-	rt := k6common.GetRuntime(apiCtx)
-	injected, err := h.execCtx.getInjectedScript(apiCtx)
-	if err != nil {
-		return err
-	}
-	pageFn := rt.ToValue(`
-		(injected, node, resetSelectionIfNotFocused) => {
+	fn := `
+		(node, injected, resetSelectionIfNotFocused) => {
 			return injected.focusNode(node, resetSelectionIfNotFocused);
 		}
-	`)
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	result, err := h.execCtx.evaluate(
-		apiCtx, opts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(h),
-			rt.ToValue(resetSelectionIfNotFocused),
-		}...)
+	result, err := h.evalWithScript(apiCtx, opts, fn, resetSelectionIfNotFocused)
 	if err != nil {
 		return err
 	}
@@ -489,15 +433,16 @@ func (h *ElementHandle) focus(apiCtx context.Context, resetSelectionIfNotFocused
 }
 
 func (h *ElementHandle) getAttribute(apiCtx context.Context, name string) (interface{}, error) {
-	js := `(element) => {
-		return element.getAttribute('` + name + `');
-	}`
-	rt := k6common.GetRuntime(apiCtx)
+	js := `
+		(element) => {
+			return element.getAttribute('` + name + `');
+		}
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	return h.execCtx.evaluate(apiCtx, opts, rt.ToValue(js), rt.ToValue(h))
+	return h.eval(apiCtx, opts, js)
 }
 
 func (h *ElementHandle) hover(apiCtx context.Context, p *Position) error {
@@ -505,42 +450,45 @@ func (h *ElementHandle) hover(apiCtx context.Context, p *Position) error {
 }
 
 func (h *ElementHandle) innerHTML(apiCtx context.Context) (interface{}, error) {
-	rt := k6common.GetRuntime(apiCtx)
-	js := `(element) => {
-		return element.innerHTML;
-	}`
+	js := `
+		(element) => {
+			return element.innerHTML;
+		}
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	return h.execCtx.evaluate(apiCtx, opts, rt.ToValue(js), rt.ToValue(h))
+	return h.eval(apiCtx, opts, js)
 }
 
 func (h *ElementHandle) innerText(apiCtx context.Context) (interface{}, error) {
-	rt := k6common.GetRuntime(apiCtx)
-	js := `(element) => {
-		return element.innerText;
-	}`
+	js := `
+		(element) => {
+			return element.innerText;
+		}
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	return h.execCtx.evaluate(apiCtx, opts, rt.ToValue(js), rt.ToValue(h))
+	return h.eval(apiCtx, opts, js)
 }
 
 func (h *ElementHandle) inputValue(apiCtx context.Context) (interface{}, error) {
-	rt := k6common.GetRuntime(apiCtx)
-	js := `(element) => {
-		if (element.nodeType !== Node.ELEMENT_NODE || (element.nodeName !== 'INPUT' && element.nodeName !== 'TEXTAREA' && element.nodeName !== 'SELECT')) {
-        	throw Error('Node is not an <input>, <textarea> or <select> element');
+	js := `
+		(element) => {
+			if (element.nodeType !== Node.ELEMENT_NODE || (element.nodeName !== 'INPUT' && element.nodeName !== 'TEXTAREA' && element.nodeName !== 'SELECT')) {
+        			throw Error('Node is not an <input>, <textarea> or <select> element');
+			}
+			return element.value;
 		}
-		return element.value;
-	}`
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	return h.execCtx.evaluate(apiCtx, opts, rt.ToValue(js), rt.ToValue(h))
+	return h.eval(apiCtx, opts, js)
 }
 
 func (h *ElementHandle) isChecked(apiCtx context.Context, timeout time.Duration) (bool, error) {
@@ -568,30 +516,21 @@ func (h *ElementHandle) isVisible(apiCtx context.Context, timeout time.Duration)
 }
 
 func (h *ElementHandle) offsetPosition(apiCtx context.Context, offset *Position) (*Position, error) {
-	rt := k6common.GetRuntime(apiCtx)
-	box := h.BoundingBox()
-	injected, err := h.execCtx.getInjectedScript(apiCtx)
-	if err != nil {
-		return nil, err
-	}
-	pageFn := rt.ToValue(`
-		(injected, node) => {
+	fn := `
+		(node, injected) => {
 			return injected.getElementBorderWidth(node);
 		}
-	`)
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	result, err := h.execCtx.evaluate(
-		apiCtx, opts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(h),
-		}...)
+	result, err := h.evalWithScript(apiCtx, opts, fn)
 	if err != nil {
 		return nil, err
 	}
 
+	rt := k6common.GetRuntime(apiCtx)
 	var border struct{ Top, Left float64 }
 	switch result := result.(type) {
 	case goja.Value:
@@ -608,6 +547,7 @@ func (h *ElementHandle) offsetPosition(apiCtx context.Context, offset *Position)
 		}
 	}
 
+	box := h.BoundingBox()
 	if box == nil || (border.Left == 0 && border.Top == 0) {
 		return nil, errorFromDOMError("error:notvisible")
 	}
@@ -665,20 +605,16 @@ func (h *ElementHandle) press(apiCtx context.Context, key string, opts *Keyboard
 }
 
 func (h *ElementHandle) selectOption(apiCtx context.Context, values goja.Value) (interface{}, error) {
-	rt := k6common.GetRuntime(apiCtx)
-	injected, err := h.execCtx.getInjectedScript(apiCtx)
-	if err != nil {
-		return nil, err
-	}
-
 	convertSelectOptionValues := func(values goja.Value) ([]interface{}, error) {
 		if goja.IsNull(values) || goja.IsUndefined(values) {
 			return nil, nil
 		}
 
-		opts := make([]interface{}, 0)
-
-		t := values.Export()
+		var (
+			opts []interface{}
+			t    = values.Export()
+			rt   = k6common.GetRuntime(h.ctx)
+		)
 		switch values.ExportType().Kind() {
 		case reflect.Map:
 			s := reflect.ValueOf(t)
@@ -744,21 +680,16 @@ func (h *ElementHandle) selectOption(apiCtx context.Context, values goja.Value) 
 		return nil, err
 	}
 
-	pageFn := rt.ToValue(`
-			(injected, node, values) => {
-				return injected.selectOptions(node, values);
-			}
-		`)
+	fn := `
+		(node, injected, values) => {
+			return injected.selectOptions(node, values);
+		}
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.execCtx.evaluate(
-		apiCtx, opts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(h),
-			rt.ToValue(convValues),
-		}...)
+	result, err := h.evalWithScript(apiCtx, opts, fn, convValues)
 	if err != nil {
 		return nil, err
 	}
@@ -772,25 +703,16 @@ func (h *ElementHandle) selectOption(apiCtx context.Context, values goja.Value) 
 }
 
 func (h *ElementHandle) selectText(apiCtx context.Context) error {
-	rt := k6common.GetRuntime(apiCtx)
-	injected, err := h.execCtx.getInjectedScript(apiCtx)
-	if err != nil {
-		return err
-	}
-	pageFn := rt.ToValue(`
-			(injected, node) => {
-				return injected.selectText(node);
-			}
-		`)
+	fn := `
+		(node, injected) => {
+			return injected.selectText(node);
+		}
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	result, err := h.execCtx.evaluate(
-		apiCtx, opts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(h),
-		}...)
+	result, err := h.evalWithScript(apiCtx, opts, fn)
 	if err != nil {
 		return err
 	}
@@ -833,15 +755,16 @@ func (h *ElementHandle) tap(apiCtx context.Context, p *Position) error {
 }
 
 func (h *ElementHandle) textContent(apiCtx context.Context) (interface{}, error) {
-	rt := k6common.GetRuntime(apiCtx)
-	js := `(element) => {
-		return element.textContent;
-	}`
+	js := `
+		(element) => {
+			return element.textContent;
+		}
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	return h.execCtx.evaluate(apiCtx, opts, rt.ToValue(js), rt.ToValue(h))
+	return h.eval(apiCtx, opts, js)
 }
 
 func (h *ElementHandle) typ(apiCtx context.Context, text string, opts *KeyboardOptions) error {
@@ -857,17 +780,18 @@ func (h *ElementHandle) typ(apiCtx context.Context, text string, opts *KeyboardO
 }
 
 func (h *ElementHandle) waitAndScrollIntoViewIfNeeded(apiCtx context.Context, force, noWaitAfter bool, timeout time.Duration) error {
-	rt := k6common.GetRuntime(apiCtx)
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
-		pageFn := rt.ToValue(`(element) => {
-			element.scrollIntoViewIfNeeded(true);
-			return [window.scrollX, window.scrollY];
-		}`)
+		fn := `
+			(element) => {
+				element.scrollIntoViewIfNeeded(true);
+				return [window.scrollX, window.scrollY];
+			}
+		`
 		opts := evaluateOptions{
 			forceCallable: true,
 			returnByValue: true,
 		}
-		return h.execCtx.evaluate(apiCtx, opts, pageFn, rt.ToValue(h))
+		return h.eval(apiCtx, opts, fn)
 	}
 	actFn := elementHandleActionFn(h, []string{"visible", "stable"}, fn, force, noWaitAfter, timeout)
 	_, err := callApiWithTimeout(h.ctx, actFn, timeout)
@@ -878,27 +802,16 @@ func (h *ElementHandle) waitAndScrollIntoViewIfNeeded(apiCtx context.Context, fo
 }
 
 func (h *ElementHandle) waitForElementState(apiCtx context.Context, states []string, timeout time.Duration) (bool, error) {
-	rt := k6common.GetRuntime(apiCtx)
-	injected, err := h.execCtx.getInjectedScript(apiCtx)
-	if err != nil {
-		return false, err
-	}
-	pageFn := rt.ToValue(`
-		(injected, node, states, timeout) => {
+	fn := `
+		(node, injected, states, timeout) => {
 			return injected.waitForElementStates(node, states, timeout);
 		}
-	`)
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	result, err := h.execCtx.evaluate(
-		apiCtx, opts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(h),
-			rt.ToValue(states),
-			rt.ToValue(timeout.Milliseconds()),
-		}...)
+	result, err := h.evalWithScript(apiCtx, opts, fn, states, timeout.Milliseconds())
 	if err != nil {
 		return false, err
 	}
@@ -917,35 +830,24 @@ func (h *ElementHandle) waitForElementState(apiCtx context.Context, states []str
 }
 
 func (h *ElementHandle) waitForSelector(apiCtx context.Context, selector string, opts *FrameWaitForSelectorOptions) (*ElementHandle, error) {
-	rt := k6common.GetRuntime(apiCtx)
-	injected, err := h.execCtx.getInjectedScript(apiCtx)
-	if err != nil {
-		return nil, err
-	}
-
 	parsedSelector, err := NewSelector(selector)
 	if err != nil {
 		return nil, err
 	}
-
-	pageFn := rt.ToValue(`
-		(injected, selector, scope, strict, state, timeout, ...args) => {
-			return injected.waitForSelector(selector, scope, strict, state, 'raf', timeout, ...args);
+	fn := `
+		(node, injected, selector, strict, state, timeout, ...args) => {
+			return injected.waitForSelector(selector, node, strict, state, 'raf', timeout, ...args);
 		}
-	`)
+	`
 	eopts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.execCtx.evaluate(
-		apiCtx, eopts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(parsedSelector),
-			rt.ToValue(h),
-			rt.ToValue(opts.Strict),
-			rt.ToValue(opts.State.String()),
-			rt.ToValue(opts.Timeout.Milliseconds()),
-		}...)
+	result, err := h.evalWithScript(
+		apiCtx,
+		eopts, fn, parsedSelector,
+		opts.Strict, opts.State.String(), opts.Timeout.Milliseconds(),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1220,23 +1122,18 @@ func (h *ElementHandle) IsVisible() bool {
 
 // OwnerFrame returns the frame containing this element
 func (h *ElementHandle) OwnerFrame() api.Frame {
-	rt := k6common.GetRuntime(h.ctx)
-	injected, err := h.execCtx.getInjectedScript(h.ctx)
-	if err != nil {
-		k6common.Throw(rt, fmt.Errorf("unable to run injection script: %w", err))
-	}
-	pageFn := rt.ToValue(`
-		(injected, node) => {
+	fn := `
+		(node, injected) => {
 			return injected.getDocumentElement(node);
 		}
-	`)
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	res, err := h.execCtx.evaluate(h.ctx, opts, pageFn, []goja.Value{rt.ToValue(injected), rt.ToValue(h)}...)
+	res, err := h.evalWithScript(h.ctx, opts, fn)
 	if err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed getting document element: %w", err))
+		k6Throw(h.ctx, "cannot get document element: %w", err)
 	}
 	if res == nil {
 		return nil
@@ -1251,9 +1148,8 @@ func (h *ElementHandle) OwnerFrame() api.Frame {
 	var node *cdp.Node
 	action := dom.DescribeNode().WithObjectID(documentHandle.remoteObject.ObjectID)
 	if node, err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-		k6common.Throw(rt, fmt.Errorf("unable to describe DOM node: %w", err))
+		k6Throw(h.ctx, "cannot describe DOM node: %w", err)
 	}
-
 	if node == nil || node.FrameID == "" {
 		return nil
 	}
@@ -1284,26 +1180,16 @@ func (h *ElementHandle) Query(selector string) api.ElementHandle {
 	if err != nil {
 		k6common.Throw(rt, err)
 	}
-
-	injected, err := h.execCtx.getInjectedScript(h.ctx)
-	if err != nil {
-		k6common.Throw(rt, err)
-	}
-	pageFn := rt.ToValue(`
-		(injected, selector, scope) => {
-			return injected.querySelector(selector, scope || document, false);
+	fn := `
+		(node, injected, selector) => {
+			return injected.querySelector(selector, node || document, false);
 		}
-	`)
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.execCtx.evaluate(
-		h.ctx, opts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(parsedSelector),
-			rt.ToValue(h),
-		}...)
+	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector)
 	if err != nil {
 		k6common.Throw(rt, err)
 	}
@@ -1311,8 +1197,10 @@ func (h *ElementHandle) Query(selector string) api.ElementHandle {
 		return nil
 	}
 
-	handle := result.(api.JSHandle)
-	element := handle.AsElement()
+	var (
+		handle  = result.(api.JSHandle)
+		element = handle.AsElement()
+	)
 	applySlowMo(h.ctx)
 	if element != nil {
 		return element
@@ -1324,33 +1212,22 @@ func (h *ElementHandle) Query(selector string) api.ElementHandle {
 // QueryAll queries element subtree for matching elements. If no element matches the selector,
 // the return value resolves to "null"
 func (h *ElementHandle) QueryAll(selector string) []api.ElementHandle {
-	rt := k6common.GetRuntime(h.ctx)
 	parsedSelector, err := NewSelector(selector)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot parse selector %q: %v", selector, err)
 	}
-
-	injected, err := h.execCtx.getInjectedScript(h.ctx)
-	if err != nil {
-		k6common.Throw(rt, err)
-	}
-	pageFn := rt.ToValue(`
-		(injected, selector, scope) => {
-			return injected.querySelectorAll(selector, scope || document, false);
+	fn := `
+		(node, injected, selector) => {
+			return injected.querySelectorAll(selector, node || document, false);
 		}
-	`)
+	`
 	opts := evaluateOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.execCtx.evaluate(
-		h.ctx, opts, pageFn, []goja.Value{
-			rt.ToValue(injected),
-			rt.ToValue(parsedSelector),
-			rt.ToValue(h),
-		}...)
+	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot evaluate selector %q: %v", selector, err)
 	}
 	if result == nil {
 		return nil
@@ -1363,6 +1240,7 @@ func (h *ElementHandle) QueryAll(selector string) []api.ElementHandle {
 	for _, property := range properties {
 		elementHandle := property.AsElement()
 		if elementHandle != nil {
+			//nolint
 			result = append(elements, elementHandle)
 		} else {
 			property.Dispose()
@@ -1546,4 +1424,41 @@ func (h *ElementHandle) WaitForSelector(selector string, opts goja.Value) api.El
 	}
 
 	return handle
+}
+
+// evalWithScript evaluates a given js function in the scope of this ElementHandle and allows to call the injected
+// script's functions.
+func (h *ElementHandle) evalWithScript(
+	ctx context.Context,
+	opts evaluateOptions, js string, args ...interface{},
+) (interface{}, error) {
+	// get the injected script's handle so that js function can call its functions.
+	script, err := h.execCtx.getInjectedScript(h.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get injected script: %w", err)
+	}
+	// passing `script` allows `js` to use `script`'s functions.
+	args = append(append([]interface{}(nil), script), args...)
+	return h.eval(ctx, opts, js, args...)
+}
+
+// eval evaluates a given js function in the scope of this ElementHandle.
+func (h *ElementHandle) eval(
+	ctx context.Context,
+	opts evaluateOptions, js string, args ...interface{},
+) (interface{}, error) {
+	// passing `h` makes it evaluate js code in the element handle's scope.
+	args = append(append([]interface{}(nil), h), args...)
+	// convert the arguments to goja values.
+	rt := k6common.GetRuntime(ctx)
+	gargs := make([]goja.Value, len(args))
+	for i, arg := range args {
+		gargs[i] = rt.ToValue(arg)
+	}
+	// call the javascript function.
+	result, err := h.execCtx.evaluate(ctx, opts, rt.ToValue(js), gargs...)
+	if err != nil {
+		err = fmt.Errorf("evaluate: %w", err)
+	}
+	return result, err
 }

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1405,12 +1405,10 @@ func (h *ElementHandle) evalWithScript(
 	ctx context.Context,
 	opts evaluateOptions, js string, args ...interface{},
 ) (interface{}, error) {
-	// get the injected script's handle so that js function can call its functions.
 	script, err := h.execCtx.getInjectedScript(h.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get injected script: %w", err)
 	}
-	// passing `script` allows `js` to use `script`'s functions.
 	args = append([]interface{}{script}, args...)
 	return h.eval(ctx, opts, js, args...)
 }
@@ -1422,13 +1420,11 @@ func (h *ElementHandle) eval(
 ) (interface{}, error) {
 	// passing `h` makes it evaluate js code in the element handle's scope.
 	args = append([]interface{}{h}, args...)
-	// convert the arguments to goja values.
 	rt := k6common.GetRuntime(ctx)
 	gargs := make([]goja.Value, len(args))
 	for i, arg := range args {
 		gargs[i] = rt.ToValue(arg)
 	}
-	// call the javascript function.
 	result, err := h.execCtx.evaluate(ctx, opts, rt.ToValue(js), gargs...)
 	if err != nil {
 		err = fmt.Errorf("element handle cannot evaluate: %w", err)

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -198,7 +198,7 @@ func (h *ElementHandle) boundingBox() (*Rect, error) {
 	var err error
 	action := dom.GetBoxModel().WithObjectID(h.remoteObject.ObjectID)
 	if box, err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-		return nil, fmt.Errorf("unable to get box model of DOM node: %w", err)
+		return nil, fmt.Errorf("cannot get bounding box model of DOM node: %w", err)
 	}
 
 	quad := box.Border
@@ -220,7 +220,7 @@ func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, point Position)
 			return false, err
 		}
 		if box == nil {
-			return false, errors.New("unable to get bounding box of element")
+			return false, errors.New("cannot get bounding box of element")
 		}
 		// Translate from viewport coordinates to frame coordinates.
 		point.X = point.X - box.X
@@ -275,7 +275,7 @@ func (h *ElementHandle) checkElementState(apiCtx context.Context, state string) 
 		*returnVal = value.ToBoolean()
 		return returnVal, nil
 	}
-	return nil, fmt.Errorf("unable to check state %q of element: %q", state, reflect.TypeOf(result))
+	return nil, fmt.Errorf("cannot check state %q of element: %q", state, reflect.TypeOf(result))
 }
 
 func (h *ElementHandle) click(p *Position, opts *MouseClickOptions) error {
@@ -290,7 +290,7 @@ func (h *ElementHandle) clickablePoint() (*Position, error) {
 	action := dom.GetContentQuads().
 		WithObjectID(h.remoteObject.ObjectID)
 	if quads, err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-		return nil, fmt.Errorf("unable to request node content quads %T: %w", action, err)
+		return nil, fmt.Errorf("cannot request node content quads %T: %w", action, err)
 	}
 	if len(quads) == 0 {
 		return nil, fmt.Errorf("node is either not visible or not an HTMLElement: %w", err)
@@ -298,7 +298,7 @@ func (h *ElementHandle) clickablePoint() (*Position, error) {
 
 	action2 := cdppage.GetLayoutMetrics()
 	if layoutViewport, _, _, _, _, _, err = action2.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-		return nil, fmt.Errorf("unable to get page layout metrics %T: %w", action, err)
+		return nil, fmt.Errorf("cannot get page layout metrics %T: %w", action, err)
 	}
 
 	// Filter out quads that have too small area to click into.
@@ -826,7 +826,7 @@ func (h *ElementHandle) waitForElementState(apiCtx context.Context, states []str
 	case reflect.Bool:
 		return value.ToBoolean(), nil
 	}
-	return false, fmt.Errorf("unable to check states %v of element: %q", states, reflect.TypeOf(result))
+	return false, fmt.Errorf("cannot check states %v of element: %q", states, reflect.TypeOf(result))
 }
 
 func (h *ElementHandle) waitForSelector(apiCtx context.Context, selector string, opts *FrameWaitForSelectorOptions) (*ElementHandle, error) {
@@ -881,10 +881,9 @@ func (h *ElementHandle) Check(opts goja.Value) {
 // Click scrolls element into view and clicks in the center of the element
 // TODO: look into making more robust using retries (see: https://github.com/microsoft/playwright/blob/master/src/server/dom.ts#L298)
 func (h *ElementHandle) Click(opts goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	actionOpts := NewElementHandleClickOptions(h.defaultTimeout())
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannot parse element click options: %w", err)
 	}
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
 		return nil, handle.click(p, actionOpts.ToMouseClickOptions())
@@ -892,21 +891,20 @@ func (h *ElementHandle) Click(opts goja.Value) {
 	pointerFn := elementHandlePointerActionFn(h, true, fn, &actionOpts.ElementHandleBasePointerOptions)
 	_, err := callApiWithTimeout(h.ctx, pointerFn, actionOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot click on element: %w", err)
 	}
 	applySlowMo(h.ctx)
 }
 
 func (h *ElementHandle) ContentFrame() api.Frame {
-	rt := k6common.GetRuntime(h.ctx)
-
-	var node *cdp.Node
-	var err error
+	var (
+		node *cdp.Node
+		err  error
+	)
 	action := dom.DescribeNode().WithObjectID(h.remoteObject.ObjectID)
 	if node, err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-		k6common.Throw(rt, fmt.Errorf("unable to describe DOM node: %w", err))
+		k6Throw(h.ctx, "cannot get remote node %q: %w", h.remoteObject.ObjectID, err)
 	}
-
 	if node == nil || node.FrameID == "" {
 		return nil
 	}
@@ -915,10 +913,9 @@ func (h *ElementHandle) ContentFrame() api.Frame {
 }
 
 func (h *ElementHandle) Dblclick(opts goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	actionOpts := NewElementHandleDblclickOptions(h.defaultTimeout())
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannot parse element double click options: %w", err)
 	}
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
 		return nil, handle.dblClick(p, actionOpts.ToMouseClickOptions())
@@ -926,13 +923,12 @@ func (h *ElementHandle) Dblclick(opts goja.Value) {
 	pointerFn := elementHandlePointerActionFn(h, true, fn, &actionOpts.ElementHandleBasePointerOptions)
 	_, err := callApiWithTimeout(h.ctx, pointerFn, actionOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot double click on element: %w", err)
 	}
 	applySlowMo(h.ctx)
 }
 
 func (h *ElementHandle) DispatchEvent(typ string, eventInit goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.dispatchEvent(apiCtx, typ, eventInit)
 	}
@@ -940,16 +936,15 @@ func (h *ElementHandle) DispatchEvent(typ string, eventInit goja.Value) {
 	actFn := elementHandleActionFn(h, []string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
 	_, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot dispatch element event: %w", err)
 	}
 	applySlowMo(h.ctx)
 }
 
 func (h *ElementHandle) Fill(value string, opts goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	actionOpts := NewElementHandleBaseOptions(h.defaultTimeout())
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannot parse element fill options: %w", err)
 	}
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.fill(apiCtx, value)
@@ -957,14 +952,13 @@ func (h *ElementHandle) Fill(value string, opts goja.Value) {
 	actFn := elementHandleActionFn(h, []string{"visible", "enabled", "editable"}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
 	_, err := callApiWithTimeout(h.ctx, actFn, actionOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot handle element fill action: %w", err)
 	}
 	applySlowMo(h.ctx)
 }
 
 // Focus scrolls element into view and focuses the element
 func (h *ElementHandle) Focus() {
-	rt := k6common.GetRuntime(h.ctx)
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return nil, handle.focus(apiCtx, false)
 	}
@@ -972,7 +966,7 @@ func (h *ElementHandle) Focus() {
 	actFn := elementHandleActionFn(h, []string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
 	_, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot focus on element: %w", err)
 	}
 	applySlowMo(h.ctx)
 }
@@ -986,7 +980,7 @@ func (h *ElementHandle) GetAttribute(name string) goja.Value {
 	actFn := elementHandleActionFn(h, []string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
 	value, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
 	if err != nil {
-		k6Throw(h.ctx, "GetAttribute(%q): %q", name, err)
+		k6Throw(h.ctx, "cannot get attribute of %q: %q", name, err)
 	}
 	applySlowMo(h.ctx)
 	return value.(goja.Value)
@@ -994,10 +988,9 @@ func (h *ElementHandle) GetAttribute(name string) goja.Value {
 
 // Hover scrolls element into view and hovers over its center point
 func (h *ElementHandle) Hover(opts goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	actionOpts := NewElementHandleHoverOptions(h.defaultTimeout())
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannot parse element hover options: %w", err)
 	}
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
 		return nil, handle.hover(apiCtx, p)
@@ -1005,14 +998,13 @@ func (h *ElementHandle) Hover(opts goja.Value) {
 	pointerFn := elementHandlePointerActionFn(h, true, fn, &actionOpts.ElementHandleBasePointerOptions)
 	_, err := callApiWithTimeout(h.ctx, pointerFn, actionOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot hover on element: %w", err)
 	}
 	applySlowMo(h.ctx)
 }
 
 // InnerHTML returns the inner HTML of the element
 func (h *ElementHandle) InnerHTML() string {
-	rt := k6common.GetRuntime(h.ctx)
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.innerHTML(apiCtx)
 	}
@@ -1020,7 +1012,7 @@ func (h *ElementHandle) InnerHTML() string {
 	actFn := elementHandleActionFn(h, []string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
 	value, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot get element's inner HTML: %w", err)
 	}
 	applySlowMo(h.ctx)
 	return value.(goja.Value).String()
@@ -1028,7 +1020,6 @@ func (h *ElementHandle) InnerHTML() string {
 
 // InnerText returns the inner text of the element
 func (h *ElementHandle) InnerText() string {
-	rt := k6common.GetRuntime(h.ctx)
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.innerText(apiCtx)
 	}
@@ -1036,17 +1027,16 @@ func (h *ElementHandle) InnerText() string {
 	actFn := elementHandleActionFn(h, []string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
 	value, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot get element's inner text: %w", err)
 	}
 	applySlowMo(h.ctx)
 	return value.(goja.Value).String()
 }
 
 func (h *ElementHandle) InputValue(opts goja.Value) string {
-	rt := k6common.GetRuntime(h.ctx)
 	actionOpts := NewElementHandleBaseOptions(h.defaultTimeout())
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannot parse element input value options: %w", err)
 	}
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.inputValue(apiCtx)
@@ -1054,7 +1044,7 @@ func (h *ElementHandle) InputValue(opts goja.Value) string {
 	actFn := elementHandleActionFn(h, []string{}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
 	value, err := callApiWithTimeout(h.ctx, actFn, actionOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot get element's input value: %w", err)
 	}
 	applySlowMo(h.ctx)
 	return value.(goja.Value).String()
@@ -1062,60 +1052,54 @@ func (h *ElementHandle) InputValue(opts goja.Value) string {
 
 // IsChecked checks if a checkbox or radio is checked
 func (h *ElementHandle) IsChecked() bool {
-	rt := k6common.GetRuntime(h.ctx)
 	result, err := h.isChecked(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot handle element is check: %w", err)
 	}
 	return result
 }
 
 // IsDisabled checks if the element is disabled
 func (h *ElementHandle) IsDisabled() bool {
-	rt := k6common.GetRuntime(h.ctx)
 	result, err := h.isDisabled(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot handle element is disabled: %w", err)
 	}
 	return result
 }
 
 // IsEditable checks if the element is editable
 func (h *ElementHandle) IsEditable() bool {
-	rt := k6common.GetRuntime(h.ctx)
 	result, err := h.isEditable(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot handle element is editable: %w", err)
 	}
 	return result
 }
 
 // IsEnabled checks if the element is enabled
 func (h *ElementHandle) IsEnabled() bool {
-	rt := k6common.GetRuntime(h.ctx)
 	result, err := h.isEnabled(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot handle element is enabled: %w", err)
 	}
 	return result
 }
 
 // IsHidden checks if the element is hidden
 func (h *ElementHandle) IsHidden() bool {
-	rt := k6common.GetRuntime(h.ctx)
 	result, err := h.isHidden(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot handle element is hidden: %w", err)
 	}
 	return result
 }
 
 // IsVisible checks if the element is visible
 func (h *ElementHandle) IsVisible() bool {
-	rt := k6common.GetRuntime(h.ctx)
 	result, err := h.isVisible(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot check element is visible: %w", err)
 	}
 	return result
 }
@@ -1148,7 +1132,7 @@ func (h *ElementHandle) OwnerFrame() api.Frame {
 	var node *cdp.Node
 	action := dom.DescribeNode().WithObjectID(documentHandle.remoteObject.ObjectID)
 	if node, err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-		k6Throw(h.ctx, "cannot describe DOM node: %w", err)
+		k6Throw(h.ctx, "cannot describe owner frame DOM node: %w", err)
 	}
 	if node == nil || node.FrameID == "" {
 		return nil
@@ -1158,7 +1142,6 @@ func (h *ElementHandle) OwnerFrame() api.Frame {
 }
 
 func (h *ElementHandle) Press(key string, opts goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	parsedOpts := NewElementHandlePressOptions(h.defaultTimeout())
 	parsedOpts.Parse(h.ctx, opts)
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
@@ -1167,7 +1150,7 @@ func (h *ElementHandle) Press(key string, opts goja.Value) {
 	actFn := elementHandleActionFn(h, []string{}, fn, false, parsedOpts.NoWaitAfter, parsedOpts.Timeout)
 	_, err := callApiWithTimeout(h.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot handle element key (%q) press: %w", key, err)
 	}
 	applySlowMo(h.ctx)
 }
@@ -1175,10 +1158,9 @@ func (h *ElementHandle) Press(key string, opts goja.Value) {
 // Query runs "element.querySelector" within the page. If no element matches the selector,
 // the return value resolves to "null"
 func (h *ElementHandle) Query(selector string) api.ElementHandle {
-	rt := k6common.GetRuntime(h.ctx)
 	parsedSelector, err := NewSelector(selector)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot parse selector (%q) in element query: %w", selector, err)
 	}
 	fn := `
 		(node, injected, selector) => {
@@ -1191,7 +1173,7 @@ func (h *ElementHandle) Query(selector string) api.ElementHandle {
 	}
 	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot query element for selector (%q): %w", selector, err)
 	}
 	if result == nil {
 		return nil
@@ -1214,7 +1196,7 @@ func (h *ElementHandle) Query(selector string) api.ElementHandle {
 func (h *ElementHandle) QueryAll(selector string) []api.ElementHandle {
 	parsedSelector, err := NewSelector(selector)
 	if err != nil {
-		k6Throw(h.ctx, "cannot parse selector %q: %v", selector, err)
+		k6Throw(h.ctx, "cannot parse selector %q in element query all: %v", selector, err)
 	}
 	fn := `
 		(node, injected, selector) => {
@@ -1254,26 +1236,25 @@ func (h *ElementHandle) Screenshot(opts goja.Value) goja.ArrayBuffer {
 	rt := k6common.GetRuntime(h.ctx)
 	parsedOpts := NewElementHandleScreenshotOptions(h.defaultTimeout())
 	if err := parsedOpts.Parse(h.ctx, opts); err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannot parse element screenshoot options: %w", err)
 	}
 
 	s := newScreenshotter(h.ctx)
 	buf, err := s.screenshotElement(h, parsedOpts)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot take screenshot: %w", err)
 	}
 	return rt.NewArrayBuffer(*buf)
 }
 
 func (h *ElementHandle) ScrollIntoViewIfNeeded(opts goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	actionOpts := NewElementHandleBaseOptions(h.defaultTimeout())
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannot parse element scroll into view options: %w", err)
 	}
 	err := h.waitAndScrollIntoViewIfNeeded(h.ctx, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot handle element scroll into view: %w", err)
 	}
 	applySlowMo(h.ctx)
 }
@@ -1282,7 +1263,7 @@ func (h *ElementHandle) SelectOption(values goja.Value, opts goja.Value) []strin
 	rt := k6common.GetRuntime(h.ctx)
 	actionOpts := NewElementHandleBaseOptions(h.defaultTimeout())
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannot parse element selection options: %w", err)
 	}
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.selectOption(apiCtx, values)
@@ -1290,21 +1271,20 @@ func (h *ElementHandle) SelectOption(values goja.Value, opts goja.Value) []strin
 	actFn := elementHandleActionFn(h, []string{}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
 	selectedOptions, err := callApiWithTimeout(h.ctx, actFn, actionOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot handle element select option: %w", err)
 	}
 	var returnVal []string
 	if err := rt.ExportTo(selectedOptions.(goja.Value), &returnVal); err != nil {
-		k6common.Throw(rt, fmt.Errorf("unable to unpack selected options: %w", err))
+		k6Throw(h.ctx, "cannot unpack options in element select option: %w", err)
 	}
 	applySlowMo(h.ctx)
 	return returnVal
 }
 
 func (h *ElementHandle) SelectText(opts goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	actionOpts := NewElementHandleBaseOptions(h.defaultTimeout())
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot parse element select text options: %w", err)
 	}
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return nil, handle.selectText(apiCtx)
@@ -1312,18 +1292,17 @@ func (h *ElementHandle) SelectText(opts goja.Value) {
 	actFn := elementHandleActionFn(h, []string{}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
 	_, err := callApiWithTimeout(h.ctx, actFn, actionOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot select element text: %w", err)
 	}
 	applySlowMo(h.ctx)
 }
 
 // SetChecked checks or unchecks an element.
 func (h *ElementHandle) SetChecked(checked bool, opts goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	parsedOpts := NewElementHandleSetCheckedOptions(h.defaultTimeout())
 	err := parsedOpts.Parse(h.ctx, opts)
 	if err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannot parse element set checked options: %w", err)
 	}
 
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
@@ -1332,23 +1311,21 @@ func (h *ElementHandle) SetChecked(checked bool, opts goja.Value) {
 	pointerFn := elementHandlePointerActionFn(h, true, fn, &parsedOpts.ElementHandleBasePointerOptions)
 	_, err = callApiWithTimeout(h.ctx, pointerFn, parsedOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot check element: %w", err)
 	}
 	applySlowMo(h.ctx)
 }
 
 func (h *ElementHandle) SetInputFiles(files goja.Value, opts goja.Value) {
 	// TODO: implement
-	rt := k6common.GetRuntime(h.ctx)
-	k6common.Throw(rt, errors.New("ElementHandle.setInputFiles() has not been implemented yet"))
+	k6Throw(h.ctx, "ElementHandle.setInputFiles() has not been implemented yet")
 }
 
 func (h *ElementHandle) Tap(opts goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	parsedOpts := NewElementHandleTapOptions(h.defaultTimeout())
 	err := parsedOpts.Parse(h.ctx, opts)
 	if err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannot parse element tap options: %w", err)
 	}
 
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
@@ -1357,13 +1334,12 @@ func (h *ElementHandle) Tap(opts goja.Value) {
 	pointerFn := elementHandlePointerActionFn(h, true, fn, &parsedOpts.ElementHandleBasePointerOptions)
 	_, err = callApiWithTimeout(h.ctx, pointerFn, parsedOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot tap element: %w", err)
 	}
 	applySlowMo(h.ctx)
 }
 
 func (h *ElementHandle) TextContent() string {
-	rt := k6common.GetRuntime(h.ctx)
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.textContent(apiCtx)
 	}
@@ -1371,7 +1347,7 @@ func (h *ElementHandle) TextContent() string {
 	actFn := elementHandleActionFn(h, []string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
 	value, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot get text content of element: %w", err)
 	}
 	applySlowMo(h.ctx)
 	return value.(goja.Value).String()
@@ -1379,7 +1355,6 @@ func (h *ElementHandle) TextContent() string {
 
 // Type scrolls element into view, focuses element and types text
 func (h *ElementHandle) Type(text string, opts goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	parsedOpts := NewElementHandleTypeOptions(h.defaultTimeout())
 	parsedOpts.Parse(h.ctx, opts)
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
@@ -1388,7 +1363,7 @@ func (h *ElementHandle) Type(text string, opts goja.Value) {
 	actFn := elementHandleActionFn(h, []string{}, fn, false, parsedOpts.NoWaitAfter, parsedOpts.Timeout)
 	_, err := callApiWithTimeout(h.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "cannot type (%q) into element: %w", text, err)
 	}
 	applySlowMo(h.ctx)
 }
@@ -1399,28 +1374,26 @@ func (h *ElementHandle) Uncheck(opts goja.Value) {
 }
 
 func (h *ElementHandle) WaitForElementState(state string, opts goja.Value) {
-	rt := k6common.GetRuntime(h.ctx)
 	parsedOpts := NewElementHandleWaitForElementStateOptions(time.Duration(h.frame.manager.timeoutSettings.timeout()) * time.Second)
 	err := parsedOpts.Parse(h.ctx, opts)
 	if err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannt parse element wait for state options: %w", err)
 	}
 	_, err = h.waitForElementState(h.ctx, []string{state}, parsedOpts.Timeout)
 	if err != nil {
-		k6common.Throw(rt, fmt.Errorf("error while waiting for state: %w", err))
+		k6Throw(h.ctx, "error while waiting for state: %w", err)
 	}
 }
 
 func (h *ElementHandle) WaitForSelector(selector string, opts goja.Value) api.ElementHandle {
-	rt := k6common.GetRuntime(h.ctx)
 	parsedOpts := NewFrameWaitForSelectorOptions(h.defaultTimeout())
 	if err := parsedOpts.Parse(h.ctx, opts); err != nil {
-		k6common.Throw(rt, fmt.Errorf("failed parsing options: %w", err))
+		k6Throw(h.ctx, "cannot parse element wait for selector options: %w", err)
 	}
 
 	handle, err := h.waitForSelector(h.ctx, selector, parsedOpts)
 	if err != nil {
-		k6common.Throw(rt, err)
+		k6Throw(h.ctx, "error while waiting for selector (%q): %w", selector, err)
 	}
 
 	return handle
@@ -1458,7 +1431,7 @@ func (h *ElementHandle) eval(
 	// call the javascript function.
 	result, err := h.execCtx.evaluate(ctx, opts, rt.ToValue(js), gargs...)
 	if err != nil {
-		err = fmt.Errorf("evaluate: %w", err)
+		err = fmt.Errorf("element handle cannot evaluate: %w", err)
 	}
 	return result, err
 }

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -49,11 +49,11 @@ func (ew executionWorld) valid() bool {
 	return ew == mainWorld || ew == utilityWorld
 }
 
-type evaluateOptions struct {
+type evalOptions struct {
 	forceCallable, returnByValue bool
 }
 
-func (ea evaluateOptions) String() string {
+func (ea evalOptions) String() string {
 	return fmt.Sprintf("forceCallable:%t returnByValue:%t", ea.forceCallable, ea.returnByValue)
 }
 
@@ -162,11 +162,10 @@ func (e *ExecutionContext) adoptElementHandle(eh *ElementHandle) (*ElementHandle
 	return e.adoptBackendNodeID(node.BackendNodeID)
 }
 
-// evaluate will evaluate provided callable within this execution context
-// and return by value or handle
-func (e *ExecutionContext) evaluate(
+// eval will evaluate provided callable within this execution context and return by value or handle.
+func (e *ExecutionContext) eval(
 	apiCtx context.Context,
-	opts evaluateOptions, pageFunc goja.Value, args ...goja.Value,
+	opts evalOptions, pageFunc goja.Value, args ...goja.Value,
 ) (res interface{}, err error) {
 	e.logger.Debugf(
 		"ExecutionContext:evaluate",
@@ -290,11 +289,11 @@ func (e *ExecutionContext) getInjectedScript(apiCtx context.Context) (api.JSHand
 			expressionWithSourceURL = expression + "\n" + suffix
 		}
 
-		opts := evaluateOptions{
+		opts := evalOptions{
 			forceCallable: false,
 			returnByValue: false,
 		}
-		handle, err := e.evaluate(apiCtx, opts, rt.ToValue(expressionWithSourceURL))
+		handle, err := e.eval(apiCtx, opts, rt.ToValue(expressionWithSourceURL))
 		if handle == nil || err != nil {
 			return nil, fmt.Errorf("cannot get injected script (%q): %w", suffix, err)
 		}
@@ -303,28 +302,28 @@ func (e *ExecutionContext) getInjectedScript(apiCtx context.Context) (api.JSHand
 	return e.injectedScript, nil
 }
 
-// Evaluate will evaluate provided page function within this execution context
-func (e *ExecutionContext) Evaluate(
+// Eval will evaluate provided page function within this execution context
+func (e *ExecutionContext) Eval(
 	apiCtx context.Context,
 	pageFunc goja.Value, args ...goja.Value,
 ) (interface{}, error) {
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
-	return e.evaluate(apiCtx, opts, pageFunc, args...)
+	return e.eval(apiCtx, opts, pageFunc, args...)
 }
 
-// EvaluateHandle will evaluate provided page function within this execution context
-func (e *ExecutionContext) EvaluateHandle(
+// EvalHandle will evaluate provided page function within this execution context
+func (e *ExecutionContext) EvalHandle(
 	apiCtx context.Context,
 	pageFunc goja.Value, args ...goja.Value,
 ) (api.JSHandle, error) {
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	res, err := e.evaluate(apiCtx, opts, pageFunc, args...)
+	res, err := e.eval(apiCtx, opts, pageFunc, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -321,7 +321,7 @@ func (f *Frame) document() (*ElementHandle, error) {
 
 	f.waitForExecutionContext(mainWorld)
 
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: false,
 		returnByValue: false,
 	}
@@ -531,11 +531,11 @@ func (f *Frame) waitForFunction(
 	} else {
 		predicate = fmt.Sprintf("return (%s)(...args);", predicateFn.ToString().String())
 	}
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := execCtx.evaluate(
+	result, err := execCtx.eval(
 		apiCtx, opts, pageFn, append([]goja.Value{
 			rt.ToValue(injected),
 			rt.ToValue(predicate),
@@ -721,7 +721,7 @@ func (f *Frame) Evaluate(pageFunc goja.Value, args ...goja.Value) interface{} {
 
 	f.waitForExecutionContext(mainWorld)
 
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -750,7 +750,7 @@ func (f *Frame) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (handle 
 		if ec == nil {
 			k6common.Throw(rt, fmt.Errorf("cannot find execution context: %q", mainWorld))
 		}
-		handle, err = ec.EvaluateHandle(f.ctx, pageFunc, args...)
+		handle, err = ec.EvalHandle(f.ctx, pageFunc, args...)
 	}
 	f.executionContextMu.RUnlock()
 	if err != nil {
@@ -1245,7 +1245,7 @@ func (f *Frame) SetContent(html string, opts goja.Value) {
 
 	f.waitForExecutionContext(utilityWorld)
 
-	eopts := evaluateOptions{
+	eopts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -1474,7 +1474,7 @@ func (f *Frame) adoptBackendNodeID(world executionWorld, id cdp.BackendNodeID) (
 func (f *Frame) evaluate(
 	apiCtx context.Context,
 	world executionWorld,
-	opts evaluateOptions, pageFunc goja.Value, args ...goja.Value,
+	opts evalOptions, pageFunc goja.Value, args ...goja.Value,
 ) (interface{}, error) {
 	f.log.Debugf("Frame:evaluate", "fid:%s furl:%q world:%s opts:%s", f.ID(), f.URL(), world, opts)
 
@@ -1485,7 +1485,7 @@ func (f *Frame) evaluate(
 	if ec == nil {
 		return nil, fmt.Errorf("cannot find execution context: %q", world)
 	}
-	eh, err := ec.evaluate(apiCtx, opts, pageFunc, args...)
+	eh, err := ec.eval(apiCtx, opts, pageFunc, args...)
 	if err != nil {
 		return nil, fmt.Errorf("frame cannot evaluate: %w", err)
 	}
@@ -1502,11 +1502,11 @@ type frameExecutionContext interface {
 	// execution context from another execution context.
 	adoptElementHandle(elementHandle *ElementHandle) (*ElementHandle, error)
 
-	// evaluate will evaluate provided callable within this execution
+	// eval will evaluate provided callable within this execution
 	// context and return by value or handle.
-	evaluate(
+	eval(
 		apiCtx context.Context,
-		opts evaluateOptions,
+		opts evalOptions,
 		pageFunc goja.Value, args ...goja.Value,
 	) (res interface{}, err error)
 
@@ -1514,16 +1514,16 @@ type frameExecutionContext interface {
 	// functions.
 	getInjectedScript(apiCtx context.Context) (api.JSHandle, error)
 
-	// Evaluate will evaluate provided page function within this execution
+	// Eval will evaluate provided page function within this execution
 	// context.
-	Evaluate(
+	Eval(
 		apiCtx context.Context,
 		pageFunc goja.Value, args ...goja.Value,
 	) (interface{}, error)
 
-	// EvaluateHandle will evaluate provided page function within this
+	// EvalHandle will evaluate provided page function within this
 	// execution context.
-	EvaluateHandle(
+	EvalHandle(
 		apiCtx context.Context,
 		pageFunc goja.Value, args ...goja.Value,
 	) (api.JSHandle, error)

--- a/common/frame_test.go
+++ b/common/frame_test.go
@@ -43,7 +43,7 @@ func TestFrameNilDocument(t *testing.T) {
 
 	// frame should not panic with a nil document
 	stub := &executionContextTestStub{
-		evaluateFn: func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+		evalFn: func(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
 			// return nil to test for panic
 			return nil, nil
 		},
@@ -68,7 +68,7 @@ func TestFrameNilDocument(t *testing.T) {
 
 	// frame gets the document from the evaluate call
 	want := &ElementHandle{}
-	stub.evaluateFn = func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+	stub.evalFn = func(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
 		return want, nil
 	}
 	got, err := frame.document()
@@ -116,9 +116,9 @@ func TestFrameManagerFrameAbortedNavigationShouldEmitANonNilPendingDocument(t *t
 
 type executionContextTestStub struct {
 	ExecutionContext
-	evaluateFn func(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error)
+	evalFn func(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error)
 }
 
-func (e executionContextTestStub) evaluate(apiCtx context.Context, opts evaluateOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
-	return e.evaluateFn(apiCtx, opts, pageFunc, args...)
+func (e executionContextTestStub) eval(apiCtx context.Context, opts evalOptions, pageFunc goja.Value, args ...goja.Value) (res interface{}, err error) {
+	return e.evalFn(apiCtx, opts, pageFunc, args...)
 }

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -95,7 +95,7 @@ func (h *BaseJSHandle) Dispose() {
 func (h *BaseJSHandle) Evaluate(pageFunc goja.Value, args ...goja.Value) interface{} {
 	rt := k6common.GetRuntime(h.ctx)
 	args = append([]goja.Value{rt.ToValue(h)}, args...)
-	res, err := h.execCtx.Evaluate(h.ctx, pageFunc, args...)
+	res, err := h.execCtx.Eval(h.ctx, pageFunc, args...)
 	if err != nil {
 		k6common.Throw(rt, err)
 	}
@@ -106,7 +106,7 @@ func (h *BaseJSHandle) Evaluate(pageFunc goja.Value, args ...goja.Value) interfa
 func (h *BaseJSHandle) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) api.JSHandle {
 	rt := k6common.GetRuntime(h.ctx)
 	args = append([]goja.Value{rt.ToValue(h)}, args...)
-	res, err := h.execCtx.EvaluateHandle(h.ctx, pageFunc, args...)
+	res, err := h.execCtx.EvalHandle(h.ctx, pageFunc, args...)
 	if err != nil {
 		k6common.Throw(rt, err)
 	}

--- a/common/page.go
+++ b/common/page.go
@@ -225,11 +225,11 @@ func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) cdp.Frame
 		}
 	`)
 
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.execCtx.evaluate(apiCtx, opts, pageFn, []goja.Value{rt.ToValue(h)}...)
+	result, err := h.execCtx.eval(apiCtx, opts, pageFn, []goja.Value{rt.ToValue(h)}...)
 	if err != nil {
 		p.logger.Debugf("Page:getOwnerFrame:return", "sid:%v err:%v", p.sessionID(), err)
 		return ""

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -47,7 +47,7 @@ func newScreenshotter(ctx context.Context) *screenshotter {
 
 func (s *screenshotter) fullPageSize(p *Page) (*Size, error) {
 	rt := k6common.GetRuntime(s.ctx)
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}
@@ -91,7 +91,7 @@ func (s *screenshotter) originalViewportSize(p *Page) (*Size, *Size, error) {
 		return &viewportSize, &originalViewportSize, nil
 	}
 
-	opts := evaluateOptions{
+	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
 	}

--- a/tests/element_handle_click_test.go
+++ b/tests/element_handle_click_test.go
@@ -140,5 +140,5 @@ func TestElementHandleClickWithDetachedNode(t *testing.T) {
 		}))
 	}
 	panicTestFn()
-	assert.Equal(t, "element is not attached to the DOM", errorMsg, "expected click to result in correct error to be thrown")
+	assert.Contains(t, errorMsg, "element is not attached to the DOM", "expected click to result in correct error to be thrown")
 }


### PR DESCRIPTION
This PR is a new one for #196. We had reverted #196 because it included the `QueryAll` (#195) fix by mistake.