### PR TITLE
Add locator.selectOption

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -54,8 +54,8 @@ type Locator interface {
 	// InputValue returns the element's input value that matches
 	// the locator's selector with strict mode on.
 	InputValue(opts goja.Value) string
-	// SelectOption selects the given options and returns the array of
-	// option values of the element found that matches the locator's
-	// selector with strict mode on.
+	// SelectOption, filters option values of the first element that matches
+	// the locator's selector (with strict mode on), selects the
+	// options, and returns the filtered options.
 	SelectOption(values goja.Value, opts goja.Value) []string
 }

--- a/api/locator.go
+++ b/api/locator.go
@@ -54,4 +54,8 @@ type Locator interface {
 	// InputValue returns the element's input value that matches
 	// the locator's selector with strict mode on.
 	InputValue(opts goja.Value) string
+	// SelectOption selects the given options and returns the array of
+	// option values of the element found that matches the locator's
+	// selector with strict mode on.
+	SelectOption(values goja.Value, opts goja.Value) []string
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -1498,8 +1498,8 @@ func (f *Frame) Press(selector string, key string, opts goja.Value) {
 	applySlowMo(f.ctx)
 }
 
-// SelectOption selects the given options and returns the array of
-// option values of the first element found that matches the selector.
+// SelectOption filters option values of the first element that matches
+// the selector, selects the options, and returns the filtered options.
 func (f *Frame) SelectOption(selector string, values goja.Value, opts goja.Value) []string {
 	f.log.Debugf("Frame:SelectOption", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
@@ -1534,7 +1534,7 @@ func (f *Frame) selectOption(selector string, values goja.Value, opts *FrameSele
 		return nil, fmt.Errorf("unexpected select element type %T", v)
 	}
 
-	// gets <option> values inside <select>.
+	// pack the selected <option> values inside <select> into a slice
 	optHandles, err := selectHandle.getProperties()
 	if err != nil {
 		return nil, fmt.Errorf("getProperties: %w", err)

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -36,6 +36,7 @@ import (
 type jsHandle interface {
 	api.JSHandle
 	dispose() error
+	getProperties() (map[string]jsHandle, error)
 }
 
 var _ jsHandle = &BaseJSHandle{}
@@ -58,7 +59,7 @@ func NewJSHandle(
 	f *Frame,
 	ro *runtime.RemoteObject,
 	l *log.Logger,
-) api.JSHandle {
+) jsHandle {
 	eh := &BaseJSHandle{
 		ctx:          ctx,
 		session:      s,
@@ -131,26 +132,36 @@ func (h *BaseJSHandle) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) a
 
 // GetProperties retreives the JS handle's properties.
 func (h *BaseJSHandle) GetProperties() map[string]api.JSHandle {
-	var (
-		result []*runtime.PropertyDescriptor
-		err    error
-	)
-
-	action := runtime.GetProperties(h.remoteObject.ObjectID).
-		WithOwnProperties(true)
-	if result, _, _, _, err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-		k6ext.Panic(h.ctx, "unable to get properties for JS handle %T: %w", action, err)
+	handles, err := h.getProperties()
+	if err != nil {
+		k6ext.Panic(h.ctx, "getProperties: %w", err)
 	}
 
-	props := make(map[string]api.JSHandle, len(result))
-	for i := 0; i < len(result); i++ {
-		if !result[i].Enumerable {
+	jsHandles := make(map[string]api.JSHandle, len(handles))
+	for k, v := range handles {
+		jsHandles[k] = v
+	}
+
+	return jsHandles
+}
+
+// getProperties is like GetProperties, but does not panic.
+func (h *BaseJSHandle) getProperties() (map[string]jsHandle, error) {
+	act := runtime.GetProperties(h.remoteObject.ObjectID).WithOwnProperties(true)
+	result, _, _, _, err := act.Do(cdp.WithExecutor(h.ctx, h.session)) //nolint:dogsled
+	if err != nil {
+		return nil, fmt.Errorf("cannot get properties for element %T: %w", act, err)
+	}
+
+	props := make(map[string]jsHandle, len(result))
+	for _, r := range result {
+		if !r.Enumerable {
 			continue
 		}
-		props[result[i].Name] = NewJSHandle(
-			h.ctx, h.session, h.execCtx, h.execCtx.Frame(), result[i].Value, h.logger)
+		props[r.Name] = NewJSHandle(h.ctx, h.session, h.execCtx, h.execCtx.Frame(), r.Value, h.logger)
 	}
-	return props
+
+	return props, nil
 }
 
 // GetProperty retreves a single property of the JS handle.

--- a/common/locator.go
+++ b/common/locator.go
@@ -454,3 +454,25 @@ func (l *Locator) inputValue(opts *FrameInputValueOptions) (string, error) {
 	opts.Strict = true
 	return l.frame.inputValue(l.selector, opts)
 }
+
+// SelectOption returns the element's input value that matches
+// the locator's selector with strict mode on.
+func (l *Locator) SelectOption(values goja.Value, opts goja.Value) []string {
+	l.log.Debugf("Locator:SelectOption", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+
+	copts := NewFrameSelectOptionOptions(l.frame.defaultTimeout())
+	if err := copts.Parse(l.ctx, opts); err != nil {
+		k6ext.Panic(l.ctx, "parse: %w", err)
+	}
+	v, err := l.selectOption(values, copts)
+	if err != nil {
+		k6ext.Panic(l.ctx, "selectOption: %w", err)
+	}
+
+	return v
+}
+
+func (l *Locator) selectOption(values goja.Value, opts *FrameSelectOptionOptions) ([]string, error) {
+	opts.Strict = true
+	return l.frame.selectOption(l.selector, values, opts)
+}

--- a/common/locator.go
+++ b/common/locator.go
@@ -455,8 +455,9 @@ func (l *Locator) inputValue(opts *FrameInputValueOptions) (string, error) {
 	return l.frame.inputValue(l.selector, opts)
 }
 
-// SelectOption returns the element's input value that matches
-// the locator's selector with strict mode on.
+// SelectOption filters option values of the first element that matches
+// the locator's selector (with strict mode on), selects the options,
+// and returns the filtered options.
 func (l *Locator) SelectOption(values goja.Value, opts goja.Value) []string {
 	l.log.Debugf("Locator:SelectOption", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
 

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -296,11 +296,31 @@ func TestLocatorInputValue(t *testing.T) {
 		require.Equal(t, "text area", p.Locator("textarea", nil).InputValue(nil))
 	})
 	t.Run("ok/select", func(t *testing.T) {
-		require.Equal(t, "option text", p.Locator("select", nil).InputValue(nil))
+		require.Equal(t, "option text", p.Locator("#selectElement", nil).InputValue(nil))
 	})
 	t.Run("strict", func(t *testing.T) {
 		require.Panics(t, func() {
 			p.Locator("input", nil).InputValue(nil)
+		}, "should not select multiple elements")
+	})
+}
+
+//nolint:tparallel
+func TestLocatorSelectOption(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	require.NotNil(t, p.Goto(tb.staticURL("/locators.html"), nil))
+
+	t.Run("ok", func(t *testing.T) {
+		rv := p.Locator("#selectElement", nil).SelectOption(tb.toGojaValue(`option text 2`), nil)
+		require.Len(t, rv, 1)
+		require.Equal(t, "option text 2", rv[0])
+	})
+	t.Run("strict", func(t *testing.T) {
+		require.Panics(t, func() {
+			p.Locator("select", nil).SelectOption(tb.toGojaValue(""), nil)
 		}, "should not select multiple elements")
 	})
 }

--- a/tests/static/locators.html
+++ b/tests/static/locators.html
@@ -14,7 +14,8 @@
     <div id="divHello"><span>hello</span></div>
     <div><span>bye</span></div>
     <textarea>text area</textarea>
-    <select><option value="option text"></select>
+    <select id="selectElement"><option value="option text"></option><option value="option text 2"></option></select>
+    <select><</select>
     <script>
         window.result = false;
         window.dblclick = false;

--- a/tests/static/locators.html
+++ b/tests/static/locators.html
@@ -15,7 +15,7 @@
     <div><span>bye</span></div>
     <textarea>text area</textarea>
     <select id="selectElement"><option value="option text"></option><option value="option text 2"></option></select>
-    <select><</select>
+    <select></select>
     <script>
         window.result = false;
         window.dblclick = false;


### PR DESCRIPTION
In this PR, I introduced an unexported new interface called `jsHandle` that wraps the existing public interface `api.JSHandle`. The reason is that `JSHandle`'s `Dispose` and `GetProperties` methods can panic.

Since we're aiming to separate the JS layer from the actual logic as discussed in #271, I needed to make their unexported variants return errors instead of panicking. Please let me know if there is a better way.

Besides that, the test does not try to verify the `SelectOption` from all aspects because it should be the `ElementHandle` test's job. Here, we only verify whether it routes the locator call to the `Frame`.

Closes #353.