### PR TITLE
Fix negative metric emission

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -359,6 +359,15 @@ func (f *Frame) emitMetric(m *k6stats.Metric, t time.Time) {
 	f.log.Debugf("Frame:emitMetric", "fid:%s furl:%q m:%s init:%q t:%q v:%f",
 		f.ID(), f.URL(), m.Name, f.initTime, t, value)
 
+	if f.initTime.IsZero() {
+		// Internal race condition: we haven't processed the init/commit event
+		// yet, so the value will be wrong and emitting the metric would skew
+		// the results (i.e. the value would be in the order of years). Choose
+		// the lesser of 2 wrongs for now and ignore it instead.
+		// See https://github.com/grafana/xk6-browser/discussions/142#discussioncomment-2416943
+		return
+	}
+
 	state := f.vu.State()
 	tags := state.CloneTags()
 	if state.Options.SystemTags.Has(k6stats.TagURL) {


### PR DESCRIPTION
This issue happened when receiving `Page.lifecycleEvent`s for different frames which overwrote the global `FrameSession.initTime` value on which the metric value calculation was being done.

The fix is simple: store the `init` time on `Frame` instead and calculate the elapsed time per frame, since the metric emission is done per frame anyway. Unfortunately this exposes another issue worked around by 47d9e82, but should ultimately be fixed by fixing the racy way CDP events are handled; some discussion about this [here](https://github.com/grafana/xk6-browser/discussions/142).

I tried to explain both behaviors in [this comment](https://github.com/grafana/xk6-browser/issues/191#issuecomment-1086016760).

This also does some refactoring to DRY things.

I didn't add any tests since the issue is only reproducible (~1/10 runs) with the script from [this comment](https://github.com/grafana/xk6-browser/pull/117#issuecomment-1002521620), which tests a very complex site, and reproducing it in an integration or unit test would be very difficult, and likely flaky since we would have to depend on sleep. That said, I've run the script dozens of times and couldn't reproduce the issue anymore. **Please test it yourself and report any weirdness.**

Closes #191