### PR TITLE
Fix Browser.onAttachedToTarget nil pointer

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -176,10 +176,10 @@ func (b *Browser) initEvents() error {
 			case event := <-chHandler:
 				if ev, ok := event.data.(*target.EventAttachedToTarget); ok {
 					b.logger.Debugf("Browser:initEvents:onAttachedToTarget", "sid:%v tid:%v", ev.SessionID, ev.TargetInfo.TargetID)
-					go b.onAttachedToTarget(ev)
+					b.onAttachedToTarget(ev)
 				} else if ev, ok := event.data.(*target.EventDetachedFromTarget); ok {
 					b.logger.Debugf("Browser:initEvents:onDetachedFromTarget", "sid:%v", ev.SessionID)
-					go b.onDetachedFromTarget(ev)
+					b.onDetachedFromTarget(ev)
 				} else if event.typ == EventConnectionClose {
 					b.logger.Debugf("Browser:initEvents:EventConnectionClose", "")
 


### PR DESCRIPTION
Running `Browser.onAttachedToTarget` and `onDetachedFromTarget` on different goroutines causes `Connection.recvLoop.EventTargetAttachedToTarget` out of sync. This commit runs these events of `Browser` on the same goroutine.

This now works without goroutines because we have fixed many severe bugs lately.

Note: If you have any idea how to test this, please let me know :)