### PR TITLE
Fix zombie browser processes

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -162,6 +162,12 @@ func (b *Browser) initEvents() error {
 	}, chHandler)
 
 	go func() {
+		defer func() {
+			b.browserProc.didLoseConnection()
+			if b.cancelFn != nil {
+				b.cancelFn()
+			}
+		}()
 		for {
 			select {
 			case <-cancelCtx.Done():
@@ -175,8 +181,6 @@ func (b *Browser) initEvents() error {
 					b.onDetachedFromTarget(ev)
 				} else if event.typ == EventConnectionClose {
 					b.logger.Debugf("Browser:initEvents:EventConnectionClose", "")
-					b.browserProc.didLoseConnection()
-					b.cancelFn()
 					return
 				}
 			}

--- a/common/browser.go
+++ b/common/browser.go
@@ -163,6 +163,7 @@ func (b *Browser) initEvents() error {
 
 	go func() {
 		defer func() {
+			b.logger.Debugf("Browser:initEvents:defer", "ctx err: %v", cancelCtx.Err())
 			b.browserProc.didLoseConnection()
 			if b.cancelFn != nil {
 				b.cancelFn()


### PR DESCRIPTION
This PR fixes #305 by closing browser processes when the context is canceled.

Before this fix, browser processes remained active even after the test or k6 test runs. Hundreds of zombie browser processes were left, especially for local testing.

Fixes: #305