### PR TITLE
Add lifecycle event validation to `WaitForLoadState`

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -1583,12 +1583,9 @@ func (f *Frame) WaitForLoadState(state string, opts goja.Value) {
 		k6Throw(f.ctx, "cannot parse waitForLoadState options: %v", err)
 	}
 
-	waitUntil := LifecycleEventLoad
-	switch state {
-	case "domcontentloaded":
-		waitUntil = LifecycleEventDOMContentLoad
-	case "networkidle":
-		waitUntil = LifecycleEventNetworkIdle
+	var waitUntil LifecycleEvent
+	if err = waitUntil.UnmarshalText([]byte(state)); err != nil {
+		k6Throw(f.ctx, "waitForLoadState error: %v", err)
 	}
 
 	if f.hasLifecycleEventFired(waitUntil) {

--- a/common/frame.go
+++ b/common/frame.go
@@ -1583,9 +1583,11 @@ func (f *Frame) WaitForLoadState(state string, opts goja.Value) {
 		k6Throw(f.ctx, "cannot parse waitForLoadState options: %v", err)
 	}
 
-	var waitUntil LifecycleEvent
-	if err = waitUntil.UnmarshalText([]byte(state)); err != nil {
-		k6Throw(f.ctx, "waitForLoadState error: %v", err)
+	waitUntil := LifecycleEventLoad
+	if state != "" {
+		if err = waitUntil.UnmarshalText([]byte(state)); err != nil {
+			k6Throw(f.ctx, "waitForLoadState error: %v", err)
+		}
 	}
 
 	if f.hasLifecycleEventFired(waitUntil) {

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -678,10 +678,8 @@ func (o *FrameWaitForNavigationOptions) Parse(ctx context.Context, opts goja.Val
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			case "waitUntil":
 				lifeCycle := opts.Get(k).String()
-				if l, ok := lifecycleEventToID[lifeCycle]; ok {
-					o.WaitUntil = l
-				} else {
-					return fmt.Errorf("%q is not a valid lifecycle", lifeCycle)
+				if err := o.WaitUntil.UnmarshalText([]byte(lifeCycle)); err != nil {
+					return fmt.Errorf("error parsing waitForNavigation options: %w", err)
 				}
 			}
 		}

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -502,10 +502,8 @@ func (o *FrameSetContentOptions) Parse(ctx context.Context, opts goja.Value) err
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			case "waitUntil":
 				lifeCycle := opts.Get(k).String()
-				if l, ok := lifecycleEventToID[lifeCycle]; ok {
-					o.WaitUntil = l
-				} else {
-					return fmt.Errorf("%q is not a valid lifecycle", lifeCycle)
+				if err := o.WaitUntil.UnmarshalText([]byte(lifeCycle)); err != nil {
+					return fmt.Errorf("error parsing setContent options: %w", err)
 				}
 			}
 		}

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -297,10 +297,8 @@ func (o *FrameGotoOptions) Parse(ctx context.Context, opts goja.Value) error {
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			case "waitUntil":
 				lifeCycle := opts.Get(k).String()
-				if l, ok := lifecycleEventToID[lifeCycle]; ok {
-					o.WaitUntil = l
-				} else {
-					return fmt.Errorf("%q is not a valid lifecycle", lifeCycle)
+				if err := o.WaitUntil.UnmarshalText([]byte(lifeCycle)); err != nil {
+					return fmt.Errorf("error parsing goto options: %w", err)
 				}
 			}
 		}

--- a/common/frame_options_test.go
+++ b/common/frame_options_test.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrameWaitForNavigationOptionsParse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		mockVU := newMockVU(t)
+		opts := mockVU.RuntimeField.ToValue(map[string]interface{}{
+			"url":       "https://example.com/",
+			"timeout":   "1000",
+			"waitUntil": "networkidle",
+		})
+		navOpts := NewFrameWaitForNavigationOptions(0)
+		err := navOpts.Parse(mockVU.CtxField, opts)
+		require.NoError(t, err)
+
+		assert.Equal(t, "https://example.com/", navOpts.URL)
+		assert.Equal(t, time.Second, navOpts.Timeout)
+		assert.Equal(t, LifecycleEventNetworkIdle, navOpts.WaitUntil)
+	})
+
+	t.Run("err/invalid_waitUntil", func(t *testing.T) {
+		t.Parallel()
+
+		mockVU := newMockVU(t)
+		opts := mockVU.RuntimeField.ToValue(map[string]interface{}{
+			"waitUntil": "none",
+		})
+		navOpts := NewFrameWaitForNavigationOptions(0)
+		err := navOpts.Parse(mockVU.CtxField, opts)
+
+		assert.EqualError(t, err,
+			`error parsing waitForNavigation options: `+
+				`invalid lifecycle event: "none"; must be one of: `+
+				`load, domcontentloaded, networkidle`)
+	})
+}

