### PR TITLE
Make session an anonymous interface within NetworkManager

### DIFF
--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -34,6 +34,7 @@ import (
 	"github.com/chromedp/cdproto/emulation"
 	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
 	k6common "go.k6.io/k6/js/common"
 	k6lib "go.k6.io/k6/lib"
@@ -48,9 +49,13 @@ var _ EventEmitter = &NetworkManager{}
 type NetworkManager struct {
 	BaseEventEmitter
 
-	ctx          context.Context
-	logger       *Logger
-	session      session
+	ctx     context.Context
+	logger  *Logger
+	session interface {
+		EventEmitter
+		cdp.Executor
+		ID() target.SessionID
+	}
 	parent       *NetworkManager
 	frameManager *FrameManager
 	credentials  *Credentials

--- a/common/session.go
+++ b/common/session.go
@@ -32,13 +32,9 @@ import (
 	k6lib "go.k6.io/k6/lib"
 )
 
-var _ session = &Session{}
-
-type session interface {
-	EventEmitter
-	cdp.Executor
-	ID() target.SessionID
-}
+// Ensure Session implements the EventEmitter and Executor interfaces
+var _ EventEmitter = &Session{}
+var _ cdp.Executor = &Session{}
 
 // Session represents a CDP session to a target
 type Session struct {


### PR DESCRIPTION
Resolves https://github.com/grafana/xk6-browser/pull/204#discussion_r796395070

I prefer the anonymous interface approach rather than coming up with some common one we're not sure we'll have a need for yet.