### PR TITLE
Add locator.dblclick([options])

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -6,4 +6,6 @@ import "github.com/dop251/goja"
 type Locator interface {
 	// Click on an element using locator's selector with strict mode on.
 	Click(opts goja.Value)
+	// Dblclick double clicks on an element using locator's selector with strict mode on.
+	Dblclick(opts goja.Value)
 }

--- a/common/locator.go
+++ b/common/locator.go
@@ -50,3 +50,26 @@ func (l *Locator) click(opts *FrameClickOptions) error {
 	opts.Strict = true
 	return l.frame.click(l.selector, opts)
 }
+
+// Dblclick double clicks on an element using locator's selector with strict mode on.
+func (l *Locator) Dblclick(opts goja.Value) {
+	l.log.Debugf("Locator:Dblclick", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+
+	var err error
+	defer func() { panicOrSlowMo(l.ctx, err) }()
+
+	copts := NewFrameDblClickOptions(l.frame.defaultTimeout())
+	if err = copts.Parse(l.ctx, opts); err != nil {
+		return
+	}
+	if err = l.dblclick(copts); err != nil {
+		return
+	}
+}
+
+// Dblclick is like Dblclick but takes parsed options and neither throws an
+// error, or applies slow motion.
+func (l *Locator) dblclick(opts *FrameDblclickOptions) error {
+	opts.Strict = true
+	return l.frame.dblclick(l.selector, opts)
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -29,3 +29,26 @@ func TestLocatorClick(t *testing.T) {
 		require.Panics(t, func() { link.Click(nil) })
 	})
 }
+
+func TestLocatorDblclick(t *testing.T) {
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	require.NotNil(t, p.Goto(tb.staticURL("/strict_link.html"), nil))
+
+	// Selecting a single element and clicking on it is OK.
+	t.Run("ok", func(t *testing.T) {
+		dblclick := func() bool {
+			cr := p.Evaluate(tb.toGojaValue(`() => window.dblclick`))
+			return cr.(goja.Value).ToBoolean() //nolint:forcetypeassert
+		}
+		link := p.Locator("#link", nil)
+		link.Dblclick(nil)
+		require.True(t, dblclick(), "could not double click the link")
+	})
+	// There are two links in the document (strict_link.html).
+	// The strict mode should disallow selecting multiple elements.
+	t.Run("strict", func(t *testing.T) {
+		link := p.Locator("a", nil)
+		require.Panics(t, func() { link.Dblclick(nil) })
+	})
+}

--- a/tests/static/strict_link.html
+++ b/tests/static/strict_link.html
@@ -10,9 +10,13 @@
     <a href="#" onclick="event.preventDefault()">Click</a>
     <script>
         window.result = false;
+        window.dblclick = false;
 
         document.querySelector('#link').addEventListener(
             'click', e => { result = true; }, false
+        );
+        document.querySelector('#link').addEventListener(
+            'dblclick', e => { dblclick = true; }, false
         );
     </script>
 </body>


### PR DESCRIPTION
This PR closes #331.

* Extracts `Frame.dblclick` from `Frame.Dblclick` so that we can use `dblclick` from `Locator.Dblclick`.
* Adds `locator.Dblclick` and a test.

