### PR TITLE
Make concealed elements clickable

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -24,8 +24,8 @@ var _ api.ElementHandle = &ElementHandle{}
 var _ api.JSHandle = &ElementHandle{}
 
 type (
-	elementHandleActionFn        func(context.Context, *ElementHandle) (interface{}, error)
-	elementHandlePointerActionFn func(context.Context, *ElementHandle, *Position) (interface{}, error)
+	elementHandleActionFunc        func(context.Context, *ElementHandle) (interface{}, error)
+	elementHandlePointerActionFunc func(context.Context, *ElementHandle, *Position) (interface{}, error)
 
 	// evalFunc is a common interface for both evalWithScript and eval.
 	// It helps abstracting these methods to aid with testing.
@@ -33,7 +33,7 @@ type (
 )
 
 func getElementHandleActionFn(
-	h *ElementHandle, states []string, fn elementHandleActionFn, force, noWaitAfter bool, timeout time.Duration,
+	h *ElementHandle, states []string, fn elementHandleActionFunc, force, noWaitAfter bool, timeout time.Duration,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// All or a subset of the following actionability checks are made before performing the actual action:
 	// 1. Attached to DOM
@@ -79,7 +79,7 @@ func getElementHandleActionFn(
 func getElementHandlePointerActionFn(
 	h *ElementHandle,
 	checkEnabled bool,
-	fn elementHandlePointerActionFn,
+	fn elementHandlePointerActionFunc,
 	opts *ElementHandleBasePointerOptions,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// All or a subset of the following actionability checks are made before performing the actual action:

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1,39 +1,3 @@
-/**
- * Copyright (c) Microsoft Corporation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- *
- * xk6-browser - a browser automation extension for k6
- * Copyright (C) 2021 Load Impact
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
-
 package common
 
 import (

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -135,7 +135,7 @@ func getElementHandlePointerActionFn(
 				states = append(states, "enabled")
 			}
 			if _, err = h.waitForElementState(apiCtx, states, opts.Timeout); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("cannot wait for element state: %w", err)
 			}
 		}
 
@@ -167,7 +167,7 @@ func getElementHandlePointerActionFn(
 			)
 		}
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot scroll into view: %w", err)
 		}
 
 		// Get the clickable point
@@ -177,13 +177,13 @@ func getElementHandlePointerActionFn(
 			p, err = h.clickablePoint()
 		}
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot get element position: %w", err)
 		}
 		// Do a final actionability check to see if element can receive events
 		// at mouse position in question
 		if !opts.Force {
 			if ok, err := h.checkHitTargetAt(apiCtx, *p); !ok {
-				return nil, err
+				return nil, fmt.Errorf("cannot check hit target: %w", err)
 			}
 		}
 		// Are we only "trialing" the action but not actually performing
@@ -196,12 +196,12 @@ func getElementHandlePointerActionFn(
 		h.frame.manager.addBarrier(b)
 		defer h.frame.manager.removeBarrier(b)
 		if res, err = fn(apiCtx, h, p); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot evaluate pointer action: %w", err)
 		}
 		// Do we need to wait for navigation to happen
 		if !opts.NoWaitAfter {
 			if err = b.Wait(apiCtx); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("cannot wait for navigation: %w", err)
 			}
 		}
 

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -150,19 +150,10 @@ func getElementHandlePointerActionFn(
 			}
 			err = h.scrollRectIntoViewIfNeeded(apiCtx, rect)
 		} else {
-			scrollIntoView := `
-				(node, injected, options) => {
-					// we can only scroll to element nodes
-					if (node.nodeType !== 1 /* Node.ELEMENT_NODE */) {
-						return;
-					}
-					return node.scrollIntoView(options);
-				}
-			`
-			_, err = h.evalWithScript(
+			_, err = h.eval(
 				apiCtx,
-				evalOptions{forceCallable: true, returnByValue: true},
-				scrollIntoView,
+				evalOptions{forceCallable: true, returnByValue: false},
+				js.ScrollIntoView,
 				sopts,
 			)
 		}

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -41,6 +41,34 @@ type ElementHandleBasePointerOptions struct {
 	Trial    bool      `json:"trial"`
 }
 
+// ScrollPosition is a parameter for scrolling an element.
+type ScrollPosition string
+
+const (
+	// ScrollPositionStart scrolls an element at the top of its parent.
+	ScrollPositionStart ScrollPosition = "start"
+	// ScrollPositionCenter scrolls an element at the center of its parent.
+	ScrollPositionCenter ScrollPosition = "center"
+	// ScrollPositionEnd scrolls an element at the end of its parent.
+	ScrollPositionEnd ScrollPosition = "end"
+	// ScrollPositionNearest scrolls an element at the nearest position of its parent.
+	ScrollPositionNearest ScrollPosition = "nearest"
+)
+
+// ScrollIntoViewOptions change the behavior of ScrollIntoView.
+// See: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+type ScrollIntoViewOptions struct {
+	// Block defines vertical alignment.
+	// One of start, center, end, or nearest.
+	// Defaults to start.
+	Block ScrollPosition `json:"block"`
+
+	// Inline defines horizontal alignment.
+	// One of start, center, end, or nearest.
+	// Defaults to nearest.
+	Inline ScrollPosition `json:"inline"`
+}
+
 type ElementHandleCheckOptions struct {
 	ElementHandleBasePointerOptions
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -1609,8 +1609,8 @@ func frameActionFn(
 			resultCh <- nil
 			return
 		}
-		actFn := getElementHandleActionFn(handle, states, fn, false, false, timeout)
-		actFn(apiCtx, resultCh, errCh)
+		f := handle.newAction(states, fn, false, false, timeout)
+		f(apiCtx, resultCh, errCh)
 	}
 }
 
@@ -1637,7 +1637,7 @@ func framePointerActionFn(
 			resultCh <- nil
 			return
 		}
-		pointerActFn := getElementHandlePointerActionFn(handle, true, fn, opts)
-		pointerActFn(apiCtx, resultCh, errCh)
+		f := handle.newPointerAction(fn, opts)
+		f(apiCtx, resultCh, errCh)
 	}
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -658,7 +658,9 @@ func (f *Frame) Check(selector string, opts goja.Value) {
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
 		return nil, handle.setChecked(apiCtx, true, p)
 	}
-	actFn := framePointerActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions)
+	actFn := f.newPointerAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions,
+	)
 	_, err = callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -693,7 +695,9 @@ func (f *Frame) Click(selector string, opts goja.Value) {
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
 		return nil, handle.click(p, parsedOpts.ToMouseClickOptions())
 	}
-	actFn := framePointerActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions)
+	actFn := f.newPointerAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions,
+	)
 	_, err = callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -732,7 +736,9 @@ func (f *Frame) Dblclick(selector string, opts goja.Value) {
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
 		return nil, handle.dblClick(p, parsedOpts.ToMouseClickOptions())
 	}
-	actFn := framePointerActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions)
+	actFn := f.newPointerAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions,
+	)
 	_, err = callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -753,7 +759,10 @@ func (f *Frame) DispatchEvent(selector string, typ string, eventInit goja.Value,
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.dispatchEvent(apiCtx, typ, eventInit)
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, parsedOpts.Force, parsedOpts.NoWaitAfter, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{},
+		parsedOpts.Force, parsedOpts.NoWaitAfter, parsedOpts.Timeout,
+	)
 	_, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -822,7 +831,10 @@ func (f *Frame) Fill(selector string, value string, opts goja.Value) {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.fill(apiCtx, value)
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{"visible", "enabled", "editable"}, parsedOpts.Force, parsedOpts.NoWaitAfter, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{"visible", "enabled", "editable"},
+		parsedOpts.Force, parsedOpts.NoWaitAfter, parsedOpts.Timeout,
+	)
 	_, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -844,7 +856,9 @@ func (f *Frame) Focus(selector string, opts goja.Value) {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return nil, handle.focus(apiCtx, true)
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	_, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -876,7 +890,9 @@ func (f *Frame) GetAttribute(selector string, name string, opts goja.Value) goja
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.getAttribute(apiCtx, name)
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -907,7 +923,9 @@ func (f *Frame) Hover(selector string, opts goja.Value) {
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
 		return nil, handle.hover(apiCtx, p)
 	}
-	actFn := framePointerActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions)
+	actFn := f.newPointerAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions,
+	)
 	_, err = callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -928,7 +946,9 @@ func (f *Frame) InnerHTML(selector string, opts goja.Value) string {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.innerHTML(apiCtx)
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -950,7 +970,9 @@ func (f *Frame) InnerText(selector string, opts goja.Value) string {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.innerText(apiCtx)
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -972,7 +994,9 @@ func (f *Frame) InputValue(selector string, opts goja.Value) string {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.inputValue(apiCtx)
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -998,7 +1022,9 @@ func (f *Frame) IsChecked(selector string, opts goja.Value) bool {
 		}
 		return value, err
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1040,7 +1066,9 @@ func (f *Frame) IsDisabled(selector string, opts goja.Value) bool {
 		}
 		return value, err
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1066,7 +1094,9 @@ func (f *Frame) IsEditable(selector string, opts goja.Value) bool {
 		}
 		return value, err
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1092,7 +1122,9 @@ func (f *Frame) IsEnabled(selector string, opts goja.Value) bool {
 		}
 		return value, err
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1118,7 +1150,9 @@ func (f *Frame) IsHidden(selector string, opts goja.Value) bool {
 		}
 		return value, err
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1144,7 +1178,9 @@ func (f *Frame) IsVisible(selector string, opts goja.Value) bool {
 		}
 		return value, err
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1232,7 +1268,10 @@ func (f *Frame) Press(selector string, key string, opts goja.Value) {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return nil, handle.press(apiCtx, key, parsedOpts.ToKeyboardOptions())
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, parsedOpts.NoWaitAfter, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false,
+		parsedOpts.NoWaitAfter, parsedOpts.Timeout,
+	)
 	_, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1253,7 +1292,10 @@ func (f *Frame) SelectOption(selector string, values goja.Value, opts goja.Value
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.selectOption(apiCtx, values)
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, parsedOpts.Force, parsedOpts.NoWaitAfter, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{},
+		parsedOpts.Force, parsedOpts.NoWaitAfter, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1324,7 +1366,9 @@ func (f *Frame) Tap(selector string, opts goja.Value) {
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
 		return nil, handle.tap(apiCtx, p)
 	}
-	actFn := framePointerActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions)
+	actFn := f.newPointerAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions,
+	)
 	_, err = callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1345,7 +1389,9 @@ func (f *Frame) TextContent(selector string, opts goja.Value) string {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.textContent(apiCtx)
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
 	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1374,7 +1420,10 @@ func (f *Frame) Type(selector string, text string, opts goja.Value) {
 	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return nil, handle.typ(apiCtx, text, parsedOpts.ToKeyboardOptions())
 	}
-	actFn := frameActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, parsedOpts.NoWaitAfter, parsedOpts.Timeout)
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false,
+		parsedOpts.NoWaitAfter, parsedOpts.Timeout,
+	)
 	_, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1396,7 +1445,9 @@ func (f *Frame) Uncheck(selector string, opts goja.Value) {
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
 		return nil, handle.setChecked(apiCtx, false, p)
 	}
-	actFn := framePointerActionFn(f, selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions)
+	actFn := f.newPointerAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions,
+	)
 	_, err = callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6common.Throw(rt, err)
@@ -1439,7 +1490,8 @@ func (f *Frame) WaitForFunction(pageFunc goja.Value, opts goja.Value, args ...go
 	f.executionContextMu.RLock()
 	defer f.executionContextMu.RUnlock()
 
-	handle, err := f.waitForFunction(f.ctx, utilityWorld, pageFunc, parsedOpts.Polling, parsedOpts.Interval, parsedOpts.Timeout, args...)
+	handle, err := f.waitForFunction(f.ctx, utilityWorld, pageFunc,
+		parsedOpts.Polling, parsedOpts.Interval, parsedOpts.Timeout, args...)
 	if err != nil {
 		k6common.Throw(rt, err)
 	}
@@ -1587,15 +1639,14 @@ type frameExecutionContext interface {
 }
 
 //nolint:unparam
-func frameActionFn(
-	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandleActionFunc, states []string,
+func (f *Frame) newAction(
+	selector string, state DOMElementState, strict bool, fn elementHandleActionFunc, states []string,
 	force, noWaitAfter bool, timeout time.Duration,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame action in the following steps:
 	// 1. Find element matching specified selector
 	// 2. Wait for it to reach specified DOM state
 	// 3. Run element handle action (incl. actionability checks)
-
 	return func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 		waitOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
 		waitOpts.State = state
@@ -1615,15 +1666,14 @@ func frameActionFn(
 }
 
 //nolint:unparam
-func framePointerActionFn(
-	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandlePointerActionFunc,
+func (f *Frame) newPointerAction(
+	selector string, state DOMElementState, strict bool, fn elementHandlePointerActionFunc,
 	opts *ElementHandleBasePointerOptions,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame pointer action in the following steps:
 	// 1. Find element matching specified selector
 	// 2. Wait for it to reach specified DOM state
 	// 3. Run element handle action (incl. actionability checks)
-
 	return func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 		waitOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
 		waitOpts.State = state

--- a/common/frame.go
+++ b/common/frame.go
@@ -1588,7 +1588,7 @@ type frameExecutionContext interface {
 
 //nolint:unparam
 func frameActionFn(
-	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandleActionFn, states []string,
+	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandleActionFunc, states []string,
 	force, noWaitAfter bool, timeout time.Duration,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame action in the following steps:
@@ -1616,7 +1616,7 @@ func frameActionFn(
 
 //nolint:unparam
 func framePointerActionFn(
-	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandlePointerActionFn,
+	f *Frame, selector string, state DOMElementState, strict bool, fn elementHandlePointerActionFunc,
 	opts *ElementHandleBasePointerOptions,
 ) func(apiCtx context.Context, resultCh chan interface{}, errCh chan error) {
 	// We execute a frame pointer action in the following steps:

--- a/common/js/actions.go
+++ b/common/js/actions.go
@@ -1,0 +1,9 @@
+package js
+
+import (
+	_ "embed"
+)
+
+//go:embed scroll_into_view.js
+// ScrollIntoView scrolls an element into view.
+var ScrollIntoView string

--- a/common/js/scroll_into_view.js
+++ b/common/js/scroll_into_view.js
@@ -1,0 +1,13 @@
+/**
+ * Scrolls an element into view.
+ * @param {Node} node - The element to scroll into.
+ * @param {ScrollIntoViewOptions} options.
+ * @returns {void}
+ */
+function scrollIntoView(node, options) {
+  // we can only scroll to element nodes
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return;
+  }
+  node.scrollIntoView(options);
+}

--- a/tests/static/concealed_link.html
+++ b/tests/static/concealed_link.html
@@ -1,0 +1,50 @@
+<html>
+<head>
+    <title>Concealed element test</title>
+    <style>
+        * {
+            padding: 0;
+            margin: 0;
+        }
+        ol {
+            padding-top: 160px;
+        }
+        li {
+            height: 80px;
+            border: 1px solid black;
+        }
+        .sticky {
+            z-index: 9999;
+            width: 100%;
+            position: fixed;
+            height: 160px;
+            background: black;
+        }
+    </style>
+</head>
+<body>    
+    <div class="sticky"></div>
+    <ol>
+        <li>item 1</li>
+        <li>item 2</li>
+        <li>item 3</li>
+        <li id="concealed">item 4</li>
+        <li>item 5</li>
+        <li>item 6</li>
+        <li>item 7</li>
+        <li>item 8</li>
+        <li>item 9</li>
+        <li id="last">item 10</li>
+    </ol>
+
+    <script type="text/javascript">
+        window.clickResult = '🙈';
+
+        el = document.querySelector('#concealed');
+        el.addEventListener('click', function (ev) {
+            ev.preventDefault();
+            window.clickResult = "🐵";
+        })
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds an auto-scrolling retry mechanism for all `ElementHandle` pointer actions, including `Click.` So that we can reduce test flakiness which is one of our main goals, as explained earlier by Robin.

### Problem

According to the [actionability checks](https://playwright.dev/docs/actionability), we can only click on elements on the viewport. However, sometimes an existing element that we want to click can be out of the viewport, and we can't bring it to the viewport even after we scroll.

The previous code only attempts to scroll once, but sometimes it isn't enough. Even after scrolling, the target element stays invisible (see the explanations below).

### Solution

Try scrolling into it with [various scrolling options (see: scrollIntoViewOptions at the link)](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) until the element satisfies the actionability checks: Becomes visible and clickable. Return an error only when we exhaust all our retry attempts.

We made this PR possible by improving the actionability checks in #270.

### Reproduce

<details>
<summary>The script.</summary>

```javascript
import launcher from 'k6/x/browser';

export default function () {
  const browser = launcher.launch('chromium', {
    headless: false,
    slowMo: '1s',
  });
  const page = browser.newContext({
    // screen: { width: 1920, height: 1080 },
    // viewport: { width: 1920, height: 1080 },
  }).newPage();
  page.goto('http://ecommerce.test.k6.io/', { waitUntil: 'networkidle' });
  page.waitForSelector('.woocommerce-result-count');
  page.click('.woocommerce-loop-product__title');
  page.click('button[name="add-to-cart"]');
  page.waitForSelector('.woocommerce-message')
  page.click('.cart-contents');
  page.waitForSelector('.woocommerce-cart-form__cart-item');
  page.close();
  browser.close();
}
```

</details>

1. Please run the script on the main branch (current: https://github.com/grafana/xk6-browser/commit/48545fa87a7de203ba57d110b4a5c2d1f5653209).
2. You should receive an error: `another element is intercepting with pointer action.` It's because the target element `button[name="add-to-cart"]` that we want to click stays behind the sticky footer `.woocommerce-store-notice`, even after the first scroll.

You can see the solution in action by rerunning the script, this time, on this branch.

### Shortcomings

The current solution retries with various scrolling options. However, we scroll too much and the element stays on top of the page:

<img width="892" alt="Screen Shot 2022-03-12 at 19 47 24" src="https://user-images.githubusercontent.com/621232/158026926-4d33f6b6-7c10-4b34-b74c-74d06738ff84.png">

Instead of scrolling a little bit:  

<img width="915" alt="Screen Shot 2022-03-12 at 19 48 47" src="https://user-images.githubusercontent.com/621232/158026946-e2c05561-0ba4-4265-9b07-cf57fca3200f.png">

The same thing happens if we use a scroll hack in the script mentioned above:

```js
// Try to scroll.
page.evaluate(() => {
  const el = document.querySelector('button[name="add-to-cart"]');
  el.scrollIntoView();
});
page.click('button[name="add-to-cart"]');
```

---

### Remaining tasks

- [x] PoC fix & test -> [See](https://github.com/grafana/xk6-browser/tree/feat/make-concealed-elements-clickable-old)
- [x] Research: getElementHandlePointerActionFn and ScrollIntoViewIfNeeded usage
- [x] Research: Quad math
- [x] Fix: checkHitTarget bug (_we think a concealed element is clickable when it's not_)
- [x] Refactor `getElementHandlePointerActionFn` so that it can be retried
- [x] Retry ScrollIntoView with different options
- [x] Polish the test
- [x] Use ScrollIntoView js action
- [x] Refactor `clickablePoint` and `filteredQuads` algorithm
- [x] Clear commit history
  - [x] Fix checkHitTarget bug
  - [x] Add TestElementHandleClickConcealedLink
  - [x] Add ScrollPosition
  - [x] Add customizable ScrollIntoView
  - [x] Add ScrollIntoView retry
- [x] Refactor `getElementHandlePointerActionFn`
  - [x] Find a better way to organize element pointer actions
- [x] Split up the checkHitTarget commit
  - [x] Move related commits to: #266's PR.
  - [x] Test: checkHitTarget
  - [x] Remove #266 related commits from here and rebase to it.

Closes: #171 