### PR TITLE
Release notes v0.3.0

### DIFF
--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -15,6 +15,9 @@ This is a minor release with some important bug fixes, a couple of new features,
 
   We maintain an internal list of popular devices with their viewport size, user agent and scaling factor, which is useful to test how a web site looks and behaves on different devices. See [this example](https://github.com/grafana/xk6-browser/blob/v0.3.0/examples/device_emulation.js) for details.
 
+- Made concealed elements clickable. ([#264](https://github.com/grafana/xk6-browser/pull/264))
+
+  We've added an automatic retry mechanism to improve the reliability of element and pointer actions. We will further improve this in future releases - hence our users' experience.
 
 
 ## Bugs fixed

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -66,6 +66,8 @@ This is a minor release with some important bug fixes, a couple of new features,
 
 - We have started updating our [JavaScript API documentation](https://k6.io/docs/javascript-api/xk6-browser/), which we know how important it is to serve as a reference while writing your scripts. This is an ardous task that won't be possible in a couple of weeks, but rest assured we're prioritizing it in all upcoming development cycles, and will be releasing gradual changes as they're done.
 
+- We added a [project roadmap](https://github.com/grafana/xk6-browser/blob/v0.3.0/ROADMAP.md) to share our development goals with the community.
+
 
 
 ## Internals

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -38,7 +38,14 @@ This is a minor release with some important bug fixes, a couple of new features,
 
 - Fixed `Page.waitForFunction()`. ([#294](https://github.com/grafana/xk6-browser/pull/294))
 
-  This was previously broken and untested, and with the fix all polling variants (`requestAnimationFrame`, DOM mutation and interval) should work correctly. See [this example](https://github.com/grafana/xk6-browser/blob/v0.3.0/examples/waitforfunction.js) for details.
+  `waitForFunction()` previously wasn't working. The fix is a rewrite of the feature that ensures all three polling variants work. Valid `polling` options are:
+  * `raf`: run the predicate function in a [`requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame) callback. This will run most frequently, up to 60 times a second.
+  * `mutation`: run the predicate function on every DOM mutation.
+  * number: run the predicate function at an interval, this many milliseconds apart.
+
+  Also note that this is now an async method that returns a `Promise`, so you must use `then()` to resolve it.
+
+  See [this example](https://github.com/grafana/xk6-browser/blob/v0.3.0/examples/waitforfunction.js) for details.
 
 - Fixed `Page.innerHTML()`, `Page.innerText()` and `Page.textContent()` panic. ([#299](https://github.com/grafana/xk6-browser/pull/299))
 

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -48,6 +48,8 @@ This is a minor release with some important bug fixes, a couple of new features,
 
 - Cleanly close the WebSocket connection when `Browser.close()` is called. ([#268](https://github.com/grafana/xk6-browser/pull/268))
 
+- Added lifecycle event validation to `Page.waitForLoadState()`. ([#300](https://github.com/grafana/xk6-browser/pull/300))
+
 - We have started updating our [JavaScript API documentation](https://k6.io/docs/javascript-api/xk6-browser/), which we know how important it is to serve as a reference while writing your scripts. This is an ardous task that won't be possible in a couple of weeks, but rest assured we're prioritizing it in all upcoming development cycles, and will be releasing gradual changes as they're done.
 
 

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -39,7 +39,7 @@ This is a minor release with some important bug fixes, a couple of new features,
 - Fixed `Page.waitForFunction()`. ([#294](https://github.com/grafana/xk6-browser/pull/294))
 
   `waitForFunction()` previously wasn't working. The fix is a rewrite of the feature that ensures all three polling variants work. Valid `polling` options are:
-  * `raf`: run the predicate function in a [`requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame) callback. This will run most frequently, up to 60 times a second.
+  * `raf` (default): run the predicate function in a [`requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame) callback. This will run most frequently, up to 60 times a second.
   * `mutation`: run the predicate function on every DOM mutation.
   * number: run the predicate function at an interval, this many milliseconds apart.
 

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -1,6 +1,6 @@
 xk6-browser v0.3.0 is here! :tada:
 
-This is a minor release with some important bug fixes, a couple of new features, some improvements, code refactors, and a long-overdue update to our [JavaScript API documentation](https://k6.io/docs/javascript-api/xk6-browser/)!
+This is a minor release with some important bug fixes, a couple of new features, improvements and code refactors!
 
 
 ## New features
@@ -46,7 +46,7 @@ This is a minor release with some important bug fixes, a couple of new features,
 
 - Cleanly close the WebSocket connection when `Browser.close()` is called. ([#268](https://github.com/grafana/xk6-browser/pull/268))
 
-- We have updated our [JavaScript API documentation](https://k6.io/docs/javascript-api/xk6-browser/), which is a helpful reference when writing your scripts. Check it out!
+- We have started updating our [JavaScript API documentation](https://k6.io/docs/javascript-api/xk6-browser/), which we know how important it is to serve as a reference while writing your scripts. This is an ardous task that won't be possible in a couple of weeks, but rest assured we're prioritizing it in all upcoming development cycles, and will be releasing gradual changes as they're done.
 
 
 

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -42,6 +42,10 @@ This is a minor release with some important bug fixes, a couple of new features,
 
 - Fixed `Page.innerHTML()`, `Page.innerText()` and `Page.textContent()` panic. ([#299](https://github.com/grafana/xk6-browser/pull/299))
 
+- Fixed the `executablePath` option. ([#246](https://github.com/grafana/xk6-browser/pull/246))
+
+  Although you could fill this option out, it wasn't working before, and we were using a predefined path by default. We implemented the option code, and you can now run a Chrome browser of your choice by providing the file path.
+
 
 ## Improvements
 

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -7,22 +7,10 @@ xk6-browser v0.3.0 is here! :tada:
 
 ## Bugs fixed
 
-- Immediately return when an element is not clickable. ([#264](https://github.com/grafana/xk6-browser/pull/264))
+- Make concealed elements clickable. ([#264](https://github.com/grafana/xk6-browser/pull/264))
 
-  xk6-browser was resulting in _"wait for selector did not result in any nodes" error when clicked on an element that was obscured by another element. Now it detects whether the element is behind an element, hence not clickable, and returns an error instead without waiting.
+  Previously, interacting with an element obscured by another was failing with `wait for selector did not result in any nodes`. Now we properly detect this scenario and retry the action with different scroll positions. This affects all `Element` and `Frame` `click()`, `dblclick()`, `hover()`, `check()`, `uncheck()` and `tap()` actions.
 
-  Affected actions by this fix:
-  * ElementHandle.Click
-  * ElementHandle.Dblclick
-  * ElementHandle.Hover
-  * ElementHandle.SetChecked
-  * ElementHandle.Tap
-  * Frame.Click
-  * Frame.Dblclick
-  * Frame.Hover
-  * Frame.Check
-  * Frame.Tap
-  * Frame.Uncheck
 
 
 ## Improvements
@@ -30,5 +18,3 @@ xk6-browser v0.3.0 is here! :tada:
 
 
 ## Internals
-
-

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -32,7 +32,7 @@ This is a minor release with some important bug fixes, a couple of new features,
 
 - Fixed keyboard press of special keys. ([#283](https://github.com/grafana/xk6-browser/pull/283))
 
-  Previously pressing some keys like Backspace, Delete, ArrowLeft and AltGraph would panic because of a wrong CDP argument.
+  Previously pressing some keys like Backspace, Delete, ArrowLeft, and AltGraph would panic.
 
 - Fixed negative metric emission in certain rare scenarios. ([#288](https://github.com/grafana/xk6-browser/pull/288))
 

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -57,5 +57,4 @@ This is a minor release with some important bug fixes, a couple of new features,
 - Several code refactors to improve maintainability. ([#269](https://github.com/grafana/xk6-browser/pull/269), [#293](https://github.com/grafana/xk6-browser/pull/293))
 
 - All dependencies were updated to their latest versions. ([#274](https://github.com/grafana/xk6-browser/pull/274))
-
-- Use new JS extension API. ([#286](https://github.com/grafana/xk6-browser/pull/286))
+  Specifically, k6 was updated to [v0.38.0](https://github.com/grafana/k6/releases/tag/v0.38.0), which required us to fix some breaking changes ([#286](https://github.com/grafana/xk6-browser/pull/286)), [#302](https://github.com/grafana/xk6-browser/pull/302)).

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -61,4 +61,4 @@ This is a minor release with some important bug fixes, a couple of new features,
 - Several code refactors to improve maintainability. ([#269](https://github.com/grafana/xk6-browser/pull/269), [#293](https://github.com/grafana/xk6-browser/pull/293))
 
 - All dependencies were updated to their latest versions. ([#274](https://github.com/grafana/xk6-browser/pull/274))
-  Specifically, k6 was updated to [v0.38.0](https://github.com/grafana/k6/releases/tag/v0.38.0), which required us to fix some breaking changes ([#286](https://github.com/grafana/xk6-browser/pull/286)), [#302](https://github.com/grafana/xk6-browser/pull/302)).
+  Specifically, k6 was updated to [v0.38.0](https://github.com/grafana/k6/releases/tag/v0.38.0), which required us to fix some breaking changes ([#286](https://github.com/grafana/xk6-browser/pull/286), [#302](https://github.com/grafana/xk6-browser/pull/302)).

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -1,6 +1,6 @@
 xk6-browser v0.3.0 is here! :tada:
 
-This is a minor release with some important bug fixes, a couple of new features, improvements and code refactors!
+This is a minor release with some important bug fixes, a couple of new features, improvements and code refactoring!
 
 
 ## New features

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -1,20 +1,61 @@
 xk6-browser v0.3.0 is here! :tada:
 
+This is a minor release with some important bug fixes, a couple of new features, some improvements, code refactors, and a long-overdue update to our [JavaScript API documentation](https://k6.io/docs/javascript-api/xk6-browser/)!
+
 
 ## New features
+
+- Implemented `Browser.on(event)`. ([#268](https://github.com/grafana/xk6-browser/pull/268), [#287](https://github.com/grafana/xk6-browser/pull/287))
+
+  `on('disconnected')` returns a `Promise` you can wait on to get notified when the WebSocket connection to the browser is closed. See [this example](https://github.com/grafana/xk6-browser/blob/v0.3.0/examples/browser_on.js) for details.
+
+  This is the first async method in xk6-browser, using the newly released [event loop support in k6](https://github.com/grafana/k6/pull/2228), and marks the start of our transition to async APIs. :tada:
+
+- Exposed preconfigured mobile device emulation settings. ([#289](https://github.com/grafana/xk6-browser/pull/289))
+
+  We maintain an internal list of popular devices with their viewport size, user agent and scaling factor, which is useful to test how a web site looks and behaves on different devices. See [this example](https://github.com/grafana/xk6-browser/blob/v0.3.0/examples/device_emulation.js) for details.
 
 
 
 ## Bugs fixed
 
-- Make concealed elements clickable. ([#264](https://github.com/grafana/xk6-browser/pull/264))
+- Made concealed elements clickable. ([#264](https://github.com/grafana/xk6-browser/pull/264))
 
   Previously, interacting with an element obscured by another was failing with `wait for selector did not result in any nodes`. Now we properly detect this scenario and retry the action with different scroll positions. This affects all `Element` and `Frame` `click()`, `dblclick()`, `hover()`, `check()`, `uncheck()` and `tap()` actions.
 
+- Fixed `waitForSelector()` flakiness by retrying once on failure. ([#260](https://github.com/grafana/xk6-browser/pull/260))
+
+- Fixed data race accessing `Frame.documentHandle` while switching execution contexts. ([#263](https://github.com/grafana/xk6-browser/pull/263))
+
+- Fixed keyboard press of special keys. ([#283](https://github.com/grafana/xk6-browser/pull/283))
+
+  Previously pressing some keys like Backspace, Delete, ArrowLeft and AltGraph would panic because of a wrong CDP argument.
+
+- Fixed negative metric emission in certain rare scenarios. ([#288](https://github.com/grafana/xk6-browser/pull/288))
+
+- Fixed `Page.waitForFunction()`. ([#294](https://github.com/grafana/xk6-browser/pull/294))
+
+  This was previously broken and untested, and with the fix all polling variants (`requestAnimationFrame`, DOM mutation and interval) should work correctly. See [this example](https://github.com/grafana/xk6-browser/blob/v0.3.0/examples/waitforfunction.js) for details.
 
 
 ## Improvements
 
+- Improved detection of non-clickable elements. ([#270](https://github.com/grafana/xk6-browser/pull/270))
+
+  We now properly detect elements obscured by another element and return an error instead of waiting. This enables the fix in [#264](https://github.com/grafana/xk6-browser/pull/264).
+
+- Cleanly close the WebSocket connection when `Browser.close()` is called. ([#268](https://github.com/grafana/xk6-browser/pull/268))
+
+- We have updated our [JavaScript API documentation](https://k6.io/docs/javascript-api/xk6-browser/), which is a helpful reference when writing your scripts. Check it out!
+
 
 
 ## Internals
+
+- Refactored the `chromium` package to fix linter issues and improve code structure. ([#246](https://github.com/grafana/xk6-browser/pull/246))
+
+- Several code refactors to improve maintainability. ([#269](https://github.com/grafana/xk6-browser/pull/269), [#293](https://github.com/grafana/xk6-browser/pull/293))
+
+- All dependencies were updated to their latest versions. ([#274](https://github.com/grafana/xk6-browser/pull/274))
+
+- Use new JS extension API. ([#286](https://github.com/grafana/xk6-browser/pull/286))

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -1,0 +1,34 @@
+xk6-browser v0.3.0 is here! :tada:
+
+
+## New features
+
+
+
+## Bugs fixed
+
+- Immediately return when an element is not clickable. ([#264](https://github.com/grafana/xk6-browser/pull/264))
+
+  xk6-browser was resulting in _"wait for selector did not result in any nodes" error when clicked on an element that was obscured by another element. Now it detects whether the element is behind an element, hence not clickable, and returns an error instead without waiting.
+
+  Affected actions by this fix:
+  * ElementHandle.Click
+  * ElementHandle.Dblclick
+  * ElementHandle.Hover
+  * ElementHandle.SetChecked
+  * ElementHandle.Tap
+  * Frame.Click
+  * Frame.Dblclick
+  * Frame.Hover
+  * Frame.Check
+  * Frame.Tap
+  * Frame.Uncheck
+
+
+## Improvements
+
+
+
+## Internals
+
+

--- a/release notes/v0.3.0.md
+++ b/release notes/v0.3.0.md
@@ -37,6 +37,8 @@ This is a minor release with some important bug fixes, a couple of new features,
 
   This was previously broken and untested, and with the fix all polling variants (`requestAnimationFrame`, DOM mutation and interval) should work correctly. See [this example](https://github.com/grafana/xk6-browser/blob/v0.3.0/examples/waitforfunction.js) for details.
 
+- Fixed `Page.innerHTML()`, `Page.innerText()` and `Page.textContent()` panic. ([#299](https://github.com/grafana/xk6-browser/pull/299))
+
 
 ## Improvements
 


### PR DESCRIPTION
TODO:

- [x] #264
- [x] #266 (Change it in the README from 264 to 266 after moving the commits)
- [x] #270
- [x] #270 — Explain ([this](https://github.com/grafana/xk6-browser/pull/270#issue-1164933984)): cdppage.GetLayoutMetrics now uses CSS layout metric when calculating the client's inner width and height (viewport) instead of depending on the first layout parameter ([deprecated](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-getLayoutMetrics) and was returning incorrect results).
- [x] #261
- [x] #258
- [x] #246 
- [x] #246 — Fixes `LaunchOptions.ExecutablePath`.
- [x] #269
- [x] #260