### PR TITLE
Add locator.isEnabled

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -18,4 +18,7 @@ type Locator interface {
 	// IsEditable returns true if the element matches the locator's
 	// selector and is editable. Otherwise, returns false.
 	IsEditable(opts goja.Value) bool
+	// IsEnabled returns true if the element matches the locator's
+	// selector and is enabled. Otherwise, returns false.
+	IsEnabled(opts goja.Value) bool
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -1215,31 +1215,45 @@ func (f *Frame) isEditable(selector string, opts *FrameIsEditableOptions) (bool,
 	return bv, nil
 }
 
+// IsEnabled returns true if the first element that matches the selector
+// is enabled. Otherwise, returns false.
 func (f *Frame) IsEnabled(selector string, opts goja.Value) bool {
 	f.log.Debugf("Frame:IsEnabled", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	parsedOpts := NewFrameIsEnabledOptions(f.defaultTimeout())
-	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
+	popts := NewFrameIsEnabledOptions(f.defaultTimeout())
+	if err := popts.Parse(f.ctx, opts); err != nil {
 		k6ext.Panic(f.ctx, "%w", err)
 	}
-
-	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
-		value, err := handle.isEnabled(apiCtx, 0) // Zero timeout when checking state
-		if err == ErrTimedOut {                   // We don't care about timeout errors here!
-			return value, nil
-		}
-		return value, err
-	}
-	actFn := f.newAction(
-		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
-	)
-	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
+	enabled, err := f.isEnabled(selector, popts)
 	if err != nil {
 		k6ext.Panic(f.ctx, "%w", err)
 	}
 
-	applySlowMo(f.ctx)
-	return value.(bool)
+	return enabled
+}
+
+func (f *Frame) isEnabled(selector string, opts *FrameIsEnabledOptions) (bool, error) {
+	isEnabled := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
+		v, err := handle.isEnabled(apiCtx, 0) // Zero timeout when checking state
+		if errors.Is(err, ErrTimedOut) {      // We don't care about timeout errors here!
+			return v, nil
+		}
+		return v, err
+	}
+	act := f.newAction(
+		selector, DOMElementStateAttached, opts.Strict, isEnabled, []string{}, false, true, opts.Timeout,
+	)
+	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	if err != nil {
+		return false, err
+	}
+
+	bv, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("isEnabled returned %T; want bool", v)
+	}
+
+	return bv, nil
 }
 
 func (f *Frame) IsHidden(selector string, opts goja.Value) bool {

--- a/common/locator.go
+++ b/common/locator.go
@@ -168,3 +168,27 @@ func (l *Locator) isEditable(opts *FrameIsEditableOptions) (bool, error) {
 	opts.Strict = true
 	return l.frame.isEditable(l.selector, opts)
 }
+
+// IsEnabled returns true if the element matches the locator's
+// selector and is Enabled. Otherwise, returns false.
+func (l *Locator) IsEnabled(opts goja.Value) bool {
+	l.log.Debugf("Locator:IsEnabled", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+
+	copts := NewFrameIsEnabledOptions(l.frame.defaultTimeout())
+	if err := copts.Parse(l.ctx, opts); err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+	enabled, err := l.isEnabled(copts)
+	if err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+
+	return enabled
+}
+
+// isEnabled is like IsEnabled but takes parsed options and does not
+// throw an error.
+func (l *Locator) isEnabled(opts *FrameIsEnabledOptions) (bool, error) {
+	opts.Strict = true
+	return l.frame.isEnabled(l.selector, opts)
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -109,3 +109,21 @@ func TestLocatorIsEditable(t *testing.T) {
 		require.Panics(t, func() { input.IsEditable(nil) }, "should not select multiple elements")
 	})
 }
+
+func TestLocatorIsEnabled(t *testing.T) {
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	require.NotNil(t, p.Goto(tb.staticURL("/locators.html"), nil))
+
+	t.Run("enabled", func(t *testing.T) {
+		el := p.Locator("#inputText", nil)
+		require.True(t, el.IsEnabled(nil))
+
+		p.Evaluate(tb.toGojaValue(`() => document.getElementById('inputText').disabled = true`))
+		require.False(t, el.IsEnabled(nil))
+	})
+	t.Run("strict", func(t *testing.T) {
+		input := p.Locator("input", nil)
+		require.Panics(t, func() { input.IsEnabled(nil) }, "should not select multiple elements")
+	})
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -124,4 +124,15 @@ func TestLocatorElementState(t *testing.T) {
 			require.False(t, tt.query(l))
 		})
 	}
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	require.NotNil(t, p.Goto(tb.staticURL("/locators.html"), nil))
+
+	for _, tt := range tests {
+		t.Run("strict/"+tt.state, func(t *testing.T) {
+			l := p.Locator("input", nil)
+			require.Panics(t, func() { tt.query(l) }, "should not select multiple elements")
+		})
+	}
 }


### PR DESCRIPTION
This PR closes #349.

* Extracts `Frame.isEnabled` from `Frame.IsEnabled` so that we can use `isEnabled` from `Locator.IsEnabled`.
* Adds `locator.IsEnabled` and a test.
* Refactors the locator state tests.
* Removes applying slow motion in the `Frame.IsEnabled` as discussed in #234.