### PR TITLE
Add test short skip for slow mo tests

### DIFF
--- a/tests/launch_options_slowmo_test.go
+++ b/tests/launch_options_slowmo_test.go
@@ -32,6 +32,10 @@ import (
 )
 
 func TestLaunchOptionsSlowMo(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	tb := newTestBrowser(t, withFileServer())
 
 	t.Run("Page", func(t *testing.T) {


### PR DESCRIPTION
We can skip slow motion tests when we give the `-short` flag. The rest of the tests become 10 seconds faster to run. I think we don't need to run slow-motion tests all the time. I'd like to merge this. WDYT, @imiric?

```
➜  k6b git:(test/skip-slowmo) ✗ go test ./tests -failfast -race
ok  	github.com/grafana/xk6-browser/tests	26.945s
➜  k6b git:(test/skip-slowmo) ✗ go test ./tests -failfast -race -short
ok  	github.com/grafana/xk6-browser/tests	17.964s
```