### PR TITLE
Skip TestWaitForFrameNavigationWithinDocument

### DIFF
--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
+	if os.Getenv("SKIP_FLAKY") == "true" {
+		t.SkipNow()
+	}
 	t.Parallel()
 
 	var timeout time.Duration = 200


### PR DESCRIPTION
This change skips running the flaky test: `TestWaitForFrameNavigationWithinDocument` if `SKIP_FLAKY=true` is provided
as an environment variable while running the tests.

The reason behind this change is constantly getting failures breaks the development flow.

**Note:** This environment variable should only be used while in development.