### PR TITLE
Add locator.fill

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -30,4 +30,6 @@ type Locator interface {
 	// IsHidden returns true if the element matches the locator's
 	// selector and is hidden. Otherwise, returns false.
 	IsHidden(opts goja.Value) bool
+	// Fill out the element using locator's selector with strict mode on.
+	Fill(value string, opts goja.Value)
 }

--- a/common/locator.go
+++ b/common/locator.go
@@ -264,3 +264,27 @@ func (l *Locator) isHidden(opts *FrameIsHiddenOptions) (bool, error) {
 	opts.Strict = true
 	return l.frame.isHidden(l.selector, opts)
 }
+
+// Fill out the element using locator's selector with strict mode on.
+func (l *Locator) Fill(value string, opts goja.Value) {
+	l.log.Debugf(
+		"Locator:Fill", "fid:%s furl:%q sel:%q val:%q opts:%+v",
+		l.frame.ID(), l.frame.URL(), l.selector, value, opts,
+	)
+
+	var err error
+	defer func() { panicOrSlowMo(l.ctx, err) }()
+
+	copts := NewFrameFillOptions(l.frame.defaultTimeout())
+	if err = copts.Parse(l.ctx, opts); err != nil {
+		return
+	}
+	if err = l.fill(value, copts); err != nil {
+		return
+	}
+}
+
+func (l *Locator) fill(value string, opts *FrameFillOptions) error {
+	opts.Strict = true
+	return l.frame.fill(l.selector, value, opts)
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -151,3 +151,21 @@ func TestLocatorElementState(t *testing.T) {
 		})
 	}
 }
+
+func TestLocatorFill(t *testing.T) {
+	const value = "fill me up"
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	require.NotNil(t, p.Goto(tb.staticURL("/locators.html"), nil))
+
+	t.Run("ok", func(t *testing.T) {
+		link := p.Locator("#inputText", nil)
+		link.Fill(value, nil)
+		require.Equal(t, value, p.InputValue("#inputText", nil))
+	})
+	t.Run("strict", func(t *testing.T) {
+		link := p.Locator("input", nil)
+		require.Panics(t, func() { link.Fill(value, nil) }, "should not select multiple elements")
+	})
+}


### PR DESCRIPTION
* Extracts `Frame.fill` from `Frame.Fill` so that we can use `fill` from `Locator.Fill`.
* Adds `locator.Fill` and a test.

Closes #338.