### PR TITLE
Add locator. isHidden

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -27,4 +27,7 @@ type Locator interface {
 	// IsVisible returns true if the element matches the locator's
 	// selector and is visible. Otherwise, returns false.
 	IsVisible(opts goja.Value) bool
+	// IsHidden returns true if the element matches the locator's
+	// selector and is hidden. Otherwise, returns false.
+	IsHidden(opts goja.Value) bool
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -1270,31 +1270,45 @@ func (f *Frame) isDisabled(selector string, opts *FrameIsDisabledOptions) (bool,
 	return bv, nil
 }
 
+// IsHidden returns true if the first element that matches the selector
+// is hidden. Otherwise, returns false.
 func (f *Frame) IsHidden(selector string, opts goja.Value) bool {
 	f.log.Debugf("Frame:IsHidden", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	parsedOpts := NewFrameIsHiddenOptions(f.defaultTimeout())
-	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
+	popts := NewFrameIsHiddenOptions(f.defaultTimeout())
+	if err := popts.Parse(f.ctx, opts); err != nil {
 		k6ext.Panic(f.ctx, "%w", err)
 	}
-
-	fn := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
-		value, err := handle.isHidden(apiCtx, 0) // Zero timeout when checking state
-		if err == ErrTimedOut {                  // We don't care about timeout errors here!
-			return value, nil
-		}
-		return value, err
-	}
-	actFn := f.newAction(
-		selector, DOMElementStateAttached, parsedOpts.Strict, fn, []string{}, false, true, parsedOpts.Timeout,
-	)
-	value, err := callApiWithTimeout(f.ctx, actFn, parsedOpts.Timeout)
+	hidden, err := f.isHidden(selector, popts)
 	if err != nil {
 		k6ext.Panic(f.ctx, "%w", err)
 	}
 
-	applySlowMo(f.ctx)
-	return value.(bool)
+	return hidden
+}
+
+func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, error) {
+	isHidden := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
+		v, err := handle.isHidden(apiCtx, 0) // Zero timeout when checking state
+		if errors.Is(err, ErrTimedOut) {     // We don't care about timeout errors here!
+			return v, nil
+		}
+		return v, err
+	}
+	act := f.newAction(
+		selector, DOMElementStateAttached, opts.Strict, isHidden, []string{}, false, true, opts.Timeout,
+	)
+	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	if err != nil {
+		return false, err
+	}
+
+	bv, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("isHidden returned %T; want bool", v)
+	}
+
+	return bv, nil
 }
 
 // IsVisible returns true if the first element that matches the selector

--- a/common/locator.go
+++ b/common/locator.go
@@ -240,3 +240,27 @@ func (l *Locator) isVisible(opts *FrameIsVisibleOptions) (bool, error) {
 	opts.Strict = true
 	return l.frame.isVisible(l.selector, opts)
 }
+
+// IsHidden returns true if the element matches the locator's
+// selector and is hidden. Otherwise, returns false.
+func (l *Locator) IsHidden(opts goja.Value) bool {
+	l.log.Debugf("Locator:IsHidden", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+
+	copts := NewFrameIsHiddenOptions(l.frame.defaultTimeout())
+	if err := copts.Parse(l.ctx, opts); err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+	hidden, err := l.isHidden(copts)
+	if err != nil {
+		k6ext.Panic(l.ctx, "%w", err)
+	}
+
+	return hidden
+}
+
+// isHidden is like IsHidden but takes parsed options and does not
+// throw an error.
+func (l *Locator) isHidden(opts *FrameIsHiddenOptions) (bool, error) {
+	opts.Strict = true
+	return l.frame.isHidden(l.selector, opts)
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -119,6 +119,11 @@ func TestLocatorElementState(t *testing.T) {
 			`() => document.getElementById('inputText').style.visibility = 'hidden'`,
 			func(l api.Locator) bool { return l.IsVisible(nil) },
 		},
+		{
+			"hidden",
+			`() => document.getElementById('inputText').style.visibility = 'hidden'`,
+			func(l api.Locator) bool { return !l.IsHidden(nil) },
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR closes #350.

* Extracts `Frame.isHidden` from `Frame.IsHidden` so that we can use `isHidden` from `Locator.IsHidden`.
* Adds `locator.IsHidden` and a test.
* Removes applying slow motion in the `Frame.IsHidden` as discussed in #234.