### PR TITLE
Add grant permissions support to BrowserContext

### DIFF
--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -22,6 +22,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dop251/goja"
 )
@@ -116,8 +117,11 @@ func (b *BrowserContextOptions) Parse(ctx context.Context, opts goja.Value) erro
 			case "offline":
 				b.Offline = opts.Get(k).ToBoolean()
 			case "permissions":
-				permissions := opts.Get(k).Export().([]string)
-				b.Permissions = append(b.Permissions, permissions...)
+				if ps, ok := opts.Get(k).Export().([]interface{}); ok {
+					for _, p := range ps {
+						b.Permissions = append(b.Permissions, fmt.Sprintf("%v", p))
+					}
+				}
 			case "reducedMotion":
 				switch ReducedMotion(opts.Get(k).String()) {
 				case "reduce":

--- a/common/browser_context_options_test.go
+++ b/common/browser_context_options_test.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBrowserContextOptionsPermissions(t *testing.T) {
+	vu := newMockVU(t)
+
+	var opts BrowserContextOptions
+	err := opts.Parse(vu.CtxField, vu.RuntimeField.ToValue((struct {
+		Permissions []interface{} `js:"permissions"`
+	}{
+		Permissions: []interface{}{"camera", "microphone"},
+	})))
+	assert.NoError(t, err)
+	assert.Len(t, opts.Permissions, 2)
+	assert.Equal(t, opts.Permissions, []string{"camera", "microphone"})
+}

--- a/examples/grant_permission.js
+++ b/examples/grant_permission.js
@@ -1,0 +1,20 @@
+import launcher from 'k6/x/browser';
+
+export default function () {
+  const browser = launcher.launch('chromium', {
+    headless: __ENV.XK6_HEADLESS ? true : false,
+  });
+
+  // grant camera and microphone permissions to the
+  // new browser context.
+  const context = browser.newContext({
+    permissions: ["camera", "microphone"],
+  });
+  
+  const page = context.newPage();
+  page.goto('http://whatsmyuseragent.org/');
+  page.screenshot({ path: `example-chromium.png` });
+
+  page.close();
+  browser.close();
+}


### PR DESCRIPTION
This change is both a fix and enablement of a missing feature.

Previously:
+ `BrowserContext` permissions was failing (see issue #313).
+ `BrowserContext` permissions options were defunct.

Updates:
+ Fixes getting permissions from a script.
+ Grants permissions specified in the `BrowserContext` options when launching a new browser context.

Closes: #313