### PR TITLE
Add locator.isVisible

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -24,4 +24,7 @@ type Locator interface {
 	// IsDisabled returns true if the element matches the locator's
 	// selector and is disabled. Otherwise, returns false.
 	IsDisabled(opts goja.Value) bool
+	// IsVisible returns true if the element matches the locator's
+	// selector and is visible. Otherwise, returns false.
+	IsVisible(opts goja.Value) bool
 }

--- a/common/locator.go
+++ b/common/locator.go
@@ -216,3 +216,27 @@ func (l *Locator) isDisabled(opts *FrameIsDisabledOptions) (bool, error) {
 	opts.Strict = true
 	return l.frame.isDisabled(l.selector, opts)
 }
+
+// IsVisible returns true if the element matches the locator's
+// selector and is visible. Otherwise, returns false.
+func (l *Locator) IsVisible(opts goja.Value) bool {
+	l.log.Debugf("Locator:IsVisible", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+
+	copts := NewFrameIsVisibleOptions(l.frame.defaultTimeout())
+	if err := copts.Parse(l.ctx, opts); err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+	visible, err := l.isVisible(copts)
+	if err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+
+	return visible
+}
+
+// isVisible is like IsVisible but takes parsed options and does not
+// throw an error.
+func (l *Locator) isVisible(opts *FrameIsVisibleOptions) (bool, error) {
+	opts.Strict = true
+	return l.frame.isVisible(l.selector, opts)
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -114,6 +114,11 @@ func TestLocatorElementState(t *testing.T) {
 			`() => document.getElementById('inputText').disabled = true`,
 			func(l api.Locator) bool { return !l.IsDisabled(nil) },
 		},
+		{
+			"visible",
+			`() => document.getElementById('inputText').style.visibility = 'hidden'`,
+			func(l api.Locator) bool { return l.IsVisible(nil) },
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR closes #351.

* Extracts `Frame.isVisible` from `Frame.IsVisible` so that we can use `isVisible` from `Locator.IsVisible`.
* Adds `locator.IsVisible` and a test.
* Removes applying slow motion in the `Frame.IsVisible` as discussed in #234.