### PR TITLE
Add basic auth support

### DIFF
--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -44,6 +44,12 @@ type BrowserContext interface {
 	SetDefaultTimeout(timeout int64)
 	SetExtraHTTPHeaders(headers map[string]string)
 	SetGeolocation(geolocation goja.Value)
+	// SetHTTPCredentials sets username/password credentials to use for HTTP authentication.
+	//
+	// Deprecated: Create a new BrowserContext with httpCredentials instead.
+	// See for details:
+	// - https://github.com/microsoft/playwright/issues/2196#issuecomment-627134837
+	// - https://github.com/microsoft/playwright/pull/2763
 	SetHTTPCredentials(httpCredentials goja.Value)
 	SetOffline(offline bool)
 	StorageState(opts goja.Value)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -285,7 +285,14 @@ func (b *BrowserContext) SetGeolocation(geolocation goja.Value) {
 }
 
 // SetHTTPCredentials sets username/password credentials to use for HTTP authentication.
+//
+// Deprecated: Create a new BrowserContext with httpCredentials instead.
+// See for details:
+// - https://github.com/microsoft/playwright/issues/2196#issuecomment-627134837
+// - https://github.com/microsoft/playwright/pull/2763
 func (b *BrowserContext) SetHTTPCredentials(httpCredentials goja.Value) {
+	b.logger.Warnf("setHTTPCredentials", "setHTTPCredentials is deprecated."+
+		" Create a new BrowserContext with httpCredentials instead.")
 	b.logger.Debugf("BrowserContext:SetHTTPCredentials", "bctxid:%v", b.id)
 
 	c := NewCredentials()

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -421,7 +421,7 @@ func (fs *FrameSession) initOptions() error {
 	}
 
 	fs.updateOffline(true)
-	fs.updateHttpCredentials(true)
+	fs.updateHTTPCredentials(true)
 	if err := fs.updateEmulateMedia(true); err != nil {
 		return err
 	}
@@ -976,7 +976,7 @@ func (fs *FrameSession) updateGeolocation(initial bool) error {
 	return nil
 }
 
-func (fs *FrameSession) updateHttpCredentials(initial bool) {
+func (fs *FrameSession) updateHTTPCredentials(initial bool) {
 	fs.logger.Debugf("NewFrameSession:updateHttpCredentials", "sid:%v tid:%v", fs.session.id, fs.targetID)
 
 	credentials := fs.page.browserCtx.opts.HttpCredentials

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -630,7 +630,7 @@ func (m *NetworkManager) updateProtocolCacheDisabled() error {
 }
 
 func (m *NetworkManager) updateProtocolRequestInterception() error {
-	enabled := m.userReqInterceptionEnabled || m.credentials != nil
+	enabled := m.userReqInterceptionEnabled
 	if enabled == m.protocolReqInterceptionEnabled {
 		return nil
 	}
@@ -666,6 +666,9 @@ func (m *NetworkManager) updateProtocolRequestInterception() error {
 // Authenticate sets HTTP authentication credentials to use.
 func (m *NetworkManager) Authenticate(credentials *Credentials) {
 	m.credentials = credentials
+	if credentials != nil {
+		m.userReqInterceptionEnabled = true
+	}
 	if err := m.updateProtocolRequestInterception(); err != nil {
 		rt := k6common.GetRuntime(m.ctx)
 		k6common.Throw(rt, err)

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -635,31 +635,30 @@ func (m *NetworkManager) updateProtocolRequestInterception() error {
 		return nil
 	}
 	m.protocolReqInterceptionEnabled = enabled
-	if enabled {
-		actions := []Action{
-			network.SetCacheDisabled(true),
-			fetch.Enable().
-				WithHandleAuthRequests(true).
-				WithPatterns([]*fetch.RequestPattern{
-					{URLPattern: "*", RequestStage: fetch.RequestStageRequest},
-				}),
-		}
-		for _, action := range actions {
-			if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
-				return fmt.Errorf("unable to execute %T: %w", action, err)
-			}
-		}
-	} else {
-		actions := []Action{
+
+	actions := []Action{
+		network.SetCacheDisabled(true),
+		fetch.Enable().
+			WithHandleAuthRequests(true).
+			WithPatterns([]*fetch.RequestPattern{
+				{
+					URLPattern:   "*",
+					RequestStage: fetch.RequestStageRequest,
+				},
+			}),
+	}
+	if !enabled {
+		actions = []Action{
 			network.SetCacheDisabled(false),
 			fetch.Disable(),
 		}
-		for _, action := range actions {
-			if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
-				return fmt.Errorf("unable to execute %T: %w", action, err)
-			}
+	}
+	for _, action := range actions {
+		if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
+			return fmt.Errorf("cannot execute %T: %w", action, err)
 		}
 	}
+
 	return nil
 }
 

--- a/common/page.go
+++ b/common/page.go
@@ -346,7 +346,7 @@ func (p *Page) updateHttpCredentials() {
 	p.logger.Debugf("Page:updateHttpCredentials", "sid:%v", p.sessionID())
 
 	for _, fs := range p.frameSessions {
-		fs.updateHttpCredentials(false)
+		fs.updateHTTPCredentials(false)
 	}
 }
 

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -21,6 +21,7 @@
 package tests
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -89,16 +90,7 @@ func TestBasicAuth(t *testing.T) {
 		validPassword = "validpass"
 	)
 
-	browser := newTestBrowser(t, withHTTPServer()).
-		withHandler("/auth", func(w http.ResponseWriter, r *http.Request) {
-			user, pass, ok := r.BasicAuth()
-			if !ok {
-				w.Header().Set("WWW-Authenticate", `Basic realm="u=User,p=Pass"`)
-			}
-			if user != validUser || pass != validPassword {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			}
-		})
+	browser := newTestBrowser(t, withHTTPServer())
 
 	auth := func(tb testing.TB, user, pass string) api.Response {
 		tb.Helper()
@@ -114,7 +106,7 @@ func TestBasicAuth(t *testing.T) {
 			})).
 			NewPage().
 			Goto(
-				browser.URL("/auth"),
+				browser.URL(fmt.Sprintf("/basic-auth/%s/%s", validUser, validPassword)),
 				browser.rt.ToValue(struct {
 					WaitUntil string `js:"waitUntil"`
 				}{
@@ -128,7 +120,6 @@ func TestBasicAuth(t *testing.T) {
 		require.NotNil(t, resp)
 		assert.Equal(t, http.StatusOK, int(resp.Status()))
 	})
-
 	t.Run("invalid", func(t *testing.T) {
 		resp := auth(t, "invalidUser", "invalidPassword")
 		require.NotNil(t, resp)

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -21,12 +21,16 @@
 package tests
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k6lib "go.k6.io/k6/lib"
 	k6types "go.k6.io/k6/lib/types"
+
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/common"
 )
 
 func TestURLSkipRequest(t *testing.T) {
@@ -77,4 +81,57 @@ func TestBlockIPs(t *testing.T) {
 	// Ensure other requests go through
 	resp := p.Goto(tb.URL("/get"), nil)
 	assert.NotNil(t, resp)
+}
+
+func TestBasicAuth(t *testing.T) {
+	const (
+		validUser     = "validuser"
+		validPassword = "validpass"
+	)
+
+	browser := newTestBrowser(t, withHTTPServer()).
+		withHandler("/auth", func(w http.ResponseWriter, r *http.Request) {
+			user, pass, ok := r.BasicAuth()
+			if !ok {
+				w.Header().Set("WWW-Authenticate", `Basic realm="u=User,p=Pass"`)
+			}
+			if user != validUser || pass != validPassword {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			}
+		})
+
+	auth := func(tb testing.TB, user, pass string) api.Response {
+		tb.Helper()
+
+		return browser.NewContext(
+			browser.rt.ToValue(struct {
+				HttpCredentials *common.Credentials `js:"httpCredentials"` //nolint:revive
+			}{
+				HttpCredentials: &common.Credentials{
+					Username: user,
+					Password: pass,
+				},
+			})).
+			NewPage().
+			Goto(
+				browser.URL("/auth"),
+				browser.rt.ToValue(struct {
+					WaitUntil string `js:"waitUntil"`
+				}{
+					WaitUntil: "load",
+				}),
+			)
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		resp := auth(t, validUser, validPassword)
+		require.NotNil(t, resp)
+		assert.Equal(t, http.StatusOK, int(resp.Status()))
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		resp := auth(t, "invalidUser", "invalidPassword")
+		require.NotNil(t, resp)
+		assert.Equal(t, http.StatusUnauthorized, int(resp.Status()))
+	})
 }


### PR DESCRIPTION
TODO:

- [x] Prototype a working version
- [x] Find a way to intercept requests also for basic auth (FrameSession reqIntercept)
- [x] Find out why initial is necessary in FrameSession.updateHttpCredentials
- [x] Add logs
- [x] Add a functional test
- [x] Cancel failed auth on the first try
- [x] Add deprecation comments for `(*BrowserContext).SetHTTPCredentials` and `api`'s
- [x] Barely investigate [routes](https://github.com/grafana/xk6-browser/issues/105#issuecomment-1017416749). Also: #10 and #12.

Scheduled for later:
Playwright compatibility: Cancel auth when loading is finished or failed

Closes: #203