### PR TITLE
Unit test queryAll

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -63,7 +63,7 @@ type (
 	elementHandleActionFn        func(context.Context, *ElementHandle) (interface{}, error)
 	elementHandlePointerActionFn func(context.Context, *ElementHandle, *Position) (interface{}, error)
 
-	// evalFunc is currently one of evalWithScript and eval.
+	// evalFunc is a common interface for both evalWithScript and eval.
 	// It helps abstracting these methods to aid with testing.
 	evalFunc func(ctx context.Context, opts evalOptions, js string, args ...interface{}) (interface{}, error)
 )

--- a/common/element_handle_test.go
+++ b/common/element_handle_test.go
@@ -77,7 +77,7 @@ func TestQueryAll(t *testing.T) {
 			returnHandle:     func() interface{} { return &jsHandleStub{} },
 			wantDisposeCalls: 1,
 		},
-		// disposes the main handler and all its nil children
+		// disposes the main handle and all its nil children
 		"disposes_handles": {
 			selector: "*",
 			returnHandle: func() interface{} {
@@ -137,7 +137,7 @@ func TestQueryAll(t *testing.T) {
 
 			if want := tt.wantDisposeCalls; want > 0 {
 				stub, ok := returnHandle.(*jsHandleStub)
-				assert.True(t, ok)
+				require.True(t, ok)
 				assert.Equal(t, want, stub.disposeCalls)
 			}
 		})

--- a/common/element_handle_test.go
+++ b/common/element_handle_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/common/js"
 )
 
 func TestErrorFromDOMError(t *testing.T) {
@@ -141,6 +142,28 @@ func TestQueryAll(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("eval_call", func(t *testing.T) {
+		const selector = "body"
+
+		_, _ = (&ElementHandle{}).queryAll(
+			selector,
+			func(_ context.Context, opts evalOptions, jsFunc string, args ...interface{}) (interface{}, error) {
+				assert.Equal(t, js.QueryAll, jsFunc)
+
+				assert.Equal(t, opts.forceCallable, true)
+				assert.Equal(t, opts.returnByValue, false)
+
+				assert.NotEmpty(t, args)
+				assert.IsType(t, args[0], &Selector{})
+				sel, ok := args[0].(*Selector)
+				require.True(t, ok)
+				assert.Equal(t, sel.Selector, selector)
+
+				return nil, nil //nolint:nilnil
+			},
+		)
+	})
 }
 
 type jsHandleStub struct {

--- a/common/element_handle_test.go
+++ b/common/element_handle_test.go
@@ -169,7 +169,6 @@ func TestQueryAll(t *testing.T) {
 type jsHandleStub struct {
 	api.JSHandle
 
-	disposeFn    func()
 	disposeCalls int
 
 	asElementFn     func() api.ElementHandle
@@ -185,9 +184,6 @@ func (s *jsHandleStub) AsElement() api.ElementHandle {
 
 func (s *jsHandleStub) Dispose() {
 	s.disposeCalls++
-	if s.disposeFn != nil {
-		s.disposeFn()
-	}
 }
 
 func (s *jsHandleStub) GetProperties() map[string]api.JSHandle {


### PR DESCRIPTION
This one depends on #225, and it's a part of the tasks in #215.

Things to remember before undrafting.

- [x] Remove: 70063cb

Abstract away the following first:

- [x] h.evalWithScript

Tests:

- [x] Error with an invalid selector
- [x] Error when it cannot evaluate the javascript
- [x] Nil result without an error
- [x] Catches the invalid JSHandle type

Further Tests:

- [x] Disposes the returned element
- [x] Disposes the handles (_should only dispose non-nil ones_)
- [x] Receives correct function: js.QueryAll
- [x] Receives correct evalOptions
