### PR TITLE
Do `waitForFunction` predicate truthy check inside `injected_script.js`

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -591,10 +591,7 @@ func (f *Frame) waitForFunction(
 
 	pageFn := `
 		(injected, predicate, polling, timeout, ...args) => {
-			const fn = (...args) => {
-				return predicate(...args) || injected.continuePolling;
-			}
-			return injected.waitForPredicateFunction(fn, polling, timeout, ...args);
+			return injected.waitForPredicateFunction(predicate, polling, timeout, ...args);
 		}
 	`
 


### PR DESCRIPTION
This avoids having to export `continuePolling` and doing the check from the wrapper function in Go, since it's really a JS implementation detail. It also hopefully avoids [the need for a comment explaining internal details of injected_script](https://github.com/grafana/xk6-browser/pull/294/files#r866750362).