### PR TITLE
Fix keyboard press of special keys

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,11 @@ issues:
   # When true it disables revive's comment warnings, and we want them enabled.
   exclude-use-default: false
 
+  exclude-rules:
+    - linters:
+        - funlen
+      source: "^func Test"
+
 linters:
   disable-all: true
   enable:

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -197,6 +197,8 @@ func (k *Keyboard) keyDefinitionFromKey(key keyboardlayout.KeyInput) keyboardlay
 	var keyDef keyboardlayout.KeyDefinition
 	if srcKeyDef.Key != "" {
 		keyDef.Key = srcKeyDef.Key
+	}
+	if len(srcKeyDef.Key) == 1 {
 		keyDef.Text = srcKeyDef.Key
 	}
 	if shift != 0 && srcKeyDef.ShiftKeyCode != 0 {

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -1,0 +1,64 @@
+package tests
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/keyboardlayout"
+)
+
+func TestKeyboardPress(t *testing.T) {
+	tb := newTestBrowser(t)
+
+	t.Run("all_keys", func(t *testing.T) {
+		p := tb.NewPage(nil)
+		cp, ok := p.(*common.Page)
+		require.True(t, ok)
+		kb := cp.Keyboard
+		layout := keyboardlayout.GetKeyboardLayout("us")
+
+		assert.NotPanics(t, func() {
+			for k := range layout.Keys {
+				kb.Press(string(k), nil)
+			}
+		})
+	})
+
+	t.Run("backspace", func(t *testing.T) {
+		p := tb.NewPage(nil)
+		cp, ok := p.(*common.Page)
+		require.True(t, ok)
+		kb := cp.Keyboard
+
+		p.SetContent(`<input>`, nil)
+		el := p.Query("input")
+		p.Focus("input", nil)
+
+		kb.Type("Hello World!", nil)
+		require.Equal(t, "Hello World!", el.InputValue(nil))
+
+		kb.Press("Backspace", nil)
+		assert.Equal(t, "Hello World", el.InputValue(nil))
+	})
+
+	t.Run("newline", func(t *testing.T) {
+		p := tb.NewPage(nil)
+		cp, ok := p.(*common.Page)
+		require.True(t, ok)
+		kb := cp.Keyboard
+
+		p.SetContent(`<textarea>`, nil)
+		el := p.Query("textarea")
+		p.Focus("textarea", nil)
+
+		kb.Type("Hello", nil)
+		kb.Press("Enter", nil)
+		kb.Press("Enter", nil)
+		kb.Type("World!", nil)
+		assert.Equal(t, "Hello\n\nWorld!", el.InputValue(nil))
+	})
+}

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	_ "embed"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,6 +46,32 @@ func TestKeyboardPress(t *testing.T) {
 		assert.Equal(t, "Hello World", el.InputValue(nil))
 	})
 
+	t.Run("combo", func(t *testing.T) {
+		t.Skip("FIXME") // See https://github.com/grafana/xk6-browser/issues/285
+		p := tb.NewPage(nil)
+		cp, ok := p.(*common.Page)
+		require.True(t, ok)
+		kb := cp.Keyboard
+
+		p.SetContent(`<input>`, nil)
+		el := p.Query("input")
+		p.Focus("input", nil)
+
+		kb.Press("Shift+KeyA", nil)
+		kb.Press("Shift+b", nil)
+		kb.Press("C", nil)
+		kb.Press("d", nil)
+		require.Equal(t, "AbCd", el.InputValue(nil))
+
+		metaKey := "Control"
+		if runtime.GOOS == "darwin" {
+			metaKey = "Meta"
+		}
+		kb.Press(metaKey+"+A", nil)
+		kb.Press("Delete", nil)
+		assert.Equal(t, "", el.InputValue(nil))
+	})
+
 	t.Run("newline", func(t *testing.T) {
 		p := tb.NewPage(nil)
 		cp, ok := p.(*common.Page)
@@ -60,5 +87,34 @@ func TestKeyboardPress(t *testing.T) {
 		kb.Press("Enter", nil)
 		kb.Type("World!", nil)
 		assert.Equal(t, "Hello\n\nWorld!", el.InputValue(nil))
+	})
+
+	// Replicates the test from https://playwright.dev/docs/api/class-keyboard
+	t.Run("selection", func(t *testing.T) {
+		t.Skip("FIXME") // See https://github.com/grafana/xk6-browser/issues/284
+		p := tb.NewPage(nil)
+		cp, ok := p.(*common.Page)
+		require.True(t, ok)
+		kb := cp.Keyboard
+
+		p.SetContent(`<input>`, nil)
+		el := p.Query("input")
+		p.Focus("input", nil)
+
+		kb.Type("Hello World!", nil)
+		require.Equal(t, "Hello World!", el.InputValue(nil))
+
+		kb.Press("ArrowLeft", nil)
+		// Should hold the key until Up() is called.
+		kb.Down("Shift")
+		for i := 0; i < len(" World"); i++ {
+			kb.Press("ArrowLeft", nil)
+		}
+		// Should release the key but the selection should remain active.
+		kb.Up("Shift")
+		// Should delete the selection.
+		kb.Press("Backspace", nil)
+
+		assert.Equal(t, "Hello!", el.InputValue(nil))
 	})
 }


### PR DESCRIPTION
Previously pressing some keys like Backspace, Delete, ArrowLeft and AltGraph would panic because we were sending an unsupported `text` argument in the [`Input.dispatchKeyEvent` command](https://chromedevtools.github.io/devtools-protocol/tot/Input/#method-dispatchKeyEvent). The fix simply does this only for single character keys, and replicates [what Puppeteer does](https://github.com/puppeteer/puppeteer/blob/7659bf92e6f2e4efe8edef6d326cbeca358a995b/src/common/Input.ts#L159).

I added some tests for currently missing functionality that Playwright supports, and will create issues for fixing them (see #284 and #285).

Fixes #239