### PR TITLE
Revert "Remove BASEREV and new-from-rev from CI workflow"

### DIFF
--- a/.github/workflows/all.yaml
+++ b/.github/workflows/all.yaml
@@ -51,7 +51,9 @@ jobs:
         run: go install "github.com/golangci/golangci-lint/cmd/golangci-lint@v$GOLANG_CI_VERSION"
       - name: Run linters
         run: |
-          golangci-lint run --timeout=3m --out-format=tab ./...
+          BASEREV=$(git merge-base HEAD origin/main)
+          echo "Base revision: $BASEREV"
+          golangci-lint run --timeout=3m --out-format=tab --new-from-rev "$BASEREV" ./...
 
   test-prev:
     strategy:


### PR DESCRIPTION
This reverts commit 2a5a92c8294fd5e7ced48e56afb380aea04406b7.

We're planning to add more linters, see: #216 and #58. So we've decided to re-enable the `--new-from-rev` option. See the discussion:
- https://github.com/grafana/xk6-browser/pull/216#issuecomment-1029781140
- https://github.com/grafana/xk6-browser/pull/216#issuecomment-1029797172