### PR TITLE
Add locator.Uncheck

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -10,4 +10,6 @@ type Locator interface {
 	Dblclick(opts goja.Value)
 	// Check element using locator's selector with strict mode on.
 	Check(opts goja.Value)
+	// Uncheck element using locator's selector with strict mode on.
+	Uncheck(opts goja.Value)
 }

--- a/common/locator.go
+++ b/common/locator.go
@@ -96,3 +96,26 @@ func (l *Locator) check(opts *FrameCheckOptions) error {
 	opts.Strict = true
 	return l.frame.check(l.selector, opts)
 }
+
+// Uncheck on an element using locator's selector with strict mode on.
+func (l *Locator) Uncheck(opts goja.Value) {
+	l.log.Debugf("Locator:Uncheck", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+
+	var err error
+	defer func() { panicOrSlowMo(l.ctx, err) }()
+
+	copts := NewFrameUncheckOptions(l.frame.defaultTimeout())
+	if err = copts.Parse(l.ctx, opts); err != nil {
+		return
+	}
+	if err = l.uncheck(copts); err != nil {
+		return
+	}
+}
+
+// uncheck is like Uncheck but takes parsed options and neither throws
+// an error, or applies slow motion.
+func (l *Locator) uncheck(opts *FrameUncheckOptions) error {
+	opts.Strict = true
+	return l.frame.uncheck(l.selector, opts)
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -78,3 +78,29 @@ func TestLocatorCheck(t *testing.T) {
 		)
 	})
 }
+
+func TestLocatorUncheck(t *testing.T) {
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	require.NotNil(t, p.Goto(tb.staticURL("/locators.html"), nil))
+
+	// Selecting a single element and checking it is OK.
+	t.Run("ok", func(t *testing.T) {
+		uncheck := func() bool {
+			cr := p.Evaluate(tb.toGojaValue(`() => window.uncheck`))
+			return cr.(goja.Value).ToBoolean() //nolint:forcetypeassert
+		}
+		input := p.Locator("#checkedInput", nil)
+		input.Uncheck(nil)
+		require.True(t, uncheck(), "could not uncheck the input box")
+	})
+	// There are two checked input boxes in the document (locators.html).
+	// The strict mode should disallow selecting multiple elements.
+	t.Run("strict", func(t *testing.T) {
+		input := p.Locator("input", nil)
+		require.Panics(t,
+			func() { input.Uncheck(nil) },
+			"should not select multiple elements",
+		)
+	})
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -58,15 +58,20 @@ func TestLocatorCheck(t *testing.T) {
 	p := tb.NewPage(nil)
 	require.NotNil(t, p.Goto(tb.staticURL("/locators.html"), nil))
 
-	// Selecting a single element and checking it is OK.
-	t.Run("ok", func(t *testing.T) {
-		check := func() bool {
-			cr := p.Evaluate(tb.toGojaValue(`() => window.check`))
-			return cr.(goja.Value).ToBoolean() //nolint:forcetypeassert
-		}
-		input := p.Locator("#input", nil)
-		input.Check(nil)
+	check := func() bool {
+		cr := p.Evaluate(tb.toGojaValue(`() => window.check`))
+		return cr.(goja.Value).ToBoolean() //nolint:forcetypeassert
+	}
+
+	t.Run("check", func(t *testing.T) {
+		checkbox := p.Locator("#inputCheckbox", nil)
+		checkbox.Check(nil)
 		require.True(t, check(), "could not check the input box")
+	})
+	t.Run("uncheck", func(t *testing.T) {
+		checkbox := p.Locator("#inputCheckbox", nil)
+		checkbox.Uncheck(nil)
+		require.False(t, check(), "could not uncheck the input box")
 	})
 	// There are two input boxes in the document (locators.html).
 	// The strict mode should disallow selecting multiple elements.
@@ -74,32 +79,6 @@ func TestLocatorCheck(t *testing.T) {
 		input := p.Locator("input", nil)
 		require.Panics(t,
 			func() { input.Check(nil) },
-			"should not select multiple elements",
-		)
-	})
-}
-
-func TestLocatorUncheck(t *testing.T) {
-	tb := newTestBrowser(t, withFileServer())
-	p := tb.NewPage(nil)
-	require.NotNil(t, p.Goto(tb.staticURL("/locators.html"), nil))
-
-	// Selecting a single element and checking it is OK.
-	t.Run("ok", func(t *testing.T) {
-		uncheck := func() bool {
-			cr := p.Evaluate(tb.toGojaValue(`() => window.uncheck`))
-			return cr.(goja.Value).ToBoolean() //nolint:forcetypeassert
-		}
-		input := p.Locator("#checkedInput", nil)
-		input.Uncheck(nil)
-		require.True(t, uncheck(), "could not uncheck the input box")
-	})
-	// There are two checked input boxes in the document (locators.html).
-	// The strict mode should disallow selecting multiple elements.
-	t.Run("strict", func(t *testing.T) {
-		input := p.Locator("input", nil)
-		require.Panics(t,
-			func() { input.Uncheck(nil) },
 			"should not select multiple elements",
 		)
 	})

--- a/tests/static/locators.html
+++ b/tests/static/locators.html
@@ -10,10 +10,13 @@
     <a href="#" onclick="event.preventDefault()">Click</a>
     <input id="input" type="checkbox" />
     <input type="checkbox" />
+    <input id="checkedInput" type="checkbox" checked />
+    <input type="checkbox" checked />
     <script>
         window.result = false;
         window.dblclick = false;
         window.check = false;
+        window.uncheck = false;
 
         document.querySelector('#link').addEventListener(
             'click', e => { result = true; }, false
@@ -23,6 +26,9 @@
         );
         document.querySelector('#input').addEventListener(
             'change', e => { window.check = e.currentTarget.checked; }, false
+        );
+        document.querySelector('#checkedInput').addEventListener(
+            'change', e => { window.uncheck = !event.currentTarget.checked; }, false
         );
     </script>
 </body>

--- a/tests/static/locators.html
+++ b/tests/static/locators.html
@@ -8,15 +8,12 @@
 <body>
     <a id="link" href="#" onclick="event.preventDefault()">Click</a>
     <a href="#" onclick="event.preventDefault()">Click</a>
-    <input id="input" type="checkbox" />
+    <input id="inputCheckbox" type="checkbox" />
     <input type="checkbox" />
-    <input id="checkedInput" type="checkbox" checked />
-    <input type="checkbox" checked />
     <script>
         window.result = false;
         window.dblclick = false;
         window.check = false;
-        window.uncheck = false;
 
         document.querySelector('#link').addEventListener(
             'click', e => { result = true; }, false
@@ -24,11 +21,8 @@
         document.querySelector('#link').addEventListener(
             'dblclick', e => { dblclick = true; }, false
         );
-        document.querySelector('#input').addEventListener(
+        document.querySelector('#inputCheckbox').addEventListener(
             'change', e => { window.check = e.currentTarget.checked; }, false
-        );
-        document.querySelector('#checkedInput').addEventListener(
-            'change', e => { window.uncheck = !event.currentTarget.checked; }, false
         );
     </script>
 </body>


### PR DESCRIPTION
This PR closes #359.

* Extracts `Frame.uncheck` from `Frame.Uncheck` so that we can use `uncheck` from `Locator.Uncheck`.
* Adds `locator.Uncheck` and a test.

These other commits from #362 will disappear when we merge #362. I'll rebase this PR if necessary. I based off this branch from #362 because otherwise, a lot of conflicts happen, which is hair pulling 🤦