### PR TITLE
Add `Browser.On` integration tests

### DIFF
--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	k6common "go.k6.io/k6/js/common"
+	k6eventloop "go.k6.io/k6/js/eventloop"
 	k6modulestest "go.k6.io/k6/js/modulestest"
 	k6lib "go.k6.io/k6/lib"
 	k6metrics "go.k6.io/k6/lib/metrics"
@@ -276,6 +277,9 @@ func newMockVU(tb testing.TB) *k6modulestest.VU {
 	}
 	ctx := WithVU(context.Background(), mockVU)
 	mockVU.CtxField = ctx
+
+	loop := k6eventloop.New(mockVU)
+	mockVU.RegisterCallbackField = loop.RegisterCallback
 
 	return mockVU
 }

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -30,7 +30,6 @@ import (
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/require"
 	k6http "go.k6.io/k6/js/modules/k6/http"
-	k6modulestest "go.k6.io/k6/js/modulestest"
 	k6lib "go.k6.io/k6/lib"
 	k6httpmultibin "go.k6.io/k6/lib/testutils/httpmultibin"
 	k6stats "go.k6.io/k6/stats"
@@ -42,11 +41,14 @@ import (
 
 // testBrowser is a test testBrowser for integration testing.
 type testBrowser struct {
-	t        testing.TB
+	t testing.TB
+	// TODO: Consider dropping the rt, state and samples fields since they're
+	// accessible via vu.
 	ctx      context.Context
 	rt       *goja.Runtime
 	state    *k6lib.State
 	http     *k6httpmultibin.HTTPMultiBin
+	vu       *mockVU
 	logCache *logCache
 	samples  chan<- k6stats.SampleContainer
 	api.Browser
@@ -132,6 +134,7 @@ func newTestBrowser(tb testing.TB, opts ...interface{}) *testBrowser {
 		rt:       rt,
 		state:    state,
 		http:     testServer,
+		vu:       mockVU,
 		samples:  state.Samples,
 		logCache: lc,
 		Browser:  b,
@@ -295,7 +298,7 @@ func withLogCache() logCacheOption {
 	return struct{}{}
 }
 
-func setupHTTPTestModuleInstance(tb testing.TB) *k6modulestest.VU {
+func setupHTTPTestModuleInstance(tb testing.TB) *mockVU {
 	tb.Helper()
 
 	var (

--- a/tests/test_context.go
+++ b/tests/test_context.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	k6common "go.k6.io/k6/js/common"
+	k6eventloop "go.k6.io/k6/js/eventloop"
 	k6modulestest "go.k6.io/k6/js/modulestest"
 	k6lib "go.k6.io/k6/lib"
 	k6metrics "go.k6.io/k6/lib/metrics"
@@ -56,6 +57,9 @@ func newMockVU(tb testing.TB) *k6modulestest.VU {
 	ctx := context.Background()
 	ctx = common.WithVU(ctx, mockVU)
 	mockVU.CtxField = ctx
+
+	loop := k6eventloop.New(mockVU)
+	mockVU.RegisterCallbackField = loop.RegisterCallback
 
 	return mockVU
 }


### PR DESCRIPTION
This adds missing integration tests for `Browser.On` that weren't possible before https://github.com/grafana/k6/pull/2399 was merged. It also does minor refactoring to expose some fields to the test, and allow closing the browser from the test. See the commits for details.

Closes #95