### PR TITLE
`TestWaitForFrameNavigationWithinDocument` fixes for CI

### DIFF
--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -30,7 +30,6 @@ func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
 


### PR DESCRIPTION
[The previous timings were apparently insufficient in CI](https://github.com/grafana/xk6-browser/runs/5317231381), so this increases them slightly for local test runs (total runtime from ~0.6s to ~0.9s), and hopefully enough in CI for the `WaitForNavigation` timeout not to be reached.

The error manifests itself as a data race in the testing package, but the cause is `WaitForNavigation` panicking because of the timeout.

It also removes `t.Parallel()` from the subtests to hopefully fix #254.