### PR TITLE
Add golangci-lint configuration

### DIFF
--- a/.github/workflows/all.yaml
+++ b/.github/workflows/all.yaml
@@ -35,7 +35,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-        GOLANG_CI_VERSION: "1.39.0"
+        GOLANG_CI_VERSION: "1.44.0"
         GO111MODULE: 'on'
     steps:
       - name: Checkout code

--- a/.github/workflows/all.yaml
+++ b/.github/workflows/all.yaml
@@ -35,8 +35,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-        GOLANG_CI_VERSION: "1.44.0"
-        GO111MODULE: 'on'
+      GO111MODULE: 'on'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -48,7 +47,9 @@ jobs:
           go-version: 1.17.x
       - name: Install golangci-lint
         working-directory: /tmp
-        run: go install "github.com/golangci/golangci-lint/cmd/golangci-lint@v$GOLANG_CI_VERSION"
+        run: |
+          GOLANGCI_LINT_VERSION=$(head -n 1 "${GITHUB_WORKSPACE}/.golangci.yml" | tr -d '# ')
+          go install "github.com/golangci/golangci-lint/cmd/golangci-lint@$GOLANGCI_LINT_VERSION"
       - name: Run linters
         run: |
           BASEREV=$(git merge-base HEAD origin/main)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,7 +69,6 @@ linters:
     - unparam
     - unused
     - varcheck
-    - varnamelen
     - wastedassign
     - whitespace
     - wrapcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,3 +88,7 @@ linters-settings:
     block-size: 10
   lll:
     maxlength: 120
+  gosec:
+    config:
+      G301: '0755'
+      G306: '0644'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,90 @@
+run:
+  timeout: 5m
+
+issues:
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+
+  # Disable default exclude rules, see `golangci-lint run --help`.
+  # When true it disables revive's comment warnings, and we want them enabled.
+  exclude-use-default: false
+
+linters:
+  disable-all: true
+  enable:
+    - cyclop
+    - deadcode
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forbidigo
+    - forcetypeassert
+    - funlen
+    - gci
+    - gochecknoglobals
+    - gocognit
+    - goconst
+    - gocritic
+    - godot
+    - gofmt
+    - gofumpt
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ifshort
+    - importas
+    - ineffassign
+    - lll
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - nlreturn
+    - nolintlint
+    - predeclared
+    - prealloc
+    - revive
+    - staticcheck
+    - structcheck
+    - tagliatelle
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - varnamelen
+    - wastedassign
+    - whitespace
+    - wrapcheck
+
+linters-settings:
+  gci:
+    local: github.com/grafana/xk6-browser
+  dupl:
+    threshold: 400
+  gofmt:
+    simplify: true
+  goimports:
+    local-prefixes: github.com/grafana/xk6-browser
+  importas:
+    alias:
+      - pkg: go.k6.io/k6/.*/(\w+)
+        alias: k6$1
+  nlreturn:
+    block-size: 10
+  lll:
+    maxlength: 120

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+# v1.44.0
+# Please don't remove the first line. It's used in CI to determine the
+# golangci-lint version. See the lint step in .github/workflows/all.yaml
 run:
   timeout: 5m
 

--- a/api/frame.go
+++ b/api/frame.go
@@ -22,7 +22,7 @@ package api
 
 import "github.com/dop251/goja"
 
-// Frame is the interface of a CDP target frame
+// Frame is the interface of a CDP target frame.
 type Frame interface {
 	AddScriptTag(opts goja.Value)
 	AddStyleTag(opts goja.Value)

--- a/api/keyboard.go
+++ b/api/keyboard.go
@@ -22,7 +22,7 @@ package api
 
 import "github.com/dop251/goja"
 
-// Keyboard is the interface of a keyboard input device
+// Keyboard is the interface of a keyboard input device.
 type Keyboard interface {
 	Down(key string)
 	InsertText(char string)

--- a/api/mouse.go
+++ b/api/mouse.go
@@ -22,7 +22,7 @@ package api
 
 import "github.com/dop251/goja"
 
-// Mouse is the interface of a mouse input device
+// Mouse is the interface of a mouse input device.
 type Mouse interface {
 	Click(x float64, y float64, opts goja.Value)
 	DblClick(x float64, y float64, opts goja.Value)

--- a/api/mouse.go
+++ b/api/mouse.go
@@ -29,5 +29,5 @@ type Mouse interface {
 	Down(x float64, y float64, opts goja.Value)
 	Move(x float64, y float64, opts goja.Value)
 	Up(x float64, y float64, opts goja.Value)
-	//Wheel(opts goja.Value)
+	// Wheel(opts goja.Value)
 }

--- a/api/request.go
+++ b/api/request.go
@@ -22,7 +22,7 @@ package api
 
 import "github.com/dop251/goja"
 
-// Request is the interface of an HTTP request
+// Request is the interface of an HTTP request.
 type Request interface {
 	AllHeaders() map[string]string
 	Failure() goja.Value

--- a/api/response.go
+++ b/api/response.go
@@ -22,7 +22,7 @@ package api
 
 import "github.com/dop251/goja"
 
-// Response is the interface of an HTTP response
+// Response is the interface of an HTTP response.
 type Response interface {
 	AllHeaders() map[string]string
 	Body() goja.ArrayBuffer

--- a/api/route.go
+++ b/api/route.go
@@ -22,7 +22,7 @@ package api
 
 import "github.com/dop251/goja"
 
-// Route is the interface of a route for managing request interception
+// Route is the interface of a route for managing request interception.
 type Route interface {
 	Abort(errorCode string)
 	Continue(opts goja.Value)

--- a/api/video.go
+++ b/api/video.go
@@ -20,7 +20,7 @@
 
 package api
 
-// Video is the interface of a recorded video
+// Video is the interface of a recorded video.
 type Video interface {
 	Path() string
 }

--- a/chromium/allocator.go
+++ b/chromium/allocator.go
@@ -181,7 +181,7 @@ readLoop:
 	return wsURL, nil
 }
 
-// Allocate starts a new local browser process
+// Allocate starts a new local browser process.
 func (a *Allocator) Allocate(ctx context.Context, launchOpts *common.LaunchOptions) (_ *common.BrowserProcess, rerr error) {
 	// Create cancelable context for the browser process
 	ctx, cancel := context.WithCancel(ctx)

--- a/chromium/allocator.go
+++ b/chromium/allocator.go
@@ -104,8 +104,8 @@ func (a *Allocator) buildCmdArgs(userDataDir *string, removeDir *bool) ([]string
 
 	// Force the first page to be blank, instead of the welcome page;
 	// --no-first-run doesn't enforce that.
-	//args = append(args, "about:blank")
-	//args = append(args, "--no-startup-window")
+	// args = append(args, "about:blank")
+	// args = append(args, "--no-startup-window")
 	return args, nil
 }
 

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -31,10 +31,11 @@ import (
 	"strings"
 
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/common"
 	k6common "go.k6.io/k6/js/common"
 	k6lib "go.k6.io/k6/lib"
+
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/common"
 )
 
 // Ensure BrowserType implements the api.BrowserType interface.

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -177,7 +177,7 @@ func (b *BrowserType) flags(lopts *common.LaunchOptions, k6opts *k6lib.Options) 
 	return f
 }
 
-// makes an extension wide logger
+// makes an extension wide logger.
 func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*common.Logger, error) {
 	var (
 		k6Logger            = k6lib.GetState(ctx).Logger

--- a/chromium/browser_type_test.go
+++ b/chromium/browser_type_test.go
@@ -68,21 +68,24 @@ func TestBrowserTypeFlags(t *testing.T) {
 			flag:       "browser-arg-trim-double-quote",
 			expInitVal: nil,
 			changeOpts: &common.LaunchOptions{Args: []string{
-				`   browser-arg-trim-double-quote =  "value  "  `}},
+				`   browser-arg-trim-double-quote =  "value  "  `,
+			}},
 			expChangedVal: "value  ",
 		},
 		{
 			flag:       "browser-arg-trim-single-quote",
 			expInitVal: nil,
 			changeOpts: &common.LaunchOptions{Args: []string{
-				`   browser-arg-trim-single-quote=' value '`}},
+				`   browser-arg-trim-single-quote=' value '`,
+			}},
 			expChangedVal: " value ",
 		},
 		{
 			flag:       "browser-args",
 			expInitVal: nil,
 			changeOpts: &common.LaunchOptions{Args: []string{
-				"browser-arg1='value1", "browser-arg2=''value2''", "browser-flag"}},
+				"browser-arg1='value1", "browser-arg2=''value2''", "browser-flag",
+			}},
 			post: func(t *testing.T, flags map[string]interface{}) {
 				assert.Equal(t, "'value1", flags["browser-arg1"])
 				assert.Equal(t, "'value2'", flags["browser-arg2"])
@@ -93,12 +96,14 @@ func TestBrowserTypeFlags(t *testing.T) {
 			flag:       "host-resolver-rules",
 			expInitVal: nil,
 			changeOpts: &common.LaunchOptions{Args: []string{
-				`host-resolver-rules="MAP * www.example.com, EXCLUDE *.youtube.*"`}},
+				`host-resolver-rules="MAP * www.example.com, EXCLUDE *.youtube.*"`,
+			}},
 			changeK6Opts: &k6lib.Options{
 				Hosts: map[string]*k6lib.HostAddress{
 					"test.k6.io":         host,
 					"httpbin.test.k6.io": host,
-				}},
+				},
+			},
 			expChangedVal: "MAP * www.example.com, EXCLUDE *.youtube.*," +
 				"MAP httpbin.test.k6.io 127.0.0.1:8000,MAP test.k6.io 127.0.0.1:8000",
 		},

