### PR TITLE
Refactor k6 VU and tests

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/k6"
 
 	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
@@ -46,7 +47,7 @@ type BrowserType struct {
 // - Initializes the goja runtime.
 func NewBrowserType(ctx context.Context) api.BrowserType {
 	var (
-		vu    = common.GetVU(ctx)
+		vu    = k6.GetVU(ctx)
 		rt    = vu.Runtime()
 		hooks = common.NewHooks()
 	)
@@ -406,7 +407,7 @@ func parseWebsocketURL(ctx context.Context, rc io.Reader) (wsURL string, _ error
 // makeLogger makes and returns an extension wide logger.
 func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*common.Logger, error) {
 	var (
-		k6Logger            = common.GetVU(ctx).State().Logger
+		k6Logger            = k6.GetVU(ctx).State().Logger
 		reCategoryFilter, _ = regexp.Compile(launchOpts.LogCategoryFilter)
 		logger              = common.NewLogger(ctx, k6Logger, launchOpts.Debug, reCategoryFilter)
 	)

--- a/common/browser.go
+++ b/common/browser.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -106,7 +107,7 @@ func newBrowser(ctx context.Context, cancelFn context.CancelFunc, browserProc *B
 		contexts:            make(map[cdp.BrowserContextID]*BrowserContext),
 		pages:               make(map[target.ID]*Page),
 		sessionIDtoTargetID: make(map[target.SessionID]target.ID),
-		vu:                  GetVU(ctx),
+		vu:                  k6.GetVU(ctx),
 		logger:              logger,
 	}
 }

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -70,7 +71,7 @@ func NewBrowserContext(
 		id:               id,
 		opts:             opts,
 		logger:           logger,
-		vu:               GetVU(ctx),
+		vu:               k6.GetVU(ctx),
 		timeoutSettings:  NewTimeoutSettings(nil),
 	}
 

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/grafana/xk6-browser/k6"
+
 	"github.com/dop251/goja"
 )
 
@@ -67,7 +69,7 @@ func NewBrowserContextOptions() *BrowserContextOptions {
 }
 
 func (b *BrowserContextOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {

--- a/common/browser_context_options_test.go
+++ b/common/browser_context_options_test.go
@@ -3,14 +3,16 @@ package common
 import (
 	"testing"
 
+	"github.com/grafana/xk6-browser/k6/k6test"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBrowserContextOptionsPermissions(t *testing.T) {
-	vu := newMockVU(t)
+	vu := k6test.NewVU(t)
 
 	var opts BrowserContextOptions
-	err := opts.Parse(vu.CtxField, vu.RuntimeField.ToValue((struct {
+	err := opts.Parse(vu.Context(), vu.ToGojaValue((struct {
 		Permissions []interface{} `js:"permissions"`
 	}{
 		Permissions: []interface{}{"camera", "microphone"},

--- a/common/context.go
+++ b/common/context.go
@@ -22,8 +22,6 @@ package common
 
 import (
 	"context"
-
-	k6modules "go.k6.io/k6/js/modules"
 )
 
 type ctxKey int
@@ -32,7 +30,6 @@ const (
 	ctxKeyLaunchOptions ctxKey = iota
 	ctxKeyPid
 	ctxKeyHooks
-	ctxKeyVU
 	ctxKeyCustomK6Metrics
 )
 
@@ -69,23 +66,6 @@ func WithProcessID(ctx context.Context, pid int) context.Context {
 func GetProcessID(ctx context.Context) int {
 	v, _ := ctx.Value(ctxKeyPid).(int)
 	return v // it will return zero on error
-}
-
-// WithVU returns a new context based on ctx with the k6 VU instance attached.
-func WithVU(ctx context.Context, vu k6modules.VU) context.Context {
-	return context.WithValue(ctx, ctxKeyVU, vu)
-}
-
-// GetVU returns the attached k6 VU instance from ctx, which can be used to
-// retrieve the goja runtime and other k6 objects relevant to the currently
-// executing VU.
-// See https://github.com/grafana/k6/blob/v0.37.0/js/initcontext.go#L168-L186
-func GetVU(ctx context.Context) k6modules.VU {
-	v := ctx.Value(ctxKeyVU)
-	if vu, ok := v.(k6modules.VU); ok {
-		return vu
-	}
-	return nil
 }
 
 // WithCustomK6Metrics attaches the CustomK6Metrics object to the context.

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/xk6-browser/k6"
+
 	"github.com/dop251/goja"
 )
 
@@ -135,7 +137,7 @@ func NewElementHandleBaseOptions(defaultTimeout time.Duration) *ElementHandleBas
 }
 
 func (o *ElementHandleBaseOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -161,7 +163,7 @@ func NewElementHandleBasePointerOptions(defaultTimeout time.Duration) *ElementHa
 }
 
 func (o *ElementHandleBasePointerOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleBaseOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -205,7 +207,7 @@ func NewElementHandleClickOptions(defaultTimeout time.Duration) *ElementHandleCl
 }
 
 func (o *ElementHandleClickOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -249,7 +251,7 @@ func NewElementHandleDblclickOptions(defaultTimeout time.Duration) *ElementHandl
 }
 
 func (o *ElementHandleDblclickOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -289,7 +291,7 @@ func NewElementHandleHoverOptions(defaultTimeout time.Duration) *ElementHandleHo
 }
 
 func (o *ElementHandleHoverOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -318,7 +320,7 @@ func NewElementHandlePressOptions(defaultTimeout time.Duration) *ElementHandlePr
 }
 
 func (o *ElementHandlePressOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -354,7 +356,7 @@ func NewElementHandleScreenshotOptions(defaultTimeout time.Duration) *ElementHan
 }
 
 func (o *ElementHandleScreenshotOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		formatSpecified := false
 		opts := opts.ToObject(rt)
@@ -394,7 +396,7 @@ func NewElementHandleSetCheckedOptions(defaultTimeout time.Duration) *ElementHan
 }
 
 func (o *ElementHandleSetCheckedOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
@@ -420,7 +422,7 @@ func NewElementHandleTapOptions(defaultTimeout time.Duration) *ElementHandleTapO
 }
 
 func (o *ElementHandleTapOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -449,7 +451,7 @@ func NewElementHandleTypeOptions(defaultTimeout time.Duration) *ElementHandleTyp
 }
 
 func (o *ElementHandleTypeOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -481,7 +483,7 @@ func NewElementHandleWaitForElementStateOptions(defaultTimeout time.Duration) *E
 }
 
 func (o *ElementHandleWaitForElementStateOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -28,6 +28,7 @@ import (
 	"regexp"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -88,7 +89,7 @@ func NewExecutionContext(
 		frame:          f,
 		id:             id,
 		injectedScript: nil,
-		vu:             GetVU(ctx),
+		vu:             k6.GetVU(ctx),
 		logger:         l,
 	}
 	if s != nil {

--- a/common/frame.go
+++ b/common/frame.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6"
 
 	k6modules "go.k6.io/k6/js/modules"
 	k6metrics "go.k6.io/k6/metrics"
@@ -116,7 +117,7 @@ func NewFrame(ctx context.Context, m *FrameManager, parentFrame *Frame, frameID 
 		parentFrame:            parentFrame,
 		childFrames:            make(map[api.Frame]bool),
 		id:                     frameID,
-		vu:                     GetVU(ctx),
+		vu:                     k6.GetVU(ctx),
 		lifecycleEvents:        make(map[LifecycleEvent]bool),
 		subtreeLifecycleEvents: make(map[LifecycleEvent]bool),
 		inflightRequests:       make(map[network.RequestID]bool),

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6"
 
 	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
@@ -87,7 +88,7 @@ func NewFrameManager(
 		frames:           make(map[cdp.FrameID]*Frame),
 		inflightRequests: make(map[network.RequestID]bool),
 		barriers:         make([]*Barrier, 0),
-		vu:               GetVU(ctx),
+		vu:               k6.GetVU(ctx),
 		logger:           l,
 		id:               atomic.AddInt64(&frameManagerID, 1),
 	}

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -26,6 +26,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/grafana/xk6-browser/k6"
+
 	"github.com/dop251/goja"
 )
 
@@ -166,7 +168,7 @@ func NewFrameBaseOptions(defaultTimeout time.Duration) *FrameBaseOptions {
 }
 
 func (o *FrameBaseOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -189,7 +191,7 @@ func NewFrameCheckOptions(defaultTimeout time.Duration) *FrameCheckOptions {
 }
 
 func (o *FrameCheckOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -213,7 +215,7 @@ func NewFrameClickOptions(defaultTimeout time.Duration) *FrameClickOptions {
 }
 
 func (o *FrameClickOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleClickOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -237,7 +239,7 @@ func NewFrameDblClickOptions(defaultTimeout time.Duration) *FrameDblclickOptions
 }
 
 func (o *FrameDblclickOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleDblclickOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -261,7 +263,7 @@ func NewFrameFillOptions(defaultTimeout time.Duration) *FrameFillOptions {
 }
 
 func (o *FrameFillOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleBaseOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -286,7 +288,7 @@ func NewFrameGotoOptions(defaultReferer string, defaultTimeout time.Duration) *F
 }
 
 func (o *FrameGotoOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -314,7 +316,7 @@ func NewFrameHoverOptions(defaultTimeout time.Duration) *FrameHoverOptions {
 }
 
 func (o *FrameHoverOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleHoverOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -468,7 +470,7 @@ func NewFrameSelectOptionOptions(defaultTimeout time.Duration) *FrameSelectOptio
 }
 
 func (o *FrameSelectOptionOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleBaseOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -492,7 +494,7 @@ func NewFrameSetContentOptions(defaultTimeout time.Duration) *FrameSetContentOpt
 }
 
 func (o *FrameSetContentOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
@@ -521,7 +523,7 @@ func NewFrameTapOptions(defaultTimeout time.Duration) *FrameTapOptions {
 }
 
 func (o *FrameTapOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -577,7 +579,7 @@ func NewFrameUncheckOptions(defaultTimeout time.Duration) *FrameUncheckOptions {
 }
 
 func (o *FrameUncheckOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
@@ -603,7 +605,7 @@ func NewFrameWaitForFunctionOptions(defaultTimeout time.Duration) *FrameWaitForF
 
 // Parse JavaScript waitForFunction options.
 func (o *FrameWaitForFunctionOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
@@ -641,7 +643,7 @@ func NewFrameWaitForLoadStateOptions(defaultTimeout time.Duration) *FrameWaitFor
 }
 
 func (o *FrameWaitForLoadStateOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -663,7 +665,7 @@ func NewFrameWaitForNavigationOptions(defaultTimeout time.Duration) *FrameWaitFo
 }
 
 func (o *FrameWaitForNavigationOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -692,7 +694,7 @@ func NewFrameWaitForSelectorOptions(defaultTimeout time.Duration) *FrameWaitForS
 }
 
 func (o *FrameWaitForSelectorOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)

--- a/common/frame_options_test.go
+++ b/common/frame_options_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/xk6-browser/k6/k6test"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,13 +16,13 @@ func TestFrameGotoOptionsParse(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		t.Parallel()
 
-		mockVU := newMockVU(t)
-		opts := mockVU.RuntimeField.ToValue(map[string]interface{}{
+		vu := k6test.NewVU(t)
+		opts := vu.ToGojaValue(map[string]interface{}{
 			"timeout":   "1000",
 			"waitUntil": "networkidle",
 		})
 		gotoOpts := NewFrameGotoOptions("https://example.com/", 0)
-		err := gotoOpts.Parse(mockVU.CtxField, opts)
+		err := gotoOpts.Parse(vu.Context(), opts)
 		require.NoError(t, err)
 
 		assert.Equal(t, "https://example.com/", gotoOpts.Referer)
@@ -31,12 +33,12 @@ func TestFrameGotoOptionsParse(t *testing.T) {
 	t.Run("err/invalid_waitUntil", func(t *testing.T) {
 		t.Parallel()
 
-		mockVU := newMockVU(t)
-		opts := mockVU.RuntimeField.ToValue(map[string]interface{}{
+		vu := k6test.NewVU(t)
+		opts := vu.ToGojaValue(map[string]interface{}{
 			"waitUntil": "none",
 		})
 		navOpts := NewFrameGotoOptions("", 0)
-		err := navOpts.Parse(mockVU.CtxField, opts)
+		err := navOpts.Parse(vu.Context(), opts)
 
 		assert.EqualError(t, err,
 			`error parsing goto options: `+
@@ -51,12 +53,12 @@ func TestFrameSetContentOptionsParse(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		t.Parallel()
 
-		mockVU := newMockVU(t)
-		opts := mockVU.RuntimeField.ToValue(map[string]interface{}{
+		vu := k6test.NewVU(t)
+		opts := vu.ToGojaValue(map[string]interface{}{
 			"waitUntil": "networkidle",
 		})
 		scOpts := NewFrameSetContentOptions(30 * time.Second)
-		err := scOpts.Parse(mockVU.CtxField, opts)
+		err := scOpts.Parse(vu.Context(), opts)
 		require.NoError(t, err)
 
 		assert.Equal(t, 30*time.Second, scOpts.Timeout)
@@ -66,12 +68,12 @@ func TestFrameSetContentOptionsParse(t *testing.T) {
 	t.Run("err/invalid_waitUntil", func(t *testing.T) {
 		t.Parallel()
 
-		mockVU := newMockVU(t)
-		opts := mockVU.RuntimeField.ToValue(map[string]interface{}{
+		vu := k6test.NewVU(t)
+		opts := vu.ToGojaValue(map[string]interface{}{
 			"waitUntil": "none",
 		})
 		navOpts := NewFrameSetContentOptions(0)
-		err := navOpts.Parse(mockVU.CtxField, opts)
+		err := navOpts.Parse(vu.Context(), opts)
 
 		assert.EqualError(t, err,
 			`error parsing setContent options: `+
@@ -86,14 +88,14 @@ func TestFrameWaitForNavigationOptionsParse(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		t.Parallel()
 
-		mockVU := newMockVU(t)
-		opts := mockVU.RuntimeField.ToValue(map[string]interface{}{
+		vu := k6test.NewVU(t)
+		opts := vu.ToGojaValue(map[string]interface{}{
 			"url":       "https://example.com/",
 			"timeout":   "1000",
 			"waitUntil": "networkidle",
 		})
 		navOpts := NewFrameWaitForNavigationOptions(0)
-		err := navOpts.Parse(mockVU.CtxField, opts)
+		err := navOpts.Parse(vu.Context(), opts)
 		require.NoError(t, err)
 
 		assert.Equal(t, "https://example.com/", navOpts.URL)
@@ -104,12 +106,12 @@ func TestFrameWaitForNavigationOptionsParse(t *testing.T) {
 	t.Run("err/invalid_waitUntil", func(t *testing.T) {
 		t.Parallel()
 
-		mockVU := newMockVU(t)
-		opts := mockVU.RuntimeField.ToValue(map[string]interface{}{
+		vu := k6test.NewVU(t)
+		opts := vu.ToGojaValue(map[string]interface{}{
 			"waitUntil": "none",
 		})
 		navOpts := NewFrameWaitForNavigationOptions(0)
-		err := navOpts.Parse(mockVU.CtxField, opts)
+		err := navOpts.Parse(vu.Context(), opts)
 
 		assert.EqualError(t, err,
 			`error parsing waitForNavigation options: `+

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6"
 
 	k6modules "go.k6.io/k6/js/modules"
 	k6metrics "go.k6.io/k6/metrics"
@@ -104,7 +105,7 @@ func NewFrameSession(
 		isolatedWorlds:       make(map[string]bool),
 		eventCh:              make(chan Event),
 		childSessions:        make(map[cdp.FrameID]*FrameSession),
-		vu:                   GetVU(ctx),
+		vu:                   k6.GetVU(ctx),
 		k6Metrics:            GetCustomK6Metrics(ctx),
 		logger:               l,
 		serializer: &logrus.Logger{

--- a/common/frame_test.go
+++ b/common/frame_test.go
@@ -1,29 +1,11 @@
-/*
- *
- * xk6-browser - a browser automation extension for k6
- * Copyright (C) 2021 Load Impact
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
-
 package common
 
 import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/grafana/xk6-browser/k6/k6test"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/stretchr/testify/require"
@@ -34,11 +16,11 @@ import (
 func TestFrameNilDocument(t *testing.T) {
 	t.Parallel()
 
-	mockVU := newMockVU(t)
+	vu := k6test.NewVU(t)
 	log := NewNullLogger()
 
-	fm := NewFrameManager(mockVU.CtxField, nil, nil, nil, log)
-	frame := NewFrame(mockVU.CtxField, fm, nil, cdp.FrameID("42"), log)
+	fm := NewFrameManager(vu.Context(), nil, nil, nil, log)
+	frame := NewFrame(vu.Context(), fm, nil, cdp.FrameID("42"), log)
 
 	// frame should not panic with a nil document
 	stub := &executionContextTestStub{

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -28,6 +28,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/grafana/xk6-browser/k6"
+
 	k6common "go.k6.io/k6/js/common"
 
 	cdpruntime "github.com/chromedp/cdproto/runtime"
@@ -200,7 +202,7 @@ func waitForEvent(ctx context.Context, emitter EventEmitter, events []string, pr
 // browser process from the context and kills it if it still exists.
 // TODO: test.
 func k6Throw(ctx context.Context, format string, a ...interface{}) {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if rt == nil {
 		// this should never happen unless a programmer error
 		panic("cannot get k6 runtime")

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -27,19 +27,11 @@ import (
 	"math"
 	"testing"
 
-	k6common "go.k6.io/k6/js/common"
-	k6eventloop "go.k6.io/k6/js/eventloop"
-	k6modulestest "go.k6.io/k6/js/modulestest"
-	k6lib "go.k6.io/k6/lib"
-	k6metrics "go.k6.io/k6/metrics"
-
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
-	"github.com/oxtoacart/bpool"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v3"
 )
 
 func newExecCtx() (*ExecutionContext, context.Context, *goja.Runtime) {
@@ -238,56 +230,4 @@ func TestConvertArgument(t *testing.T) {
 		require.Empty(t, arg.Value)
 		require.Empty(t, arg.UnserializableValue)
 	})
-}
-
-type mockVU struct {
-	*k6modulestest.VU
-	loop *k6eventloop.EventLoop
-}
-
-func newMockVU(tb testing.TB) *mockVU {
-	tb.Helper()
-
-	rt := goja.New()
-	rt.SetFieldNameMapper(k6common.FieldNameMapper{})
-
-	samples := make(chan k6metrics.SampleContainer, 1000)
-
-	root, err := k6lib.NewGroup("", nil)
-	require.NoError(tb, err)
-
-	state := &k6lib.State{
-		Options: k6lib.Options{
-			MaxRedirects: null.IntFrom(10),
-			UserAgent:    null.StringFrom("TestUserAgent"),
-			Throw:        null.BoolFrom(true),
-			SystemTags:   &k6metrics.DefaultSystemTagSet,
-			Batch:        null.IntFrom(20),
-			BatchPerHost: null.IntFrom(20),
-			// HTTPDebug:    null.StringFrom("full"),
-		},
-		Logger:         logrus.StandardLogger(),
-		Group:          root,
-		BPool:          bpool.NewBufferPool(1),
-		Samples:        samples,
-		Tags:           k6lib.NewTagMap(map[string]string{"group": root.Path}),
-		BuiltinMetrics: k6metrics.RegisterBuiltinMetrics(k6metrics.NewRegistry()),
-	}
-	mockVU := &mockVU{
-		VU: &k6modulestest.VU{
-			RuntimeField: rt,
-			InitEnvField: &k6common.InitEnvironment{
-				Registry: k6metrics.NewRegistry(),
-			},
-			StateField: state,
-		},
-	}
-	ctx := WithVU(context.Background(), mockVU)
-	mockVU.CtxField = ctx
-
-	loop := k6eventloop.New(mockVU)
-	mockVU.RegisterCallbackField = loop.RegisterCallback
-	mockVU.loop = loop
-
-	return mockVU
 }

--- a/common/keyboard_options.go
+++ b/common/keyboard_options.go
@@ -23,6 +23,8 @@ package common
 import (
 	"context"
 
+	"github.com/grafana/xk6-browser/k6"
+
 	"github.com/dop251/goja"
 )
 
@@ -37,7 +39,7 @@ func NewKeyboardOptions() *KeyboardOptions {
 }
 
 func (o *KeyboardOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {

--- a/common/launch.go
+++ b/common/launch.go
@@ -26,6 +26,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/grafana/xk6-browser/k6"
+
 	"github.com/dop251/goja"
 )
 
@@ -69,7 +71,7 @@ func NewLaunchOptions() *LaunchOptions {
 
 // Parse parses launch options from a JS object.
 func (l *LaunchOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {

--- a/common/launch_test.go
+++ b/common/launch_test.go
@@ -3,6 +3,8 @@ package common
 import (
 	"testing"
 
+	"github.com/grafana/xk6-browser/k6/k6test"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,10 +37,10 @@ func TestLaunchOptionsParse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockVU := newMockVU(t)
-			opts := mockVU.RuntimeField.ToValue(tc.opts)
+			vu := k6test.NewVU(t)
+			opts := vu.ToGojaValue(tc.opts)
 			lopts := NewLaunchOptions()
-			err := lopts.Parse(mockVU.CtxField, opts)
+			err := lopts.Parse(vu.Context(), opts)
 			require.NoError(t, err)
 			tc.assert(t, lopts)
 		})

--- a/common/mouse_options.go
+++ b/common/mouse_options.go
@@ -23,6 +23,8 @@ package common
 import (
 	"context"
 
+	"github.com/grafana/xk6-browser/k6"
+
 	"github.com/dop251/goja"
 )
 
@@ -55,7 +57,7 @@ func NewMouseClickOptions() *MouseClickOptions {
 }
 
 func (o *MouseClickOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -87,7 +89,7 @@ func NewMouseDblClickOptions() *MouseDblClickOptions {
 }
 
 func (o *MouseDblClickOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -116,7 +118,7 @@ func NewMouseDownUpOptions() *MouseDownUpOptions {
 }
 
 func (o *MouseDownUpOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -138,7 +140,7 @@ func NewMouseMoveOptions() *MouseMoveOptions {
 }
 
 func (o *MouseMoveOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -29,6 +29,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/xk6-browser/k6"
+
 	k6modules "go.k6.io/k6/js/modules"
 	k6lib "go.k6.io/k6/lib"
 	k6netext "go.k6.io/k6/lib/netext"
@@ -77,7 +79,7 @@ type NetworkManager struct {
 func NewNetworkManager(
 	ctx context.Context, s session, fm *FrameManager, parent *NetworkManager,
 ) (*NetworkManager, error) {
-	vu := GetVU(ctx)
+	vu := k6.GetVU(ctx)
 	state := vu.State()
 
 	resolver, err := newResolver(state.Options.DNS)

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"testing"
 
+	"github.com/grafana/xk6-browser/k6/k6test"
+
 	k6lib "go.k6.io/k6/lib"
 	k6mockresolver "go.k6.io/k6/lib/testutils/mockresolver"
 	k6types "go.k6.io/k6/lib/types"
@@ -53,15 +55,16 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 		},
 	}, nil)
 
-	mockVU := newMockVU(t)
-	mockVU.StateField.Options = k6opts
-	logger := NewLogger(mockVU.CtxField, mockVU.StateField.Logger, false, nil)
+	vu := k6test.NewVU(t)
+	st := vu.State()
+	st.Options = k6opts
+	logger := NewLogger(vu.Context(), st.Logger, false, nil)
 	nm := &NetworkManager{
-		ctx:      mockVU.CtxField,
+		ctx:      vu.Context(),
 		logger:   logger,
 		session:  session,
 		resolver: mr,
-		vu:       mockVU,
+		vu:       vu,
 	}
 
 	return nm, session

--- a/common/page.go
+++ b/common/page.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -119,7 +120,7 @@ func NewPage(
 		frameSessions:    make(map[cdp.FrameID]*FrameSession),
 		workers:          make(map[target.SessionID]*Worker),
 		routes:           make([]api.Route, 0),
-		vu:               GetVU(ctx),
+		vu:               k6.GetVU(ctx),
 		logger:           logger,
 	}
 

--- a/common/page_options.go
+++ b/common/page_options.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/xk6-browser/k6"
+
 	"github.com/chromedp/cdproto/page"
 	"github.com/dop251/goja"
 )
@@ -59,7 +61,7 @@ func NewPageEmulateMediaOptions(defaultMedia MediaType, defaultColorScheme Color
 }
 
 func (o *PageEmulateMediaOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -84,7 +86,7 @@ func NewPageReloadOptions(defaultWaitUntil LifecycleEvent, defaultTimeout time.D
 }
 
 func (o *PageReloadOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
@@ -116,7 +118,7 @@ func NewPageScreenshotOptions() *PageScreenshotOptions {
 }
 
 func (o *PageScreenshotOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
 		formatSpecified := false
 		opts := opts.ToObject(rt)

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -29,6 +29,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/grafana/xk6-browser/k6"
+
 	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
 	"github.com/hashicorp/go-multierror"
@@ -148,7 +150,7 @@ func valueFromRemoteObject(ctx context.Context, robj *cdpruntime.RemoteObject) (
 	if val == "undefined" {
 		return goja.Undefined(), err
 	}
-	return GetVU(ctx).Runtime().ToValue(val), err
+	return k6.Runtime(ctx).ToValue(val), err
 }
 
 func handleParseRemoteObjectErr(ctx context.Context, err error, logger *logrus.Entry) {

--- a/common/request.go
+++ b/common/request.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -97,7 +98,7 @@ func NewRequest(
 		errorText:           "",
 		timestamp:           event.Timestamp.Time(),
 		wallTime:            event.WallTime.Time(),
-		vu:                  GetVU(ctx),
+		vu:                  k6.GetVU(ctx),
 	}
 	for n, v := range event.Request.Headers {
 		switch v := v.(type) {

--- a/common/request_test.go
+++ b/common/request_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6/k6test"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
@@ -48,8 +49,8 @@ func TestRequest(t *testing.T) {
 		Timestamp: &ts,
 		WallTime:  &wt,
 	}
-	mockVU := newMockVU(t)
-	req, err := NewRequest(mockVU.CtxField, evt, nil, nil, "intercept", false)
+	vu := k6test.NewVU(t)
+	req, err := NewRequest(vu.Context(), evt, nil, nil, "intercept", false)
 	require.NoError(t, err)
 
 	t.Run("error_parse_url", func(t *testing.T) {
@@ -65,8 +66,8 @@ func TestRequest(t *testing.T) {
 			Timestamp: &ts,
 			WallTime:  &wt,
 		}
-		mockVU := newMockVU(t)
-		req, err := NewRequest(mockVU.CtxField, evt, nil, nil, "intercept", false)
+		vu := k6test.NewVU(t)
+		req, err := NewRequest(vu.Context(), evt, nil, nil, "intercept", false)
 		require.EqualError(t, err, `cannot parse URL: parse ":": missing protocol scheme`)
 		require.Nil(t, req)
 	})

--- a/common/response.go
+++ b/common/response.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -83,7 +84,7 @@ type Response struct {
 
 // NewHTTPResponse creates a new HTTP response.
 func NewHTTPResponse(ctx context.Context, req *Request, resp *network.Response, timestamp *cdp.MonotonicTime) *Response {
-	vu := GetVU(ctx)
+	vu := k6.GetVU(ctx)
 	state := vu.State()
 	r := Response{
 		ctx: ctx,

--- a/common/types.go
+++ b/common/types.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6"
 
 	"github.com/dop251/goja"
 )
@@ -158,7 +159,7 @@ func NewGeolocation() *Geolocation {
 }
 
 func (g *Geolocation) Parse(ctx context.Context, opts goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	longitude := 0.0
 	latitude := 0.0
 	accuracy := 0.0
@@ -458,7 +459,7 @@ type Screen struct {
 }
 
 func (s *Screen) Parse(ctx context.Context, screen goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if screen != nil && !goja.IsUndefined(screen) && !goja.IsNull(screen) {
 		screen := screen.ToObject(rt)
 		for _, k := range screen.Keys() {
@@ -492,7 +493,7 @@ func (s Size) enclosingIntSize() *Size {
 }
 
 func (s *Size) Parse(ctx context.Context, viewport goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if viewport != nil && !goja.IsUndefined(viewport) && !goja.IsNull(viewport) {
 		viewport := viewport.ToObject(rt)
 		for _, k := range viewport.Keys() {
@@ -515,7 +516,7 @@ type Viewport struct {
 
 // Parse viewport details from a given goja viewport value.
 func (v *Viewport) Parse(ctx context.Context, viewport goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if viewport != nil && !goja.IsUndefined(viewport) && !goja.IsNull(viewport) {
 		viewport := viewport.ToObject(rt)
 		for _, k := range viewport.Keys() {
@@ -560,7 +561,7 @@ func NewCredentials() *Credentials {
 }
 
 func (c *Credentials) Parse(ctx context.Context, credentials goja.Value) error {
-	rt := GetVU(ctx).Runtime()
+	rt := k6.Runtime(ctx)
 	if credentials != nil && !goja.IsUndefined(credentials) && !goja.IsNull(credentials) {
 		credentials := credentials.ToObject(rt)
 		for _, k := range credentials.Keys() {

--- a/k6/context.go
+++ b/k6/context.go
@@ -1,0 +1,35 @@
+package k6
+
+import (
+	"context"
+
+	k6modules "go.k6.io/k6/js/modules"
+
+	"github.com/dop251/goja"
+)
+
+type ctxKey int
+
+const ctxKeyVU ctxKey = 1
+
+// WithVU returns a new context based on ctx with the k6 VU instance attached.
+func WithVU(ctx context.Context, vu k6modules.VU) context.Context {
+	return context.WithValue(ctx, ctxKeyVU, vu)
+}
+
+// GetVU returns the attached k6 VU instance from ctx, which can be used to
+// retrieve the goja runtime and other k6 objects relevant to the currently
+// executing VU.
+// See https://github.com/grafana/k6/blob/v0.37.0/js/initcontext.go#L168-L186
+func GetVU(ctx context.Context) k6modules.VU {
+	v := ctx.Value(ctxKeyVU)
+	if vu, ok := v.(k6modules.VU); ok {
+		return vu
+	}
+	return nil
+}
+
+// Runtime is a convenience function for getting a k6 VU runtime.
+func Runtime(ctx context.Context) *goja.Runtime {
+	return GetVU(ctx).Runtime()
+}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/chromium"
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/k6"
 
 	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
@@ -95,7 +96,7 @@ func (m *JSModule) Launch(browserName string, opts goja.Value) api.Browser {
 		<-ctx.Done()
 	}()*/
 
-	ctx := common.WithVU(m.vu.Context(), m.vu)
+	ctx := k6.WithVU(m.vu.Context(), m.vu)
 	ctx = common.WithCustomK6Metrics(ctx, m.k6Metrics)
 
 	if browserName == "chromium" {

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -66,7 +66,7 @@ func TestBrowserContextOptionsDefaultViewport(t *testing.T) {
 
 func TestBrowserContextOptionsSetViewport(t *testing.T) {
 	tb := newTestBrowser(t)
-	bctx := tb.NewContext(tb.rt.ToValue(struct {
+	bctx := tb.NewContext(tb.toGojaValue(struct {
 		Viewport common.Viewport `js:"viewport"`
 	}{
 		Viewport: common.Viewport{
@@ -84,7 +84,7 @@ func TestBrowserContextOptionsSetViewport(t *testing.T) {
 
 func TestBrowserContextOptionsExtraHTTPHeaders(t *testing.T) {
 	tb := newTestBrowser(t, withHTTPServer())
-	bctx := tb.NewContext(tb.rt.ToValue(struct {
+	bctx := tb.NewContext(tb.toGojaValue(struct {
 		ExtraHTTPHeaders map[string]string `js:"extraHTTPHeaders"`
 	}{
 		ExtraHTTPHeaders: map[string]string{

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -67,7 +67,7 @@ func TestBrowserOn(t *testing.T) {
 		rt := b.vu.Runtime()
 		require.NoError(t, rt.Set("b", b.Browser))
 
-		err := b.vu.loop.Start(func() error {
+		err := b.vu.Loop.Start(func() error {
 			if _, err := rt.RunString(fmt.Sprintf(script, "wrongevent")); err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -87,7 +87,7 @@ func TestBrowserOn(t *testing.T) {
 		var log []string
 		require.NoError(t, rt.Set("log", func(s string) { log = append(log, s) }))
 
-		err := b.vu.loop.Start(func() error {
+		err := b.vu.Loop.Start(func() error {
 			time.AfterFunc(100*time.Millisecond, func() { b.Browser.Close() })
 			if _, err := rt.RunString(fmt.Sprintf(script, "disconnected")); err != nil {
 				return fmt.Errorf("%w", err)
@@ -108,7 +108,7 @@ func TestBrowserOn(t *testing.T) {
 		var log []string
 		require.NoError(t, rt.Set("log", func(s string) { log = append(log, s) }))
 
-		err := b.vu.loop.Start(func() error {
+		err := b.vu.Loop.Start(func() error {
 			time.AfterFunc(100*time.Millisecond, func() { cancel() })
 			if _, err := rt.RunString(fmt.Sprintf(script, "disconnected")); err != nil {
 				return fmt.Errorf("%w", err)

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -79,9 +79,9 @@ func TestElementHandleBoundingBoxSVG(t *testing.T) {
         return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
     }`
 	var r api.Rect
-	webBbox := p.Evaluate(tb.rt.ToValue(pageFn), tb.rt.ToValue(element))
+	webBbox := p.Evaluate(tb.toGojaValue(pageFn), tb.toGojaValue(element))
 	wb, _ := webBbox.(goja.Value)
-	err := tb.rt.ExportTo(wb, &r)
+	err := tb.runtime().ExportTo(wb, &r)
 	require.NoError(t, err)
 
 	require.EqualValues(t, bbox, &r)
@@ -94,7 +94,7 @@ func TestElementHandleClick(t *testing.T) {
 	p.SetContent(htmlInputButton, nil)
 
 	button := p.Query("button")
-	button.Click(tb.rt.ToValue(struct {
+	button.Click(tb.toGojaValue(struct {
 		NoWaitAfter bool `js:"noWaitAfter"`
 	}{
 		// FIX: this is just a workaround because navigation is never triggered
@@ -102,7 +102,7 @@ func TestElementHandleClick(t *testing.T) {
 		NoWaitAfter: true,
 	}))
 
-	result := p.Evaluate(tb.rt.ToValue("() => window['result']"))
+	result := p.Evaluate(tb.toGojaValue("() => window['result']"))
 	res, ok := result.(goja.Value)
 	require.True(t, ok)
 	assert.Equal(t, res.String(), "Clicked")
@@ -115,10 +115,10 @@ func TestElementHandleClickWithNodeRemoved(t *testing.T) {
 	p.SetContent(htmlInputButton, nil)
 
 	// Remove all nodes
-	p.Evaluate(tb.rt.ToValue("() => delete window['Node']"))
+	p.Evaluate(tb.toGojaValue("() => delete window['Node']"))
 
 	button := p.Query("button")
-	button.Click(tb.rt.ToValue(struct {
+	button.Click(tb.toGojaValue(struct {
 		NoWaitAfter bool `js:"noWaitAfter"`
 	}{
 		// FIX: this is just a workaround because navigation is never triggered
@@ -126,7 +126,7 @@ func TestElementHandleClickWithNodeRemoved(t *testing.T) {
 		NoWaitAfter: true,
 	}))
 
-	result := p.Evaluate(tb.rt.ToValue("() => window['result']"))
+	result := p.Evaluate(tb.toGojaValue("() => window['result']"))
 	res, ok := result.(goja.Value)
 	require.True(t, ok)
 	assert.Equal(t, res.String(), "Clicked")
@@ -141,7 +141,7 @@ func TestElementHandleClickWithDetachedNode(t *testing.T) {
 	button := p.Query("button")
 
 	// Detach node
-	p.Evaluate(tb.rt.ToValue("button => button.remove()"), tb.rt.ToValue(button))
+	p.Evaluate(tb.toGojaValue("button => button.remove()"), tb.toGojaValue(button))
 
 	// We expect the click to fail with the correct error raised
 	var errorMsg string
@@ -153,7 +153,7 @@ func TestElementHandleClickWithDetachedNode(t *testing.T) {
 				errorMsg = errMsg.String()
 			}
 		}()
-		button.Click(tb.rt.ToValue(struct {
+		button.Click(tb.toGojaValue(struct {
 			NoWaitAfter bool `js:"noWaitAfter"`
 		}{
 			// FIX: this is just a workaround because navigation is never triggered and we'd be waiting for
@@ -174,7 +174,7 @@ func TestElementHandleClickConcealedLink(t *testing.T) {
 
 	tb := newTestBrowser(t, withFileServer())
 	p := tb.NewContext(
-		tb.rt.ToValue(struct {
+		tb.toGojaValue(struct {
 			Viewport common.Viewport `js:"viewport"`
 		}{
 			Viewport: common.Viewport{
@@ -188,7 +188,7 @@ func TestElementHandleClickConcealedLink(t *testing.T) {
 		const cmd = `
 			() => window.clickResult
 		`
-		cr := p.Evaluate(tb.rt.ToValue(cmd))
+		cr := p.Evaluate(tb.toGojaValue(cmd))
 		return cr.(goja.Value).String() //nolint:forcetypeassert
 	}
 	require.NotNil(t, p.Goto(tb.staticURL("/concealed_link.html"), nil))
@@ -296,11 +296,11 @@ func TestElementHandleScreenshot(t *testing.T) {
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
-	p.SetViewportSize(tb.rt.ToValue(struct {
+	p.SetViewportSize(tb.toGojaValue(struct {
 		Width  float64 `js:"width"`
 		Height float64 `js:"height"`
 	}{Width: 800, Height: 600}))
-	p.Evaluate(tb.rt.ToValue(`
+	p.Evaluate(tb.toGojaValue(`
 		() => {
 			document.body.style.margin = '0';
 			document.body.style.padding = '0';
@@ -344,7 +344,7 @@ func TestElementHandleWaitForSelector(t *testing.T) {
 	p.SetContent(`<div class="root"></div>`, nil)
 
 	root := p.Query(".root")
-	p.Evaluate(tb.rt.ToValue(`
+	p.Evaluate(tb.toGojaValue(`
         () => {
 		setTimeout(() => {
 			const div = document.createElement('div');
@@ -355,7 +355,7 @@ func TestElementHandleWaitForSelector(t *testing.T) {
 			}, 100);
 		}
 	`))
-	element := root.WaitForSelector(".element-to-appear", tb.rt.ToValue(struct {
+	element := root.WaitForSelector(".element-to-appear", tb.toGojaValue(struct {
 		Timeout int64 `js:"timeout"`
 	}{Timeout: 1000}))
 

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -46,7 +46,7 @@ func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 			done := make(chan struct{}, 1)
 			go func() {
 				require.NotPanics(t, func() {
-					p.WaitForNavigation(tb.rt.ToValue(&common.FrameWaitForNavigationOptions{
+					p.WaitForNavigation(tb.toGojaValue(&common.FrameWaitForNavigationOptions{
 						Timeout: timeout * 3, // interpreted as ms
 					}))
 				})

--- a/tests/js_handle_get_properties_test.go
+++ b/tests/js_handle_get_properties_test.go
@@ -31,7 +31,7 @@ func TestJSHandleGetProperties(t *testing.T) {
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
-	handle := p.EvaluateHandle(tb.rt.ToValue(`
+	handle := p.EvaluateHandle(tb.toGojaValue(`
 	() => {
 		return {
 			prop1: "one",

--- a/tests/launch_options_slowmo_test.go
+++ b/tests/launch_options_slowmo_test.go
@@ -61,7 +61,7 @@ func TestLaunchOptionsSlowMo(t *testing.T) {
 		})
 		t.Run("emulateMedia", func(t *testing.T) {
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p api.Page) {
-				p.EmulateMedia(tb.rt.ToValue(struct {
+				p.EmulateMedia(tb.toGojaValue(struct {
 					Media string `js:"media"`
 				}{
 					Media: "print",
@@ -70,12 +70,12 @@ func TestLaunchOptionsSlowMo(t *testing.T) {
 		})
 		t.Run("evaluate", func(t *testing.T) {
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p api.Page) {
-				p.Evaluate(tb.rt.ToValue("() => void 0"))
+				p.Evaluate(tb.toGojaValue("() => void 0"))
 			})
 		})
 		t.Run("evaluateHandle", func(t *testing.T) {
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p api.Page) {
-				p.EvaluateHandle(tb.rt.ToValue("() => window"))
+				p.EvaluateHandle(tb.toGojaValue("() => window"))
 			})
 		})
 		t.Run("fill", func(t *testing.T) {
@@ -120,7 +120,7 @@ func TestLaunchOptionsSlowMo(t *testing.T) {
 		})*/
 		t.Run("selectOption", func(t *testing.T) {
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p api.Page) {
-				p.SelectOption("select", tb.rt.ToValue("foo"), nil)
+				p.SelectOption("select", tb.toGojaValue("foo"), nil)
 			})
 		})
 		t.Run("setViewportSize", func(t *testing.T) {
@@ -163,12 +163,12 @@ func TestLaunchOptionsSlowMo(t *testing.T) {
 		})
 		t.Run("evaluate", func(t *testing.T) {
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f api.Frame) {
-				f.Evaluate(tb.rt.ToValue("() => void 0"))
+				f.Evaluate(tb.toGojaValue("() => void 0"))
 			})
 		})
 		t.Run("evaluateHandle", func(t *testing.T) {
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f api.Frame) {
-				f.EvaluateHandle(tb.rt.ToValue("() => window"))
+				f.EvaluateHandle(tb.toGojaValue("() => window"))
 			})
 		})
 		t.Run("fill", func(t *testing.T) {
@@ -208,7 +208,7 @@ func TestLaunchOptionsSlowMo(t *testing.T) {
 		})*/
 		t.Run("selectOption", func(t *testing.T) {
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f api.Frame) {
-				f.SelectOption("select", tb.rt.ToValue("foo"), nil)
+				f.SelectOption("select", tb.toGojaValue("foo"), nil)
 			})
 		})
 		t.Run("type", func(t *testing.T) {

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -53,7 +53,7 @@ func TestBlockHostnames(t *testing.T) {
 
 	blocked, err := k6types.NewNullHostnameTrie([]string{"*.test"})
 	require.NoError(t, err)
-	tb.state.Options.BlockedHostnames = blocked
+	tb.vu.State().Options.BlockedHostnames = blocked
 
 	p := tb.NewPage(nil)
 	res := p.Goto("http://host.test/", nil)
@@ -71,7 +71,7 @@ func TestBlockIPs(t *testing.T) {
 
 	ipnet, err := k6lib.ParseCIDR("10.0.0.0/8")
 	require.NoError(t, err)
-	tb.state.Options.BlacklistIPs = []*k6lib.IPNet{ipnet}
+	tb.vu.State().Options.BlacklistIPs = []*k6lib.IPNet{ipnet}
 
 	p := tb.NewPage(nil)
 	res := p.Goto("http://10.0.0.1:8000/", nil)
@@ -97,7 +97,7 @@ func TestBasicAuth(t *testing.T) {
 		tb.Helper()
 
 		return browser.NewContext(
-			browser.rt.ToValue(struct {
+			browser.toGojaValue(struct {
 				HttpCredentials *common.Credentials `js:"httpCredentials"` //nolint:revive
 			}{
 				HttpCredentials: &common.Credentials{
@@ -108,7 +108,7 @@ func TestBasicAuth(t *testing.T) {
 			NewPage().
 			Goto(
 				browser.URL(fmt.Sprintf("/basic-auth/%s/%s", validUser, validPassword)),
-				browser.rt.ToValue(struct {
+				browser.toGojaValue(struct {
 					WaitUntil string `js:"waitUntil"`
 				}{
 					WaitUntil: "load",


### PR DESCRIPTION
This PR refactors the VU usage in the extension.

* `newMockVU` was duplicated. This commit moves it into a new package named `k6`.
* Replaces `mockVU` with `vu` for brevity.
* Instead of crowding the common package (which is already big), moves the handling of VUs in contexts to the k6 package. And testing into the k6test package.
* Provides helper methods for the functions we need to use frequently.

Removes `rt`, `state`, and `samples` fields from the test browser.

Renamings:
* `newMockVU(t)` -> `k6.NewMockVU(t)`
* `mockVu` -> `vu`
* `mockVU.RuntimeField.ToValue` -> `vu.ToGojaValue`
* `GetVU(ctx).Runtime()` -> `k6.Runtime(ctx)`
* `vu.CtxField` -> `vu.Context()`
* `common.WithVU` -> `k6.WithVU`
* `common.GetVU` -> `k6.GetVU`
* `test_context.go mockVU/newMockVU` -> `k6test.VU` `k6test.NewVU`
* `common/helpers_test.go mockVU/newMockVU` -> `k6test.VU` `k6test.NewVU`
* `tests/test_browser.go runtime|toGojaValue`