### PR TITLE
Fix `WaitForNavigation` within the same document

### DIFF
--- a/common/event_emitter.go
+++ b/common/event_emitter.go
@@ -84,6 +84,11 @@ type Event struct {
 	data interface{}
 }
 
+// NavigationEvent is emitted when we receive a Page.frameNavigated or
+// Page.navigatedWithinDocument CDP event.
+// See:
+// - https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-frameNavigated
+// - https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-navigatedWithinDocument
 type NavigationEvent struct {
 	newDocument *DocumentInfo
 	url         string

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -29,13 +29,11 @@ func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 			resp := p.Goto(tb.staticURL("/nav_in_doc.html"), nil)
 			require.NotNil(t, resp)
 
-			el := p.Query(tc.selector)
-			require.NotNil(t, el)
 			// A click right away could possibly trigger navigation before we
 			// had a chance to call WaitForNavigation below, so give it some
 			// time to simulate the JS overhead, waiting for XHR response, etc.
 			time.AfterFunc(200*time.Millisecond, func() {
-				el.Click(nil)
+				p.Click(tc.selector, nil)
 			})
 
 			done := make(chan struct{}, 1)

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -38,21 +38,19 @@ func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 				el.Click(nil)
 			})
 
-			done := make(chan struct{})
+			done := make(chan struct{}, 1)
 			go func() {
-				defer close(done)
 				require.NotPanics(t, func() {
 					p.WaitForNavigation(tb.rt.ToValue(&common.FrameWaitForNavigationOptions{
 						Timeout: 1000, // 1s
 					}))
 				})
+				done <- struct{}{}
 			}()
 
 			select {
 			case <-done:
 			case <-time.After(2 * time.Second):
-				// WaitForNavigation is stuck?
-				close(done)
 				t.Fatal("Test timed out")
 			}
 		})

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"net/http"
 	"testing"
 	"time"
 
@@ -10,29 +9,8 @@ import (
 	"github.com/grafana/xk6-browser/common"
 )
 
-//nolint: funlen
 func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 	t.Parallel()
-
-	navHTML := `
-<html>
-  <head>
-    <title>Navigation test within the same document</title>
-  </head>
-  <body>
-    <a id="nav-history" href="#">Navigate with History API</a>
-    <a id="nav-anchor" href="#anchor">Navigate with anchor link</a>
-    <div id="anchor">Some div...</div>
-    <script>
-      const el = document.querySelector('a#nav-history');
-      el.addEventListener('click', function(evt) {
-        evt.preventDefault();
-        history.pushState({}, 'navigated', '/nav2');
-      });
-    </script>
-  </body>
-</html>
-`
 
 	testCases := []struct {
 		name, selector string
@@ -45,15 +23,10 @@ func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tb := newTestBrowser(t, withHTTPServer())
-			tb.withHandler("/nav", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "text/html")
-				_, err := w.Write([]byte(navHTML))
-				require.NoError(t, err)
-			}))
+			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
 
-			resp := p.Goto(tb.URL("/nav"), nil)
+			resp := p.Goto(tb.staticURL("/nav_in_doc.html"), nil)
 			require.NotNil(t, resp)
 
 			el := p.Query(tc.selector)

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -1,0 +1,87 @@
+package tests
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/common"
+)
+
+//nolint: funlen
+func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
+	t.Parallel()
+
+	navHTML := `
+<html>
+  <head>
+    <title>Navigation test within the same document</title>
+  </head>
+  <body>
+    <a id="nav-history" href="#">Navigate with History API</a>
+    <a id="nav-anchor" href="#anchor">Navigate with anchor link</a>
+    <div id="anchor">Some div...</div>
+    <script>
+      const el = document.querySelector('a#nav-history');
+      el.addEventListener('click', function(evt) {
+        evt.preventDefault();
+        history.pushState({}, 'navigated', '/nav2');
+      });
+    </script>
+  </body>
+</html>
+`
+
+	testCases := []struct {
+		name, selector string
+	}{
+		{name: "history", selector: "a#nav-history"},
+		{name: "anchor", selector: "a#nav-anchor"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tb := newTestBrowser(t, withHTTPServer())
+			tb.withHandler("/nav", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				_, err := w.Write([]byte(navHTML))
+				require.NoError(t, err)
+			}))
+			p := tb.NewPage(nil)
+
+			resp := p.Goto(tb.URL("/nav"), nil)
+			require.NotNil(t, resp)
+
+			el := p.Query(tc.selector)
+			require.NotNil(t, el)
+			// A click right away could possibly trigger navigation before we
+			// had a chance to call WaitForNavigation below, so give it some
+			// time to simulate the JS overhead, waiting for XHR response, etc.
+			time.AfterFunc(200*time.Millisecond, func() {
+				el.Click(nil)
+			})
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				require.NotPanics(t, func() {
+					p.WaitForNavigation(tb.rt.ToValue(&common.FrameWaitForNavigationOptions{
+						Timeout: 1000, // 1s
+					}))
+				})
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				// WaitForNavigation is stuck?
+				close(done)
+				t.Fatal("Test timed out")
+			}
+		})
+	}
+}

--- a/tests/static/nav_in_doc.html
+++ b/tests/static/nav_in_doc.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title>Navigation test within the same document</title>
+  </head>
+  <body>
+    <a id="nav-history" href="#">Navigate with History API</a>
+    <a id="nav-anchor" href="#anchor">Navigate with anchor link</a>
+    <div id="anchor">Some div...</div>
+    <script>
+      const el = document.querySelector('a#nav-history');
+      el.addEventListener('click', function(evt) {
+        evt.preventDefault();
+        history.pushState({}, 'navigated', '/nav2');
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Previously `WaitForNavigation` assumed that a `LifecycleEvent` would always be fired, but this is not the case for navigation within the same document (e.g. via anchor links or the History API), so in those cases the call would timeout after 30s.

The fix simply checks if we received a new document, otherwise it skips waiting for the `LifecycleEvent`. Even if that wait didn't time out, it would've failed with a nil pointer panic accessing `event.newDocument.request`.

Closes #226