### PR TITLE
Spelling fix for "networkidle"

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ export default function() {
     page.$('input[type="submit"]').click();
 
     // Wait for next page to load
-    page.waitForLoadState('networkdidle');
+    page.waitForLoadState('networkidle');
 
     page.close();
     browser.close();


### PR DESCRIPTION
One of the `page.waitForLoadState` names is incorrect.

Produces the following errors when you run the sample:

```
...
ERRO[0008] waitForLoadState error: invalid lifecycle event: "networklidle"; must be one of: load, domcontentloaded, networkidle
running at reflect.methodValueCall (native)
default at n (webpack://perf-customer-scenario-tests/./src/ui/sample.test.ts:22:2(72))
	at native  executor=per-vu-iterations scenario=default source=stacktrace

running (00m08.9s), 0/1 VUs, 1 complete and 0 interrupted iterations
default ✓ [======================================] 1 VUs  00m08.9s/10m0s  1/1 iters, 1 per VU
....
ERRO[0009] err:websocket: close 1006 (abnormal closure): unexpected EOF  category="Connection:handleIOError" elapsed="0 ms" goroutine=82
```