### PR TITLE
Add locator.IsEditable

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -15,4 +15,7 @@ type Locator interface {
 	// IsChecked returns true if the element matches the locator's
 	// selector and is checked. Otherwise, returns false.
 	IsChecked(opts goja.Value) bool
+	// IsEditable returns true if the element matches the locator's
+	// selector and is editable. Otherwise, returns false.
+	IsEditable(opts goja.Value) bool
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -1174,31 +1174,45 @@ func (f *Frame) IsDisabled(selector string, opts goja.Value) bool {
 	return value.(bool)
 }
 
+// IsEditable returns true if the first element that matches the selector
+// is editable. Otherwise, returns false.
 func (f *Frame) IsEditable(selector string, opts goja.Value) bool {
 	f.log.Debugf("Frame:IsEditable", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	parsedOpts := NewFrameIsEditableOptions(f.defaultTimeout())
-	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
+	popts := NewFrameIsEditableOptions(f.defaultTimeout())
+	if err := popts.Parse(f.ctx, opts); err != nil {
 		k6ext.Panic(f.ctx, "%w", err)
 	}
-
-	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
-		value, err := handle.isEditable(apiCtx, 0) // Zero timeout when checking state
-		if err == ErrTimedOut {                    // We don't care about timeout errors here!
-			return value, nil
-		}
-		return value, err
-	}
-	actFn := f.newAction(
-		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
-	)
-	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
+	editable, err := f.isEditable(selector, popts)
 	if err != nil {
 		k6ext.Panic(f.ctx, "%w", err)
 	}
 
-	applySlowMo(f.ctx)
-	return value.(bool)
+	return editable
+}
+
+func (f *Frame) isEditable(selector string, opts *FrameIsEditableOptions) (bool, error) {
+	isEditable := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
+		v, err := handle.isEditable(apiCtx, 0) // Zero timeout when checking state
+		if errors.Is(err, ErrTimedOut) {       // We don't care about timeout errors here!
+			return v, nil
+		}
+		return v, err
+	}
+	act := f.newAction(
+		selector, DOMElementStateAttached, opts.Strict, isEditable, []string{}, false, true, opts.Timeout,
+	)
+	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	if err != nil {
+		return false, err
+	}
+
+	bv, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("isEditable returned %T; want bool", v)
+	}
+
+	return bv, nil
 }
 
 func (f *Frame) IsEnabled(selector string, opts goja.Value) bool {

--- a/common/locator.go
+++ b/common/locator.go
@@ -3,10 +3,10 @@ package common
 import (
 	"context"
 
-	"github.com/dop251/goja"
-
 	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/log"
+
+	"github.com/dop251/goja"
 )
 
 // Locator represent a way to find element(s) on the page at any moment.
@@ -143,4 +143,28 @@ func (l *Locator) IsChecked(opts goja.Value) bool {
 func (l *Locator) isChecked(opts *FrameIsCheckedOptions) (bool, error) {
 	opts.Strict = true
 	return l.frame.isChecked(l.selector, opts)
+}
+
+// IsEditable returns true if the element matches the locator's
+// selector and is Editable. Otherwise, returns false.
+func (l *Locator) IsEditable(opts goja.Value) bool {
+	l.log.Debugf("Locator:IsEditable", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+
+	copts := NewFrameIsEditableOptions(l.frame.defaultTimeout())
+	if err := copts.Parse(l.ctx, opts); err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+	editable, err := l.isEditable(copts)
+	if err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+
+	return editable
+}
+
+// isEditable is like IsEditable but takes parsed options and does not
+// throw an error.
+func (l *Locator) isEditable(opts *FrameIsEditableOptions) (bool, error) {
+	opts.Strict = true
+	return l.frame.isEditable(l.selector, opts)
 }

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -82,12 +82,30 @@ func TestLocatorCheck(t *testing.T) {
 		cb.Uncheck(nil)
 		require.False(t, cb.IsChecked(nil))
 	})
-	// There are two input boxes in the document (locators.html).
+	// There are multiple input boxes in the document (locators.html).
 	// The strict mode should disallow selecting multiple elements.
 	t.Run("strict", func(t *testing.T) {
 		input := p.Locator("input", nil)
 		require.Panics(t, func() { input.Check(nil) }, "should not select multiple elements")
 		require.Panics(t, func() { input.Uncheck(nil) }, "should not select multiple elements")
 		require.Panics(t, func() { input.IsChecked(nil) }, "should not select multiple elements")
+	})
+}
+
+func TestLocatorIsEditable(t *testing.T) {
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	require.NotNil(t, p.Goto(tb.staticURL("/locators.html"), nil))
+
+	t.Run("editable", func(t *testing.T) {
+		el := p.Locator("#inputText", nil)
+		require.True(t, el.IsEditable(nil))
+
+		p.Evaluate(tb.toGojaValue(`() => document.getElementById('inputText').readOnly = true`))
+		require.False(t, el.IsEditable(nil))
+	})
+	t.Run("strict", func(t *testing.T) {
+		input := p.Locator("input", nil)
+		require.Panics(t, func() { input.IsEditable(nil) }, "should not select multiple elements")
 	})
 }

--- a/tests/static/locators.html
+++ b/tests/static/locators.html
@@ -10,6 +10,7 @@
     <a href="#" onclick="event.preventDefault()">Click</a>
     <input id="inputCheckbox" type="checkbox" />
     <input type="checkbox" />
+    <input id="inputText" type="text" value="something" />
     <script>
         window.result = false;
         window.dblclick = false;


### PR DESCRIPTION
This PR closes #348.

* Extracts `Frame.isEditable` from `Frame.IsEditable` so that we can use `isEditable` from `Locator.IsEditable`.
* Adds `locator.IsEditable` and a test.
* Removes applying slow motion in the `Frame.IsEditable` as discussed in #234.