### PR TITLE
Add locator.getAttribute

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -34,4 +34,6 @@ type Locator interface {
 	Fill(value string, opts goja.Value)
 	// Focus on the element using locator's selector with strict mode on.
 	Focus(opts goja.Value)
+	// GetAttribute of the element using locator's selector with strict mode on.
+	GetAttribute(name string, opts goja.Value) goja.Value
 }

--- a/api/locator.go
+++ b/api/locator.go
@@ -2,6 +2,12 @@ package api
 
 import "github.com/dop251/goja"
 
+// Strict mode:
+// All operations on locators throw an exception if more
+// than one element matches the locator's selector.
+//
+// See Issue #100 for more details.
+
 // Locator represents a way to find element(s) on a page at any moment.
 type Locator interface {
 	// Click on an element using locator's selector with strict mode on.

--- a/common/locator.go
+++ b/common/locator.go
@@ -309,3 +309,30 @@ func (l *Locator) focus(opts *FrameBaseOptions) error {
 	opts.Strict = true
 	return l.frame.focus(l.selector, opts)
 }
+
+// GetAttribute of the element using locator's selector with strict mode on.
+func (l *Locator) GetAttribute(name string, opts goja.Value) goja.Value {
+	l.log.Debugf(
+		"Locator:GetAttribute", "fid:%s furl:%q sel:%q name:%q opts:%+v",
+		l.frame.ID(), l.frame.URL(), l.selector, name, opts,
+	)
+
+	var err error
+	defer func() { panicOrSlowMo(l.ctx, err) }()
+
+	copts := NewFrameBaseOptions(l.frame.defaultTimeout())
+	if err = copts.Parse(l.ctx, opts); err != nil {
+		return nil
+	}
+	var v goja.Value
+	if v, err = l.getAttribute(name, copts); err != nil {
+		return nil
+	}
+
+	return v
+}
+
+func (l *Locator) getAttribute(name string, opts *FrameBaseOptions) (goja.Value, error) {
+	opts.Strict = true
+	return l.frame.getAttribute(l.selector, name, opts)
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -207,7 +207,7 @@ func TestLocatorFocus(t *testing.T) {
 	})
 }
 
-// Skip adding t.Parallel to subtests because they might cause flakiness.
+// Skip adding t.Parallel to subtests because goja or our code might race.
 //nolint:tparallel
 func TestLocatorGetAttribute(t *testing.T) {
 	t.Parallel()

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -206,3 +206,24 @@ func TestLocatorFocus(t *testing.T) {
 		require.Panics(t, func() { link.Focus(nil) }, "should not select multiple elements")
 	})
 }
+
+// Skip adding t.Parallel to subtests because they might cause flakiness.
+//nolint:tparallel
+func TestLocatorGetAttribute(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	require.NotNil(t, p.Goto(tb.staticURL("/locators.html"), nil))
+
+	t.Run("ok", func(t *testing.T) {
+		l := p.Locator("#inputText", nil)
+		v := l.GetAttribute("value", nil)
+		require.NotNil(t, v)
+		require.Equal(t, "something", v.ToString().String())
+	})
+	t.Run("strict", func(t *testing.T) {
+		l := p.Locator("input", nil)
+		require.Panics(t, func() { l.GetAttribute("value", nil) }, "should not select multiple elements")
+	})
+}


### PR DESCRIPTION
* Extracts `Frame.getAttribute` from `Frame.GetAttribute` so that we can use `getAttribute` from `Locator.GetAttribute`.
* Adds `locator.GetAttribute` and a test.

Closes #341 