### PR TITLE
Fix gci linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.44.0
+# v1.46.2
 # Please don't remove the first line. It's used in CI to determine the
 # golangci-lint version. See the lint step in .github/workflows/all.yaml
 run:
@@ -80,7 +80,11 @@ linters:
 
 linters-settings:
   gci:
-    local: github.com/grafana/xk6-browser
+    sections:
+      - standard
+      - prefix(github.com/grafana/xk6-browser)
+      - prefix(go.k6.io)
+      - default
   dupl:
     threshold: 400
   gofmt:

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -14,13 +14,14 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dop251/goja"
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/common"
+
 	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
 	k6lib "go.k6.io/k6/lib"
 
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/common"
+	"github.com/dop251/goja"
 )
 
 // Ensure BrowserType implements the api.BrowserType interface.

--- a/chromium/browser_type_test.go
+++ b/chromium/browser_type_test.go
@@ -5,11 +5,12 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/grafana/xk6-browser/common"
+
 	k6lib "go.k6.io/k6/lib"
 
-	"github.com/grafana/xk6-browser/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 //nolint:funlen

--- a/common/browser.go
+++ b/common/browser.go
@@ -27,15 +27,16 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/grafana/xk6-browser/api"
+
+	k6modules "go.k6.io/k6/js/modules"
+
 	"github.com/chromedp/cdproto"
 	cdpbrowser "github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
 	"github.com/gorilla/websocket"
-	k6modules "go.k6.io/k6/js/modules"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure Browser implements the EventEmitter and Browser interfaces.

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -26,14 +26,15 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/grafana/xk6-browser/api"
+
+	k6modules "go.k6.io/k6/js/modules"
+
 	cdpbrowser "github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/storage"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
-	k6modules "go.k6.io/k6/js/modules"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure BrowserContext implements the EventEmitter and api.BrowserContext interfaces.

--- a/common/connection_test.go
+++ b/common/connection_test.go
@@ -26,6 +26,8 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/grafana/xk6-browser/tests/ws"
+
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/target"
@@ -33,8 +35,6 @@ import (
 	"github.com/mailru/easyjson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/xk6-browser/tests/ws"
 )
 
 func TestConnection(t *testing.T) {

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/common/js"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
 	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/dop251/goja"
-
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/common/js"
 )
 
 // Ensure ElementHandle implements the api.ElementHandle and api.JSHandle interfaces.

--- a/common/element_handle_test.go
+++ b/common/element_handle_test.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/common/js"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestErrorFromDOMError(t *testing.T) {

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -27,14 +27,15 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/grafana/xk6-browser/api"
+
+	k6modules "go.k6.io/k6/js/modules"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
-	k6modules "go.k6.io/k6/js/modules"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 const evaluationScriptURL = "__xk6_browser_evaluation_script__"

--- a/common/frame.go
+++ b/common/frame.go
@@ -27,14 +27,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/xk6-browser/api"
+
+	k6modules "go.k6.io/k6/js/modules"
+	k6metrics "go.k6.io/k6/metrics"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
-	k6modules "go.k6.io/k6/js/modules"
-	k6metrics "go.k6.io/k6/metrics"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 // maxRetry controls how many times to retry if an action fails.

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -29,13 +29,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/chromedp/cdproto/cdp"
-	"github.com/chromedp/cdproto/network"
-	"github.com/dop251/goja"
+	"github.com/grafana/xk6-browser/api"
+
 	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
 
