### PR TITLE
Implement page.locator(selector)

### DIFF
--- a/api/frame.go
+++ b/api/frame.go
@@ -52,6 +52,8 @@ type Frame interface {
 	IsVisible(selector string, opts goja.Value) bool
 	ID() string
 	LoaderID() string
+	// Locator creates and returns a new locator for this frame.
+	Locator(selector string, opts goja.Value) Locator
 	Name() string
 	Query(selector string) ElementHandle
 	QueryAll(selector string) []ElementHandle

--- a/api/locator.go
+++ b/api/locator.go
@@ -1,0 +1,4 @@
+package api
+
+// Locator represents a way to find element(s) on a page at any moment.
+type Locator interface{}

--- a/api/page.go
+++ b/api/page.go
@@ -61,6 +61,8 @@ type Page interface {
 	IsEnabled(selector string, opts goja.Value) bool
 	IsHidden(selector string, opts goja.Value) bool
 	IsVisible(selector string, opts goja.Value) bool
+	// Locator creates and returns a new locator for this page (main frame).
+	Locator(selector string, opts goja.Value) Locator
 	MainFrame() Frame
 	Opener() Page
 	Pause()

--- a/common/frame.go
+++ b/common/frame.go
@@ -1249,6 +1249,13 @@ func (f *Frame) ID() string {
 	return f.id.String()
 }
 
+// Locator creates and returns a new locator for this frame.
+func (f *Frame) Locator(selector string, opts goja.Value) api.Locator {
+	f.log.Debugf("Frame:Locator", "fid:%s furl:%q selector:%q opts:%+v", f.ID(), f.URL(), selector, opts)
+
+	return NewLocator(f.ctx, selector, f, f.log)
+}
+
 // LoaderID returns the ID of the frame that loaded this frame.
 func (f *Frame) LoaderID() string {
 	f.propertiesMu.RLock()

--- a/common/locator.go
+++ b/common/locator.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"context"
+)
+
+// Locator represent a way to find element(s) on the page at any moment.
+type Locator struct {
+	selector string
+
+	frame *Frame
+
+	ctx context.Context
+	log *Logger
+}
+
+// NewLocator creates and returns a new locator.
+func NewLocator(ctx context.Context, selector string, f *Frame, l *Logger) *Locator {
+	return &Locator{
+		selector: selector,
+		frame:    f,
+		ctx:      ctx,
+		log:      l,
+	}
+}

--- a/common/logger.go
+++ b/common/logger.go
@@ -85,6 +85,9 @@ func (l *Logger) Warnf(category string, msg string, args ...interface{}) {
 }
 
 func (l *Logger) Logf(level logrus.Level, category string, msg string, args ...interface{}) {
+	if l == nil {
+		return
+	}
 	// don't log if the current log level isn't in the required level.
 	if l.log.GetLevel() < level {
 		return

--- a/common/page.go
+++ b/common/page.go
@@ -615,6 +615,13 @@ func (p *Page) IsVisible(selector string, opts goja.Value) bool {
 	return p.MainFrame().IsVisible(selector, opts)
 }
 
+// Locator creates and returns a new locator for this page (main frame).
+func (p *Page) Locator(selector string, opts goja.Value) api.Locator {
+	p.logger.Debugf("Page:Locator", "sid:%s sel: %q opts:%+v", p.sessionID(), selector, opts)
+
+	return p.MainFrame().Locator(selector, opts)
+}
+
 // MainFrame returns the main frame on the page.
 func (p *Page) MainFrame() api.Frame {
 	mf := p.frameManager.MainFrame()

--- a/common/page_test.go
+++ b/common/page_test.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPageLocator can be removed later on when we add integration
+// tests. Since we don't yet have any of them, it makes sense to keep
+// this test.
+func TestPageLocator(t *testing.T) {
+	const (
+		wantMainFrameID = "1"
+		wantSelector    = "span"
+	)
+	ctx := context.TODO()
+	p := &Page{
+		ctx: ctx,
+		frameManager: &FrameManager{
+			ctx:       ctx,
+			mainFrame: &Frame{id: wantMainFrameID, ctx: ctx},
+		},
+	}
+	l := p.Locator(wantSelector, nil).(*Locator) //nolint:forcetypeassert
+	assert.Equal(t, wantSelector, l.selector)
+	assert.Equal(t, wantMainFrameID, string(l.frame.id))
+
+	// other behavior will be tested via integration tests
+}


### PR DESCRIPTION
This PR aims to add support for creating and returning a new page locator. As explained in issue #308, this PR won't add support for locator options yet.

**Notes to the reviewer**

* Please read issues #100 and #308 to understand what is a `Locator`.
* Check the Playwright documentation to see whether we're implementing the API correctly.
* Thanks!

**TODO**

- [x] Add the `Locator` method to `Page` and `Frame` in `api`
- [x] Add the `Locator` method to `Page` and `Frame` in `common`
- [x] Unit test `Page.Locator`
- [x] Disable the logger if it is nil

Closes: #308