### PR TITLE
Refactor logger into its own package

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -17,7 +17,7 @@ import (
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/k6"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 
 	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
@@ -406,11 +406,11 @@ func parseWebsocketURL(ctx context.Context, rc io.Reader) (wsURL string, _ error
 }
 
 // makeLogger makes and returns an extension wide logger.
-func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*logger.Logger, error) {
+func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*log.Logger, error) {
 	var (
 		k6Logger            = k6.GetVU(ctx).State().Logger
 		reCategoryFilter, _ = regexp.Compile(launchOpts.LogCategoryFilter)
-		logger              = logger.New(k6Logger, launchOpts.Debug, reCategoryFilter)
+		logger              = log.New(k6Logger, launchOpts.Debug, reCategoryFilter)
 	)
 
 	// set the log level from the launch options (usually from a script's options).

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/k6"
+	"github.com/grafana/xk6-browser/logger"
 
 	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
@@ -405,11 +406,11 @@ func parseWebsocketURL(ctx context.Context, rc io.Reader) (wsURL string, _ error
 }
 
 // makeLogger makes and returns an extension wide logger.
-func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*common.Logger, error) {
+func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*logger.Logger, error) {
 	var (
 		k6Logger            = k6.GetVU(ctx).State().Logger
 		reCategoryFilter, _ = regexp.Compile(launchOpts.LogCategoryFilter)
-		logger              = common.NewLogger(ctx, k6Logger, launchOpts.Debug, reCategoryFilter)
+		logger              = logger.New(k6Logger, launchOpts.Debug, reCategoryFilter)
 	)
 
 	// set the log level from the launch options (usually from a script's options).

--- a/common/barrier_test.go
+++ b/common/barrier_test.go
@@ -25,8 +25,9 @@ import (
 	"testing"
 
 	"github.com/chromedp/cdproto/cdp"
-	"github.com/grafana/xk6-browser/log"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/log"
 )
 
 func TestBarrier(t *testing.T) {

--- a/common/barrier_test.go
+++ b/common/barrier_test.go
@@ -25,15 +25,14 @@ import (
 	"testing"
 
 	"github.com/chromedp/cdproto/cdp"
+	"github.com/grafana/xk6-browser/log"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/xk6-browser/logger"
 )
 
 func TestBarrier(t *testing.T) {
 	ctx := context.Background()
 
-	log := logger.NewNullLogger()
+	log := log.NewNullLogger()
 
 	timeoutSettings := NewTimeoutSettings(nil)
 	frameManager := NewFrameManager(ctx, nil, nil, timeoutSettings, log)

--- a/common/barrier_test.go
+++ b/common/barrier_test.go
@@ -26,12 +26,14 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/logger"
 )
 
 func TestBarrier(t *testing.T) {
 	ctx := context.Background()
 
-	log := NewNullLogger()
+	log := logger.NewNullLogger()
 
 	timeoutSettings := NewTimeoutSettings(nil)
 	frameManager := NewFrameManager(ctx, nil, nil, timeoutSettings, log)

--- a/common/browser.go
+++ b/common/browser.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 )
 
 // Ensure Browser implements the EventEmitter and Browser interfaces.
@@ -83,7 +83,7 @@ type Browser struct {
 
 	vu k6modules.VU
 
-	logger *logger.Logger
+	logger *log.Logger
 }
 
 // NewBrowser creates a new browser, connects to it, then returns it.
@@ -92,7 +92,7 @@ func NewBrowser(
 	cancel context.CancelFunc,
 	browserProc *BrowserProcess,
 	launchOpts *LaunchOptions,
-	logger *logger.Logger,
+	logger *log.Logger,
 ) (*Browser, error) {
 	b := newBrowser(ctx, cancel, browserProc, launchOpts, logger)
 	if err := b.connect(); err != nil {
@@ -107,7 +107,7 @@ func newBrowser(
 	cancelFn context.CancelFunc,
 	browserProc *BrowserProcess,
 	launchOpts *LaunchOptions,
-	logger *logger.Logger,
+	logger *log.Logger,
 ) *Browser {
 	return &Browser{
 		BaseEventEmitter:    NewBaseEventEmitter(ctx),

--- a/common/browser.go
+++ b/common/browser.go
@@ -27,17 +27,17 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/k6"
-
-	k6modules "go.k6.io/k6/js/modules"
-
 	"github.com/chromedp/cdproto"
 	cdpbrowser "github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
 	"github.com/gorilla/websocket"
+	k6modules "go.k6.io/k6/js/modules"
+
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6"
+	"github.com/grafana/xk6-browser/logger"
 )
 
 // Ensure Browser implements the EventEmitter and Browser interfaces.
@@ -83,11 +83,17 @@ type Browser struct {
 
 	vu k6modules.VU
 
-	logger *Logger
+	logger *logger.Logger
 }
 
 // NewBrowser creates a new browser, connects to it, then returns it.
-func NewBrowser(ctx context.Context, cancel context.CancelFunc, browserProc *BrowserProcess, launchOpts *LaunchOptions, logger *Logger) (*Browser, error) {
+func NewBrowser(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	browserProc *BrowserProcess,
+	launchOpts *LaunchOptions,
+	logger *logger.Logger,
+) (*Browser, error) {
 	b := newBrowser(ctx, cancel, browserProc, launchOpts, logger)
 	if err := b.connect(); err != nil {
 		return nil, err
@@ -96,7 +102,13 @@ func NewBrowser(ctx context.Context, cancel context.CancelFunc, browserProc *Bro
 }
 
 // newBrowser returns a ready to use Browser without connecting to an actual browser.
-func newBrowser(ctx context.Context, cancelFn context.CancelFunc, browserProc *BrowserProcess, launchOpts *LaunchOptions, logger *Logger) *Browser {
+func newBrowser(
+	ctx context.Context,
+	cancelFn context.CancelFunc,
+	browserProc *BrowserProcess,
+	launchOpts *LaunchOptions,
+	logger *logger.Logger,
+) *Browser {
 	return &Browser{
 		BaseEventEmitter:    NewBaseEventEmitter(ctx),
 		ctx:                 ctx,

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
+	"github.com/grafana/xk6-browser/logger"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -54,7 +55,7 @@ type BrowserContext struct {
 	id              cdp.BrowserContextID
 	opts            *BrowserContextOptions
 	timeoutSettings *TimeoutSettings
-	logger          *Logger
+	logger          *logger.Logger
 	vu              k6modules.VU
 
 	evaluateOnNewDocumentSources []string
@@ -62,7 +63,7 @@ type BrowserContext struct {
 
 // NewBrowserContext creates a new browser context.
 func NewBrowserContext(
-	ctx context.Context, browser *Browser, id cdp.BrowserContextID, opts *BrowserContextOptions, logger *Logger,
+	ctx context.Context, browser *Browser, id cdp.BrowserContextID, opts *BrowserContextOptions, logger *logger.Logger,
 ) *BrowserContext {
 	b := BrowserContext{
 		BaseEventEmitter: NewBaseEventEmitter(ctx),

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -45,7 +45,7 @@ var _ api.BrowserContext = &BrowserContext{}
 
 // BrowserContext stores context information for a single independent browser session.
 // A newly launched browser instance contains a default browser context.
-// Any browser context created aside from the default will be considered an "ingognito"
+// Any browser context created aside from the default will be considered an "incognito"
 // browser context and will not store any data on disk.
 type BrowserContext struct {
 	BaseEventEmitter
@@ -55,7 +55,7 @@ type BrowserContext struct {
 	id              cdp.BrowserContextID
 	opts            *BrowserContextOptions
 	timeoutSettings *TimeoutSettings
-	logger          *logger.Logger
+	logger          *log.Logger
 	vu              k6modules.VU
 
 	evaluateOnNewDocumentSources []string
@@ -63,7 +63,7 @@ type BrowserContext struct {
 
 // NewBrowserContext creates a new browser context.
 func NewBrowserContext(
-	ctx context.Context, browser *Browser, id cdp.BrowserContextID, opts *BrowserContextOptions, logger *logger.Logger,
+	ctx context.Context, browser *Browser, id cdp.BrowserContextID, opts *BrowserContextOptions, logger *log.Logger,
 ) *BrowserContext {
 	b := BrowserContext{
 		BaseEventEmitter: NewBaseEventEmitter(ctx),

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -24,7 +24,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 )
 
 type BrowserProcess struct {
@@ -44,7 +44,7 @@ type BrowserProcess struct {
 	// The directory where user data for the browser is stored.
 	userDataDir string
 
-	logger *logger.Logger
+	logger *log.Logger
 }
 
 func NewBrowserProcess(
@@ -112,6 +112,6 @@ func (p *BrowserProcess) Pid() int {
 }
 
 // AttachLogger attaches a logger to the browser process.
-func (p *BrowserProcess) AttachLogger(logger *logger.Logger) {
+func (p *BrowserProcess) AttachLogger(logger *log.Logger) {
 	p.logger = logger
 }

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -23,6 +23,8 @@ package common
 import (
 	"context"
 	"os"
+
+	"github.com/grafana/xk6-browser/logger"
 )
 
 type BrowserProcess struct {
@@ -42,7 +44,7 @@ type BrowserProcess struct {
 	// The directory where user data for the browser is stored.
 	userDataDir string
 
-	logger *Logger
+	logger *logger.Logger
 }
 
 func NewBrowserProcess(
@@ -110,6 +112,6 @@ func (p *BrowserProcess) Pid() int {
 }
 
 // AttachLogger attaches a logger to the browser process.
-func (p *BrowserProcess) AttachLogger(logger *Logger) {
+func (p *BrowserProcess) AttachLogger(logger *logger.Logger) {
 	p.logger = logger
 }

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -8,10 +8,9 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/target"
+	"github.com/grafana/xk6-browser/log"
 	"github.com/mailru/easyjson"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/xk6-browser/logger"
 )
 
 func TestBrowserNewPageInContext(t *testing.T) {
@@ -23,7 +22,7 @@ func TestBrowserNewPageInContext(t *testing.T) {
 	}
 	newTestCase := func(id cdp.BrowserContextID) *testCase {
 		ctx := context.Background()
-		b := newBrowser(ctx, nil, nil, NewLaunchOptions(), logger.NewNullLogger())
+		b := newBrowser(ctx, nil, nil, NewLaunchOptions(), log.NewNullLogger())
 		// set a new browser context in the browser with `id`, so that newPageInContext can find it.
 		b.contexts[id] = NewBrowserContext(ctx, b, id, nil, nil)
 		return &testCase{

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/chromedp/cdproto/target"
 	"github.com/mailru/easyjson"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/logger"
 )
 
 func TestBrowserNewPageInContext(t *testing.T) {
@@ -21,7 +23,7 @@ func TestBrowserNewPageInContext(t *testing.T) {
 	}
 	newTestCase := func(id cdp.BrowserContextID) *testCase {
 		ctx := context.Background()
-		b := newBrowser(ctx, nil, nil, NewLaunchOptions(), NewNullLogger())
+		b := newBrowser(ctx, nil, nil, NewLaunchOptions(), logger.NewNullLogger())
 		// set a new browser context in the browser with `id`, so that newPageInContext can find it.
 		b.contexts[id] = NewBrowserContext(ctx, b, id, nil, nil)
 		return &testCase{

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/target"
-	"github.com/grafana/xk6-browser/log"
 	"github.com/mailru/easyjson"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/log"
 )
 
 func TestBrowserNewPageInContext(t *testing.T) {

--- a/common/connection.go
+++ b/common/connection.go
@@ -35,10 +35,11 @@ import (
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
 	"github.com/gorilla/websocket"
-	"github.com/grafana/xk6-browser/log"
 	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jlexer"
 	"github.com/mailru/easyjson/jwriter"
+
+	"github.com/grafana/xk6-browser/log"
 )
 
 const wsWriteBufferSize = 1 << 20

--- a/common/connection.go
+++ b/common/connection.go
@@ -35,11 +35,10 @@ import (
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
 	"github.com/gorilla/websocket"
+	"github.com/grafana/xk6-browser/log"
 	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jlexer"
 	"github.com/mailru/easyjson/jwriter"
-
-	"github.com/grafana/xk6-browser/logger"
 )
 
 const wsWriteBufferSize = 1 << 20
@@ -119,7 +118,7 @@ type Connection struct {
 
 	ctx          context.Context
 	wsURL        string
-	logger       *logger.Logger
+	logger       *log.Logger
 	conn         *websocket.Conn
 	sendCh       chan *cdproto.Message
 	recvCh       chan *cdproto.Message
@@ -138,7 +137,7 @@ type Connection struct {
 }
 
 // NewConnection creates a new browser.
-func NewConnection(ctx context.Context, wsURL string, logger *logger.Logger) (*Connection, error) {
+func NewConnection(ctx context.Context, wsURL string, logger *log.Logger) (*Connection, error) {
 	var header http.Header
 	var tlsConfig *tls.Config
 	wsd := websocket.Dialer{

--- a/common/connection.go
+++ b/common/connection.go
@@ -38,6 +38,8 @@ import (
 	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jlexer"
 	"github.com/mailru/easyjson/jwriter"
+
+	"github.com/grafana/xk6-browser/logger"
 )
 
 const wsWriteBufferSize = 1 << 20
@@ -117,7 +119,7 @@ type Connection struct {
 
 	ctx          context.Context
 	wsURL        string
-	logger       *Logger
+	logger       *logger.Logger
 	conn         *websocket.Conn
 	sendCh       chan *cdproto.Message
 	recvCh       chan *cdproto.Message
@@ -136,7 +138,7 @@ type Connection struct {
 }
 
 // NewConnection creates a new browser.
-func NewConnection(ctx context.Context, wsURL string, logger *Logger) (*Connection, error) {
+func NewConnection(ctx context.Context, wsURL string, logger *logger.Logger) (*Connection, error) {
 	var header http.Header
 	var tlsConfig *tls.Config
 	wsd := websocket.Dialer{

--- a/common/connection_test.go
+++ b/common/connection_test.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/grafana/xk6-browser/logger"
 	"github.com/grafana/xk6-browser/tests/ws"
 
 	"github.com/chromedp/cdproto"
@@ -44,7 +45,7 @@ func TestConnection(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/echo", url.Host)
-		conn, err := NewConnection(ctx, wsURL, NewNullLogger())
+		conn, err := NewConnection(ctx, wsURL, logger.NewNullLogger())
 		conn.Close()
 
 		require.NoError(t, err)
@@ -58,7 +59,7 @@ func TestConnectionClosureAbnormal(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/closure-abnormal", url.Host)
-		conn, err := NewConnection(ctx, wsURL, NewNullLogger())
+		conn, err := NewConnection(ctx, wsURL, logger.NewNullLogger())
 
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
@@ -75,7 +76,7 @@ func TestConnectionSendRecv(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, NewNullLogger())
+		conn, err := NewConnection(ctx, wsURL, logger.NewNullLogger())
 
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
@@ -138,7 +139,7 @@ func TestConnectionCreateSession(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, NewNullLogger())
+		conn, err := NewConnection(ctx, wsURL, logger.NewNullLogger())
 
 		if assert.NoError(t, err) {
 			session, err := conn.createSession(&target.Info{

--- a/common/connection_test.go
+++ b/common/connection_test.go
@@ -26,7 +26,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 	"github.com/grafana/xk6-browser/tests/ws"
 
 	"github.com/chromedp/cdproto"
@@ -45,7 +45,7 @@ func TestConnection(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/echo", url.Host)
-		conn, err := NewConnection(ctx, wsURL, logger.NewNullLogger())
+		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
 		conn.Close()
 
 		require.NoError(t, err)
@@ -59,7 +59,7 @@ func TestConnectionClosureAbnormal(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/closure-abnormal", url.Host)
-		conn, err := NewConnection(ctx, wsURL, logger.NewNullLogger())
+		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
 
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
@@ -76,7 +76,7 @@ func TestConnectionSendRecv(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, logger.NewNullLogger())
+		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
 
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
@@ -139,7 +139,7 @@ func TestConnectionCreateSession(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, logger.NewNullLogger())
+		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
 
 		if assert.NoError(t, err) {
 			session, err := conn.createSession(&target.Info{

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -66,7 +66,7 @@ func (ea evalOptions) String() string {
 // ExecutionContext represents a JS execution context.
 type ExecutionContext struct {
 	ctx            context.Context
-	logger         *logger.Logger
+	logger         *log.Logger
 	session        session
 	frame          *Frame
 	id             runtime.ExecutionContextID
@@ -82,7 +82,7 @@ type ExecutionContext struct {
 
 // NewExecutionContext creates a new JS execution context.
 func NewExecutionContext(
-	ctx context.Context, s session, f *Frame, id runtime.ExecutionContextID, l *logger.Logger,
+	ctx context.Context, s session, f *Frame, id runtime.ExecutionContextID, l *log.Logger,
 ) *ExecutionContext {
 	e := &ExecutionContext{
 		ctx:            ctx,

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
+	"github.com/grafana/xk6-browser/logger"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -65,7 +66,7 @@ func (ea evalOptions) String() string {
 // ExecutionContext represents a JS execution context.
 type ExecutionContext struct {
 	ctx            context.Context
-	logger         *Logger
+	logger         *logger.Logger
 	session        session
 	frame          *Frame
 	id             runtime.ExecutionContextID
@@ -81,7 +82,7 @@ type ExecutionContext struct {
 
 // NewExecutionContext creates a new JS execution context.
 func NewExecutionContext(
-	ctx context.Context, s session, f *Frame, id runtime.ExecutionContextID, l *Logger,
+	ctx context.Context, s session, f *Frame, id runtime.ExecutionContextID, l *logger.Logger,
 ) *ExecutionContext {
 	e := &ExecutionContext{
 		ctx:            ctx,

--- a/common/frame.go
+++ b/common/frame.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
+	"github.com/grafana/xk6-browser/logger"
 
 	k6modules "go.k6.io/k6/js/modules"
 	k6metrics "go.k6.io/k6/metrics"
@@ -72,11 +73,13 @@ type Frame struct {
 	currentDocument *DocumentInfo
 	pendingDocument *DocumentInfo
 
-	log *Logger
+	log *logger.Logger
 }
 
 // NewFrame creates a new HTML document frame.
-func NewFrame(ctx context.Context, m *FrameManager, parentFrame *Frame, frameID cdp.FrameID, log *Logger) *Frame {
+func NewFrame(
+	ctx context.Context, m *FrameManager, parentFrame *Frame, frameID cdp.FrameID, log *logger.Logger,
+) *Frame {
 	if log.DebugMode() {
 		var pfid string
 		if parentFrame != nil {

--- a/common/frame.go
+++ b/common/frame.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 
 	k6modules "go.k6.io/k6/js/modules"
 	k6metrics "go.k6.io/k6/metrics"
@@ -73,12 +73,12 @@ type Frame struct {
 	currentDocument *DocumentInfo
 	pendingDocument *DocumentInfo
 
-	log *logger.Logger
+	log *log.Logger
 }
 
 // NewFrame creates a new HTML document frame.
 func NewFrame(
-	ctx context.Context, m *FrameManager, parentFrame *Frame, frameID cdp.FrameID, log *logger.Logger,
+	ctx context.Context, m *FrameManager, parentFrame *Frame, frameID cdp.FrameID, log *log.Logger,
 ) *Frame {
 	if log.DebugMode() {
 		var pfid string

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 
 	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
@@ -66,7 +66,7 @@ type FrameManager struct {
 
 	vu k6modules.VU
 
-	logger *logger.Logger
+	logger *log.Logger
 	id     int64
 }
 
@@ -79,7 +79,7 @@ func NewFrameManager(
 	s session,
 	p *Page,
 	ts *TimeoutSettings,
-	l *logger.Logger,
+	l *log.Logger,
 ) *FrameManager {
 	m := &FrameManager{
 		ctx:              ctx,

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
+	"github.com/grafana/xk6-browser/logger"
 
 	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
@@ -65,7 +66,7 @@ type FrameManager struct {
 
 	vu k6modules.VU
 
-	logger *Logger
+	logger *logger.Logger
 	id     int64
 }
 
@@ -78,7 +79,7 @@ func NewFrameManager(
 	s session,
 	p *Page,
 	ts *TimeoutSettings,
-	l *Logger,
+	l *logger.Logger,
 ) *FrameManager {
 	m := &FrameManager{
 		ctx:              ctx,

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -506,7 +506,7 @@ func (fs *FrameSession) navigateFrame(frame *Frame, url, referrer string) (strin
 }
 
 func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICalled) {
-	l := fs.serializer.Log.
+	l := fs.serializer.
 		WithTime(event.Timestamp.Time()).
 		WithField("source", "browser-console-api")
 
@@ -674,7 +674,7 @@ func (fs *FrameSession) onFrameStoppedLoading(frameID cdp.FrameID) {
 }
 
 func (fs *FrameSession) onLogEntryAdded(event *cdplog.EventEntryAdded) {
-	l := fs.logger.Log.
+	l := fs.logger.
 		WithTime(event.Entry.Timestamp.Time()).
 		WithField("source", "browser").
 		WithField("url", event.Entry.URL).

--- a/common/frame_test.go
+++ b/common/frame_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/k6/k6test"
+	"github.com/grafana/xk6-browser/logger"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/stretchr/testify/require"
@@ -17,7 +18,7 @@ func TestFrameNilDocument(t *testing.T) {
 	t.Parallel()
 
 	vu := k6test.NewVU(t)
-	log := NewNullLogger()
+	log := logger.NewNullLogger()
 
 	fm := NewFrameManager(vu.Context(), nil, nil, nil, log)
 	frame := NewFrame(vu.Context(), fm, nil, cdp.FrameID("42"), log)
@@ -67,7 +68,7 @@ func TestFrameNilDocument(t *testing.T) {
 func TestFrameManagerFrameAbortedNavigationShouldEmitANonNilPendingDocument(t *testing.T) {
 	t.Parallel()
 
-	ctx, log := context.Background(), NewNullLogger()
+	ctx, log := context.Background(), logger.NewNullLogger()
 
 	// add the frame to frame manager
 	fm := NewFrameManager(ctx, nil, nil, NewTimeoutSettings(nil), log)

--- a/common/frame_test.go
+++ b/common/frame_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/k6/k6test"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/stretchr/testify/require"
@@ -18,7 +18,7 @@ func TestFrameNilDocument(t *testing.T) {
 	t.Parallel()
 
 	vu := k6test.NewVU(t)
-	log := logger.NewNullLogger()
+	log := log.NewNullLogger()
 
 	fm := NewFrameManager(vu.Context(), nil, nil, nil, log)
 	frame := NewFrame(vu.Context(), fm, nil, cdp.FrameID("42"), log)
@@ -68,7 +68,7 @@ func TestFrameNilDocument(t *testing.T) {
 func TestFrameManagerFrameAbortedNavigationShouldEmitANonNilPendingDocument(t *testing.T) {
 	t.Parallel()
 
-	ctx, log := context.Background(), logger.NewNullLogger()
+	ctx, log := context.Background(), log.NewNullLogger()
 
 	// add the frame to frame manager
 	fm := NewFrameManager(ctx, nil, nil, NewTimeoutSettings(nil), log)

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -29,6 +29,7 @@ import (
 
 	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/k6"
 )
 

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -30,15 +30,14 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
+	"github.com/grafana/xk6-browser/log"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/xk6-browser/logger"
 )
 
 func newExecCtx() (*ExecutionContext, context.Context, *goja.Runtime) {
 	ctx := context.Background()
-	logger := logger.New(logrus.New(), false, nil)
+	logger := log.New(logrus.New(), false, nil)
 	execCtx := NewExecutionContext(ctx, nil, nil, runtime.ExecutionContextID(123456789), logger)
 
 	return execCtx, ctx, goja.New()
@@ -145,7 +144,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := logger.NewNullLogger()
+		log := log.NewNullLogger()
 
 		timeoutSettings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSettings, log)
@@ -168,7 +167,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle wrong context", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := logger.NewNullLogger()
+		log := log.NewNullLogger()
 
 		timeoutSettings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSettings, log)
@@ -190,7 +189,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle is disposed", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := logger.NewNullLogger()
+		log := log.NewNullLogger()
 
 		timeoutSettings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSettings, log)
@@ -212,7 +211,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle as *ElementHandle", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := logger.NewNullLogger()
+		log := log.NewNullLogger()
 
 		timeoutSettings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSettings, log)

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -32,11 +32,13 @@ import (
 	"github.com/dop251/goja"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/logger"
 )
 
 func newExecCtx() (*ExecutionContext, context.Context, *goja.Runtime) {
 	ctx := context.Background()
-	logger := NewLogger(ctx, logrus.New(), false, nil)
+	logger := logger.New(logrus.New(), false, nil)
 	execCtx := NewExecutionContext(ctx, nil, nil, runtime.ExecutionContextID(123456789), logger)
 
 	return execCtx, ctx, goja.New()
@@ -143,7 +145,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := NewNullLogger()
+		log := logger.NewNullLogger()
 
 		timeoutSettings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSettings, log)
@@ -166,7 +168,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle wrong context", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := NewNullLogger()
+		log := logger.NewNullLogger()
 
 		timeoutSettings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSettings, log)
@@ -188,7 +190,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle is disposed", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := NewNullLogger()
+		log := logger.NewNullLogger()
 
 		timeoutSettings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSettings, log)
@@ -210,7 +212,7 @@ func TestConvertArgument(t *testing.T) {
 
 	t.Run("*BaseJSHandle as *ElementHandle", func(t *testing.T) {
 		execCtx, ctx, rt := newExecCtx()
-		log := NewNullLogger()
+		log := logger.NewNullLogger()
 
 		timeoutSettings := NewTimeoutSettings(nil)
 		frameManager := NewFrameManager(ctx, nil, nil, timeoutSettings, log)

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -30,9 +30,10 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
-	"github.com/grafana/xk6-browser/log"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/log"
 )
 
 func newExecCtx() (*ExecutionContext, context.Context, *goja.Runtime) {

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/runtime"
@@ -38,7 +38,7 @@ var _ api.JSHandle = &BaseJSHandle{}
 // BaseJSHandle represents a JS object in an execution context.
 type BaseJSHandle struct {
 	ctx          context.Context
-	logger       *logger.Logger
+	logger       *log.Logger
 	session      session
 	execCtx      *ExecutionContext
 	remoteObject *runtime.RemoteObject
@@ -52,7 +52,7 @@ func NewJSHandle(
 	ectx *ExecutionContext,
 	f *Frame,
 	ro *runtime.RemoteObject,
-	l *logger.Logger,
+	l *log.Logger,
 ) api.JSHandle {
 	eh := &BaseJSHandle{
 		ctx:          ctx,

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
+	"github.com/grafana/xk6-browser/logger"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/runtime"
@@ -37,7 +38,7 @@ var _ api.JSHandle = &BaseJSHandle{}
 // BaseJSHandle represents a JS object in an execution context.
 type BaseJSHandle struct {
 	ctx          context.Context
-	logger       *Logger
+	logger       *logger.Logger
 	session      session
 	execCtx      *ExecutionContext
 	remoteObject *runtime.RemoteObject
@@ -51,7 +52,7 @@ func NewJSHandle(
 	ectx *ExecutionContext,
 	f *Frame,
 	ro *runtime.RemoteObject,
-	l *Logger,
+	l *logger.Logger,
 ) api.JSHandle {
 	eh := &BaseJSHandle{
 		ctx:          ctx,

--- a/common/locator.go
+++ b/common/locator.go
@@ -4,8 +4,7 @@ import (
 	"context"
 
 	"github.com/dop251/goja"
-
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 )
 
 // Locator represent a way to find element(s) on the page at any moment.
@@ -15,11 +14,11 @@ type Locator struct {
 	frame *Frame
 
 	ctx context.Context
-	log *logger.Logger
+	log *log.Logger
 }
 
 // NewLocator creates and returns a new locator.
-func NewLocator(ctx context.Context, selector string, f *Frame, l *logger.Logger) *Locator {
+func NewLocator(ctx context.Context, selector string, f *Frame, l *log.Logger) *Locator {
 	return &Locator{
 		selector: selector,
 		frame:    f,

--- a/common/locator.go
+++ b/common/locator.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/dop251/goja"
+
+	"github.com/grafana/xk6-browser/logger"
 )
 
 // Locator represent a way to find element(s) on the page at any moment.
@@ -13,11 +15,11 @@ type Locator struct {
 	frame *Frame
 
 	ctx context.Context
-	log *Logger
+	log *logger.Logger
 }
 
 // NewLocator creates and returns a new locator.
-func NewLocator(ctx context.Context, selector string, f *Frame, l *Logger) *Locator {
+func NewLocator(ctx context.Context, selector string, f *Frame, l *logger.Logger) *Locator {
 	return &Locator{
 		selector: selector,
 		frame:    f,

--- a/common/locator.go
+++ b/common/locator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/log"
 )
 

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/k6"
+	"github.com/grafana/xk6-browser/logger"
 
 	k6modules "go.k6.io/k6/js/modules"
 	k6lib "go.k6.io/k6/lib"
@@ -53,7 +54,7 @@ type NetworkManager struct {
 	BaseEventEmitter
 
 	ctx          context.Context
-	logger       *Logger
+	logger       *logger.Logger
 	session      session
 	parent       *NetworkManager
 	frameManager *FrameManager
@@ -92,7 +93,7 @@ func NewNetworkManager(
 		ctx:              ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:           NewLogger(ctx, state.Logger, false, nil),
+		logger:           logger.New(state.Logger, false, nil),
 		session:          s,
 		parent:           parent,
 		frameManager:     fm,

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/k6"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 
 	k6modules "go.k6.io/k6/js/modules"
 	k6lib "go.k6.io/k6/lib"
@@ -54,7 +54,7 @@ type NetworkManager struct {
 	BaseEventEmitter
 
 	ctx          context.Context
-	logger       *logger.Logger
+	logger       *log.Logger
 	session      session
 	parent       *NetworkManager
 	frameManager *FrameManager
@@ -93,7 +93,7 @@ func NewNetworkManager(
 		ctx:              ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:           logger.New(state.Logger, false, nil),
+		logger:           log.New(state.Logger, false, nil),
 		session:          s,
 		parent:           parent,
 		frameManager:     fm,

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/grafana/xk6-browser/k6/k6test"
+	"github.com/grafana/xk6-browser/logger"
 
 	k6lib "go.k6.io/k6/lib"
 	k6mockresolver "go.k6.io/k6/lib/testutils/mockresolver"
@@ -58,7 +59,7 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 	vu := k6test.NewVU(t)
 	st := vu.State()
 	st.Options = k6opts
-	logger := NewLogger(vu.Context(), st.Logger, false, nil)
+	logger := logger.New(st.Logger, false, nil)
 	nm := &NetworkManager{
 		ctx:      vu.Context(),
 		logger:   logger,

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/grafana/xk6-browser/k6/k6test"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 
 	k6lib "go.k6.io/k6/lib"
 	k6mockresolver "go.k6.io/k6/lib/testutils/mockresolver"
@@ -59,7 +59,7 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 	vu := k6test.NewVU(t)
 	st := vu.State()
 	st.Options = k6opts
-	logger := logger.New(st.Logger, false, nil)
+	logger := log.New(st.Logger, false, nil)
 	nm := &NetworkManager{
 		ctx:      vu.Context(),
 		logger:   logger,

--- a/common/page.go
+++ b/common/page.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
+	"github.com/grafana/xk6-browser/logger"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -89,7 +90,7 @@ type Page struct {
 	routes        []api.Route
 	vu            k6modules.VU
 
-	logger *Logger
+	logger *logger.Logger
 }
 
 // NewPage creates a new browser page context.
@@ -100,7 +101,7 @@ func NewPage(
 	tid target.ID,
 	opener *Page,
 	bp bool,
-	logger *Logger,
+	logger *logger.Logger,
 ) (*Page, error) {
 	p := Page{
 		BaseEventEmitter: NewBaseEventEmitter(ctx),

--- a/common/page.go
+++ b/common/page.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -90,7 +90,7 @@ type Page struct {
 	routes        []api.Route
 	vu            k6modules.VU
 
-	logger *logger.Logger
+	logger *log.Logger
 }
 
 // NewPage creates a new browser page context.
@@ -101,7 +101,7 @@ func NewPage(
 	tid target.ID,
 	opener *Page,
 	bp bool,
-	logger *logger.Logger,
+	logger *log.Logger,
 ) (*Page, error) {
 	p := Page{
 		BaseEventEmitter: NewBaseEventEmitter(ctx),

--- a/common/response.go
+++ b/common/response.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -61,7 +61,7 @@ type SecurityDetails struct {
 // Response represents a browser HTTP response.
 type Response struct {
 	ctx               context.Context
-	logger            *logger.Logger
+	logger            *log.Logger
 	request           *Request
 	remoteAddress     *RemoteAddress
 	securityDetails   *SecurityDetails
@@ -91,7 +91,7 @@ func NewHTTPResponse(ctx context.Context, req *Request, resp *network.Response, 
 		ctx: ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:            logger.New(state.Logger, false, nil),
+		logger:            log.New(state.Logger, false, nil),
 		request:           req,
 		remoteAddress:     &RemoteAddress{IPAddress: resp.RemoteIPAddress, Port: resp.RemotePort},
 		securityDetails:   nil,

--- a/common/response.go
+++ b/common/response.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6"
+	"github.com/grafana/xk6-browser/logger"
 
 	k6modules "go.k6.io/k6/js/modules"
 
@@ -60,7 +61,7 @@ type SecurityDetails struct {
 // Response represents a browser HTTP response.
 type Response struct {
 	ctx               context.Context
-	logger            *Logger
+	logger            *logger.Logger
 	request           *Request
 	remoteAddress     *RemoteAddress
 	securityDetails   *SecurityDetails
@@ -90,7 +91,7 @@ func NewHTTPResponse(ctx context.Context, req *Request, resp *network.Response, 
 		ctx: ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:            NewLogger(ctx, state.Logger, false, nil),
+		logger:            logger.New(state.Logger, false, nil),
 		request:           req,
 		remoteAddress:     &RemoteAddress{IPAddress: resp.RemoteIPAddress, Port: resp.RemotePort},
 		securityDetails:   nil,

--- a/common/session.go
+++ b/common/session.go
@@ -29,6 +29,8 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/target"
 	"github.com/mailru/easyjson"
+
+	"github.com/grafana/xk6-browser/logger"
 )
 
 // Ensure Session implements the EventEmitter and Executor interfaces.
@@ -48,11 +50,13 @@ type Session struct {
 	closed   bool
 	crashed  bool
 
-	logger *Logger
+	logger *logger.Logger
 }
 
 // NewSession creates a new session.
-func NewSession(ctx context.Context, conn *Connection, id target.SessionID, tid target.ID, logger *Logger) *Session {
+func NewSession(
+	ctx context.Context, conn *Connection, id target.SessionID, tid target.ID, logger *logger.Logger,
+) *Session {
 	s := Session{
 		BaseEventEmitter: NewBaseEventEmitter(ctx),
 		conn:             conn,

--- a/common/session.go
+++ b/common/session.go
@@ -28,8 +28,9 @@ import (
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/target"
-	"github.com/grafana/xk6-browser/log"
 	"github.com/mailru/easyjson"
+
+	"github.com/grafana/xk6-browser/log"
 )
 
 // Ensure Session implements the EventEmitter and Executor interfaces.

--- a/common/session.go
+++ b/common/session.go
@@ -28,9 +28,8 @@ import (
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/target"
+	"github.com/grafana/xk6-browser/log"
 	"github.com/mailru/easyjson"
-
-	"github.com/grafana/xk6-browser/logger"
 )
 
 // Ensure Session implements the EventEmitter and Executor interfaces.
@@ -50,12 +49,12 @@ type Session struct {
 	closed   bool
 	crashed  bool
 
-	logger *logger.Logger
+	logger *log.Logger
 }
 
 // NewSession creates a new session.
 func NewSession(
-	ctx context.Context, conn *Connection, id target.SessionID, tid target.ID, logger *logger.Logger,
+	ctx context.Context, conn *Connection, id target.SessionID, tid target.ID, logger *log.Logger,
 ) *Session {
 	s := Session{
 		BaseEventEmitter: NewBaseEventEmitter(ctx),

--- a/common/session_test.go
+++ b/common/session_test.go
@@ -26,7 +26,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/grafana/xk6-browser/logger"
+	"github.com/grafana/xk6-browser/log"
 	"github.com/grafana/xk6-browser/tests/ws"
 
 	"github.com/chromedp/cdproto"
@@ -104,7 +104,7 @@ func TestSessionCreateSession(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, logger.NewNullLogger())
+		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
 
 		if assert.NoError(t, err) {
 			session, err := conn.createSession(&target.Info{

--- a/common/session_test.go
+++ b/common/session_test.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/grafana/xk6-browser/logger"
 	"github.com/grafana/xk6-browser/tests/ws"
 
 	"github.com/chromedp/cdproto"
@@ -103,7 +104,7 @@ func TestSessionCreateSession(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, NewNullLogger())
+		conn, err := NewConnection(ctx, wsURL, logger.NewNullLogger())
 
 		if assert.NoError(t, err) {
 			session, err := conn.createSession(&target.Info{

--- a/log/logger.go
+++ b/log/logger.go
@@ -18,7 +18,7 @@
  *
  */
 
-package logger
+package log
 
 import (
 	"encoding/json"

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -18,7 +18,7 @@
  *
  */
 
-package logger
+package log
 
 import (
 	"testing"

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -18,7 +18,7 @@
  *
  */
 
-package common
+package logger
 
 import (
 	"testing"


### PR DESCRIPTION
Logger is a common process but it should live in its own package, that
is dedicated to all things logging. This will also allow us to easily import
the logger anywhere, helps avoid cyclic imports, it gives us a clean api,
and could allow us to easily migrate to other logging modules if we need.