-	"github.com/grafana/xk6-browser/api"
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/network"
+	"github.com/dop251/goja"
 )
 
 // FrameManager manages all frames in a page and their life-cycles, it's a purely internal component.

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -29,6 +29,11 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/grafana/xk6-browser/api"
+
+	k6modules "go.k6.io/k6/js/modules"
+	k6metrics "go.k6.io/k6/metrics"
+
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/cdproto/cdp"
@@ -42,10 +47,6 @@ import (
 	"github.com/chromedp/cdproto/security"
 	"github.com/chromedp/cdproto/target"
 	"github.com/sirupsen/logrus"
-	k6modules "go.k6.io/k6/js/modules"
-	k6metrics "go.k6.io/k6/metrics"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 const utilityWorldName = "__k6_browser_utility_world__"

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -28,9 +28,10 @@ import (
 	"os"
 	"time"
 
+	k6common "go.k6.io/k6/js/common"
+
 	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
-	k6common "go.k6.io/k6/js/common"
 )
 
 func convertBaseJSHandleTypes(ctx context.Context, execCtx *ExecutionContext, objHandle *BaseJSHandle) (*cdpruntime.CallArgument, error) {

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -27,17 +27,18 @@ import (
 	"math"
 	"testing"
 
+	k6common "go.k6.io/k6/js/common"
+	k6eventloop "go.k6.io/k6/js/eventloop"
+	k6modulestest "go.k6.io/k6/js/modulestest"
+	k6lib "go.k6.io/k6/lib"
+	k6metrics "go.k6.io/k6/metrics"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
 	"github.com/oxtoacart/bpool"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	k6common "go.k6.io/k6/js/common"
-	k6eventloop "go.k6.io/k6/js/eventloop"
-	k6modulestest "go.k6.io/k6/js/modulestest"
-	k6lib "go.k6.io/k6/lib"
-	k6metrics "go.k6.io/k6/metrics"
 	"gopkg.in/guregu/null.v3"
 )
 

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -23,11 +23,11 @@ package common
 import (
 	"context"
 
+	"github.com/grafana/xk6-browser/api"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure BaseJSHandle implements the api.JSHandle interface.

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -25,12 +25,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/keyboardlayout"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/input"
 	"github.com/dop251/goja"
-
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/keyboardlayout"
 )
 
 var _ api.Keyboard = &Keyboard{}

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -24,11 +24,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/grafana/xk6-browser/api"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/input"
 	"github.com/dop251/goja"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure Mouse implements the api.Mouse interface.

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -29,17 +29,18 @@ import (
 	"sync"
 	"time"
 
+	k6modules "go.k6.io/k6/js/modules"
+	k6lib "go.k6.io/k6/lib"
+	k6netext "go.k6.io/k6/lib/netext"
+	k6types "go.k6.io/k6/lib/types"
+	k6metrics "go.k6.io/k6/metrics"
+
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/emulation"
 	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/cdproto/network"
 	"github.com/dop251/goja"
-	k6modules "go.k6.io/k6/js/modules"
-	k6lib "go.k6.io/k6/lib"
-	k6netext "go.k6.io/k6/lib/netext"
-	k6types "go.k6.io/k6/lib/types"
-	k6metrics "go.k6.io/k6/metrics"
 )
 
 // Ensure NetworkManager implements the EventEmitter interface.

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -6,14 +6,15 @@ import (
 	"net"
 	"testing"
 
+	k6lib "go.k6.io/k6/lib"
+	k6mockresolver "go.k6.io/k6/lib/testutils/mockresolver"
+	k6types "go.k6.io/k6/lib/types"
+
 	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/cdproto/network"
 	"github.com/mailru/easyjson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	k6lib "go.k6.io/k6/lib"
-	k6mockresolver "go.k6.io/k6/lib/testutils/mockresolver"
-	k6types "go.k6.io/k6/lib/types"
 )
 
 const mockHostname = "host.test"

--- a/common/page.go
+++ b/common/page.go
@@ -28,15 +28,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/xk6-browser/api"
+
+	k6modules "go.k6.io/k6/js/modules"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
 	"github.com/chromedp/cdproto/emulation"
 	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
-	k6modules "go.k6.io/k6/js/modules"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure page implements the EventEmitter, Target and Page interfaces.

--- a/common/request.go
+++ b/common/request.go
@@ -27,12 +27,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/xk6-browser/api"
+
+	k6modules "go.k6.io/k6/js/modules"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/dop251/goja"
-	k6modules "go.k6.io/k6/js/modules"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure Request implements the api.Request interface.

--- a/common/request_test.go
+++ b/common/request_test.go
@@ -24,12 +24,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/xk6-browser/api"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 func TestRequest(t *testing.T) {

--- a/common/response.go
+++ b/common/response.go
@@ -28,12 +28,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/xk6-browser/api"
+
+	k6modules "go.k6.io/k6/js/modules"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/dop251/goja"
-	k6modules "go.k6.io/k6/js/modules"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure Response implements the api.Response interface.

--- a/common/session_test.go
+++ b/common/session_test.go
@@ -26,6 +26,8 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/grafana/xk6-browser/tests/ws"
+
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 	cdppage "github.com/chromedp/cdproto/page"
@@ -34,8 +36,6 @@ import (
 	"github.com/mailru/easyjson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/xk6-browser/tests/ws"
 )
 
 func TestSessionCreateSession(t *testing.T) {

--- a/common/touchscreen.go
+++ b/common/touchscreen.go
@@ -23,10 +23,10 @@ package common
 import (
 	"context"
 
+	"github.com/grafana/xk6-browser/api"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/input"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure Touchscreen implements the EventEmitter and api.Touchscreen interfaces.

--- a/common/types.go
+++ b/common/types.go
@@ -29,9 +29,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dop251/goja"
-
 	"github.com/grafana/xk6-browser/api"
+
+	"github.com/dop251/goja"
 )
 
 // ColorScheme represents a browser color scheme.

--- a/common/worker.go
+++ b/common/worker.go
@@ -24,14 +24,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/grafana/xk6-browser/api"
+
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/log"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
-
-	"github.com/grafana/xk6-browser/api"
 )
 
 // Ensure Worker implements the EventEmitter, Target and api.Worker interfaces.

--- a/main.go
+++ b/main.go
@@ -23,13 +23,14 @@ package browser
 import (
 	"errors"
 
-	"github.com/dop251/goja"
-	k6common "go.k6.io/k6/js/common"
-	k6modules "go.k6.io/k6/js/modules"
-
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/chromium"
 	"github.com/grafana/xk6-browser/common"
+
+	k6common "go.k6.io/k6/js/common"
+	k6modules "go.k6.io/k6/js/modules"
+
+	"github.com/dop251/goja"
 )
 
 const version = "v0.3.0"

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -25,10 +25,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/grafana/xk6-browser/common"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/xk6-browser/common"
 )
 
 func TestBrowserContextOptionsDefaultValues(t *testing.T) {

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -7,12 +7,12 @@ import (
 	"image/png"
 	"testing"
 
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/common"
+
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/common"
 )
 
 //go:embed static/mouse_helper.js

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/grafana/xk6-browser/common"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestWaitForFrameNavigationWithinDocument(t *testing.T) {

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -5,11 +5,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/keyboardlayout"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKeyboardPress(t *testing.T) {

--- a/tests/launch_options_slowmo_test.go
+++ b/tests/launch_options_slowmo_test.go
@@ -24,11 +24,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dop251/goja"
-	"github.com/stretchr/testify/require"
-
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/common"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLaunchOptionsSlowMo(t *testing.T) {

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -25,13 +25,14 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/common"
+
 	k6lib "go.k6.io/k6/lib"
 	k6types "go.k6.io/k6/lib/types"
 
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestURLSkipRequest(t *testing.T) {

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -27,16 +27,17 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/dop251/goja"
-	"github.com/stretchr/testify/require"
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/chromium"
+	"github.com/grafana/xk6-browser/common"
+
 	k6http "go.k6.io/k6/js/modules/k6/http"
 	k6lib "go.k6.io/k6/lib"
 	k6httpmultibin "go.k6.io/k6/lib/testutils/httpmultibin"
 	k6metrics "go.k6.io/k6/metrics"
 
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/chromium"
-	"github.com/grafana/xk6-browser/common"
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/require"
 )
 
 // testBrowser is a test testBrowser for integration testing.

--- a/tests/test_context.go
+++ b/tests/test_context.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dop251/goja"
-	"github.com/oxtoacart/bpool"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
+	"github.com/grafana/xk6-browser/common"
+
 	k6common "go.k6.io/k6/js/common"
 	k6eventloop "go.k6.io/k6/js/eventloop"
 	k6modulestest "go.k6.io/k6/js/modulestest"
 	k6lib "go.k6.io/k6/lib"
 	k6metrics "go.k6.io/k6/metrics"
-	"gopkg.in/guregu/null.v3"
 
-	"github.com/grafana/xk6-browser/common"
+	"github.com/dop251/goja"
+	"github.com/oxtoacart/bpool"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v3"
 )
 
 type mockVU struct {

--- a/tests/ws/server.go
+++ b/tests/ws/server.go
@@ -30,6 +30,10 @@ import (
 	"testing"
 	"time"
 
+	k6lib "go.k6.io/k6/lib"
+	k6netext "go.k6.io/k6/lib/netext"
+	k6types "go.k6.io/k6/lib/types"
+
 	"github.com/chromedp/cdproto"
 	"github.com/gorilla/websocket"
 	"github.com/mailru/easyjson"
@@ -37,9 +41,6 @@ import (
 	"github.com/mailru/easyjson/jwriter"
 	"github.com/mccutchen/go-httpbin/httpbin"
 	"github.com/stretchr/testify/require"
-	k6lib "go.k6.io/k6/lib"
-	k6netext "go.k6.io/k6/lib/netext"
-	k6types "go.k6.io/k6/lib/types"
 	"golang.org/x/net/http2"
 )
 


### PR DESCRIPTION
The current (ac82660fe746dcab8b819d53b94389086e591f9f) `local` setting for the gci linter is defunct. There is no local setting for the gci linter (see [an example good config](https://github.com/daixiang0/gci/blob/73cde2312b7818a42a260f2d49085e3a3cd456a0/pkg/gci/internal/testdata/already-good.cfg.yaml)).

This change makes each Go file to import as follows:
* The stdlib pkgs
* xk6-browser browser pkgs
* k6 pkgs
* The other 3rd-party packages.

To make the change work, I also updated the linter version to v1.46.2. We should merge this PR after merging #315 (or better, this PR first :)). In #315, I explained that gci was problematic. The cause was the incorrect config.

---

The reference command to fix imports:

```bash
$ gci write -s Standard -s "Prefix(github.com/grafana/xk6-browser)" -s "Prefix(go.k6.io)" -s Default . 
```