--- a/common/frame_options_test.go
+++ b/common/frame_options_test.go
@@ -45,6 +45,41 @@ func TestFrameGotoOptionsParse(t *testing.T) {
 	})
 }
 
+func TestFrameSetContentOptionsParse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		mockVU := newMockVU(t)
+		opts := mockVU.RuntimeField.ToValue(map[string]interface{}{
+			"waitUntil": "networkidle",
+		})
+		scOpts := NewFrameSetContentOptions(30 * time.Second)
+		err := scOpts.Parse(mockVU.CtxField, opts)
+		require.NoError(t, err)
+
+		assert.Equal(t, 30*time.Second, scOpts.Timeout)
+		assert.Equal(t, LifecycleEventNetworkIdle, scOpts.WaitUntil)
+	})
+
+	t.Run("err/invalid_waitUntil", func(t *testing.T) {
+		t.Parallel()
+
+		mockVU := newMockVU(t)
+		opts := mockVU.RuntimeField.ToValue(map[string]interface{}{
+			"waitUntil": "none",
+		})
+		navOpts := NewFrameSetContentOptions(0)
+		err := navOpts.Parse(mockVU.CtxField, opts)
+
+		assert.EqualError(t, err,
+			`error parsing setContent options: `+
+				`invalid lifecycle event: "none"; must be one of: `+
+				`load, domcontentloaded, networkidle`)
+	})
+}
+
 func TestFrameWaitForNavigationOptionsParse(t *testing.T) {
 	t.Parallel()
 

--- a/common/types.go
+++ b/common/types.go
@@ -26,6 +26,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
+	"strings"
 
 	"github.com/dop251/goja"
 
@@ -275,6 +277,47 @@ func (l *LifecycleEvent) UnmarshalJSON(b []byte) error {
 	}
 	// Note that if the string cannot be found then it will be set to the zero value.
 	*l = lifecycleEventToID[j]
+	return nil
+}
+
+// MarshalText returns the string representation of the enum value.
+// It returns an error if the enum value is invalid.
+func (l *LifecycleEvent) MarshalText() ([]byte, error) {
+	if l == nil {
+		return []byte(""), nil
+	}
+	var (
+		ok bool
+		s  string
+	)
+	if s, ok = lifecycleEventToString[*l]; !ok {
+		return nil, fmt.Errorf("invalid lifecycle event: %v", int(*l))
+	}
+
+	return []byte(s), nil
+}
+
+// UnmarshalText unmarshals a text representation to the enum value.
+// It returns an error if given a wrong value.
+func (l *LifecycleEvent) UnmarshalText(text []byte) error {
+	var (
+		ok  bool
+		val = string(text)
+	)
+
+	if *l, ok = lifecycleEventToID[val]; !ok {
+		valid := make([]string, 0, len(lifecycleEventToID))
+		for k := range lifecycleEventToID {
+			valid = append(valid, k)
+		}
+		sort.Slice(valid, func(i, j int) bool {
+			return lifecycleEventToID[valid[j]] > lifecycleEventToID[valid[i]]
+		})
+		return fmt.Errorf(
+			"invalid lifecycle event: %q; must be one of: %s",
+			val, strings.Join(valid, ", "))
+	}
+
 	return nil
 }
 

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // See: Issue #183 for details.
@@ -59,4 +60,72 @@ func TestViewportCalculateInset(t *testing.T) {
 			}, "inset for %q should not be the same as the default one", os)
 		})
 	}
