### PR TITLE
Fix contextWithDoneChan possible goroutine leak

### DIFF
--- a/common/context.go
+++ b/common/context.go
@@ -70,8 +70,11 @@ func GetProcessID(ctx context.Context) int {
 func contextWithDoneChan(ctx context.Context, done chan struct{}) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
 	go func() {
-		<-done
-		cancel()
+		defer cancel()
+		select {
+		case <-done:
+		case <-ctx.Done():
+		}
 	}()
 	return ctx
 }

--- a/common/context_test.go
+++ b/common/context_test.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextWithDoneChan(t *testing.T) {
+	done := make(chan struct{})
+	ctx := contextWithDoneChan(context.Background(), done)
+	close(done)
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Millisecond * 100):
+		require.FailNow(t, "should cancel the context after closing the done chan")
+	}
+}


### PR DESCRIPTION
The goroutine may leak if the passed context is canceled before the done channel, even if it is closed afterward.

This doesn't add a test for checking whether the function hangs on the `done` chan if the context gets canceled. I couldn't find a clean way to do that. Please let me know if you have an idea.

Related: #237 