### PR TITLE
Fix/261 Frame.[nullContext&documentHandle] data race

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -340,14 +340,15 @@ func (f *Frame) cachedDocumentHandle() (*ElementHandle, bool) {
 }
 
 func (f *Frame) newDocumentHandle() (*ElementHandle, error) {
-	rt := k6common.GetRuntime(f.ctx)
-	doc := rt.ToValue("document")
-
-	opts := evalOptions{
-		forceCallable: false,
-		returnByValue: false,
-	}
-	result, err := f.evaluate(f.ctx, mainWorld, opts, doc)
+	result, err := f.evaluate(
+		f.ctx,
+		mainWorld,
+		evalOptions{
+			forceCallable: false,
+			returnByValue: false,
+		},
+		k6common.GetRuntime(f.ctx).ToValue("document"),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot evaluate in main execution context: %w", err)
 	}


### PR DESCRIPTION
`documentHandle` had a data race while switching execution contexts.

This doesn't contain a test because [the test that can reproduce it](https://github.com/grafana/xk6-browser/tree/test/261-frame-nullContext) depends on the correct handling of navigation (which we don't have at this moment v0.2—See: #200 and #258).

Fixes: #261