### PR TITLE
Remove k6ThrowOnce and friends

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -891,7 +891,7 @@ func (h *ElementHandle) Check(opts goja.Value) {
 func (h *ElementHandle) Click(opts goja.Value) {
 	actionOpts := NewElementHandleClickOptions(h.defaultTimeout())
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
-		k6Throw(h.ctx, "cannot parse element click options: %w", err)
+		k6Throw(h.ctx, "cannot parse element click options: %v", err)
 	}
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
 		return nil, handle.click(p, actionOpts.ToMouseClickOptions())
@@ -899,7 +899,7 @@ func (h *ElementHandle) Click(opts goja.Value) {
 	pointerFn := getElementHandlePointerActionFn(h, true, fn, &actionOpts.ElementHandleBasePointerOptions)
 	_, err := callApiWithTimeout(h.ctx, pointerFn, actionOpts.Timeout)
 	if err != nil {
-		k6Throw(h.ctx, "cannot click on element: %w", err)
+		k6Throw(h.ctx, "cannot click on element: %v", err)
 	}
 	applySlowMo(h.ctx)
 }

--- a/tests/element_handle_click_test.go
+++ b/tests/element_handle_click_test.go
@@ -127,7 +127,7 @@ func TestElementHandleClickWithDetachedNode(t *testing.T) {
 	p.Evaluate(tb.rt.ToValue("button => button.remove()"), tb.rt.ToValue(button))
 
 	// We expect the click to fail with the correct error raised
-	errorMsg := ""
+	var errorMsg string
 	panicTestFn := func() {
 		defer func() {
 			if err := recover(); err != nil {
@@ -137,9 +137,12 @@ func TestElementHandleClickWithDetachedNode(t *testing.T) {
 		button.Click(tb.rt.ToValue(struct {
 			NoWaitAfter bool `js:"noWaitAfter"`
 		}{
-			NoWaitAfter: true, // FIX: this is just a workaround because navigation is never triggered and we'd be waiting for it to happen otherwise!
+			// FIX: this is just a workaround because navigation is never triggered and we'd be waiting for
+			// it to happen otherwise!
+			NoWaitAfter: true,
 		}))
 	}
 	panicTestFn()
-	assert.Contains(t, errorMsg, "element is not attached to the DOM", "expected click to result in correct error to be thrown")
+	assert.Contains(t, errorMsg, "element is not attached to the DOM",
+		"expected click to result in correct error to be thrown")
 }


### PR DESCRIPTION
When you run tests only once, there is no problem, however if you run
them multiple times using the count flag, k6ThrowOnce kicks in and
cause k6ThrowUnsafe not to run. This happens because the Go test runner
compiles the test binary only once and uses it to run the test in the
same process.

I don't know why but somehow we or Goja have fixed the issue in k6Throw
and now this commit entirely removes the k6Throw synchronization.

I tested it several times and I didn't observe any issues.

Fixes: #218