### PR TITLE
Fix `{Page,Frame}.{innerHTML,innerText,textContent}`

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -1009,6 +1009,7 @@ func (f *Frame) InnerHTML(selector string, opts goja.Value) string {
 	return val.ToString().String()
 }
 
+// InnerText returns the innerText attribute of the element located by selector.
 func (f *Frame) InnerText(selector string, opts goja.Value) string {
 	f.log.Debugf("Frame:InnerText", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
@@ -1029,7 +1030,17 @@ func (f *Frame) InnerText(selector string, opts goja.Value) string {
 	}
 
 	applySlowMo(f.ctx)
-	return value.(string)
+
+	if value == nil {
+		return ""
+	}
+
+	val, ok := value.(goja.Value)
+	if !ok {
+		k6Throw(f.ctx, "unexpected innerText value type: %T", value)
+	}
+
+	return val.ToString().String()
 }
 
 func (f *Frame) InputValue(selector string, opts goja.Value) string {

--- a/common/frame.go
+++ b/common/frame.go
@@ -1425,6 +1425,7 @@ func (f *Frame) Tap(selector string, opts goja.Value) {
 	applySlowMo(f.ctx)
 }
 
+// TextContent returns the textContent attribute of the element located by selector.
 func (f *Frame) TextContent(selector string, opts goja.Value) string {
 	f.log.Debugf("Frame:TextContent", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
@@ -1445,7 +1446,17 @@ func (f *Frame) TextContent(selector string, opts goja.Value) string {
 	}
 
 	applySlowMo(f.ctx)
-	return value.(string)
+
+	if value == nil {
+		return ""
+	}
+
+	val, ok := value.(goja.Value)
+	if !ok {
+		k6Throw(f.ctx, "unexpected textContent value type: %T", value)
+	}
+
+	return val.ToString().String()
 }
 
 func (f *Frame) Title() string {

--- a/common/frame.go
+++ b/common/frame.go
@@ -975,6 +975,7 @@ func (f *Frame) Hover(selector string, opts goja.Value) {
 	applySlowMo(f.ctx)
 }
 
+// InnerHTML returns the innerHTML attribute of the element located by selector.
 func (f *Frame) InnerHTML(selector string, opts goja.Value) string {
 	f.log.Debugf("Frame:InnerHTML", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
@@ -995,7 +996,17 @@ func (f *Frame) InnerHTML(selector string, opts goja.Value) string {
 	}
 
 	applySlowMo(f.ctx)
-	return value.(string)
+
+	if value == nil {
+		return ""
+	}
+
+	val, ok := value.(goja.Value)
+	if !ok {
+		k6Throw(f.ctx, "unexpected innerHTML value type: %T", value)
+	}
+
+	return val.ToString().String()
 }
 
 func (f *Frame) InnerText(selector string, opts goja.Value) string {

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -214,6 +214,41 @@ func TestPageInnerHTML(t *testing.T) {
 	})
 }
 
+func TestPageInnerText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestBrowser(t).NewPage(nil)
+		p.SetContent(sampleHTML, nil)
+		assert.Equal(t, "Test\nOne", p.InnerText("div", nil))
+	})
+
+	t.Run("err_empty_selector", func(t *testing.T) {
+		t.Parallel()
+
+		defer func() {
+			assertPanicErrorContains(t, recover(), "The provided selector is empty")
+		}()
+
+		p := newTestBrowser(t).NewPage(nil)
+		p.InnerText("", nil)
+		t.Error("did not panic")
+	})
+
+	t.Run("err_wrong_selector", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t)
+		p := tb.NewPage(nil)
+		p.SetContent(sampleHTML, nil)
+		assert.Equal(t, "", p.InnerText("p", tb.rt.ToValue(jsFrameBaseOpts{
+			Timeout: "100",
+		})))
+	})
+}
+
 func TestPageInputValue(t *testing.T) {
 	p := newTestBrowser(t).NewPage(nil)
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -249,6 +249,41 @@ func TestPageInnerText(t *testing.T) {
 	})
 }
 
+func TestPageTextContent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestBrowser(t).NewPage(nil)
+		p.SetContent(sampleHTML, nil)
+		assert.Equal(t, "TestOne", p.TextContent("div", nil))
+	})
+
+	t.Run("err_empty_selector", func(t *testing.T) {
+		t.Parallel()
+
+		defer func() {
+			assertPanicErrorContains(t, recover(), "The provided selector is empty")
+		}()
+
+		p := newTestBrowser(t).NewPage(nil)
+		p.TextContent("", nil)
+		t.Error("did not panic")
+	})
+
+	t.Run("err_wrong_selector", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t)
+		p := tb.NewPage(nil)
+		p.SetContent(sampleHTML, nil)
+		assert.Equal(t, "", p.TextContent("p", tb.rt.ToValue(jsFrameBaseOpts{
+			Timeout: "100",
+		})))
+	})
+}
+
 func TestPageInputValue(t *testing.T) {
 	p := newTestBrowser(t).NewPage(nil)
 


### PR DESCRIPTION
Previously these would panic with `interface conversion: interface {} is goja.asciiString, not string`.

Most of this could be DRY'd, including the tests, but I didn't bother with any refactors.

This is based on #298, so let's merge that first.

Thanks to @wardbekker for pointing out this issue!