### PR TITLE
Add locator.IsChecked

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -12,4 +12,7 @@ type Locator interface {
 	Check(opts goja.Value)
 	// Uncheck element using locator's selector with strict mode on.
 	Uncheck(opts goja.Value)
+	// IsChecked returns true if the element matches the locator's
+	// selector and is checked. Otherwise, returns false.
+	IsChecked(opts goja.Value) bool
 }

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1095,12 +1095,14 @@ func (h *ElementHandle) SetChecked(checked bool, opts goja.Value) {
 	applySlowMo(h.ctx)
 }
 
-// Uncheck scrolls element into view and clicks in the center of the element.
+// Uncheck scrolls element into view, and if it's an input element of type
+// checkbox that is already checked, clicks on it to mark it as unchecked.
 func (h *ElementHandle) Uncheck(opts goja.Value) {
 	h.SetChecked(false, opts)
 }
 
-// Check scrolls element into view and clicks in the center of the element.
+// Check scrolls element into view, and if it's an input element of type
+// checkbox that is unchecked, clicks on it to mark it as checked.
 func (h *ElementHandle) Check(opts goja.Value) {
 	h.SetChecked(true, opts)
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -808,8 +808,6 @@ func (f *Frame) isChecked(selector string, opts *FrameIsCheckedOptions) (bool, e
 		return false, fmt.Errorf("isChecked returned %T; want bool", v)
 	}
 
-	applySlowMo(f.ctx)
-
 	return bv, nil
 }
 

--- a/common/locator.go
+++ b/common/locator.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/dop251/goja"
 
+	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/log"
 )
 
@@ -118,4 +119,28 @@ func (l *Locator) Uncheck(opts goja.Value) {
 func (l *Locator) uncheck(opts *FrameUncheckOptions) error {
 	opts.Strict = true
 	return l.frame.uncheck(l.selector, opts)
+}
+
+// IsChecked returns true if the element matches the locator's
+// selector and is checked. Otherwise, returns false.
+func (l *Locator) IsChecked(opts goja.Value) bool {
+	l.log.Debugf("Locator:IsChecked", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+
+	copts := NewFrameIsCheckedOptions(l.frame.defaultTimeout())
+	if err := copts.Parse(l.ctx, opts); err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+	checked, err := l.isChecked(copts)
+	if err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+
+	return checked
+}
+
+// isChecked is like IsChecked but takes parsed options and does not
+// throw an error.
+func (l *Locator) isChecked(opts *FrameIsCheckedOptions) (bool, error) {
+	opts.Strict = true
+	return l.frame.isChecked(l.selector, opts)
 }

--- a/common/page.go
+++ b/common/page.go
@@ -388,11 +388,26 @@ func (p *Page) BringToFront() {
 	}
 }
 
-// Check checks an element matching provided selector.
+// Check checks an element matching the provided selector.
 func (p *Page) Check(selector string, opts goja.Value) {
 	p.logger.Debugf("Page:Check", "sid:%v selector:%s", p.sessionID(), selector)
 
 	p.MainFrame().Check(selector, opts)
+}
+
+// Uncheck unchecks an element matching the provided selector.
+func (p *Page) Uncheck(selector string, opts goja.Value) {
+	p.logger.Debugf("Page:Uncheck", "sid:%v selector:%s", p.sessionID(), selector)
+
+	p.MainFrame().Uncheck(selector, opts)
+}
+
+// IsChecked returns true if the first element that matches the selector
+// is checked. Otherwise, returns false.
+func (p *Page) IsChecked(selector string, opts goja.Value) bool {
+	p.logger.Debugf("Page:IsChecked", "sid:%v selector:%s", p.sessionID(), selector)
+
+	return p.MainFrame().IsChecked(selector, opts)
 }
 
 // Click clicks an element matching provided selector.
@@ -573,12 +588,6 @@ func (p *Page) InputValue(selector string, opts goja.Value) string {
 	p.logger.Debugf("Page:InputValue", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().InputValue(selector, opts)
-}
-
-func (p *Page) IsChecked(selector string, opts goja.Value) bool {
-	p.logger.Debugf("Page:IsChecked", "sid:%v selector:%s", p.sessionID(), selector)
-
-	return p.MainFrame().IsChecked(selector, opts)
 }
 
 func (p *Page) IsClosed() bool {
@@ -814,12 +823,6 @@ func (p *Page) Type(selector string, text string, opts goja.Value) {
 	p.logger.Debugf("Page:Type", "sid:%v selector:%s text:%s", p.sessionID(), selector, text)
 
 	p.MainFrame().Type(selector, text, opts)
-}
-
-func (p *Page) Uncheck(selector string, opts goja.Value) {
-	p.logger.Debugf("Page:Uncheck", "sid:%v selector:%s", p.sessionID(), selector)
-
-	p.MainFrame().Uncheck(selector, opts)
 }
 
 func (p *Page) Unroute(url goja.Value, handler goja.Callable) {

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -73,13 +73,21 @@ func TestLocatorCheck(t *testing.T) {
 		cb.Uncheck(nil)
 		require.False(t, check(), "could not uncheck the input box")
 	})
+	t.Run("is_checked", func(t *testing.T) {
+		cb := p.Locator("#inputCheckbox", nil)
+
+		cb.Check(nil)
+		require.True(t, cb.IsChecked(nil))
+
+		cb.Uncheck(nil)
+		require.False(t, cb.IsChecked(nil))
+	})
 	// There are two input boxes in the document (locators.html).
 	// The strict mode should disallow selecting multiple elements.
 	t.Run("strict", func(t *testing.T) {
 		input := p.Locator("input", nil)
-		require.Panics(t,
-			func() { input.Check(nil) },
-			"should not select multiple elements",
-		)
+		require.Panics(t, func() { input.Check(nil) }, "should not select multiple elements")
+		require.Panics(t, func() { input.Uncheck(nil) }, "should not select multiple elements")
+		require.Panics(t, func() { input.IsChecked(nil) }, "should not select multiple elements")
 	})
 }


### PR DESCRIPTION
This PR closes #346.

* Extracts `Frame.isChecked` from `Frame.IsChecked` so that we can use `isChecked` from `Locator.IsChecked`.
* Adds `locator.IsChecked` and a test.
* Removes applying slow motion in the `Frame.IsChecked` as discussed in #234.