### PR TITLE
Add locator.isDisabled

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -21,4 +21,7 @@ type Locator interface {
 	// IsEnabled returns true if the element matches the locator's
 	// selector and is enabled. Otherwise, returns false.
 	IsEnabled(opts goja.Value) bool
+	// IsDisabled returns true if the element matches the locator's
+	// selector and is disabled. Otherwise, returns false.
+	IsDisabled(opts goja.Value) bool
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -1229,31 +1229,45 @@ func (f *Frame) isEnabled(selector string, opts *FrameIsEnabledOptions) (bool, e
 	return bv, nil
 }
 
+// IsDisabled returns true if the first element that matches the selector
+// is disabled. Otherwise, returns false.
 func (f *Frame) IsDisabled(selector string, opts goja.Value) bool {
 	f.log.Debugf("Frame:IsDisabled", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	parsedOpts := NewFrameIsDisabledOptions(f.defaultTimeout())
-	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
+	popts := NewFrameIsDisabledOptions(f.defaultTimeout())
+	if err := popts.Parse(f.ctx, opts); err != nil {
 		k6ext.Panic(f.ctx, "%w", err)
 	}
-
-	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
-		value, err := handle.isDisabled(apiCtx, 0) // Zero timeout when checking state
-		if err == ErrTimedOut {                    // We don't care about timeout errors here!
-			return value, nil
-		}
-		return value, err
-	}
-	actFn := f.newAction(
-		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
-	)
-	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
+	disabled, err := f.isDisabled(selector, popts)
 	if err != nil {
 		k6ext.Panic(f.ctx, "%w", err)
 	}
 
-	applySlowMo(f.ctx)
-	return value.(bool)
+	return disabled
+}
+
+func (f *Frame) isDisabled(selector string, opts *FrameIsDisabledOptions) (bool, error) {
+	isDisabled := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
+		v, err := handle.isDisabled(apiCtx, 0) // Zero timeout when checking state
+		if errors.Is(err, ErrTimedOut) {       // We don't care about timeout errors here!
+			return v, nil
+		}
+		return v, err
+	}
+	act := f.newAction(
+		selector, DOMElementStateAttached, opts.Strict, isDisabled, []string{}, false, true, opts.Timeout,
+	)
+	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	if err != nil {
+		return false, err
+	}
+
+	bv, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("isDisabled returned %T; want bool", v)
+	}
+
+	return bv, nil
 }
 
 func (f *Frame) IsHidden(selector string, opts goja.Value) bool {

--- a/common/frame.go
+++ b/common/frame.go
@@ -1147,33 +1147,6 @@ func (f *Frame) setDetached(detached bool) {
 	f.detached = detached
 }
 
-func (f *Frame) IsDisabled(selector string, opts goja.Value) bool {
-	f.log.Debugf("Frame:IsDisabled", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
-
-	parsedOpts := NewFrameIsDisabledOptions(f.defaultTimeout())
-	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
-	}
-
-	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
-		value, err := handle.isDisabled(apiCtx, 0) // Zero timeout when checking state
-		if err == ErrTimedOut {                    // We don't care about timeout errors here!
-			return value, nil
-		}
-		return value, err
-	}
-	actFn := f.newAction(
-		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
-	)
-	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
-	if err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
-	}
-
-	applySlowMo(f.ctx)
-	return value.(bool)
-}
-
 // IsEditable returns true if the first element that matches the selector
 // is editable. Otherwise, returns false.
 func (f *Frame) IsEditable(selector string, opts goja.Value) bool {
@@ -1254,6 +1227,33 @@ func (f *Frame) isEnabled(selector string, opts *FrameIsEnabledOptions) (bool, e
 	}
 
 	return bv, nil
+}
+
+func (f *Frame) IsDisabled(selector string, opts goja.Value) bool {
+	f.log.Debugf("Frame:IsDisabled", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
+
+	parsedOpts := NewFrameIsDisabledOptions(f.defaultTimeout())
+	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
+		k6ext.Panic(f.ctx, "%w", err)
+	}
+
+	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
+		value, err := handle.isDisabled(apiCtx, 0) // Zero timeout when checking state
+		if err == ErrTimedOut {                    // We don't care about timeout errors here!
+			return value, nil
+		}
+		return value, err
+	}
+	actFn := f.newAction(
+		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
+	)
+	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
+	if err != nil {
+		k6ext.Panic(f.ctx, "%w", err)
+	}
+
+	applySlowMo(f.ctx)
+	return value.(bool)
 }
 
 func (f *Frame) IsHidden(selector string, opts goja.Value) bool {

--- a/common/locator.go
+++ b/common/locator.go
@@ -192,3 +192,27 @@ func (l *Locator) isEnabled(opts *FrameIsEnabledOptions) (bool, error) {
 	opts.Strict = true
 	return l.frame.isEnabled(l.selector, opts)
 }
+
+// IsDisabled returns true if the element matches the locator's
+// selector and is disabled. Otherwise, returns false.
+func (l *Locator) IsDisabled(opts goja.Value) bool {
+	l.log.Debugf("Locator:IsDisabled", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+
+	copts := NewFrameIsDisabledOptions(l.frame.defaultTimeout())
+	if err := copts.Parse(l.ctx, opts); err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+	disabled, err := l.isDisabled(copts)
+	if err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+
+	return disabled
+}
+
+// IsDisabled is like IsDisabled but takes parsed options and does not
+// throw an error.
+func (l *Locator) isDisabled(opts *FrameIsDisabledOptions) (bool, error) {
+	opts.Strict = true
+	return l.frame.isDisabled(l.selector, opts)
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -105,9 +105,14 @@ func TestLocatorElementState(t *testing.T) {
 			func(l api.Locator) bool { return l.IsEditable(nil) },
 		},
 		{
-			"disabled",
+			"enabled",
 			`() => document.getElementById('inputText').disabled = true`,
 			func(l api.Locator) bool { return l.IsEnabled(nil) },
+		},
+		{
+			"disabled",
+			`() => document.getElementById('inputText').disabled = true`,
+			func(l api.Locator) bool { return !l.IsDisabled(nil) },
 		},
 	}
 


### PR DESCRIPTION
This PR closes #347.

* Extracts `Frame.isDisabled` from `Frame.IsDisabled` so that we can use `isDisabled` from `Locator.IsDisabled`.
* Adds `locator.IsDisabled` and a test.
* Removes applying slow motion in the `Frame.IsDisabled` as discussed in #234.