### PR TITLE
Fix `Page.content()`

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -754,7 +754,7 @@ func (f *Frame) Content() string {
 			if (document.documentElement) {
 				content += document.documentElement.outerHTML;
 			}
-			return document.documentElement.outerHTML;
+			return content;
 		}`
 
 	c := f.Evaluate(rt.ToValue(js))

--- a/common/frame.go
+++ b/common/frame.go
@@ -758,10 +758,6 @@ func (f *Frame) Content() string {
 		}`
 
 	c := f.Evaluate(rt.ToValue(js))
-	if c == nil {
-		return ""
-	}
-
 	content, ok := c.(goja.Value)
 	if !ok {
 		k6.Panic(f.ctx, "unexpected content() value type: %T", c)

--- a/common/frame.go
+++ b/common/frame.go
@@ -746,15 +746,28 @@ func (f *Frame) Content() string {
 	f.log.Debugf("Frame:Content", "fid:%s furl:%q", f.ID(), f.URL())
 
 	rt := f.vu.Runtime()
-	js := `let content = '';
-		if (document.doctype) {
-			content = new XMLSerializer().serializeToString(document.doctype);
-		}
-		if (document.documentElement) {
-			content += document.documentElement.outerHTML;
-		}
-		return content;`
-	return f.Evaluate(rt.ToValue(js)).(string)
+	js := `() => {
+			let content = '';
+			if (document.doctype) {
+				content = new XMLSerializer().serializeToString(document.doctype);
+			}
+			if (document.documentElement) {
+				content += document.documentElement.outerHTML;
+			}
+			return document.documentElement.outerHTML;
+		}`
+
+	c := f.Evaluate(rt.ToValue(js))
+	if c == nil {
+		return ""
+	}
+
+	content, ok := c.(goja.Value)
+	if !ok {
+		k6.Panic(f.ctx, "unexpected content() value type: %T", c)
+	}
+
+	return content.ToString().String()
 }
 
 // Dblclick double clicks an element matching provided selector.

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -80,7 +80,7 @@ func TestPageContent(t *testing.T) {
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
-	content := `<html><head></head><body><h1>Hello</h1></body></html>`
+	content := `<!DOCTYPE html><html><head></head><body><h1>Hello</h1></body></html>`
 	p.SetContent(content, nil)
 
 	assert.Equal(t, content, p.Content())

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -74,6 +74,18 @@ func TestPageEmulateMedia(t *testing.T) {
 	assert.True(t, res.ToBoolean(), "expected reduced motion setting to be 'reduce'")
 }
 
+func TestPageContent(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t)
+	p := tb.NewPage(nil)
+
+	content := `<html><head></head><body><h1>Hello</h1></body></html>`
+	p.SetContent(content, nil)
+
+	assert.Equal(t, content, p.Content())
+}
+
 func TestPageEvaluate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The `Unexpected identifier` error was because of the `return` used outside of a function context. This seemed like a regression introduced by #293, but it also happens on `v0.2.0`, so :man_shrugging:. Casting the `Evaluate()` result to `string` would've failed anyway, so this addresses both issues.

I wanted to add a `Frame.Content()` unit test, but mocking the `ExecutionContext` became troublesome, so I just added this `Page.Content()` integration test instead.

Closes #322