### PR TITLE
Add locator.focus

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -32,4 +32,6 @@ type Locator interface {
 	IsHidden(opts goja.Value) bool
 	// Fill out the element using locator's selector with strict mode on.
 	Fill(value string, opts goja.Value)
+	// Focus on the element using locator's selector with strict mode on.
+	Focus(opts goja.Value)
 }

--- a/common/locator.go
+++ b/common/locator.go
@@ -288,3 +288,24 @@ func (l *Locator) fill(value string, opts *FrameFillOptions) error {
 	opts.Strict = true
 	return l.frame.fill(l.selector, value, opts)
 }
+
+// Focus on the element using locator's selector with strict mode on.
+func (l *Locator) Focus(opts goja.Value) {
+	l.log.Debugf("Locator:Focus", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+
+	var err error
+	defer func() { panicOrSlowMo(l.ctx, err) }()
+
+	copts := NewFrameBaseOptions(l.frame.defaultTimeout())
+	if err = copts.Parse(l.ctx, opts); err != nil {
+		return
+	}
+	if err = l.focus(copts); err != nil {
+		return
+	}
+}
+
+func (l *Locator) focus(opts *FrameBaseOptions) error {
+	opts.Strict = true
+	return l.frame.focus(l.selector, opts)
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -169,3 +169,28 @@ func TestLocatorFill(t *testing.T) {
 		require.Panics(t, func() { link.Fill(value, nil) }, "should not select multiple elements")
 	})
 }
+
+func TestLocatorFocus(t *testing.T) {
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	require.NotNil(t, p.Goto(tb.staticURL("/locators.html"), nil))
+
+	t.Run("ok", func(t *testing.T) {
+		focused := func() bool {
+			ok := p.Evaluate(tb.toGojaValue(
+				`() => document.activeElement == document.getElementById('inputText')`,
+			))
+			return ok.(goja.Value).ToBoolean() //nolint:forcetypeassert
+		}
+
+		link := p.Locator("#inputText", nil)
+		require.False(t, focused(), "should not be focused first")
+
+		link.Focus(nil)
+		require.True(t, focused(), "should be focused")
+	})
+	t.Run("strict", func(t *testing.T) {
+		link := p.Locator("input", nil)
+		require.Panics(t, func() { link.Focus(nil) }, "should not select multiple elements")
+	})
+}


### PR DESCRIPTION
* Extracts `Frame.focus` from `Frame.Focus` so that we can use `focus` from `Locator.Focus`.
* Adds `locator.Focus` and a test.

Closes #339.

----

Note: Incorrectly merged #385 onto #380. I should have merged #338 first.