### PR TITLE
Add locator.click([options])

### DIFF
--- a/api/frame.go
+++ b/api/frame.go
@@ -1,23 +1,3 @@
-/*
- *
- * xk6-browser - a browser automation extension for k6
- * Copyright (C) 2021 Load Impact
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
-
 package api
 
 import "github.com/dop251/goja"

--- a/api/locator.go
+++ b/api/locator.go
@@ -1,4 +1,9 @@
 package api
 
+import "github.com/dop251/goja"
+
 // Locator represents a way to find element(s) on a page at any moment.
-type Locator interface{}
+type Locator interface {
+	// Click on an element using locator's selector with strict mode on.
+	Click(opts goja.Value)
+}

--- a/common/frame.go
+++ b/common/frame.go
@@ -717,24 +717,28 @@ func (f *Frame) ChildFrames() []api.Frame {
 func (f *Frame) Click(selector string, opts goja.Value) {
 	f.log.Debugf("Frame:Click", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	parsedOpts := NewFrameClickOptions(f.defaultTimeout())
-	err := parsedOpts.Parse(f.ctx, opts)
-	if err != nil {
+	popts := NewFrameClickOptions(f.defaultTimeout())
+	if err := popts.Parse(f.ctx, opts); err != nil {
 		k6Throw(f.ctx, "%w", err)
 	}
-
-	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
-		return nil, handle.click(p, parsedOpts.ToMouseClickOptions())
-	}
-	actFn := f.newPointerAction(
-		selector, DOMElementStateAttached, parsedOpts.Strict, fn, &parsedOpts.ElementHandleBasePointerOptions,
-	)
-	_, err = callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
-	if err != nil {
+	if err := f.click(selector, popts); err != nil {
 		k6Throw(f.ctx, "%w", err)
 	}
-
 	applySlowMo(f.ctx)
+}
+
+func (f *Frame) click(selector string, opts *FrameClickOptions) error {
+	click := func(apiCtx context.Context, handle *ElementHandle, p *Position) (interface{}, error) {
+		return nil, handle.click(p, opts.ToMouseClickOptions())
+	}
+	act := f.newPointerAction(
+		selector, DOMElementStateAttached, opts.Strict, click, &opts.ElementHandleBasePointerOptions,
+	)
+	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Content returns the HTML content of the frame.

--- a/common/frame.go
+++ b/common/frame.go
@@ -1,23 +1,3 @@
-/*
- *
- * xk6-browser - a browser automation extension for k6
- * Copyright (C) 2021 Load Impact
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
-
 package common
 
 import (

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -226,6 +226,15 @@ func k6Throw(ctx context.Context, format string, a ...interface{}) {
 	_ = p.Kill()
 }
 
+// throwOrSlowMo throws an error if err is not nil, otherwise applies
+// slow motion.
+func throwOrSlowMo(ctx context.Context, err error) {
+	if err != nil {
+		k6Throw(ctx, "%w", err)
+	}
+	applySlowMo(ctx)
+}
+
 // TrimQuotes removes surrounding single or double quotes from s.
 // We're not using strings.Trim() to avoid trimming unbalanced values,
 // e.g. `"'arg` shouldn't change.

--- a/common/locator.go
+++ b/common/locator.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"context"
+
+	"github.com/dop251/goja"
 )
 
 // Locator represent a way to find element(s) on the page at any moment.
@@ -22,4 +24,27 @@ func NewLocator(ctx context.Context, selector string, f *Frame, l *Logger) *Loca
 		ctx:      ctx,
 		log:      l,
 	}
+}
+
+// Click on an element using locator's selector with strict mode on.
+func (l *Locator) Click(opts goja.Value) {
+	l.log.Debugf("Locator:Click", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+
+	var err error
+	defer func() { throwOrSlowMo(l.ctx, err) }()
+
+	copts := NewFrameClickOptions(l.frame.defaultTimeout())
+	if err = copts.Parse(l.ctx, opts); err != nil {
+		return
+	}
+	if err = l.click(copts); err != nil {
+		return
+	}
+}
+
+// click is like Click but takes parsed options and neither throws an
+// error, or applies slow motion.
+func (l *Locator) click(opts *FrameClickOptions) error {
+	opts.Strict = true
+	return l.frame.click(l.selector, opts)
 }

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -1,0 +1,31 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocatorClick(t *testing.T) {
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	require.NotNil(t, p.Goto(tb.staticURL("/strict_link.html"), nil))
+
+	// Selecting a single element and clicking on it is OK.
+	t.Run("ok", func(t *testing.T) {
+		result := func() bool {
+			cr := p.Evaluate(tb.toGojaValue(`() => window.result`))
+			return cr.(goja.Value).ToBoolean() //nolint:forcetypeassert
+		}
+		link := p.Locator("#link", nil)
+		link.Click(nil)
+		require.True(t, result(), "could not click the link")
+	})
+	// There are two links in the document (strict_link.html).
+	// The strict mode should disallow selecting multiple elements.
+	t.Run("strict", func(t *testing.T) {
+		link := p.Locator("a", nil)
+		require.Panics(t, func() { link.Click(nil) })
+	})
+}

--- a/tests/static/strict_link.html
+++ b/tests/static/strict_link.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Clickable link test</title>
+</head>
+
+<body>
+    <a id="link" href="#" onclick="event.preventDefault()">Click</a>
+    <a href="#" onclick="event.preventDefault()">Click</a>
+    <script>
+        window.result = false;
+
+        document.querySelector('#link').addEventListener(
+            'click', e => { result = true; }, false
+        );
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
This PR adds the ability to click on an element with strict mode via `Locator`. In the test, that is why it expects a panic when the test tries to select multiple link elements. The test also verifies whether the locator can click on an element using the saved selector in the locator.

Pitfalls: Although `locator.Click` forwards the click call to `frame.Click`, I wished there was a way to set the incoming goja value's `strict` property to `true`, instead of (re)parsing the options in `locator.Click`. Do let me know if you know a way to do so.

Closes: #311 