--- a/chromium/browser_type_test.go
+++ b/chromium/browser_type_test.go
@@ -25,10 +25,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/grafana/xk6-browser/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k6lib "go.k6.io/k6/lib"
+
+	"github.com/grafana/xk6-browser/common"
 )
 
 func TestBrowserTypeFlags(t *testing.T) {

--- a/common/browser.go
+++ b/common/browser.go
@@ -37,7 +37,7 @@ import (
 	"github.com/grafana/xk6-browser/api"
 )
 
-// Ensure Browser implements the EventEmitter and Browser interfaces
+// Ensure Browser implements the EventEmitter and Browser interfaces.
 var _ EventEmitter = &Browser{}
 var _ api.Browser = &Browser{}
 
@@ -47,7 +47,7 @@ const (
 	BrowserStateClosed
 )
 
-// Browser stores a Browser context
+// Browser stores a Browser context.
 type Browser struct {
 	BaseEventEmitter
 
@@ -391,7 +391,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 	return page, err
 }
 
-// Close shuts down the browser
+// Close shuts down the browser.
 func (b *Browser) Close() {
 	b.logger.Debugf("Browser:Close", "")
 	if !atomic.CompareAndSwapInt64(&b.state, b.state, BrowserStateClosing) {
@@ -416,7 +416,7 @@ func (b *Browser) Close() {
 	b.browserProc.Terminate()
 }
 
-// Contexts returns list of browser contexts
+// Contexts returns list of browser contexts.
 func (b *Browser) Contexts() []api.BrowserContext {
 	b.contextsMu.RLock()
 	defer b.contextsMu.RUnlock()
@@ -436,7 +436,7 @@ func (b *Browser) IsConnected() bool {
 	return b.connected
 }
 
-// NewContext creates a new incognito-like browser context
+// NewContext creates a new incognito-like browser context.
 func (b *Browser) NewContext(opts goja.Value) api.BrowserContext {
 	action := target.CreateBrowserContext().WithDisposeOnDetach(true)
 	browserContextID, err := action.Do(cdp.WithExecutor(b.ctx, b.conn))
@@ -458,13 +458,13 @@ func (b *Browser) NewContext(opts goja.Value) api.BrowserContext {
 	return browserCtx
 }
 
-// NewPage creates a new tab in the browser window
+// NewPage creates a new tab in the browser window.
 func (b *Browser) NewPage(opts goja.Value) api.Page {
 	browserCtx := b.NewContext(opts)
 	return browserCtx.NewPage()
 }
 
-// UserAgent returns the controlled browser's user agent string
+// UserAgent returns the controlled browser's user agent string.
 func (b *Browser) UserAgent() string {
 	action := cdpbrowser.GetVersion()
 	_, _, _, ua, _, err := action.Do(cdp.WithExecutor(b.ctx, b.conn))
@@ -474,7 +474,7 @@ func (b *Browser) UserAgent() string {
 	return ua
 }
 
-// Version returns the controlled browser's version
+// Version returns the controlled browser's version.
 func (b *Browser) Version() string {
 	action := cdpbrowser.GetVersion()
 	_, product, _, _, _, err := action.Do(cdp.WithExecutor(b.ctx, b.conn))

--- a/common/browser.go
+++ b/common/browser.go
@@ -33,6 +33,7 @@ import (
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
 	"github.com/gorilla/websocket"
+
 	"github.com/grafana/xk6-browser/api"
 )
 

--- a/common/browser.go
+++ b/common/browser.go
@@ -237,7 +237,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 	case "background_page":
 		p, err := NewPage(b.ctx, session, browserCtx, evti.TargetID, nil, false, b.logger)
 		if err != nil {
-			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() //b.conn.isConnected()
+			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() // b.conn.isConnected()
 			if _, ok := err.(*websocket.CloseError); !ok && !isRunning {
 				// If we're no longer connected to browser, then ignore WebSocket errors
 				b.logger.Debugf("Browser:onAttachedToTarget:background_page:return", "sid:%v tid:%v websocket err:%v",
@@ -277,7 +277,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 
 		p, err := NewPage(b.ctx, session, browserCtx, evti.TargetID, opener, true, b.logger)
 		if err != nil {
-			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() //b.conn.isConnected()
+			isRunning := atomic.LoadInt64(&b.state) == BrowserStateOpen && b.IsConnected() // b.conn.isConnected()
 			if _, ok := err.(*websocket.CloseError); !ok && !isRunning {
 				// If we're no longer connected to browser, then ignore WebSocket errors
 				b.logger.Debugf("Browser:onAttachedToTarget:page:return", "sid:%v tid:%v websocket err:", ev.SessionID, evti.TargetID)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -36,7 +36,7 @@ import (
 	"github.com/grafana/xk6-browser/api"
 )
 
-// Ensure BrowserContext implements the EventEmitter and api.BrowserContext interfaces
+// Ensure BrowserContext implements the EventEmitter and api.BrowserContext interfaces.
 var _ EventEmitter = &BrowserContext{}
 var _ api.BrowserContext = &BrowserContext{}
 
@@ -206,7 +206,7 @@ func (b *BrowserContext) GrantPermissions(permissions []string, opts goja.Value)
 	}
 }
 
-// NewCDPSession returns a new CDP session attached to this target
+// NewCDPSession returns a new CDP session attached to this target.
 func (b *BrowserContext) NewCDPSession() api.CDPSession {
 	k6Throw(b.ctx, "BrowserContext.newCDPSession() has not been implemented yet")
 	return nil

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -31,8 +31,9 @@ import (
 	"github.com/chromedp/cdproto/storage"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure BrowserContext implements the EventEmitter and api.BrowserContext interfaces

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -27,7 +27,7 @@ import (
 	k6common "go.k6.io/k6/js/common"
 )
 
-// BrowserContextOptions stores browser context options
+// BrowserContextOptions stores browser context options.
 type BrowserContextOptions struct {
 	AcceptDownloads   bool              `js:"acceptDownloads"`
 	BypassCSP         bool              `js:"bypassCSP"`
@@ -51,7 +51,7 @@ type BrowserContextOptions struct {
 	Viewport          *Viewport         `js:"viewport"`
 }
 
-// NewBrowserContextOptions creates a default set of browser context options
+// NewBrowserContextOptions creates a default set of browser context options.
 func NewBrowserContextOptions() *BrowserContextOptions {
 	return &BrowserContextOptions{
 		AcceptDownloads:   false,

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -77,29 +77,29 @@ func (p *BrowserProcess) didLoseConnection() {
 	close(p.lostConnection)
 }
 
-// GracefulClose triggers a graceful closing of the browser process
+// GracefulClose triggers a graceful closing of the browser process.
 func (p *BrowserProcess) GracefulClose() {
 	p.logger.Debugf("Browser:GracefulClose", "")
 	close(p.processIsGracefullyClosing)
 }
 
-// Terminate triggers the termination of the browser process
+// Terminate triggers the termination of the browser process.
 func (p *BrowserProcess) Terminate() {
 	p.logger.Debugf("Browser:Close", "browserProc terminate")
 	p.cancel()
 }
 
-// WsURL returns the Websocket URL that the browser is listening on for CDP clients
+// WsURL returns the Websocket URL that the browser is listening on for CDP clients.
 func (p *BrowserProcess) WsURL() string {
 	return p.wsURL
 }
 
-// Pid returns the browser process ID
+// Pid returns the browser process ID.
 func (p *BrowserProcess) Pid() int {
 	return p.process.Pid
 }
 
-// WithLogger attaches a logger to the browser process
+// WithLogger attaches a logger to the browser process.
 func (p *BrowserProcess) AttachLogger(logger *Logger) {
 	p.logger = logger
 }

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -99,7 +99,7 @@ func (p *BrowserProcess) Pid() int {
 	return p.process.Pid
 }
 
-// WithLogger attaches a logger to the browser process.
+// AttachLogger attaches a logger to the browser process.
 func (p *BrowserProcess) AttachLogger(logger *Logger) {
 	p.logger = logger
 }

--- a/common/connection.go
+++ b/common/connection.go
@@ -40,7 +40,7 @@ import (
 
 const wsWriteBufferSize = 1 << 20
 
-// Ensure Connection implements the EventEmitter and Executor interfaces
+// Ensure Connection implements the EventEmitter and Executor interfaces.
 var _ EventEmitter = &Connection{}
 var _ cdp.Executor = &Connection{}
 
@@ -88,7 +88,7 @@ func (f ActionFunc) Do(ctx context.Context) error {
 │Registers with session as a├─────────────■                    │                         │                    │
 │handler for a specific CDP │             │   Event Listener   │      *  *  *  *  *      │   Event Listener   │
 │       Domain event.       │             │                    │                         │                    │
-└───────────────────────────┘             └────────────────────┘                         └────────────────────┘
+└───────────────────────────┘             └────────────────────┘                         └────────────────────┘.
 */
 type Connection struct {
 	BaseEventEmitter
@@ -113,7 +113,7 @@ type Connection struct {
 	encoder jwriter.Writer
 }
 
-// NewConnection creates a new browser
+// NewConnection creates a new browser.
 func NewConnection(ctx context.Context, wsURL string, logger *Logger) (*Connection, error) {
 	var header http.Header
 	var tlsConfig *tls.Config
@@ -467,7 +467,7 @@ func (c *Connection) Close(args ...goja.Value) {
 	_ = c.closeConnection(code)
 }
 
-// Execute implements cdproto.Executor and performs a synchronous send and receive
+// Execute implements cdproto.Executor and performs a synchronous send and receive.
 func (c *Connection) Execute(ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler) error {
 	c.logger.Debugf("connection:Execute", "wsURL:%q method:%q", c.wsURL, method)
 	id := atomic.AddInt64(&c.msgID, 1)

--- a/common/consts.go
+++ b/common/consts.go
@@ -23,12 +23,14 @@ package common
 import "time"
 
 const (
-	// Defaults.
+	// Defaults
+
 	DefaultLocale       string        = "en-US"
 	DefaultScreenWidth  int64         = 1280
 	DefaultScreenHeight int64         = 720
 	DefaultTimeout      time.Duration = 30 * time.Second
 
-	// Life-cycle consts.
+	// Life-cycle consts
+
 	LifeCycleNetworkIdleTimeout time.Duration = 500 * time.Millisecond
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -23,12 +23,12 @@ package common
 import "time"
 
 const (
-	// Defaults
+	// Defaults.
 	DefaultLocale       string        = "en-US"
 	DefaultScreenWidth  int64         = 1280
 	DefaultScreenHeight int64         = 720
 	DefaultTimeout      time.Duration = 30 * time.Second
 
-	// Life-cycle consts
+	// Life-cycle consts.
 	LifeCycleNetworkIdleTimeout time.Duration = 500 * time.Millisecond
 )

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -49,8 +49,9 @@ import (
 	"github.com/chromedp/cdproto/dom"
 	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure ElementHandle implements the api.ElementHandle and api.JSHandle interfaces.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -58,8 +58,10 @@ import (
 var _ api.ElementHandle = &ElementHandle{}
 var _ api.JSHandle = &ElementHandle{}
 
-type ElementHandleActionFn func(context.Context, *ElementHandle) (interface{}, error)
-type ElementHandlePointerActionFn func(context.Context, *ElementHandle, *Position) (interface{}, error)
+type (
+	ElementHandleActionFn        func(context.Context, *ElementHandle) (interface{}, error)
+	ElementHandlePointerActionFn func(context.Context, *ElementHandle, *Position) (interface{}, error)
+)
 
 func elementHandleActionFn(h *ElementHandle, states []string, fn ElementHandleActionFn, force, noWaitAfter bool, timeout time.Duration) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// All or a subset of the following actionability checks are made before performing the actual action:

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -63,7 +63,9 @@ type (
 	ElementHandlePointerActionFn func(context.Context, *ElementHandle, *Position) (interface{}, error)
 )
 
-func elementHandleActionFn(h *ElementHandle, states []string, fn ElementHandleActionFn, force, noWaitAfter bool, timeout time.Duration) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
+func elementHandleActionFn(
+	h *ElementHandle, states []string, fn ElementHandleActionFn, force, noWaitAfter bool, timeout time.Duration,
+) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// All or a subset of the following actionability checks are made before performing the actual action:
 	// 1. Attached to DOM
 	// 2. Visible
@@ -104,7 +106,9 @@ func elementHandleActionFn(h *ElementHandle, states []string, fn ElementHandleAc
 	}
 }
 
-func elementHandlePointerActionFn(h *ElementHandle, checkEnabled bool, fn ElementHandlePointerActionFn, opts *ElementHandleBasePointerOptions) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
+func elementHandlePointerActionFn(
+	h *ElementHandle, checkEnabled bool, fn ElementHandlePointerActionFn, opts *ElementHandleBasePointerOptions,
+) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// All or a subset of the following actionability checks are made before performing the actual action:
 	// 1. Attached to DOM
 	// 2. Visible
@@ -952,7 +956,8 @@ func (h *ElementHandle) Fill(value string, opts goja.Value) {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.fill(apiCtx, value)
 	}
-	actFn := elementHandleActionFn(h, []string{"visible", "enabled", "editable"}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
+	actFn := elementHandleActionFn(h, []string{"visible", "enabled", "editable"},
+		fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
 	_, err := callApiWithTimeout(h.ctx, actFn, actionOpts.Timeout)
 	if err != nil {
 		k6Throw(h.ctx, "cannot handle element fill action: %w", err)

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -64,7 +64,7 @@ type (
 )
 
 func getElementHandleActionFn(
-	h *ElementHandle, states []string, fn elementHandleActionFn, force, noWaitAfter bool, timeout time.Duration,
+	elh *ElementHandle, states []string, ehaFn elementHandleActionFn, force, noWaitAfter bool, timeout time.Duration,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// All or a subset of the following actionability checks are made before performing the actual action:
 	// 1. Attached to DOM
@@ -78,7 +78,7 @@ func getElementHandleActionFn(
 
 		// Check if we should run actionability checks
 		if !force {
-			_, err = h.waitForElementState(apiCtx, states, timeout)
+			_, err = elh.waitForElementState(apiCtx, states, timeout)
 			if err != nil {
 				errCh <- err
 				return
@@ -86,10 +86,10 @@ func getElementHandleActionFn(
 		}
 
 		b := NewBarrier()
-		h.frame.manager.addBarrier(b)
-		defer h.frame.manager.removeBarrier(b)
+		elh.frame.manager.addBarrier(b)
+		defer elh.frame.manager.removeBarrier(b)
 
-		result, err = fn(apiCtx, h)
+		result, err = ehaFn(apiCtx, elh)
 		if err != nil {
 			errCh <- err
 			return
@@ -108,7 +108,7 @@ func getElementHandleActionFn(
 
 //nolint:funlen,gocognit,cyclop,unparam
 func getElementHandlePointerActionFn(
-	h *ElementHandle, checkEnabled bool, fn elementHandlePointerActionFn, opts *ElementHandleBasePointerOptions,
+	elh *ElementHandle, checkEnabled bool, ehpaFn elementHandlePointerActionFn, opts *ElementHandleBasePointerOptions,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// All or a subset of the following actionability checks are made before performing the actual action:
 	// 1. Attached to DOM
@@ -127,7 +127,7 @@ func getElementHandlePointerActionFn(
 			if checkEnabled {
 				states = append(states, "enabled")
 			}
-			_, err = h.waitForElementState(apiCtx, states, opts.Timeout)
+			_, err = elh.waitForElementState(apiCtx, states, opts.Timeout)
 			if err != nil {
 				errCh <- err
 				return
@@ -142,20 +142,20 @@ func getElementHandlePointerActionFn(
 		if p != nil {
 			rect = &dom.Rect{X: p.X, Y: p.Y, Width: 0, Height: 0}
 		}
-		err = h.scrollRectIntoViewIfNeeded(apiCtx, rect)
+		err = elh.scrollRectIntoViewIfNeeded(apiCtx, rect)
 		if err != nil {
 			errCh <- err
 			return
 		}
 
 		if p != nil {
-			p, err = h.offsetPosition(apiCtx, opts.Position)
+			p, err = elh.offsetPosition(apiCtx, opts.Position)
 			if err != nil {
 				errCh <- err
 				return
 			}
 		} else {
-			p, err = h.clickablePoint()
+			p, err = elh.clickablePoint()
 			if err != nil {
 				errCh <- err
 				return
@@ -164,7 +164,7 @@ func getElementHandlePointerActionFn(
 
 		// Do a final actionability check to see if element can receive events at mouse position in question
 		if !opts.Force {
-			if ok, localErr := h.checkHitTargetAt(apiCtx, *p); !ok {
+			if ok, localErr := elh.checkHitTargetAt(apiCtx, *p); !ok {
 				errCh <- localErr
 				return
 			}
@@ -173,10 +173,10 @@ func getElementHandlePointerActionFn(
 		// Are we only "trialing" the action (ie. running the actionability checks) but not actually performing it
 		if !opts.Trial {
 			b := NewBarrier()
-			h.frame.manager.addBarrier(b)
-			defer h.frame.manager.removeBarrier(b)
+			elh.frame.manager.addBarrier(b)
+			defer elh.frame.manager.removeBarrier(b)
 
-			result, err = fn(apiCtx, h, p)
+			result, err = ehpaFn(apiCtx, elh, p)
 			if err != nil {
 				errCh <- err
 				return

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -187,7 +187,7 @@ func elementHandlePointerActionFn(h *ElementHandle, checkEnabled bool, fn Elemen
 	}
 }
 
-// ElementHandle represents a HTML element JS object inside an execution context
+// ElementHandle represents a HTML element JS object inside an execution context.
 type ElementHandle struct {
 	BaseJSHandle
 
@@ -860,12 +860,12 @@ func (h *ElementHandle) waitForSelector(apiCtx context.Context, selector string,
 	}
 }
 
-// AsElement returns this element handle
+// AsElement returns this element handle.
 func (h *ElementHandle) AsElement() api.ElementHandle {
 	return h
 }
 
-// BoundingBox returns this element's bounding box
+// BoundingBox returns this element's bounding box.
 func (h *ElementHandle) BoundingBox() *api.Rect {
 	bbox, err := h.boundingBox()
 	if err != nil {
@@ -874,7 +874,7 @@ func (h *ElementHandle) BoundingBox() *api.Rect {
 	return bbox.toApiRect()
 }
 
-// Check scrolls element into view and clicks in the center of the element
+// Check scrolls element into view and clicks in the center of the element.
 func (h *ElementHandle) Check(opts goja.Value) {
 	h.SetChecked(true, opts)
 }
@@ -958,7 +958,7 @@ func (h *ElementHandle) Fill(value string, opts goja.Value) {
 	applySlowMo(h.ctx)
 }
 
-// Focus scrolls element into view and focuses the element
+// Focus scrolls element into view and focuses the element.
 func (h *ElementHandle) Focus() {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return nil, handle.focus(apiCtx, false)
@@ -972,7 +972,7 @@ func (h *ElementHandle) Focus() {
 	applySlowMo(h.ctx)
 }
 
-// GetAttribute retrieves the value of specified element attribute
+// GetAttribute retrieves the value of specified element attribute.
 func (h *ElementHandle) GetAttribute(name string) goja.Value {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.getAttribute(apiCtx, name)
@@ -987,7 +987,7 @@ func (h *ElementHandle) GetAttribute(name string) goja.Value {
 	return value.(goja.Value)
 }
 
-// Hover scrolls element into view and hovers over its center point
+// Hover scrolls element into view and hovers over its center point.
 func (h *ElementHandle) Hover(opts goja.Value) {
 	actionOpts := NewElementHandleHoverOptions(h.defaultTimeout())
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
@@ -1004,7 +1004,7 @@ func (h *ElementHandle) Hover(opts goja.Value) {
 	applySlowMo(h.ctx)
 }
 
-// InnerHTML returns the inner HTML of the element
+// InnerHTML returns the inner HTML of the element.
 func (h *ElementHandle) InnerHTML() string {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.innerHTML(apiCtx)
@@ -1019,7 +1019,7 @@ func (h *ElementHandle) InnerHTML() string {
 	return value.(goja.Value).String()
 }
 
-// InnerText returns the inner text of the element
+// InnerText returns the inner text of the element.
 func (h *ElementHandle) InnerText() string {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.innerText(apiCtx)
@@ -1051,7 +1051,7 @@ func (h *ElementHandle) InputValue(opts goja.Value) string {
 	return value.(goja.Value).String()
 }
 
-// IsChecked checks if a checkbox or radio is checked
+// IsChecked checks if a checkbox or radio is checked.
 func (h *ElementHandle) IsChecked() bool {
 	result, err := h.isChecked(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
@@ -1060,7 +1060,7 @@ func (h *ElementHandle) IsChecked() bool {
 	return result
 }
 
-// IsDisabled checks if the element is disabled
+// IsDisabled checks if the element is disabled.
 func (h *ElementHandle) IsDisabled() bool {
 	result, err := h.isDisabled(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
@@ -1069,7 +1069,7 @@ func (h *ElementHandle) IsDisabled() bool {
 	return result
 }
 
-// IsEditable checks if the element is editable
+// IsEditable checks if the element is editable.
 func (h *ElementHandle) IsEditable() bool {
 	result, err := h.isEditable(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
@@ -1078,7 +1078,7 @@ func (h *ElementHandle) IsEditable() bool {
 	return result
 }
 
-// IsEnabled checks if the element is enabled
+// IsEnabled checks if the element is enabled.
 func (h *ElementHandle) IsEnabled() bool {
 	result, err := h.isEnabled(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
@@ -1087,7 +1087,7 @@ func (h *ElementHandle) IsEnabled() bool {
 	return result
 }
 
-// IsHidden checks if the element is hidden
+// IsHidden checks if the element is hidden.
 func (h *ElementHandle) IsHidden() bool {
 	result, err := h.isHidden(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
@@ -1096,7 +1096,7 @@ func (h *ElementHandle) IsHidden() bool {
 	return result
 }
 
-// IsVisible checks if the element is visible
+// IsVisible checks if the element is visible.
 func (h *ElementHandle) IsVisible() bool {
 	result, err := h.isVisible(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
@@ -1105,7 +1105,7 @@ func (h *ElementHandle) IsVisible() bool {
 	return result
 }
 
-// OwnerFrame returns the frame containing this element
+// OwnerFrame returns the frame containing this element.
 func (h *ElementHandle) OwnerFrame() api.Frame {
 	fn := `
 		(node, injected) => {
@@ -1159,7 +1159,7 @@ func (h *ElementHandle) Press(key string, opts goja.Value) {
 }
 
 // Query runs "element.querySelector" within the page. If no element matches the selector,
-// the return value resolves to "null"
+// the return value resolves to "null".
 func (h *ElementHandle) Query(selector string) api.ElementHandle {
 	parsedSelector, err := NewSelector(selector)
 	if err != nil {
@@ -1195,7 +1195,7 @@ func (h *ElementHandle) Query(selector string) api.ElementHandle {
 }
 
 // QueryAll queries element subtree for matching elements. If no element matches the selector,
-// the return value resolves to "null"
+// the return value resolves to "null".
 func (h *ElementHandle) QueryAll(selector string) []api.ElementHandle {
 	parsedSelector, err := NewSelector(selector)
 	if err != nil {
@@ -1355,7 +1355,7 @@ func (h *ElementHandle) TextContent() string {
 	return value.(goja.Value).String()
 }
 
-// Type scrolls element into view, focuses element and types text
+// Type scrolls element into view, focuses element and types text.
 func (h *ElementHandle) Type(text string, opts goja.Value) {
 	parsedOpts := NewElementHandleTypeOptions(h.defaultTimeout())
 	if err := parsedOpts.Parse(h.ctx, opts); err != nil {
@@ -1372,7 +1372,7 @@ func (h *ElementHandle) Type(text string, opts goja.Value) {
 	applySlowMo(h.ctx)
 }
 
-// Uncheck scrolls element into view and clicks in the center of the element
+// Uncheck scrolls element into view and clicks in the center of the element.
 func (h *ElementHandle) Uncheck(opts goja.Value) {
 	h.SetChecked(false, opts)
 }

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -106,6 +106,7 @@ func getElementHandleActionFn(
 	}
 }
 
+//nolint:funlen,gocognit,cyclop,unparam
 func getElementHandlePointerActionFn(
 	h *ElementHandle, checkEnabled bool, fn elementHandlePointerActionFn, opts *ElementHandleBasePointerOptions,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {

--- a/common/event_emitter.go
+++ b/common/event_emitter.go
@@ -24,26 +24,26 @@ import (
 	"context"
 )
 
-// Ensure BaseEventEmitter implements the EventEmitter interface
+// Ensure BaseEventEmitter implements the EventEmitter interface.
 var _ EventEmitter = &BaseEventEmitter{}
 
 const (
-	// Browser
+	// Browser.
 	EventBrowserDisconnected string = "disconnected"
 
-	// BrowserContext
+	// BrowserContext.
 	EventBrowserContextClose string = "close"
 	EventBrowserContextPage  string = "page"
 
-	// Connection
+	// Connection.
 	EventConnectionClose string = "close"
 
-	// Frame
+	// Frame.
 	EventFrameNavigation      string = "navigation"
 	EventFrameAddLifecycle    string = "addlifecycle"
 	EventFrameRemoveLifecycle string = "removelifecycle"
 
-	// Page
+	// Page.
 	EventPageClose            string = "close"
 	EventPageConsole          string = "console"
 	EventPageCrash            string = "crash"
@@ -64,14 +64,14 @@ const (
 	EventPageWebSocket        string = "websocket"
 	EventPageWorker           string = "worker"
 
-	// Session
+	// Session.
 	EventSessionClosed string = "close"
 
-	// Worker
+	// Worker.
 	EventWorkerClose string = "close"
 )
 
-// Event as emitted by an EventEmiter
+// Event as emitted by an EventEmiter.
 type Event struct {
 	typ  string
 	data interface{}
@@ -89,7 +89,7 @@ type eventHandler struct {
 	ch  chan Event
 }
 
-// EventEmitter that all event emitters need to implement
+// EventEmitter that all event emitters need to implement.
 type EventEmitter interface {
 	emit(event string, data interface{})
 	on(ctx context.Context, events []string, ch chan Event)
@@ -100,7 +100,7 @@ type EventEmitter interface {
 // eventHandler requests.
 type syncFunc func() (done chan struct{})
 
-// BaseEventEmitter emits events to registered handlers
+// BaseEventEmitter emits events to registered handlers.
 type BaseEventEmitter struct {
 	handlers    map[string][]eventHandler
 	handlersAll []eventHandler
@@ -109,7 +109,7 @@ type BaseEventEmitter struct {
 	ctx    context.Context
 }
 
-// NewBaseEventEmitter creates a new instance of a base event emitter
+// NewBaseEventEmitter creates a new instance of a base event emitter.
 func NewBaseEventEmitter(ctx context.Context) BaseEventEmitter {
 	bem := BaseEventEmitter{
 		handlers: make(map[string][]eventHandler),
@@ -180,7 +180,7 @@ func (e *BaseEventEmitter) emit(event string, data interface{}) {
 	})
 }
 
-// On registers a handler for a specific event
+// On registers a handler for a specific event.
 func (e *BaseEventEmitter) on(ctx context.Context, events []string, ch chan Event) {
 	e.sync(func() {
 		for _, event := range events {
@@ -194,7 +194,7 @@ func (e *BaseEventEmitter) on(ctx context.Context, events []string, ch chan Even
 	})
 }
 
-// OnAll registers a handler for all events
+// OnAll registers a handler for all events.
 func (e *BaseEventEmitter) onAll(ctx context.Context, ch chan Event) {
 	e.sync(func() {
 		e.handlersAll = append(e.handlersAll, eventHandler{ctx, ch})

--- a/common/event_emitter.go
+++ b/common/event_emitter.go
@@ -28,22 +28,27 @@ import (
 var _ EventEmitter = &BaseEventEmitter{}
 
 const (
-	// Browser.
+	// Browser
+
 	EventBrowserDisconnected string = "disconnected"
 
-	// BrowserContext.
+	// BrowserContext
+
 	EventBrowserContextClose string = "close"
 	EventBrowserContextPage  string = "page"
 
-	// Connection.
+	// Connection
+
 	EventConnectionClose string = "close"
 
-	// Frame.
+	// Frame
+
 	EventFrameNavigation      string = "navigation"
 	EventFrameAddLifecycle    string = "addlifecycle"
 	EventFrameRemoveLifecycle string = "removelifecycle"
 
-	// Page.
+	// Page
+
 	EventPageClose            string = "close"
 	EventPageConsole          string = "console"
 	EventPageCrash            string = "crash"
@@ -64,10 +69,12 @@ const (
 	EventPageWebSocket        string = "websocket"
 	EventPageWorker           string = "worker"
 
-	// Session.
+	// Session
+
 	EventSessionClosed string = "close"
 
-	// Worker.
+	// Worker
+
 	EventWorkerClose string = "close"
 )
 

--- a/common/event_emitter_test.go
+++ b/common/event_emitter_test.go
@@ -124,5 +124,4 @@ func TestEventEmitterAllEvents(t *testing.T) {
 			require.Equal(t, "hello world", msg.data)
 		})
 	})
-
 }

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -30,8 +30,9 @@ import (
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 const evaluationScriptURL = "__xk6_browser_evaluation_script__"

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -58,7 +58,7 @@ func (ea evalOptions) String() string {
 	return fmt.Sprintf("forceCallable:%t returnByValue:%t", ea.forceCallable, ea.returnByValue)
 }
 
-// ExecutionContext represents a JS execution context
+// ExecutionContext represents a JS execution context.
 type ExecutionContext struct {
 	ctx            context.Context
 	logger         *Logger
@@ -74,7 +74,7 @@ type ExecutionContext struct {
 	furl string           // Frame URL
 }
 
-// NewExecutionContext creates a new JS execution context
+// NewExecutionContext creates a new JS execution context.
 func NewExecutionContext(
 	ctx context.Context, session *Session, frame *Frame,
 	id runtime.ExecutionContextID, logger *Logger,
@@ -104,7 +104,7 @@ func NewExecutionContext(
 	return e
 }
 
-// Adopts specified backend node into this execution context from another execution context
+// Adopts specified backend node into this execution context from another execution context.
 func (e *ExecutionContext) adoptBackendNodeID(backendNodeID cdp.BackendNodeID) (*ElementHandle, error) {
 	e.logger.Debugf(
 		"ExecutionContext:adoptBackendNodeID",
@@ -127,7 +127,7 @@ func (e *ExecutionContext) adoptBackendNodeID(backendNodeID cdp.BackendNodeID) (
 	return NewJSHandle(e.ctx, e.session, e, e.frame, remoteObj, e.logger).AsElement().(*ElementHandle), nil
 }
 
-// Adopts the specified element handle into this execution context from another execution context
+// Adopts the specified element handle into this execution context from another execution context.
 func (e *ExecutionContext) adoptElementHandle(eh *ElementHandle) (*ElementHandle, error) {
 	var (
 		efid cdp.FrameID
@@ -273,7 +273,7 @@ func (e *ExecutionContext) eval(
 	return res, nil
 }
 
-// getInjectedScript returns a JS handle to the injected script of helper functions
+// getInjectedScript returns a JS handle to the injected script of helper functions.
 func (e *ExecutionContext) getInjectedScript(apiCtx context.Context) (api.JSHandle, error) {
 	e.logger.Debugf(
 		"ExecutionContext:getInjectedScript",
@@ -303,7 +303,7 @@ func (e *ExecutionContext) getInjectedScript(apiCtx context.Context) (api.JSHand
 	return e.injectedScript, nil
 }
 
-// Eval will evaluate provided page function within this execution context
+// Eval will evaluate provided page function within this execution context.
 func (e *ExecutionContext) Eval(
 	apiCtx context.Context,
 	pageFunc goja.Value, args ...goja.Value,
@@ -315,7 +315,7 @@ func (e *ExecutionContext) Eval(
 	return e.eval(apiCtx, opts, pageFunc, args...)
 }
 
-// EvalHandle will evaluate provided page function within this execution context
+// EvalHandle will evaluate provided page function within this execution context.
 func (e *ExecutionContext) EvalHandle(
 	apiCtx context.Context,
 	pageFunc goja.Value, args ...goja.Value,
@@ -331,7 +331,7 @@ func (e *ExecutionContext) EvalHandle(
 	return res.(api.JSHandle), nil
 }
 
-// Frame returns the frame that this execution context belongs to
+// Frame returns the frame that this execution context belongs to.
 func (e *ExecutionContext) Frame() *Frame {
 	return e.frame
 }

--- a/common/field_name_mapper.go
+++ b/common/field_name_mapper.go
@@ -26,7 +26,7 @@ import (
 	k6common "go.k6.io/k6/js/common"
 )
 
-// FieldNameMapper for goja.Runtime.SetFieldNameMapper()
+// FieldNameMapper for goja.Runtime.SetFieldNameMapper().
 type FieldNameMapper struct {
 	parent k6common.FieldNameMapper
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -1540,7 +1540,7 @@ type frameExecutionContext interface {
 
 //nolint:unparam
 func frameActionFn(
-	frame *Frame, selector string, state DOMElementState, strict bool, ehaFn elementHandleActionFn, states []string,
+	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandleActionFn, states []string,
 	force, noWaitAfter bool, timeout time.Duration,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame action in the following steps:
@@ -1549,10 +1549,10 @@ func frameActionFn(
 	// 3. Run element handle action (incl. actionability checks)
 
 	return func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
-		waitOpts := NewFrameWaitForSelectorOptions(frame.defaultTimeout())
+		waitOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
 		waitOpts.State = state
 		waitOpts.Strict = strict
-		handle, err := frame.waitForSelector(selector, waitOpts)
+		handle, err := f.waitForSelector(selector, waitOpts)
 		if err != nil {
 			errCh <- err
 			return
@@ -1561,14 +1561,14 @@ func frameActionFn(
 			resultCh <- nil
 			return
 		}
-		actFn := getElementHandleActionFn(handle, states, ehaFn, false, false, timeout)
+		actFn := getElementHandleActionFn(handle, states, fn, false, false, timeout)
 		actFn(apiCtx, resultCh, errCh)
 	}
 }
 
 //nolint:unparam
 func framePointerActionFn(
-	frame *Frame, selector string, state DOMElementState, strict bool, ehpaFn elementHandlePointerActionFn,
+	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandlePointerActionFn,
 	opts *ElementHandleBasePointerOptions,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame pointer action in the following steps:
@@ -1577,10 +1577,10 @@ func framePointerActionFn(
 	// 3. Run element handle action (incl. actionability checks)
 
 	return func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
-		waitOpts := NewFrameWaitForSelectorOptions(frame.defaultTimeout())
+		waitOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
 		waitOpts.State = state
 		waitOpts.Strict = strict
-		handle, err := frame.waitForSelector(selector, waitOpts)
+		handle, err := f.waitForSelector(selector, waitOpts)
 		if err != nil {
 			errCh <- err
 			return
@@ -1589,7 +1589,7 @@ func framePointerActionFn(
 			resultCh <- nil
 			return
 		}
-		pointerActFn := getElementHandlePointerActionFn(handle, true, ehpaFn, opts)
+		pointerActFn := getElementHandlePointerActionFn(handle, true, fn, opts)
 		pointerActFn(apiCtx, resultCh, errCh)
 	}
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -1539,7 +1539,7 @@ type frameExecutionContext interface {
 }
 
 func frameActionFn(
-	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandleActionFn, states []string,
+	frame *Frame, selector string, state DOMElementState, strict bool, ehaFn elementHandleActionFn, states []string,
 	force, noWaitAfter bool, timeout time.Duration,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame action in the following steps:
@@ -1548,10 +1548,10 @@ func frameActionFn(
 	// 3. Run element handle action (incl. actionability checks)
 
 	return func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
-		waitOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
+		waitOpts := NewFrameWaitForSelectorOptions(frame.defaultTimeout())
 		waitOpts.State = state
 		waitOpts.Strict = strict
-		handle, err := f.waitForSelector(selector, waitOpts)
+		handle, err := frame.waitForSelector(selector, waitOpts)
 		if err != nil {
 			errCh <- err
 			return
@@ -1560,13 +1560,13 @@ func frameActionFn(
 			resultCh <- nil
 			return
 		}
-		actFn := getElementHandleActionFn(handle, states, fn, false, false, timeout)
+		actFn := getElementHandleActionFn(handle, states, ehaFn, false, false, timeout)
 		actFn(apiCtx, resultCh, errCh)
 	}
 }
 
 func framePointerActionFn(
-	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandlePointerActionFn,
+	frame *Frame, selector string, state DOMElementState, strict bool, ehpaFn elementHandlePointerActionFn,
 	opts *ElementHandleBasePointerOptions,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame pointer action in the following steps:
@@ -1575,10 +1575,10 @@ func framePointerActionFn(
 	// 3. Run element handle action (incl. actionability checks)
 
 	return func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
-		waitOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
+		waitOpts := NewFrameWaitForSelectorOptions(frame.defaultTimeout())
 		waitOpts.State = state
 		waitOpts.Strict = strict
-		handle, err := f.waitForSelector(selector, waitOpts)
+		handle, err := frame.waitForSelector(selector, waitOpts)
 		if err != nil {
 			errCh <- err
 			return
@@ -1587,7 +1587,7 @@ func framePointerActionFn(
 			resultCh <- nil
 			return
 		}
-		pointerActFn := getElementHandlePointerActionFn(handle, true, fn, opts)
+		pointerActFn := getElementHandlePointerActionFn(handle, true, ehpaFn, opts)
 		pointerActFn(apiCtx, resultCh, errCh)
 	}
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -1538,6 +1538,7 @@ type frameExecutionContext interface {
 	ID() runtime.ExecutionContextID
 }
 
+//nolint:unparam
 func frameActionFn(
 	frame *Frame, selector string, state DOMElementState, strict bool, ehaFn elementHandleActionFn, states []string,
 	force, noWaitAfter bool, timeout time.Duration,
@@ -1565,6 +1566,7 @@ func frameActionFn(
 	}
 }
 
+//nolint:unparam
 func framePointerActionFn(
 	frame *Frame, selector string, state DOMElementState, strict bool, ehpaFn elementHandlePointerActionFn,
 	opts *ElementHandleBasePointerOptions,

--- a/common/frame.go
+++ b/common/frame.go
@@ -1539,7 +1539,7 @@ type frameExecutionContext interface {
 }
 
 func frameActionFn(
-	f *Frame, selector string, state DOMElementState, strict bool, fn ElementHandleActionFn, states []string,
+	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandleActionFn, states []string,
 	force, noWaitAfter bool, timeout time.Duration,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame action in the following steps:
@@ -1560,13 +1560,13 @@ func frameActionFn(
 			resultCh <- nil
 			return
 		}
-		actFn := elementHandleActionFn(handle, states, fn, false, false, timeout)
+		actFn := getElementHandleActionFn(handle, states, fn, false, false, timeout)
 		actFn(apiCtx, resultCh, errCh)
 	}
 }
 
 func framePointerActionFn(
-	f *Frame, selector string, state DOMElementState, strict bool, fn ElementHandlePointerActionFn,
+	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandlePointerActionFn,
 	opts *ElementHandleBasePointerOptions,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame pointer action in the following steps:
@@ -1587,7 +1587,7 @@ func framePointerActionFn(
 			resultCh <- nil
 			return
 		}
-		pointerActFn := elementHandlePointerActionFn(handle, true, fn, opts)
+		pointerActFn := getElementHandlePointerActionFn(handle, true, fn, opts)
 		pointerActFn(apiCtx, resultCh, errCh)
 	}
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -31,8 +31,9 @@ import (
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure frame implements the Frame interface

--- a/common/frame.go
+++ b/common/frame.go
@@ -36,7 +36,7 @@ import (
 	"github.com/grafana/xk6-browser/api"
 )
 
-// Ensure frame implements the Frame interface
+// Ensure frame implements the Frame interface.
 var _ api.Frame = &Frame{}
 
 type DocumentInfo struct {
@@ -44,7 +44,7 @@ type DocumentInfo struct {
 	request    *Request
 }
 
-// Frame represents a frame in an HTML document
+// Frame represents a frame in an HTML document.
 type Frame struct {
 	BaseEventEmitter
 
@@ -87,7 +87,7 @@ type Frame struct {
 	log *Logger
 }
 
-// NewFrame creates a new HTML document frame
+// NewFrame creates a new HTML document frame.
 func NewFrame(ctx context.Context, m *FrameManager, parentFrame *Frame, frameID cdp.FrameID, log *Logger) *Frame {
 	if log.DebugMode() {
 		var pfid string
@@ -596,7 +596,7 @@ func (f *Frame) AddStyleTag(opts goja.Value) {
 	applySlowMo(f.ctx)
 }
 
-// Check clicks the first element found that matches selector
+// Check clicks the first element found that matches selector.
 func (f *Frame) Check(selector string, opts goja.Value) {
 	f.log.Debugf("Frame:Check", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
@@ -619,7 +619,7 @@ func (f *Frame) Check(selector string, opts goja.Value) {
 	applySlowMo(f.ctx)
 }
 
-// ChildFrames returns a list of child frames
+// ChildFrames returns a list of child frames.
 func (f *Frame) ChildFrames() []api.Frame {
 	f.childFramesMu.RLock()
 	defer f.childFramesMu.RUnlock()
@@ -631,7 +631,7 @@ func (f *Frame) ChildFrames() []api.Frame {
 	return l
 }
 
-// Click clicks the first element found that matches selector
+// Click clicks the first element found that matches selector.
 func (f *Frame) Click(selector string, opts goja.Value) {
 	f.log.Debugf("Frame:Click", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
@@ -654,7 +654,7 @@ func (f *Frame) Click(selector string, opts goja.Value) {
 	applySlowMo(f.ctx)
 }
 
-// Content returns the HTML content of the frame
+// Content returns the HTML content of the frame.
 func (f *Frame) Content() string {
 	f.log.Debugf("Frame:Content", "fid:%s furl:%q", f.ID(), f.URL())
 
@@ -670,7 +670,7 @@ func (f *Frame) Content() string {
 	return f.Evaluate(rt.ToValue(js)).(string)
 }
 
-// Dblclick double clicks an element matching provided selector
+// Dblclick double clicks an element matching provided selector.
 func (f *Frame) Dblclick(selector string, opts goja.Value) {
 	f.log.Debugf("Frame:DblClick", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
@@ -714,7 +714,7 @@ func (f *Frame) DispatchEvent(selector string, typ string, eventInit goja.Value,
 	applySlowMo(f.ctx)
 }
 
-// Evaluate will evaluate provided page function within an execution context
+// Evaluate will evaluate provided page function within an execution context.
 func (f *Frame) Evaluate(pageFunc goja.Value, args ...goja.Value) interface{} {
 	f.log.Debugf("Frame:Evaluate", "fid:%s furl:%q", f.ID(), f.URL())
 
@@ -736,7 +736,7 @@ func (f *Frame) Evaluate(pageFunc goja.Value, args ...goja.Value) interface{} {
 	return result
 }
 
-// EvaluateHandle will evaluate provided page function within an execution context
+// EvaluateHandle will evaluate provided page function within an execution context.
 func (f *Frame) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (handle api.JSHandle) {
 	f.log.Debugf("Frame:EvaluateHandle", "fid:%s furl:%q", f.ID(), f.URL())
 
@@ -783,7 +783,7 @@ func (f *Frame) Fill(selector string, value string, opts goja.Value) {
 	applySlowMo(f.ctx)
 }
 
-// Focus fetches an element with selector and focuses it
+// Focus fetches an element with selector and focuses it.
 func (f *Frame) Focus(selector string, opts goja.Value) {
 	f.log.Debugf("Frame:Focus", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
@@ -838,14 +838,14 @@ func (f *Frame) GetAttribute(selector string, name string, opts goja.Value) goja
 	return value.(goja.Value)
 }
 
-// Goto will navigate the frame to the specified URL and return a HTTP response object
+// Goto will navigate the frame to the specified URL and return a HTTP response object.
 func (f *Frame) Goto(url string, opts goja.Value) api.Response {
 	resp := f.manager.NavigateFrame(f, url, opts)
 	applySlowMo(f.ctx)
 	return resp
 }
 
-// Hover hovers an element identified by provided selector
+// Hover hovers an element identified by provided selector.
 func (f *Frame) Hover(selector string, opts goja.Value) {
 	f.log.Debugf("Frame:Hover", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
@@ -960,7 +960,7 @@ func (f *Frame) IsChecked(selector string, opts goja.Value) bool {
 	return value.(bool)
 }
 
-// IsDetached returns whether the frame is detached or not
+// IsDetached returns whether the frame is detached or not.
 func (f *Frame) IsDetached() bool {
 	f.propertiesMu.RLock()
 	defer f.propertiesMu.RUnlock()
@@ -1106,7 +1106,7 @@ func (f *Frame) IsVisible(selector string, opts goja.Value) bool {
 	return value.(bool)
 }
 
-// ID returns the frame id
+// ID returns the frame id.
 func (f *Frame) ID() string {
 	f.propertiesMu.RLock()
 	defer f.propertiesMu.RUnlock()
@@ -1114,7 +1114,7 @@ func (f *Frame) ID() string {
 	return f.id.String()
 }
 
-// LoaderID returns the ID of the frame that loaded this frame
+// LoaderID returns the ID of the frame that loaded this frame.
 func (f *Frame) LoaderID() string {
 	f.propertiesMu.RLock()
 	defer f.propertiesMu.RUnlock()
@@ -1122,7 +1122,7 @@ func (f *Frame) LoaderID() string {
 	return f.loaderID
 }
 
-// Name returns the frame name
+// Name returns the frame name.
 func (f *Frame) Name() string {
 	f.propertiesMu.RLock()
 	defer f.propertiesMu.RUnlock()
@@ -1131,7 +1131,7 @@ func (f *Frame) Name() string {
 }
 
 // Query runs a selector query against the document tree, returning the first matching element or
-// "null" if no match is found
+// "null" if no match is found.
 func (f *Frame) Query(selector string) api.ElementHandle {
 	f.log.Debugf("Frame:Query", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
@@ -1162,12 +1162,12 @@ func (f *Frame) QueryAll(selector string) []api.ElementHandle {
 	return nil
 }
 
-// Page returns page that owns frame
+// Page returns page that owns frame.
 func (f *Frame) Page() api.Page {
 	return f.manager.page
 }
 
-// ParentFrame returns the parent frame, if one exists
+// ParentFrame returns the parent frame, if one exists.
 func (f *Frame) ParentFrame() api.Frame {
 	return f.parentFrame
 }
@@ -1227,7 +1227,7 @@ func (f *Frame) SelectOption(selector string, values goja.Value, opts goja.Value
 	return strArr
 }
 
-// SetContent replaces the entire HTML document content
+// SetContent replaces the entire HTML document content.
 func (f *Frame) SetContent(html string, opts goja.Value) {
 	f.log.Debugf("Frame:SetContent", "fid:%s furl:%q", f.ID(), f.URL())
 
@@ -1377,7 +1377,7 @@ func (f *Frame) setURL(url string) {
 	f.url = url
 }
 
-// WaitForFunction waits for the given predicate to return a truthy value
+// WaitForFunction waits for the given predicate to return a truthy value.
 func (f *Frame) WaitForFunction(pageFunc goja.Value, opts goja.Value, args ...goja.Value) api.JSHandle {
 	f.log.Debugf("Frame:WaitForFunction", "fid:%s furl:%q", f.ID(), f.URL())
 
@@ -1398,7 +1398,7 @@ func (f *Frame) WaitForFunction(pageFunc goja.Value, opts goja.Value, args ...go
 	return handle.(api.JSHandle)
 }
 
-// WaitForLoadState waits for the given load state to be reached
+// WaitForLoadState waits for the given load state to be reached.
 func (f *Frame) WaitForLoadState(state string, opts goja.Value) {
 	f.log.Debugf("Frame:WaitForLoadState", "fid:%s furl:%q state:%s", f.ID(), f.URL(), state)
 	defer f.log.Debugf("Frame:WaitForLoadState:return", "fid:%s furl:%q state:%s", f.ID(), f.URL(), state)
@@ -1429,12 +1429,12 @@ func (f *Frame) WaitForLoadState(state string, opts goja.Value) {
 	}
 }
 
-// WaitForNavigation waits for the given navigation lifecycle event to happen
+// WaitForNavigation waits for the given navigation lifecycle event to happen.
 func (f *Frame) WaitForNavigation(opts goja.Value) api.Response {
 	return f.manager.WaitForFrameNavigation(f, opts)
 }
 
-// WaitForSelector waits for the given selector to match the waiting criteria
+// WaitForSelector waits for the given selector to match the waiting criteria.
 func (f *Frame) WaitForSelector(selector string, opts goja.Value) api.ElementHandle {
 	rt := k6common.GetRuntime(f.ctx)
 	parsedOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
@@ -1448,7 +1448,7 @@ func (f *Frame) WaitForSelector(selector string, opts goja.Value) api.ElementHan
 	return handle
 }
 
-// WaitForTimeout waits the specified amount of milliseconds
+// WaitForTimeout waits the specified amount of milliseconds.
 func (f *Frame) WaitForTimeout(timeout int64) {
 	to := time.Duration(timeout) * time.Millisecond
 

--- a/common/frame.go
+++ b/common/frame.go
@@ -1538,7 +1538,10 @@ type frameExecutionContext interface {
 	ID() runtime.ExecutionContextID
 }
 
-func frameActionFn(f *Frame, selector string, state DOMElementState, strict bool, fn ElementHandleActionFn, states []string, force, noWaitAfter bool, timeout time.Duration) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
+func frameActionFn(
+	f *Frame, selector string, state DOMElementState, strict bool, fn ElementHandleActionFn, states []string,
+	force, noWaitAfter bool, timeout time.Duration,
+) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame action in the following steps:
 	// 1. Find element matching specified selector
 	// 2. Wait for it to reach specified DOM state
@@ -1562,7 +1565,10 @@ func frameActionFn(f *Frame, selector string, state DOMElementState, strict bool
 	}
 }
 
-func framePointerActionFn(f *Frame, selector string, state DOMElementState, strict bool, fn ElementHandlePointerActionFn, opts *ElementHandleBasePointerOptions) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
+func framePointerActionFn(
+	f *Frame, selector string, state DOMElementState, strict bool, fn ElementHandlePointerActionFn,
+	opts *ElementHandleBasePointerOptions,
+) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame pointer action in the following steps:
 	// 1. Find element matching specified selector
 	// 2. Wait for it to reach specified DOM state

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -562,7 +562,7 @@ func (m *FrameManager) setMainFrame(f *Frame) {
 	m.mainFrame = f
 }
 
-// NavigateFrame will navigate specified frame to specifed URL.
+// NavigateFrame will navigate specified frame to specified URL.
 func (m *FrameManager) NavigateFrame(frame *Frame, url string, opts goja.Value) api.Response {
 	var (
 		fmid = m.ID()

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -64,7 +64,7 @@ type FrameManager struct {
 	id     int64
 }
 
-// frameManagerID is used for giving a unique ID to a frame manager
+// frameManagerID is used for giving a unique ID to a frame manager.
 var frameManagerID int64
 
 // NewFrameManager creates a new HTML document frame manager.
@@ -531,7 +531,7 @@ func (m *FrameManager) requestStarted(req *Request) {
 	m.logger.Debugf("FrameManager:requestStarted", "fmid:%d rurl:%s pdoc:nil", m.ID(), req.URL())
 }
 
-// Frames returns a list of frames on the page
+// Frames returns a list of frames on the page.
 func (m *FrameManager) Frames() []api.Frame {
 	m.framesMu.RLock()
 	defer m.framesMu.RUnlock()
@@ -542,7 +542,7 @@ func (m *FrameManager) Frames() []api.Frame {
 	return frames
 }
 
-// MainFrame returns the main frame of the page
+// MainFrame returns the main frame of the page.
 func (m *FrameManager) MainFrame() *Frame {
 	m.mainFrameMu.RLock()
 	defer m.mainFrameMu.RUnlock()
@@ -550,7 +550,7 @@ func (m *FrameManager) MainFrame() *Frame {
 	return m.mainFrame
 }
 
-// setMainFrame sets the main frame of the page
+// setMainFrame sets the main frame of the page.
 func (m *FrameManager) setMainFrame(f *Frame) {
 	m.mainFrameMu.Lock()
 	defer m.mainFrameMu.Unlock()
@@ -562,7 +562,7 @@ func (m *FrameManager) setMainFrame(f *Frame) {
 	m.mainFrame = f
 }
 
-// NavigateFrame will navigate specified frame to specifed URL
+// NavigateFrame will navigate specified frame to specifed URL.
 func (m *FrameManager) NavigateFrame(frame *Frame, url string, opts goja.Value) api.Response {
 	var (
 		fmid = m.ID()
@@ -681,7 +681,7 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, opts goja.Value) 
 	return resp
 }
 
-// Page returns the page that this frame manager belongs to
+// Page returns the page that this frame manager belongs to.
 func (m *FrameManager) Page() api.Page {
 	if m.page != nil {
 		return m.page
@@ -689,7 +689,7 @@ func (m *FrameManager) Page() api.Page {
 	return nil
 }
 
-// WaitForFrameNavigation waits for the given navigation lifecycle event to happen
+// WaitForFrameNavigation waits for the given navigation lifecycle event to happen.
 func (m *FrameManager) WaitForFrameNavigation(frame *Frame, opts goja.Value) api.Response {
 	m.logger.Debugf("FrameManager:WaitForFrameNavigation",
 		"fmid:%d fid:%s furl:%s",

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -32,8 +32,9 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // FrameManager manages all frames in a page and their life-cycles, it's a purely internal component.

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -42,10 +42,11 @@ import (
 	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/security"
 	"github.com/chromedp/cdproto/target"
-	"github.com/grafana/xk6-browser/api"
 	"github.com/sirupsen/logrus"
 	k6lib "go.k6.io/k6/lib"
 	k6stats "go.k6.io/k6/stats"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 const utilityWorldName = "__k6_browser_utility_world__"

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -846,7 +846,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 		reason = "session closed"
 		return
 	default:
-		// Ignore context canceled error to gracefuly handle shutting down
+		// Ignore context canceled error to gracefully handle shutting down
 		// of the extension. This may happen because of generated events
 		// while a frame session is being created.
 		if errors.Is(err, context.Canceled) {

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -234,7 +234,7 @@ func waitForEvent(ctx context.Context, emitter EventEmitter, events []string, pr
 
 // k6Throw throws a k6 error, and before throwing the error, it finds the
 // browser process from the context and kills it if it still exists.
-// TODO: test
+// TODO: test.
 func k6Throw(ctx context.Context, format string, a ...interface{}) {
 	k6ThrowOnce.Do(func() {
 		k6ThrowUnsafe(ctx, format, a...)
@@ -275,7 +275,7 @@ func k6ThrowUnsafe(ctx context.Context, format string, a ...interface{}) {
 //
 // ctx, cancel := context.WithCancel(context.Background())
 // tb := testBrowser(t, withContext(ctx))
-// cancel()
+// cancel().
 var k6ThrowOnce sync.Once
 
 // TrimQuotes removes surrounding single or double quotes from s.

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -92,7 +92,6 @@ func convertArgument(ctx context.Context, execCtx *ExecutionContext, arg goja.Va
 	case reflect.TypeOf(&BaseJSHandle{}):
 		objHandle := arg.Export().(*BaseJSHandle)
 		return convertBaseJSHandleTypes(ctx, execCtx, objHandle)
-
 	}
 	b, err := json.Marshal(arg.Export())
 	return &cdpruntime.CallArgument{Value: b}, err

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -27,8 +27,9 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure BaseJSHandle implements the api.JSHandle interface.

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -35,7 +35,7 @@ import (
 // Ensure BaseJSHandle implements the api.JSHandle interface.
 var _ api.JSHandle = &BaseJSHandle{}
 
-// BaseJSHandle represents a JS object in an execution context
+// BaseJSHandle represents a JS object in an execution context.
 type BaseJSHandle struct {
 	ctx          context.Context
 	logger       *Logger
@@ -45,7 +45,7 @@ type BaseJSHandle struct {
 	disposed     bool
 }
 
-// NewJSHandle creates a new JS handle referencing a remote object
+// NewJSHandle creates a new JS handle referencing a remote object.
 func NewJSHandle(
 	ctx context.Context, session *Session, execCtx *ExecutionContext,
 	frame *Frame, remoteObject *runtime.RemoteObject, logger *Logger,
@@ -69,12 +69,12 @@ func NewJSHandle(
 	return eh
 }
 
-// AsElement returns an element handle if this JSHandle is a reference to a JS HTML element
+// AsElement returns an element handle if this JSHandle is a reference to a JS HTML element.
 func (h *BaseJSHandle) AsElement() api.ElementHandle {
 	return nil
 }
 
-// Dispose releases the remote object
+// Dispose releases the remote object.
 func (h *BaseJSHandle) Dispose() {
 	rt := k6common.GetRuntime(h.ctx)
 	if h.disposed {
@@ -92,7 +92,7 @@ func (h *BaseJSHandle) Dispose() {
 	}
 }
 
-// Evaluate will evaluate provided page function within an execution context
+// Evaluate will evaluate provided page function within an execution context.
 func (h *BaseJSHandle) Evaluate(pageFunc goja.Value, args ...goja.Value) interface{} {
 	rt := k6common.GetRuntime(h.ctx)
 	args = append([]goja.Value{rt.ToValue(h)}, args...)
@@ -103,7 +103,7 @@ func (h *BaseJSHandle) Evaluate(pageFunc goja.Value, args ...goja.Value) interfa
 	return res
 }
 
-// EvaluateHandle will evaluate provided page function within an execution context
+// EvaluateHandle will evaluate provided page function within an execution context.
 func (h *BaseJSHandle) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) api.JSHandle {
 	rt := k6common.GetRuntime(h.ctx)
 	args = append([]goja.Value{rt.ToValue(h)}, args...)
@@ -114,7 +114,7 @@ func (h *BaseJSHandle) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) a
 	return res
 }
 
-// GetProperties retreives the JS handle's properties
+// GetProperties retreives the JS handle's properties.
 func (h *BaseJSHandle) GetProperties() map[string]api.JSHandle {
 	rt := k6common.GetRuntime(h.ctx)
 
@@ -138,12 +138,12 @@ func (h *BaseJSHandle) GetProperties() map[string]api.JSHandle {
 	return props
 }
 
-// GetProperty retreves a single property of the JS handle
+// GetProperty retreves a single property of the JS handle.
 func (h *BaseJSHandle) GetProperty(propertyName string) api.JSHandle {
 	return nil
 }
 
-// JSONValue returns a JSON version of this JS handle
+// JSONValue returns a JSON version of this JS handle.
 func (h *BaseJSHandle) JSONValue() goja.Value {
 	rt := k6common.GetRuntime(h.ctx)
 	if h.remoteObject.ObjectID != "" {

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -28,6 +28,7 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/input"
 	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/keyboardlayout"
 )

--- a/common/launch.go
+++ b/common/launch.go
@@ -37,7 +37,7 @@ type ProxyOptions struct {
 	Password string
 }
 
-// LaunchOptions stores browser launch options
+// LaunchOptions stores browser launch options.
 type LaunchOptions struct {
 	Args              []string
 	Debug             bool
@@ -52,7 +52,7 @@ type LaunchOptions struct {
 	Timeout           time.Duration
 }
 
-// LaunchPersistentContextOptions stores browser launch options for persistent context
+// LaunchPersistentContextOptions stores browser launch options for persistent context.
 type LaunchPersistentContextOptions struct {
 	LaunchOptions
 	BrowserContextOptions

--- a/common/logger.go
+++ b/common/logger.go
@@ -122,7 +122,7 @@ func (l *Logger) Logf(level logrus.Level, category string, msg string, args ...i
 }
 
 // SetLevel sets the logger level from a level string.
-// Accepted values:
+// Accepted values:.
 func (l *Logger) SetLevel(level string) error {
 	pl, err := logrus.ParseLevel(level)
 	if err != nil {

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -28,8 +28,9 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/input"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure Mouse implements the api.Mouse interface

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -33,10 +33,10 @@ import (
 	"github.com/grafana/xk6-browser/api"
 )
 
-// Ensure Mouse implements the api.Mouse interface
+// Ensure Mouse implements the api.Mouse interface.
 var _ api.Mouse = &Mouse{}
 
-// Mouse represents a mouse input device
+// Mouse represents a mouse input device.
 type Mouse struct {
 	ctx             context.Context
 	session         *Session
@@ -48,7 +48,7 @@ type Mouse struct {
 	button          input.MouseButton
 }
 
-// NewMouse creates a new mouse
+// NewMouse creates a new mouse.
 func NewMouse(ctx context.Context, session *Session, frame *Frame, timeoutSettings *TimeoutSettings, keyboard *Keyboard) *Mouse {
 	m := &Mouse{
 		ctx:             ctx,
@@ -153,7 +153,7 @@ func (m *Mouse) up(x float64, y float64, opts *MouseDownUpOptions) error {
 	return nil
 }
 
-// Click will trigger a series of MouseMove, MouseDown and MouseUp events in the browser
+// Click will trigger a series of MouseMove, MouseDown and MouseUp events in the browser.
 func (m *Mouse) Click(x float64, y float64, opts goja.Value) {
 	rt := k6common.GetRuntime(m.ctx)
 	mouseOpts := NewMouseClickOptions()
@@ -176,7 +176,7 @@ func (m *Mouse) DblClick(x float64, y float64, opts goja.Value) {
 	}
 }
 
-// Down will trigger a MouseDown event in the browser
+// Down will trigger a MouseDown event in the browser.
 func (m *Mouse) Down(x float64, y float64, opts goja.Value) {
 	rt := k6common.GetRuntime(m.ctx)
 	mouseOpts := NewMouseDownUpOptions()
@@ -188,7 +188,7 @@ func (m *Mouse) Down(x float64, y float64, opts goja.Value) {
 	}
 }
 
-// Move will trigger a MouseMoved event in the browser
+// Move will trigger a MouseMoved event in the browser.
 func (m *Mouse) Move(x float64, y float64, opts goja.Value) {
 	rt := k6common.GetRuntime(m.ctx)
 	mouseOpts := NewMouseDownUpOptions()
@@ -200,7 +200,7 @@ func (m *Mouse) Move(x float64, y float64, opts goja.Value) {
 	}
 }
 
-// Up will trigger a MouseUp event in the browser
+// Up will trigger a MouseUp event in the browser.
 func (m *Mouse) Up(x float64, y float64, opts goja.Value) {
 	rt := k6common.GetRuntime(m.ctx)
 	mouseOpts := NewMouseDownUpOptions()

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -43,10 +43,10 @@ import (
 	k6stats "go.k6.io/k6/stats"
 )
 
-// Ensure NetworkManager implements the EventEmitter interface
+// Ensure NetworkManager implements the EventEmitter interface.
 var _ EventEmitter = &NetworkManager{}
 
-// NetworkManager manages all frames in HTML document
+// NetworkManager manages all frames in HTML document.
 type NetworkManager struct {
 	BaseEventEmitter
 
@@ -75,7 +75,7 @@ type NetworkManager struct {
 	protocolReqInterceptionEnabled bool
 }
 
-// NewNetworkManager creates a new network manager
+// NewNetworkManager creates a new network manager.
 func NewNetworkManager(
 	ctx context.Context, session *Session, manager *FrameManager, parent *NetworkManager,
 ) (*NetworkManager, error) {
@@ -620,7 +620,7 @@ func (m *NetworkManager) updateProtocolRequestInterception() error {
 	return nil
 }
 
-// Authenticate sets HTTP authentication credentials to use
+// Authenticate sets HTTP authentication credentials to use.
 func (m *NetworkManager) Authenticate(credentials *Credentials) {
 	m.credentials = credentials
 	if err := m.updateProtocolRequestInterception(); err != nil {
@@ -629,13 +629,13 @@ func (m *NetworkManager) Authenticate(credentials *Credentials) {
 	}
 }
 
-// ExtraHTTPHeaders returns the currently set extra HTTP request headers
+// ExtraHTTPHeaders returns the currently set extra HTTP request headers.
 func (m *NetworkManager) ExtraHTTPHeaders() goja.Value {
 	rt := k6common.GetRuntime(m.ctx)
 	return rt.ToValue(m.extraHTTPHeaders)
 }
 
-// SetExtraHTTPHeaders sets extra HTTP request headers to be sent with every request
+// SetExtraHTTPHeaders sets extra HTTP request headers to be sent with every request.
 func (m *NetworkManager) SetExtraHTTPHeaders(headers network.Headers) {
 	rt := k6common.GetRuntime(m.ctx)
 	action := network.SetExtraHTTPHeaders(headers)
@@ -644,7 +644,7 @@ func (m *NetworkManager) SetExtraHTTPHeaders(headers network.Headers) {
 	}
 }
 
-// SetOfflineMode toggles offline mode on/off
+// SetOfflineMode toggles offline mode on/off.
 func (m *NetworkManager) SetOfflineMode(offline bool) {
 	rt := k6common.GetRuntime(m.ctx)
 	if m.offline == offline {
@@ -658,7 +658,7 @@ func (m *NetworkManager) SetOfflineMode(offline bool) {
 	}
 }
 
-// SetUserAgent overrides the browser user agent string
+// SetUserAgent overrides the browser user agent string.
 func (m *NetworkManager) SetUserAgent(userAgent string) {
 	rt := k6common.GetRuntime(m.ctx)
 	action := emulation.SetUserAgentOverride(userAgent)
@@ -667,7 +667,7 @@ func (m *NetworkManager) SetUserAgent(userAgent string) {
 	}
 }
 
-// SetCacheEnabled toggles cache on/off
+// SetCacheEnabled toggles cache on/off.
 func (m *NetworkManager) SetCacheEnabled(enabled bool) {
 	m.userCacheDisabled = !enabled
 	if err := m.updateProtocolCacheDisabled(); err != nil {

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -62,7 +62,8 @@ type NetworkManager struct {
 	credentials  *Credentials
 	resolver     k6netext.Resolver
 
-	// TODO: manage inflight requests separately (move them between the two maps as they transition from inflight -> completed)
+	// TODO: manage inflight requests separately (move them between the two maps
+	// as they transition from inflight -> completed)
 	reqIDToRequest map[network.RequestID]*Request
 	reqsMu         sync.RWMutex
 

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -62,7 +62,7 @@ type NetworkManager struct {
 	credentials  *Credentials
 	resolver     k6netext.Resolver
 
-	// TODO: manage inflight requests seperately (move them between the two maps as they transition from inflight -> completed)
+	// TODO: manage inflight requests separately (move them between the two maps as they transition from inflight -> completed)
 	reqIDToRequest map[network.RequestID]*Request
 	reqsMu         sync.RWMutex
 

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 	k6lib "go.k6.io/k6/lib"
 	k6metrics "go.k6.io/k6/lib/metrics"
-	k6test "go.k6.io/k6/lib/testutils"
-	k6mockres "go.k6.io/k6/lib/testutils/mockresolver"
+	k6testutils "go.k6.io/k6/lib/testutils"
+	k6mockresolver "go.k6.io/k6/lib/testutils/mockresolver"
 	k6types "go.k6.io/k6/lib/types"
 	k6stats "go.k6.io/k6/stats"
 )
@@ -43,7 +43,7 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 
 	state := &k6lib.State{
 		Options:        k6opts,
-		Logger:         k6test.NewLogger(t),
+		Logger:         k6testutils.NewLogger(t),
 		Group:          root,
 		BPool:          bpool.NewBufferPool(1),
 		Samples:        make(chan k6stats.SampleContainer, 1000),
@@ -60,7 +60,7 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 		},
 	}
 
-	mr := k6mockres.New(map[string][]net.IP{
+	mr := k6mockresolver.New(map[string][]net.IP{
 		mockHostname: {
 			net.ParseIP("127.0.0.10"),
 			net.ParseIP("127.0.0.11"),

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -60,7 +60,7 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 		},
 	}
 
-	mr := k6mockresolver.New(map[string][]net.IP{
+	mockRes := k6mockresolver.New(map[string][]net.IP{
 		mockHostname: {
 			net.ParseIP("127.0.0.10"),
 			net.ParseIP("127.0.0.11"),
@@ -75,7 +75,7 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 		ctx:      ctx,
 		logger:   logger,
 		session:  session,
-		resolver: mr,
+		resolver: mockRes,
 	}
 
 	return nm, session

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -60,7 +60,7 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 		},
 	}
 
-	mockRes := k6mockresolver.New(map[string][]net.IP{
+	mr := k6mockresolver.New(map[string][]net.IP{
 		mockHostname: {
 			net.ParseIP("127.0.0.10"),
 			net.ParseIP("127.0.0.11"),
@@ -75,7 +75,7 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 		ctx:      ctx,
 		logger:   logger,
 		session:  session,
-		resolver: mockRes,
+		resolver: mr,
 	}
 
 	return nm, session

--- a/common/page.go
+++ b/common/page.go
@@ -34,8 +34,9 @@ import (
 	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure page implements the EventEmitter, Target and Page interfaces.

--- a/common/page.go
+++ b/common/page.go
@@ -43,7 +43,7 @@ import (
 var _ EventEmitter = &Page{}
 var _ api.Page = &Page{}
 
-// Page stores Page/tab related context
+// Page stores Page/tab related context.
 type Page struct {
 	BaseEventEmitter
 
@@ -85,7 +85,7 @@ type Page struct {
 	logger *Logger
 }
 
-// NewPage creates a new browser page context
+// NewPage creates a new browser page context.
 func NewPage(
 	ctx context.Context,
 	session *Session,
@@ -357,7 +357,7 @@ func (p *Page) viewportSize() Size {
 	}
 }
 
-// AddInitScript adds script to run in all new frames
+// AddInitScript adds script to run in all new frames.
 func (p *Page) AddInitScript(script goja.Value, arg goja.Value) {
 	rt := k6common.GetRuntime(p.ctx)
 	k6common.Throw(rt, errors.New("Page.addInitScript(script, arg) has not been implemented yet"))
@@ -373,7 +373,7 @@ func (p *Page) AddStyleTag(opts goja.Value) {
 	k6common.Throw(rt, errors.New("Page.addStyleTag(opts) has not been implemented yet"))
 }
 
-// BringToFront activates the browser tab for this page
+// BringToFront activates the browser tab for this page.
 func (p *Page) BringToFront() {
 	p.logger.Debugf("Page:BringToFront", "sid:%v", p.sessionID())
 
@@ -384,40 +384,40 @@ func (p *Page) BringToFront() {
 	}
 }
 
-// Check checks an element matching provided selector
+// Check checks an element matching provided selector.
 func (p *Page) Check(selector string, opts goja.Value) {
 	p.logger.Debugf("Page:Check", "sid:%v selector:%s", p.sessionID(), selector)
 
 	p.MainFrame().Check(selector, opts)
 }
 
-// Click clicks an element matching provided selector
+// Click clicks an element matching provided selector.
 func (p *Page) Click(selector string, opts goja.Value) {
 	p.logger.Debugf("Page:Click", "sid:%v selector:%s", p.sessionID(), selector)
 
 	p.MainFrame().Click(selector, opts)
 }
 
-// Close closes the page
+// Close closes the page.
 func (p *Page) Close(opts goja.Value) {
 	p.logger.Debugf("Page:Close", "sid:%v", p.sessionID())
 
 	p.browserCtx.Close()
 }
 
-// Content returns the HTML content of the page
+// Content returns the HTML content of the page.
 func (p *Page) Content() string {
 	p.logger.Debugf("Page:Content", "sid:%v", p.sessionID())
 
 	return p.MainFrame().Content()
 }
 
-// Context closes the page
+// Context closes the page.
 func (p *Page) Context() api.BrowserContext {
 	return p.browserCtx
 }
 
-// Dblclick double clicks an element matching provided selector
+// Dblclick double clicks an element matching provided selector.
 func (p *Page) Dblclick(selector string, opts goja.Value) {
 	p.logger.Debugf("Page:Dblclick", "sid:%v selector:%s", p.sessionID(), selector)
 
@@ -457,7 +457,7 @@ func (p *Page) EmulateMedia(opts goja.Value) {
 	applySlowMo(p.ctx)
 }
 
-// EmulateVisionDeficiency activates/deactivates emulation of a vision deficiency
+// EmulateVisionDeficiency activates/deactivates emulation of a vision deficiency.
 func (p *Page) EmulateVisionDeficiency(typ string) {
 	p.logger.Debugf("Page:EmulateVisionDeficiency", "sid:%v typ:%s", p.sessionID(), typ)
 
@@ -483,7 +483,7 @@ func (p *Page) EmulateVisionDeficiency(typ string) {
 	applySlowMo(p.ctx)
 }
 
-// Evaluate runs JS code within the execution context of the main frame of the page
+// Evaluate runs JS code within the execution context of the main frame of the page.
 func (p *Page) Evaluate(pageFunc goja.Value, args ...goja.Value) interface{} {
 	p.logger.Debugf("Page:Evaluate", "sid:%v", p.sessionID())
 
@@ -524,7 +524,7 @@ func (p *Page) Frame(frameSelector goja.Value) api.Frame {
 	return nil
 }
 
-// Frames returns a list of frames on the page
+// Frames returns a list of frames on the page.
 func (p *Page) Frames() []api.Frame {
 	return p.frameManager.Frames()
 }
@@ -548,7 +548,7 @@ func (p *Page) GoForward(opts goja.Value) api.Response {
 	return nil
 }
 
-// Goto will navigate the page to the specified URL and return a HTTP response object
+// Goto will navigate the page to the specified URL and return a HTTP response object.
 func (p *Page) Goto(url string, opts goja.Value) api.Response {
 	p.logger.Debugf("Page:Goto", "sid:%v url:%q", p.sessionID(), url)
 
@@ -622,7 +622,7 @@ func (p *Page) IsVisible(selector string, opts goja.Value) bool {
 	return p.MainFrame().IsVisible(selector, opts)
 }
 
-// MainFrame returns the main frame on the page
+// MainFrame returns the main frame on the page.
 func (p *Page) MainFrame() api.Frame {
 	mf := p.frameManager.MainFrame()
 
@@ -638,7 +638,7 @@ func (p *Page) MainFrame() api.Frame {
 	return mf
 }
 
-// Opener returns the opener of the target
+// Opener returns the opener of the target.
 func (p *Page) Opener() api.Page {
 	return p.opener
 }
@@ -672,7 +672,7 @@ func (p *Page) QueryAll(selector string) []api.ElementHandle {
 	return p.frameManager.MainFrame().QueryAll(selector)
 }
 
-// Reload will reload the current page
+// Reload will reload the current page.
 func (p *Page) Reload(opts goja.Value) api.Response {
 	p.logger.Debugf("Page:Reload", "sid:%v", p.sessionID())
 
@@ -723,7 +723,7 @@ func (p *Page) Route(url goja.Value, handler goja.Callable) {
 	k6common.Throw(rt, errors.New("Page.route(url, handler) has not been implemented yet"))
 }
 
-// Screenshot will instruct Chrome to save a screenshot of the current page and save it to specified file
+// Screenshot will instruct Chrome to save a screenshot of the current page and save it to specified file.
 func (p *Page) Screenshot(opts goja.Value) goja.ArrayBuffer {
 	rt := k6common.GetRuntime(p.ctx)
 	parsedOpts := NewPageScreenshotOptions()
@@ -750,21 +750,21 @@ func (p *Page) SetContent(html string, opts goja.Value) {
 	p.MainFrame().SetContent(html, opts)
 }
 
-// SetDefaultNavigationTimeout sets the default navigation timeout in milliseconds
+// SetDefaultNavigationTimeout sets the default navigation timeout in milliseconds.
 func (p *Page) SetDefaultNavigationTimeout(timeout int64) {
 	p.logger.Debugf("Page:SetDefaultNavigationTimeout", "sid:%v timeout:%d", p.sessionID(), timeout)
 
 	p.timeoutSettings.setDefaultNavigationTimeout(timeout)
 }
 
-// SetDefaultTimeout sets the default maximum timeout in milliseconds
+// SetDefaultTimeout sets the default maximum timeout in milliseconds.
 func (p *Page) SetDefaultTimeout(timeout int64) {
 	p.logger.Debugf("Page:SetDefaultTimeout", "sid:%v timeout:%d", p.sessionID(), timeout)
 
 	p.timeoutSettings.setDefaultTimeout(timeout)
 }
 
-// SetExtraHTTPHeaders sets default HTTP headers for page and whole frame hierarchy
+// SetExtraHTTPHeaders sets default HTTP headers for page and whole frame hierarchy.
 func (p *Page) SetExtraHTTPHeaders(headers map[string]string) {
 	p.logger.Debugf("Page:SetExtraHTTPHeaders", "sid:%v", p.sessionID())
 
@@ -778,7 +778,7 @@ func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value)
 	// TODO: needs slowMo
 }
 
-// SetViewportSize will update the viewport width and height
+// SetViewportSize will update the viewport width and height.
 func (p *Page) SetViewportSize(viewportSize goja.Value) {
 	p.logger.Debugf("Page:SetViewportSize", "sid:%v", p.sessionID())
 
@@ -830,20 +830,20 @@ func (p *Page) Unroute(url goja.Value, handler goja.Callable) {
 	k6common.Throw(rt, errors.New("Page.unroute(url, handler) has not been implemented yet"))
 }
 
-// URL returns the location of the page
+// URL returns the location of the page.
 func (p *Page) URL() string {
 	rt := k6common.GetRuntime(p.ctx)
 	return p.Evaluate(rt.ToValue("document.location.toString()")).(string)
 }
 
-// Video returns information of recorded video
+// Video returns information of recorded video.
 func (p *Page) Video() api.Video {
 	rt := k6common.GetRuntime(p.ctx)
 	k6common.Throw(rt, errors.New("Page.video() has not been implemented yet"))
 	return nil
 }
 
-// ViewportSize will return information on the viewport width and height
+// ViewportSize will return information on the viewport width and height.
 func (p *Page) ViewportSize() map[string]float64 {
 	p.logger.Debugf("Page:ViewportSize", "sid:%v", p.sessionID())
 
@@ -854,28 +854,28 @@ func (p *Page) ViewportSize() map[string]float64 {
 	}
 }
 
-// WaitForEvent waits for the specified event to trigger
+// WaitForEvent waits for the specified event to trigger.
 func (p *Page) WaitForEvent(event string, optsOrPredicate goja.Value) interface{} {
 	rt := k6common.GetRuntime(p.ctx)
 	k6common.Throw(rt, errors.New("Page.waitForEvent(event, optsOrPredicate) has not been implemented yet"))
 	return nil
 }
 
-// WaitForFunction waits for the given predicate to return a truthy value
+// WaitForFunction waits for the given predicate to return a truthy value.
 func (p *Page) WaitForFunction(pageFunc goja.Value, arg goja.Value, opts goja.Value) api.JSHandle {
 	p.logger.Debugf("Page:WaitForFunction", "sid:%v", p.sessionID())
 
 	return p.frameManager.MainFrame().WaitForFunction(pageFunc, opts, arg)
 }
 
-// WaitForLoadState waits for the specified page life cycle event
+// WaitForLoadState waits for the specified page life cycle event.
 func (p *Page) WaitForLoadState(state string, opts goja.Value) {
 	p.logger.Debugf("Page:WaitForLoadState", "sid:%v state:%q", p.sessionID(), state)
 
 	p.frameManager.MainFrame().WaitForLoadState(state, opts)
 }
 
-// WaitForNavigation waits for the given navigation lifecycle event to happen
+// WaitForNavigation waits for the given navigation lifecycle event to happen.
 func (p *Page) WaitForNavigation(opts goja.Value) api.Response {
 	p.logger.Debugf("Page:WaitForNavigation", "sid:%v", p.sessionID())
 
@@ -894,7 +894,7 @@ func (p *Page) WaitForResponse(urlOrPredicate, opts goja.Value) api.Response {
 	return nil
 }
 
-// WaitForSelector waits for the given selector to match the waiting criteria
+// WaitForSelector waits for the given selector to match the waiting criteria.
 func (p *Page) WaitForSelector(selector string, opts goja.Value) api.ElementHandle {
 	p.logger.Debugf("Page:WaitForSelector",
 		"sid:%v stid:%v ptid:%v selector:%s",
@@ -903,14 +903,14 @@ func (p *Page) WaitForSelector(selector string, opts goja.Value) api.ElementHand
 	return p.frameManager.MainFrame().WaitForSelector(selector, opts)
 }
 
-// WaitForTimeout waits the specified number of milliseconds
+// WaitForTimeout waits the specified number of milliseconds.
 func (p *Page) WaitForTimeout(timeout int64) {
 	p.logger.Debugf("Page:WaitForTimeout", "sid:%v timeout:%d", p.sessionID(), timeout)
 
 	p.frameManager.MainFrame().WaitForTimeout(timeout)
 }
 
-// Workers returns all WebWorkers of page
+// Workers returns all WebWorkers of page.
 func (p *Page) Workers() []api.Worker {
 	workers := make([]api.Worker, 0, len(p.workers))
 	for _, w := range p.workers {

--- a/common/page.go
+++ b/common/page.go
@@ -632,7 +632,6 @@ func (p *Page) MainFrame() api.Frame {
 		p.logger.Debugf("Page:MainFrame",
 			"sid:%v mfid:%v mflid:%v mfurl:%v",
 			p.sessionID(), mf.id, mf.loaderID, mf.url)
-
 	}
 
 	return mf

--- a/common/remote_object_test.go
+++ b/common/remote_object_test.go
@@ -171,7 +171,6 @@ func TestValueFromRemoteObject(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, rt.ToValue(map[string]interface{}{"num": float64(1)}), val)
 	})
-
 }
 
 func TestParseRemoteObject(t *testing.T) {

--- a/common/request.go
+++ b/common/request.go
@@ -36,10 +36,10 @@ import (
 	"github.com/grafana/xk6-browser/api"
 )
 
-// Ensure Request implements the api.Request interface
+// Ensure Request implements the api.Request interface.
 var _ api.Request = &Request{}
 
-// Request represents a browser HTTP request
+// Request represents a browser HTTP request.
 type Request struct {
 	ctx                 context.Context
 	frame               *Frame
@@ -62,7 +62,7 @@ type Request struct {
 	responseEndTiming   float64
 }
 
-// NewRequest creates a new HTTP request
+// NewRequest creates a new HTTP request.
 func NewRequest(
 	ctx context.Context, event *network.EventRequestWillBeSent, f *Frame,
 	redirectChain []*Request, interceptionID string, allowInterception bool,
@@ -156,7 +156,7 @@ func (r *Request) Failure() goja.Value {
 	return nil
 }
 
-// Frame returns the frame within which the request was made
+// Frame returns the frame within which the request was made.
 func (r *Request) Frame() api.Frame {
 	return r.frame
 }
@@ -171,7 +171,7 @@ func (r *Request) HeaderValue(name string) goja.Value {
 	return rt.ToValue(val)
 }
 
-// Headers returns the request headers
+// Headers returns the request headers.
 func (r *Request) Headers() map[string]string {
 	headers := make(map[string]string)
 	for n, v := range r.headers {
@@ -190,28 +190,28 @@ func (r *Request) HeadersArray() []api.HTTPHeader {
 	return headers
 }
 
-// IsNavigationRequest returns whether this was a navigation request or not
+// IsNavigationRequest returns whether this was a navigation request or not.
 func (r *Request) IsNavigationRequest() bool {
 	return r.isNavigationRequest
 }
 
-// Method returns the request method
+// Method returns the request method.
 func (r *Request) Method() string {
 	return r.method
 }
 
-// PostData returns the request post data, if any
+// PostData returns the request post data, if any.
 func (r *Request) PostData() string {
 	return r.postData
 }
 
-// PostDataBuffer returns the request post data as an ArrayBuffer
+// PostDataBuffer returns the request post data as an ArrayBuffer.
 func (r *Request) PostDataBuffer() goja.ArrayBuffer {
 	rt := k6common.GetRuntime(r.ctx)
 	return rt.NewArrayBuffer([]byte(r.postData))
 }
 
-// PostDataJSON returns the request post data as a JS object
+// PostDataJSON returns the request post data as a JS object.
 func (r *Request) PostDataJSON() string {
 	rt := k6common.GetRuntime(r.ctx)
 	k6common.Throw(rt, errors.New("Request.postDataJSON() has not been implemented yet"))
@@ -230,12 +230,12 @@ func (r *Request) RedirectedTo() api.Request {
 	return nil
 }
 
-// ResourceType returns the request resource type
+// ResourceType returns the request resource type.
 func (r *Request) ResourceType() string {
 	return r.resourceType
 }
 
-// Response returns the response for the request, if received
+// Response returns the response for the request, if received.
 func (r *Request) Response() api.Response {
 	return r.response
 }
@@ -263,7 +263,7 @@ func (r *Request) Timing() goja.Value {
 	})
 }
 
-// URL returns the request URL
+// URL returns the request URL.
 func (r *Request) URL() string {
 	return r.url.String()
 }

--- a/common/request.go
+++ b/common/request.go
@@ -31,8 +31,9 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure Request implements the api.Request interface

--- a/common/request_test.go
+++ b/common/request_test.go
@@ -28,10 +28,11 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 func TestRequest(t *testing.T) {

--- a/common/response.go
+++ b/common/response.go
@@ -32,9 +32,10 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
 	k6lib "go.k6.io/k6/lib"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure Response implements the api.Response interface

--- a/common/response.go
+++ b/common/response.go
@@ -38,16 +38,16 @@ import (
 	"github.com/grafana/xk6-browser/api"
 )
 
-// Ensure Response implements the api.Response interface
+// Ensure Response implements the api.Response interface.
 var _ api.Response = &Response{}
 
-// RemoteAddress contains informationa about a remote target
+// RemoteAddress contains informationa about a remote target.
 type RemoteAddress struct {
 	IPAddress string `json:"ipAddress"`
 	Port      int64  `json:"port"`
 }
 
-// SecurityDetails contains informationa about the security details of a TLS connection
+// SecurityDetails contains informationa about the security details of a TLS connection.
 type SecurityDetails struct {
 	SubjectName string   `json:"subjectName"`
 	Issuer      string   `json:"issuer"`
@@ -57,7 +57,7 @@ type SecurityDetails struct {
 	SANList     []string `json:"sanList"`
 }
 
-// Response represents a browser HTTP response
+// Response represents a browser HTTP response.
 type Response struct {
 	ctx               context.Context
 	logger            *Logger
@@ -81,7 +81,7 @@ type Response struct {
 	cachedJSON interface{}
 }
 
-// NewHTTPResponse creates a new HTTP response
+// NewHTTPResponse creates a new HTTP response.
 func NewHTTPResponse(ctx context.Context, req *Request, resp *network.Response, timestamp *cdp.MonotonicTime) *Response {
 	state := k6lib.GetState(ctx)
 	r := Response{
@@ -177,7 +177,7 @@ func (r *Response) AllHeaders() map[string]string {
 	return headers
 }
 
-// Body returns the response body as a binary buffer
+// Body returns the response body as a binary buffer.
 func (r *Response) Body() goja.ArrayBuffer {
 	rt := k6common.GetRuntime(r.ctx)
 	if r.status >= 300 && r.status <= 399 {
@@ -208,7 +208,7 @@ func (r *Response) bodySize() int64 {
 	return int64(len(r.body))
 }
 
-// Finished waits for response to finish, return error if request failed
+// Finished waits for response to finish, return error if request failed.
 func (r *Response) Finished() bool {
 	// TODO: should return nil|Error
 	rt := k6common.GetRuntime(r.ctx)
@@ -216,7 +216,7 @@ func (r *Response) Finished() bool {
 	return false
 }
 
-// Frame returns the frame within which the response was received
+// Frame returns the frame within which the response was received.
 func (r *Response) Frame() api.Frame {
 	return r.request.frame
 }
@@ -236,22 +236,22 @@ func (r *Response) HeaderValues(name string) []string {
 	return strings.Split(headers[name], ",")
 }
 
-// FromCache returns whether this response was served from disk cache
+// FromCache returns whether this response was served from disk cache.
 func (r *Response) FromCache() bool {
 	return r.fromDiskCache
 }
 
-// FromPrefetchCache returns whether this response was served from prefetch cache
+// FromPrefetchCache returns whether this response was served from prefetch cache.
 func (r *Response) FromPrefetchCache() bool {
 	return r.fromPrefetchCache
 }
 
-// FromServiceWorker returns whether this response was served by a service worker
+// FromServiceWorker returns whether this response was served by a service worker.
 func (r *Response) FromServiceWorker() bool {
 	return r.fromServiceWorker
 }
 
-// Headers returns the response headers
+// Headers returns the response headers.
 func (r *Response) Headers() map[string]string {
 	headers := make(map[string]string)
 	for n, v := range r.headers {
@@ -270,7 +270,7 @@ func (r *Response) HeadersArray() []api.HTTPHeader {
 	return headers
 }
 
-// JSON returns the response body as JSON data
+// JSON returns the response body as JSON data.
 func (r *Response) JSON() goja.Value {
 	rt := k6common.GetRuntime(r.ctx)
 	if r.cachedJSON == nil {
@@ -289,7 +289,7 @@ func (r *Response) JSON() goja.Value {
 	return rt.ToValue(r.cachedJSON)
 }
 
-// Ok returns true if status code of response if considered ok, otherwise returns false
+// Ok returns true if status code of response if considered ok, otherwise returns false.
 func (r *Response) Ok() bool {
 	if r.status == 0 || (r.status >= 200 && r.status <= 299) {
 		return true
@@ -297,7 +297,7 @@ func (r *Response) Ok() bool {
 	return false
 }
 
-// Request returns the request that led to this response
+// Request returns the request that led to this response.
 func (r *Response) Request() api.Request {
 	return r.request
 }
@@ -307,7 +307,7 @@ func (r *Response) SecurityDetails() goja.Value {
 	return rt.ToValue(r.securityDetails)
 }
 
-// ServerAdd returns the remote address of the server
+// ServerAdd returns the remote address of the server.
 func (r *Response) ServerAddr() goja.Value {
 	rt := k6common.GetRuntime(r.ctx)
 	return rt.ToValue(r.remoteAddress)
@@ -320,17 +320,17 @@ func (r *Response) Size() api.HTTPMessageSize {
 	}
 }
 
-// Status returns the response status code
+// Status returns the response status code.
 func (r *Response) Status() int64 {
 	return r.status
 }
 
-// StatusText returns the response status text
+// StatusText returns the response status text.
 func (r *Response) StatusText() string {
 	return r.statusText
 }
 
-// Text returns the response body as a string
+// Text returns the response body as a string.
 func (r *Response) Text() string {
 	rt := k6common.GetRuntime(r.ctx)
 	if err := r.fetchBody(); err != nil {
@@ -341,7 +341,7 @@ func (r *Response) Text() string {
 	return string(r.body)
 }
 
-// URL returns the request URL
+// URL returns the request URL.
 func (r *Response) URL() string {
 	return r.url
 }

--- a/common/response.go
+++ b/common/response.go
@@ -307,7 +307,7 @@ func (r *Response) SecurityDetails() goja.Value {
 	return rt.ToValue(r.securityDetails)
 }
 
-// ServerAdd returns the remote address of the server.
+// ServerAddr returns the remote address of the server.
 func (r *Response) ServerAddr() goja.Value {
 	rt := k6common.GetRuntime(r.ctx)
 	return rt.ToValue(r.remoteAddress)

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -194,10 +194,10 @@ func (s *screenshotter) screenshot(session *Session, documentRect *Rect, viewpor
 	// TODO: we should not write to disk here but put it on some queue for async disk writes
 	if path != "" {
 		dir := filepath.Dir(path)
-		if err := os.MkdirAll(dir, 0o775); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return nil, fmt.Errorf("cannot create directory for screenshot: %w", err)
 		}
-		if err := ioutil.WriteFile(path, buf, 0o664); err != nil {
+		if err := ioutil.WriteFile(path, buf, 0o644); err != nil {
 			return nil, fmt.Errorf("cannot save screenshot to file: %w", err)
 		}
 	}

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -194,10 +194,10 @@ func (s *screenshotter) screenshot(session *Session, documentRect *Rect, viewpor
 	// TODO: we should not write to disk here but put it on some queue for async disk writes
 	if path != "" {
 		dir := filepath.Dir(path)
-		if err := os.MkdirAll(dir, 0775); err != nil {
+		if err := os.MkdirAll(dir, 0o775); err != nil {
 			return nil, fmt.Errorf("cannot create directory for screenshot: %w", err)
 		}
-		if err := ioutil.WriteFile(path, buf, 0664); err != nil {
+		if err := ioutil.WriteFile(path, buf, 0o664); err != nil {
 			return nil, fmt.Errorf("cannot save screenshot to file: %w", err)
 		}
 	}

--- a/common/selectors.go
+++ b/common/selectors.go
@@ -42,10 +42,10 @@ import (
 	"strings"
 )
 
-// Matches `name:body`, a query engine name and selector for that engine
+// Matches `name:body`, a query engine name and selector for that engine.
 var reQueryEngine *regexp.Regexp = regexp.MustCompile(`^[a-zA-Z_0-9-+:*]+$`)
 
-// Matches start of XPath query
+// Matches start of XPath query.
 var reXPathSelector *regexp.Regexp = regexp.MustCompile(`^\(*//`)
 
 type SelectorPart struct {

--- a/common/session.go
+++ b/common/session.go
@@ -32,11 +32,11 @@ import (
 	k6lib "go.k6.io/k6/lib"
 )
 
-// Ensure Session implements the EventEmitter and Executor interfaces
+// Ensure Session implements the EventEmitter and Executor interfaces.
 var _ EventEmitter = &Session{}
 var _ cdp.Executor = &Session{}
 
-// Session represents a CDP session to a target
+// Session represents a CDP session to a target.
 type Session struct {
 	BaseEventEmitter
 
@@ -52,7 +52,7 @@ type Session struct {
 	logger *Logger
 }
 
-// NewSession creates a new session
+// NewSession creates a new session.
 func NewSession(ctx context.Context, conn *Connection, id target.SessionID, tid target.ID, logger *Logger) *Session {
 	s := Session{
 		BaseEventEmitter: NewBaseEventEmitter(ctx),
@@ -93,7 +93,7 @@ func (s *Session) markAsCrashed() {
 	s.crashed = true
 }
 
-// Wraps conn.ReadMessage in a channel
+// Wraps conn.ReadMessage in a channel.
 func (s *Session) readLoop() {
 	state := k6lib.GetState(s.ctx)
 
@@ -125,7 +125,7 @@ func (s *Session) readLoop() {
 	}
 }
 
-// Execute implements the cdp.Executor interface
+// Execute implements the cdp.Executor interface.
 func (s *Session) Execute(ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler) error {
 	s.logger.Debugf("Session:Execute", "sid:%v tid:%v method:%q", s.id, s.targetID, method)
 	// Certain methods aren't available to the user directly.

--- a/common/timeout.go
+++ b/common/timeout.go
@@ -20,14 +20,14 @@
 
 package common
 
-// TimeoutSettings holds information on timeout settings
+// TimeoutSettings holds information on timeout settings.
 type TimeoutSettings struct {
 	parent                   *TimeoutSettings
 	defaultTimeout           *int64
 	defaultNavigationTimeout *int64
 }
 
-// NewTimeoutSettings creates a new timeout settings object
+// NewTimeoutSettings creates a new timeout settings object.
 func NewTimeoutSettings(parent *TimeoutSettings) *TimeoutSettings {
 	t := &TimeoutSettings{
 		parent:                   parent,

--- a/common/touchscreen.go
+++ b/common/touchscreen.go
@@ -26,8 +26,9 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/input"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure Touchscreen implements the EventEmitter and api.Touchscreen interfaces

--- a/common/touchscreen.go
+++ b/common/touchscreen.go
@@ -31,7 +31,7 @@ import (
 	"github.com/grafana/xk6-browser/api"
 )
 
-// Ensure Touchscreen implements the EventEmitter and api.Touchscreen interfaces
+// Ensure Touchscreen implements the EventEmitter and api.Touchscreen interfaces.
 var _ EventEmitter = &Touchscreen{}
 var _ api.Touchscreen = &Touchscreen{}
 

--- a/common/types.go
+++ b/common/types.go
@@ -28,8 +28,9 @@ import (
 	"math"
 
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	k6common "go.k6.io/k6/js/common"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // ColorScheme represents a browser color scheme

--- a/common/types.go
+++ b/common/types.go
@@ -33,10 +33,10 @@ import (
 	"github.com/grafana/xk6-browser/api"
 )
 
-// ColorScheme represents a browser color scheme
+// ColorScheme represents a browser color scheme.
 type ColorScheme string
 
-// Valid color schemes
+// Valid color schemes.
 const (
 	ColorSchemeLight        ColorScheme = "light"
 	ColorSchemeDark         ColorScheme = "dark"
@@ -59,7 +59,7 @@ var colorSchemeToID = map[string]ColorScheme{
 	"no-preference": ColorSchemeNoPreference,
 }
 
-// MarshalJSON marshals the enum as a quoted JSON string
+// MarshalJSON marshals the enum as a quoted JSON string.
 func (c ColorScheme) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)
 	buffer.WriteString(colorSchemeToString[c])
@@ -67,7 +67,7 @@ func (c ColorScheme) MarshalJSON() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// UnmarshalJSON unmarshals a quoted JSON string to the enum value
+// UnmarshalJSON unmarshals a quoted JSON string to the enum value.
 func (c *ColorScheme) UnmarshalJSON(b []byte) error {
 	var j string
 	err := json.Unmarshal(b, &j)
@@ -79,16 +79,16 @@ func (c *ColorScheme) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Credentials holds HTTP authentication credentials
+// Credentials holds HTTP authentication credentials.
 type Credentials struct {
 	Username string `js:"username"`
 	Password string `js:"password"`
 }
 
-// DOMElementState represents a DOM element state
+// DOMElementState represents a DOM element state.
 type DOMElementState int
 
-// Valid DOM element states
+// Valid DOM element states.
 const (
 	DOMElementStateAttached DOMElementState = iota
 	DOMElementStateDetached
@@ -114,7 +114,7 @@ var domElementStateToID = map[string]DOMElementState{
 	"hidden":   DOMElementStateHidden,
 }
 
-// MarshalJSON marshals the enum as a quoted JSON string
+// MarshalJSON marshals the enum as a quoted JSON string.
 func (s DOMElementState) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)
 	buffer.WriteString(domElementStateToString[s])
@@ -122,7 +122,7 @@ func (s DOMElementState) MarshalJSON() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// UnmarshalJSON unmarshals a quoted JSON string to the enum value
+// UnmarshalJSON unmarshals a quoted JSON string to the enum value.
 func (s *DOMElementState) UnmarshalJSON(b []byte) error {
 	var j string
 	err := json.Unmarshal(b, &j)
@@ -192,10 +192,10 @@ func (g *Geolocation) Parse(ctx context.Context, opts goja.Value) error {
 	return nil
 }
 
-// ImageFormat represents an image file format
+// ImageFormat represents an image file format.
 type ImageFormat string
 
-// Valid image format options
+// Valid image format options.
 const (
 	ImageFormatJPEG ImageFormat = "jpeg"
 	ImageFormatPNG  ImageFormat = "png"
@@ -215,7 +215,7 @@ var imageFormatToID = map[string]ImageFormat{
 	"png":  ImageFormatPNG,
 }
 
-// MarshalJSON marshals the enum as a quoted JSON string
+// MarshalJSON marshals the enum as a quoted JSON string.
 func (f ImageFormat) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)
 	buffer.WriteString(imageFormatToString[f])
@@ -223,7 +223,7 @@ func (f ImageFormat) MarshalJSON() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// UnmarshalJSON unmarshals a quoted JSON string to the enum value
+// UnmarshalJSON unmarshals a quoted JSON string to the enum value.
 func (f *ImageFormat) UnmarshalJSON(b []byte) error {
 	var j string
 	err := json.Unmarshal(b, &j)
@@ -259,7 +259,7 @@ var lifecycleEventToID = map[string]LifecycleEvent{
 	"networkidle":      LifecycleEventNetworkIdle,
 }
 
-// MarshalJSON marshals the enum as a quoted JSON string
+// MarshalJSON marshals the enum as a quoted JSON string.
 func (l LifecycleEvent) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)
 	buffer.WriteString(lifecycleEventToString[l])
@@ -267,7 +267,7 @@ func (l LifecycleEvent) MarshalJSON() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// UnmarshalJSON unmarshals a quoted JSON string to the enum value
+// UnmarshalJSON unmarshals a quoted JSON string to the enum value.
 func (l *LifecycleEvent) UnmarshalJSON(b []byte) error {
 	var j string
 	err := json.Unmarshal(b, &j)
@@ -310,7 +310,7 @@ var pollingTypeToID = map[string]PollingType{
 	"interval": PollingInterval,
 }
 
-// MarshalJSON marshals the enum as a quoted JSON string
+// MarshalJSON marshals the enum as a quoted JSON string.
 func (p PollingType) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)
 	buffer.WriteString(pollingTypeToString[p])
@@ -318,7 +318,7 @@ func (p PollingType) MarshalJSON() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// UnmarshalJSON unmarshals a quoted JSON string to the enum value
+// UnmarshalJSON unmarshals a quoted JSON string to the enum value.
 func (p *PollingType) UnmarshalJSON(b []byte) error {
 	var j string
 	err := json.Unmarshal(b, &j)
@@ -354,10 +354,10 @@ func (r *Rect) toApiRect() *api.Rect {
 	return &api.Rect{X: r.X, Y: r.Y, Width: r.Width, Height: r.Height}
 }
 
-// ReducedMotion represents a browser reduce-motion setting
+// ReducedMotion represents a browser reduce-motion setting.
 type ReducedMotion string
 
-// Valid reduce-motion options
+// Valid reduce-motion options.
 const (
 	ReducedMotionReduce       ReducedMotion = "reduce"
 	ReducedMotionNoPreference ReducedMotion = "no-preference"
@@ -377,7 +377,7 @@ var reducedMotionToID = map[string]ReducedMotion{
 	"no-preference": ReducedMotionNoPreference,
 }
 
-// MarshalJSON marshals the enum as a quoted JSON string
+// MarshalJSON marshals the enum as a quoted JSON string.
 func (r ReducedMotion) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)
 	buffer.WriteString(reducedMotionToString[r])
@@ -385,7 +385,7 @@ func (r ReducedMotion) MarshalJSON() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// UnmarshalJSON unmarshals a quoted JSON string to the enum value
+// UnmarshalJSON unmarshals a quoted JSON string to the enum value.
 func (r *ReducedMotion) UnmarshalJSON(b []byte) error {
 	var j string
 	err := json.Unmarshal(b, &j)
@@ -409,7 +409,7 @@ type ResourceTiming struct {
 	ResponseEnd           float64 `js:"responseEnd"`
 }
 
-// Viewport represents a device screen
+// Viewport represents a device screen.
 type Screen struct {
 	Width  int64 `js:"width"`
 	Height int64 `js:"height"`

--- a/common/types.go
+++ b/common/types.go
@@ -409,7 +409,7 @@ type ResourceTiming struct {
 	ResponseEnd           float64 `js:"responseEnd"`
 }
 
-// Viewport represents a device screen.
+// Screen represents a device screen.
 type Screen struct {
 	Width  int64 `js:"width"`
 	Height int64 `js:"height"`

--- a/common/worker.go
+++ b/common/worker.go
@@ -34,11 +34,11 @@ import (
 	"github.com/grafana/xk6-browser/api"
 )
 
-// Ensure Worker implements the EventEmitter, Target and api.Worker interfaces
+// Ensure Worker implements the EventEmitter, Target and api.Worker interfaces.
 var _ EventEmitter = &Worker{}
 var _ api.Worker = &Worker{}
 
-// Worker represents a WebWorker
+// Worker represents a WebWorker.
 type Worker struct {
 	BaseEventEmitter
 
@@ -49,7 +49,7 @@ type Worker struct {
 	url      string
 }
 
-// NewWorker creates a new page viewport
+// NewWorker creates a new page viewport.
 func NewWorker(ctx context.Context, session *Session, id target.ID, url string) (*Worker, error) {
 	w := Worker{
 		BaseEventEmitter: NewBaseEventEmitter(ctx),
@@ -82,19 +82,19 @@ func (w *Worker) initEvents() error {
 	return nil
 }
 
-// Evaluate evaluates a page function in the context of the web worker
+// Evaluate evaluates a page function in the context of the web worker.
 func (w *Worker) Evaluate(pageFunc goja.Value, args ...goja.Value) interface{} {
 	// TODO: implement
 	return nil
 }
 
-// EvaluateHandle evaluates a page function in the context of the web worker and returns a JS handle
+// EvaluateHandle evaluates a page function in the context of the web worker and returns a JS handle.
 func (w *Worker) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) api.JSHandle {
 	// TODO: implement
 	return nil
 }
 
-// URL returns the URL of the web worker
+// URL returns the URL of the web worker.
 func (w *Worker) URL() string {
 	return w.url
 }

--- a/common/worker.go
+++ b/common/worker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/api"
 )
 

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ type (
 	// instances for each VU.
 	RootModule struct{}
 
-	// JSModule is the entrypoint into the browser JS module
+	// JSModule is the entrypoint into the browser JS module.
 	JSModule struct {
 		vu      k6modules.VU
 		Devices map[string]common.Device

--- a/main.go
+++ b/main.go
@@ -24,11 +24,12 @@ import (
 	"errors"
 
 	"github.com/dop251/goja"
+	k6common "go.k6.io/k6/js/common"
+	k6modules "go.k6.io/k6/js/modules"
+
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/chromium"
 	"github.com/grafana/xk6-browser/common"
-	k6common "go.k6.io/k6/js/common"
-	k6modules "go.k6.io/k6/js/modules"
 )
 
 const version = "v0.1.3"

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -25,9 +25,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/grafana/xk6-browser/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/common"
 )
 
 func TestBrowserContextOptionsDefaultValues(t *testing.T) {

--- a/tests/element_handle_bounding_box_test.go
+++ b/tests/element_handle_bounding_box_test.go
@@ -24,8 +24,9 @@ import (
 	"testing"
 
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 func TestElementHandleBoundingBoxInvisibleElement(t *testing.T) {

--- a/tests/element_handle_click_test.go
+++ b/tests/element_handle_click_test.go
@@ -32,6 +32,7 @@ import (
 
 //go:embed static/mouse_helper.js
 var mouseHelperScriptSource string
+
 var htmlInputButton = fmt.Sprintf(`
 <!DOCTYPE html>
 <html>

--- a/tests/launch_options_slowmo_test.go
+++ b/tests/launch_options_slowmo_test.go
@@ -25,9 +25,10 @@ import (
 	"testing"
 
 	"github.com/dop251/goja"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/common"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLaunchOptionsSlowMo(t *testing.T) {

--- a/tests/logrus_hook.go
+++ b/tests/logrus_hook.go
@@ -29,7 +29,7 @@ import (
 )
 
 // logCache implements the logrus.Hook interface and could be used to check
-// if log messages were outputted
+// if log messages were outputted.
 type logCache struct {
 	HookedLevels []logrus.Level
 
@@ -37,12 +37,12 @@ type logCache struct {
 	entries []logrus.Entry
 }
 
-// Levels just returns whatever was stored in the HookedLevels slice
+// Levels just returns whatever was stored in the HookedLevels slice.
 func (lc *logCache) Levels() []logrus.Level {
 	return lc.HookedLevels
 }
 
-// Fire saves whatever message the logrus library passed in the cache
+// Fire saves whatever message the logrus library passed in the cache.
 func (lc *logCache) Fire(e *logrus.Entry) error {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -36,7 +36,7 @@ import (
 	k6modulestest "go.k6.io/k6/js/modulestest"
 	k6lib "go.k6.io/k6/lib"
 	k6metrics "go.k6.io/k6/lib/metrics"
-	k6test "go.k6.io/k6/lib/testutils/httpmultibin"
+	k6httpmultibin "go.k6.io/k6/lib/testutils/httpmultibin"
 	k6stats "go.k6.io/k6/stats"
 	"gopkg.in/guregu/null.v3"
 
@@ -49,7 +49,7 @@ type testBrowser struct {
 	ctx      context.Context
 	rt       *goja.Runtime
 	state    *k6lib.State
-	http     *k6test.HTTPMultiBin
+	http     *k6httpmultibin.HTTPMultiBin
 	logCache *logCache
 	samples  chan k6stats.SampleContainer
 	api.Browser
@@ -113,9 +113,9 @@ func newTestBrowser(t testing.TB, opts ...interface{}) *testBrowser {
 	rt, _ := getHTTPTestModuleInstance(t, ctx, state)
 
 	// enable the HTTP test server only when necessary
-	var testServer *k6test.HTTPMultiBin
+	var testServer *k6httpmultibin.HTTPMultiBin
 	if enableHTTPMultiBin {
-		testServer = k6test.NewHTTPMultiBin(t)
+		testServer = k6httpmultibin.NewHTTPMultiBin(t)
 		state.TLSConfig = testServer.TLSClientConfig
 		state.Transport = testServer.HTTPTransport
 	}

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -28,8 +28,6 @@ import (
 	"testing"
 
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/chromium"
 	"github.com/oxtoacart/bpool"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -41,6 +39,9 @@ import (
 	k6test "go.k6.io/k6/lib/testutils/httpmultibin"
 	k6stats "go.k6.io/k6/stats"
 	"gopkg.in/guregu/null.v3"
+
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/chromium"
 )
 
 // testBrowser is a test testBrowser for integration testing.

--- a/tests/ws/server.go
+++ b/tests/ws/server.go
@@ -37,11 +37,10 @@ import (
 	"github.com/mailru/easyjson/jwriter"
 	"github.com/mccutchen/go-httpbin/httpbin"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/http2"
-
 	k6lib "go.k6.io/k6/lib"
 	k6netext "go.k6.io/k6/lib/netext"
 	k6types "go.k6.io/k6/lib/types"
+	"golang.org/x/net/http2"
 )
 
 // Server can be used as a test alternative to a real CDP compatible browser.


### PR DESCRIPTION
This adds a bunch of new linters based on the discussion below, and currently (on 50d0160) passes with `--new-from-rev` enabled. Without it there are 1298 issues... :sob:

See #58