### PR TITLE
Add combo key press

### DIFF
--- a/common/keyboard_test.go
+++ b/common/keyboard_test.go
@@ -1,0 +1,78 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/grafana/xk6-browser/k6ext/k6test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplit(t *testing.T) {
+	type args struct {
+		keys string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "empty slice on empty string",
+			args: args{
+				keys: "",
+			},
+			want: []string{""},
+		},
+		{
+			name: "empty slice on string without separator",
+			args: args{
+				keys: "HelloWorld!",
+			},
+			want: []string{"HelloWorld!"},
+		},
+		{
+			name: "string split with separator",
+			args: args{
+				keys: "Hello+World+!",
+			},
+			want: []string{"Hello", "World", "!"},
+		},
+		{
+			name: "do not split on single +",
+			args: args{
+				keys: "+",
+			},
+			want: []string{"+"},
+		},
+		{
+			name: "split ++ to + and ''",
+			args: args{
+				keys: "++",
+			},
+			want: []string{"+", ""},
+		},
+		{
+			name: "split +++ to + and +",
+			args: args{
+				keys: "+++",
+			},
+			want: []string{"+", "+"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := split(tt.args.keys)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestKeyboardPress(t *testing.T) {
+	t.Run("panics when '' empty key passed in", func(t *testing.T) {
+		vu := k6test.NewVU(t)
+		k := NewKeyboard(vu.Context(), nil)
+		assert.Panics(t, func() { k.Press("", nil) })
+	})
+}

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -47,7 +47,32 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("combo", func(t *testing.T) {
-		t.Skip("FIXME") // See https://github.com/grafana/xk6-browser/issues/285
+		p := tb.NewPage(nil)
+		cp, ok := p.(*common.Page)
+		require.True(t, ok)
+		kb := cp.Keyboard
+
+		p.SetContent(`<input>`, nil)
+		el := p.Query("input")
+		p.Focus("input", nil)
+
+		kb.Press("Shift++", nil)
+		kb.Press("Shift+=", nil)
+		kb.Press("Shift+@", nil)
+		kb.Press("Shift+6", nil)
+		kb.Press("Shift+KeyA", nil)
+		kb.Press("Shift+b", nil)
+		kb.Press("Shift+C", nil)
+
+		kb.Press("Control+KeyI", nil)
+		kb.Press("Control+J", nil)
+		kb.Press("Control+k", nil)
+
+		require.Equal(t, "+=@6AbC", el.InputValue(nil))
+	})
+
+	t.Run("meta", func(t *testing.T) {
+		t.Skip("FIXME") // See https://github.com/grafana/xk6-browser/issues/424
 		p := tb.NewPage(nil)
 		cp, ok := p.(*common.Page)
 		require.True(t, ok)
@@ -59,9 +84,9 @@ func TestKeyboardPress(t *testing.T) {
 
 		kb.Press("Shift+KeyA", nil)
 		kb.Press("Shift+b", nil)
-		kb.Press("C", nil)
-		kb.Press("d", nil)
-		require.Equal(t, "AbCd", el.InputValue(nil))
+		kb.Press("Shift+C", nil)
+
+		require.Equal(t, "AbC", el.InputValue(nil))
 
 		metaKey := "Control"
 		if runtime.GOOS == "darwin" {
@@ -70,6 +95,63 @@ func TestKeyboardPress(t *testing.T) {
 		kb.Press(metaKey+"+A", nil)
 		kb.Press("Delete", nil)
 		assert.Equal(t, "", el.InputValue(nil))
+	})
+
+	t.Run("type does not split on +", func(t *testing.T) {
+		p := tb.NewPage(nil)
+		cp, ok := p.(*common.Page)
+		require.True(t, ok)
+		kb := cp.Keyboard
+
+		p.SetContent(`<textarea>`, nil)
+		el := p.Query("textarea")
+		p.Focus("textarea", nil)
+
+		kb.Type("L+m+KeyN", nil)
+		assert.Equal(t, "L+m+KeyN", el.InputValue(nil))
+	})
+
+	t.Run("capitalization", func(t *testing.T) {
+		p := tb.NewPage(nil)
+		cp, ok := p.(*common.Page)
+		require.True(t, ok)
+		kb := cp.Keyboard
+
+		p.SetContent(`<textarea>`, nil)
+		el := p.Query("textarea")
+		p.Focus("textarea", nil)
+
+		kb.Press("C", nil)
+		kb.Press("d", nil)
+		kb.Press("KeyE", nil)
+
+		kb.Down("Shift")
+		kb.Down("f")
+		kb.Up("f")
+		kb.Down("G")
+		kb.Up("G")
+		kb.Down("KeyH")
+		kb.Up("KeyH")
+		kb.Up("Shift")
+
+		assert.Equal(t, "CdefGH", el.InputValue(nil))
+	})
+
+	t.Run("type not affected by shift", func(t *testing.T) {
+		p := tb.NewPage(nil)
+		cp, ok := p.(*common.Page)
+		require.True(t, ok)
+		kb := cp.Keyboard
+
+		p.SetContent(`<textarea>`, nil)
+		el := p.Query("textarea")
+		p.Focus("textarea", nil)
+
+		kb.Down("Shift")
+		kb.Type("oPqR", nil)
+		kb.Up("Shift")
+
+		assert.Equal(t, "oPqR", el.InputValue(nil))
 	})
 
 	t.Run("newline", func(t *testing.T) {

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -331,7 +331,6 @@ func TestLocatorElementState(t *testing.T) {
 		name string
 		do   func(api.Locator, *testBrowser)
 	}{
-
 		{
 			"IsChecked", func(l api.Locator, tb *testBrowser) { l.IsChecked(timeout(tb)) },
 		},


### PR DESCRIPTION
This fixes https://github.com/grafana/xk6-browser/issues/285

Shift+X when passed to press() and used in conjunction with down() and up() now will change the casing of the character, as long as the character is in the format `KeyX`. A key press that is `x` or `X` will ignore the shift modifier key. This fix matches the playwright behaviour.

E.g.

```
Shift+KeyA -> A
KeyA -> a
A -> A
a -> a
Shift+A -> A
Shift+a -> a
```

The Shift modifier will only change the case of a character if KeyA - KeyZ is used.