### PR TITLE
Refactor QueryAll JS and Go funcs

### DIFF
--- a/common/js/query_all.js
+++ b/common/js/query_all.js
@@ -1,0 +1,11 @@
+/**
+ * Finds all elements in a given scope.
+ * @param {Node} scope - The scope of searching. It can be a node.
+ *                       By default, it is document.
+ * @param {InjectedScript} injected - Injected script.
+ * @param {string} selector - XPath or CSS selector string.
+ * @returns {Set<Node>|string} - A set of nodes found or an error string.
+ */
+function QueryAll(scope = document, injected, selector) {
+  return injected.querySelectorAll(selector, scope);
+}

--- a/common/js/selectors.go
+++ b/common/js/selectors.go
@@ -1,0 +1,9 @@
+package js
+
+import (
+	_ "embed"
+)
+
+//go:embed query_all.js
+// QueryAll queries all the elements in a given scope (document by default).
+var QueryAll string


### PR DESCRIPTION
This PR is another step to make `QueryAll` unit testable (#215). This one does something weird and moves the javascript function in the `QueryAll` go method into a new home: `js/query_all.js`. Then it embeds the javascript function in the `js/selectors.go` so that `QueryAll` (go) can get this function's source code.

The reason behind this is separating Go and JS code. So that this change will allow us to test Go and JS code separately. It also has the benefit of code editor support. For example, you can go to the injected script's `querySelectorAll` method from `QueryAll` (js) if your editor supports it.