### PR TITLE
Fix binary signing on Windows

### DIFF
--- a/.github/workflows/all.yaml
+++ b/.github/workflows/all.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   deps:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
           test -z "$(go generate ./... && git status --porcelain)"
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       GO111MODULE: 'on'
     steps:
@@ -61,8 +61,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.16.x]
-        #platform: [ubuntu-latest, macos-latest, windows-latest]
-        platform: [ubuntu-latest]
+        #platform: [ubuntu-20.04, macos-11, windows-2019]
+        platform: [ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -95,7 +95,7 @@ jobs:
           go test -v -p 2 -race -timeout 300s ./...
 
   test-tip:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     continue-on-error: true
     steps:
       - name: Checkout code
@@ -141,8 +141,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.17.x]
-        #platform: [ubuntu-latest, macos-latest, windows-latest]
-        platform: [ubuntu-latest]
+        #platform: [ubuntu-20.04, macos-latest, windows-2019]
+        platform: [ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -191,7 +191,7 @@ jobs:
           path: coverage.html
 
   configure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
@@ -203,7 +203,7 @@ jobs:
           echo "::set-output name=version::${VERSION}"
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [configure, deps, lint, test-current-cov]
     if: startsWith(github.ref, 'refs/tags/v')
     env:
@@ -266,7 +266,7 @@ jobs:
           retention-days: 7
 
   package-windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     defaults:
       run:
         shell: powershell
@@ -327,7 +327,7 @@ jobs:
           retention-days: 7
 
   publish-github:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [configure, deps, lint, test-current-cov, build, package-windows]
     if: startsWith(github.ref, 'refs/tags/v')
     env:

--- a/.github/workflows/all.yaml
+++ b/.github/workflows/all.yaml
@@ -83,7 +83,7 @@ jobs:
         run: chrome --version
       - name: Chrome version
         if: runner.os == 'Windows'
-        shell: powershell
+        shell: pwsh
         # chrome --version doesn't work on Windows :-/
         # See https://bugs.chromium.org/p/chromium/issues/detail?id=158372
         run: (get-command chrome.exe).Version
@@ -124,7 +124,7 @@ jobs:
         run: chrome --version
       - name: Chrome version
         if: runner.os == 'Windows'
-        shell: powershell
+        shell: pwsh
         # chrome --version doesn't work on Windows :-/
         # See https://bugs.chromium.org/p/chromium/issues/detail?id=158372
         run: (get-command chrome.exe).Version
@@ -163,7 +163,7 @@ jobs:
         run: chrome --version
       - name: Chrome version
         if: runner.os == 'Windows'
-        shell: powershell
+        shell: pwsh
         # chrome --version doesn't work on Windows :-/
         # See https://bugs.chromium.org/p/chromium/issues/detail?id=158372
         run: (get-command chrome.exe).Version
@@ -269,7 +269,7 @@ jobs:
     runs-on: windows-2019
     defaults:
       run:
-        shell: powershell
+        shell: pwsh
     needs: [deps, lint, test-current-cov, configure, build]
     if: startsWith(github.ref, 'refs/tags/v')
     env:
@@ -285,7 +285,7 @@ jobs:
         run: |
           curl -O wix311-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip
           Expand-Archive -Path .\wix311-binaries.zip -DestinationPath .\wix311\
-          echo "$pwd\wix311" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "$pwd\wix311" | Out-File -FilePath $env:GITHUB_PATH -Append
       - name: Download binaries
         uses: actions/download-artifact@v2
         with:
@@ -297,7 +297,7 @@ jobs:
           move .\packaging\xk6-browser-$env:VERSION-windows-amd64\xk6-browser.exe .\packaging\
           rmdir .\packaging\xk6-browser-$env:VERSION-windows-amd64\
       - name: Add signtool to PATH
-        run: echo "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64" | Out-File -FilePath $env:GITHUB_PATH -Append
       - name: Convert base64 certificate to PFX
         run: |
           $bytes = [Convert]::FromBase64String("${{ secrets.WIN_SIGN_CERT }}")

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,7 +57,7 @@ jobs:
         run: chrome --version
       - name: Chrome version
         if: runner.os == 'Windows'
-        shell: powershell
+        shell: pwsh
         # chrome --version doesn't work on Windows :-/
         # See https://bugs.chromium.org/p/chromium/issues/detail?id=158372
         run: (get-command chrome.exe).Version


### PR DESCRIPTION
This should hopefully fix the recent failure to sign the binary, see https://github.com/grafana/xk6-browser/runs/5332928690.

I confirmed that it [works on `windows-2019`](https://github.com/grafana/xk6-browser/runs/5334303581), but not on [`windows-latest`](https://github.com/grafana/xk6-browser/runs/5334286611). The strange thing is that [`signtool` is still in the same path](https://github.com/grafana/xk6-browser/runs/5333157519) on both versions, but I'm guessing there's an issue with GH Actions and the way `GITHUB_PATH` works, but it hasn't been documented/reported yet.