### PR TITLE
Refactor: errorFromDOMError with test

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1443,3 +1443,35 @@ func (h *ElementHandle) eval(
 	}
 	return result, err
 }
+
+func errorFromDOMError(derr string) error {
+	// return the same sentinel error value for the timed out err
+	if derr == "error:timeout" {
+		return ErrTimedOut
+	}
+	if s := "error:expectednode:"; strings.HasPrefix(derr, s) {
+		return fmt.Errorf("expected node but got %s", strings.TrimPrefix(derr, s))
+	}
+	errs := map[string]string{
+		"error:notconnected":           "element is not attached to the DOM",
+		"error:notelement":             "node is not an element",
+		"error:nothtmlelement":         "not an HTMLElement",
+		"error:notfillableelement":     "element is not an <input>, <textarea> or [contenteditable] element",
+		"error:notfillableinputtype":   "input of this type cannot be filled",
+		"error:notfillablenumberinput": "cannot type text into input[type=number]",
+		"error:notvaliddate":           "malformed value",
+		"error:notinput":               "node is not an HTMLInputElement",
+		"error:hasnovalue":             "node is not an HTMLInputElement or HTMLTextAreaElement or HTMLSelectElement",
+		"error:notselect":              "element is not a <select> element",
+		"error:notcheckbox":            "not a checkbox or radio button",
+		"error:notmultiplefileinput":   "non-multiple file input can only accept single file",
+		"error:strictmodeviolation":    "strict mode violation, multiple elements returned for selector query",
+		"error:notqueryablenode":       "node is not queryable",
+		"error:nthnocapture":           "can't query n-th element in a chained selector with capture",
+	}
+	if err, ok := errs[derr]; ok {
+		return errors.New(err)
+	}
+
+	return errors.New(derr)
+}

--- a/common/element_handle_test.go
+++ b/common/element_handle_test.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorFromDOMError(t *testing.T) {
+	for _, tc := range []struct {
+		in       string
+		sentinel bool // if it returns the same error value
+		want     error
+	}{
+		{in: "error:timeout", want: ErrTimedOut, sentinel: true},
+		{in: "error:notconnected", want: errors.New("element is not attached to the DOM")},
+		{in: "error:expectednode:anything", want: errors.New("expected node but got anything")},
+		{in: "nonexistent error", want: errors.New("nonexistent error")},
+	} {
+		got := errorFromDOMError(tc.in)
+		if tc.sentinel && !errors.Is(got, tc.want) {
+			assert.Failf(t, "not sentinel", "error value of %q should be sentinel", tc.in)
+		} else {
+			require.Error(t, got)
+			assert.EqualError(t, tc.want, got.Error())
+		}
+	}
+}

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -23,12 +23,10 @@ package common
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"os"
 	"reflect"
-	"strings"
 	"time"
 
 	cdpruntime "github.com/chromedp/cdproto/runtime"
@@ -121,49 +119,6 @@ func callApiWithTimeout(ctx context.Context, fn func(context.Context, chan inter
 	}
 
 	return result, err
-}
-
-func errorFromDOMError(domErr string) error {
-	switch domErr {
-	case "error:notconnected":
-		return errors.New("element is not attached to the DOM")
-	case "error:notelement":
-		return errors.New("node is not an element")
-	case "error:nothtmlelement":
-		return errors.New("not an HTMLElement")
-	case "error:notfillableelement":
-		return errors.New("element is not an <input>, <textarea> or [contenteditable] element")
-	case "error:notfillableinputtype":
-		return errors.New("input of this type cannot be filled")
-	case "error:notfillablenumberinput":
-		return errors.New("cannot type text into input[type=number]")
-	case "error:notvaliddate":
-		return errors.New("malformed value")
-	case "error:notinput":
-		return errors.New("node is not an HTMLInputElement")
-	case "error:hasnovalue":
-		return errors.New("node is not an HTMLInputElement or HTMLTextAreaElement or HTMLSelectElement")
-	case "error:notselect":
-		return errors.New("element is not a <select> element")
-	case "error:notcheckbox":
-		return errors.New("not a checkbox or radio button")
-	case "error:notmultiplefileinput":
-		return errors.New("non-multiple file input can only accept single file")
-	case "error:strictmodeviolation":
-		return errors.New("strict mode violation, multiple elements were returned for selector query")
-	case "error:notqueryablenode":
-		return errors.New("node is not queryable")
-	case "error:nthnocapture":
-		return errors.New("can't query n-th element in a chained selector with capture")
-	case "error:timeout":
-		return ErrTimedOut
-	default:
-		if strings.HasPrefix(domErr, "error:expectednode:") {
-			i := strings.LastIndex(domErr, ":")
-			return fmt.Errorf("expected node but got %s", domErr[i:])
-		}
-	}
-	return fmt.Errorf(domErr)
 }
 
 func stringSliceContains(s []string, e string) bool {


### PR DESCRIPTION
This PR is a part of refactoring for #215. It moves `errorFromDOMError` into `ElementHandle` to increase [cohesion](https://en.wikipedia.org/wiki/Cohesion_(computer_science)). Also, it adds a test. But the test doesn't check for every error value to not bind test code to code under test.

Another reason I used a map in the function was that the cyclomatic complexity of the function was 19. Then again, I don't think that will be a problem because the map is local and won't escape.