+}
+
+func TestLifecycleEventMarshalText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok/nil", func(t *testing.T) {
+		t.Parallel()
+
+		var evt *LifecycleEvent
+		m, err := evt.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, []byte(""), m)
+	})
+
+	t.Run("err/invalid", func(t *testing.T) {
+		t.Parallel()
+
+		evt := LifecycleEvent(-1)
+		_, err := evt.MarshalText()
+		require.EqualError(t, err, "invalid lifecycle event: -1")
+	})
+}
+
+func TestLifecycleEventMarshalTextRound(t *testing.T) {
+	t.Parallel()
+
+	evt := LifecycleEventLoad
+	m, err := evt.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("load"), m)
+
+	var evt2 LifecycleEvent
+	err = evt2.UnmarshalText(m)
+	require.NoError(t, err)
+	assert.Equal(t, evt, evt2)
+}
+
+func TestLifecycleEventUnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		var evt LifecycleEvent
+		err := evt.UnmarshalText([]byte("load"))
+		require.NoError(t, err)
+		assert.Equal(t, LifecycleEventLoad, evt)
+	})
+
+	t.Run("err/invalid", func(t *testing.T) {
+		t.Parallel()
+
+		var evt LifecycleEvent
+		err := evt.UnmarshalText([]byte("none"))
+		require.EqualError(t, err,
+			`invalid lifecycle event: "none"; `+
+				`must be one of: load, domcontentloaded, networkidle`)
+	})
+
+	t.Run("err/invalid_empty", func(t *testing.T) {
+		t.Parallel()
+
+		var evt LifecycleEvent
+		err := evt.UnmarshalText([]byte(""))
+		require.EqualError(t, err,
+			`invalid lifecycle event: ""; `+
+				`must be one of: load, domcontentloaded, networkidle`)
+	})
 }

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -629,6 +629,26 @@ func TestPageWaitForFunction(t *testing.T) {
 	})
 }
 
+func TestPageWaitForLoadState(t *testing.T) {
+	t.Parallel()
+
+	// TODO: Add happy path tests once WaitForLoadState is not racy.
+
+	t.Run("err_wrong_event", func(t *testing.T) {
+		t.Parallel()
+
+		defer func() {
+			assertPanicErrorContains(t, recover(),
+				`invalid lifecycle event: "none"; `+
+					`must be one of: load, domcontentloaded, networkidle`)
+		}()
+
+		p := newTestBrowser(t).NewPage(nil)
+		p.WaitForLoadState("none", nil)
+		t.Error("did not panic")
+	})
+}
+
 // See: The issue #187 for details.
 func TestPageWaitForNavigationShouldNotPanic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -645,8 +665,7 @@ func assertPanicErrorContains(t *testing.T, err interface{}, expErrMsg string) {
 	require.IsType(t, &goja.Object{}, err)
 	gotObj, _ := err.(*goja.Object)
 	got := gotObj.Export()
-	expErr := fmt.Errorf("%w", errors.New(expErrMsg))
-	require.IsType(t, expErr, got)
+	expErr := errors.New(expErrMsg)
 	gotErr, ok := got.(error)
 	require.True(t, ok)
 	assert.Contains(t, gotErr.Error(), expErr.Error())


### PR DESCRIPTION
Previously if the user passed an invalid lifecycle event value in `page.waitForLoadState()` options, we would silently default to `load`, which might not have been the intention. This PR validates the value in `LifecycleEvent.UnmarshalText()` and fails the test with an error if it's invalid. It also reuses the validation in other parts where `LifecycleEvent` is used, such as in `Frame.Goto`, `Frame.SetContent` and `Frame.WaitForNavigation` options, which all used their own validation returning a less informative error.

Ideally lifecycle events should be exported as JS symbols to avoid typo situations, and so that we can have type definitons for them, but this is a stopgap solution until then.

Thanks to @wardbekker for reminding us about this!