### PR TITLE
Add locator.dispatchEvent

### DIFF
--- a/api/locator.go
+++ b/api/locator.go
@@ -69,4 +69,7 @@ type Locator interface {
 	Hover(opts goja.Value)
 	// Tap the element found that matches the locator's selector with strict mode on.
 	Tap(opts goja.Value)
+	// DispatchEvent dispatches an event for the element matching the
+	// locator's selector with strict mode on.
+	DispatchEvent(typ string, eventInit, opts goja.Value)
 }

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -234,7 +234,7 @@ func (h *ElementHandle) defaultTimeout() time.Duration {
 	return time.Duration(h.frame.manager.timeoutSettings.timeout()) * time.Second
 }
 
-func (h *ElementHandle) dispatchEvent(apiCtx context.Context, typ string, eventInit goja.Value) (interface{}, error) {
+func (h *ElementHandle) dispatchEvent(_ context.Context, typ string, eventInit goja.Value) (interface{}, error) {
 	fn := `
 		(node, injected, type, eventInit) => {
 			injected.dispatchEvent(node, type, eventInit);
@@ -245,6 +245,7 @@ func (h *ElementHandle) dispatchEvent(apiCtx context.Context, typ string, eventI
 		returnByValue: true,
 	}
 	_, err := h.evalWithScript(h.ctx, opts, fn, typ, eventInit)
+
 	return nil, err
 }
 

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -495,3 +495,33 @@ func (o *ElementHandleWaitForElementStateOptions) Parse(ctx context.Context, opt
 	}
 	return nil
 }
+
+// ElementHandleDispatchEventOptions are options for ElementHandle.dispatchEvent.
+type ElementHandleDispatchEventOptions struct {
+	ElementHandleBasePointerOptions
+	Timeout time.Duration `json:"timeout"`
+}
+
+// NewElementHandleDispatchEventOptions returns a new ElementHandleDispatchEventOptions.
+func NewElementHandleDispatchEventOptions(defaultTimeout time.Duration) *ElementHandleDispatchEventOptions {
+	return &ElementHandleDispatchEventOptions{
+		Timeout: defaultTimeout,
+	}
+}
+
+// Parse the ElementHandleDispatchEvent options from a goja value.
+func (o *ElementHandleDispatchEventOptions) Parse(ctx context.Context, opts goja.Value) error {
+	if !isGojaValueExists(opts) {
+		return nil
+	}
+
+	gopts := opts.ToObject(k6ext.Runtime(ctx))
+	for _, k := range gopts.Keys() {
+		if k == "timeout" {
+			o.Timeout = time.Duration(gopts.Get(k).ToInteger()) * time.Millisecond
+			break
+		}
+	}
+
+	return nil
+}

--- a/common/frame.go
+++ b/common/frame.go
@@ -883,9 +883,13 @@ func (f *Frame) dispatchEvent(selector, typ string, eventInit goja.Value, opts *
 	dispatchEvent := func(apiCtx context.Context, handle *ElementHandle) (interface{}, error) {
 		return handle.dispatchEvent(apiCtx, typ, eventInit)
 	}
+	const (
+		force       = false
+		noWaitAfter = false
+	)
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, dispatchEvent, []string{},
-		opts.Force, opts.NoWaitAfter, opts.Timeout,
+		force, noWaitAfter, opts.Timeout,
 	)
 	_, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
 

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -717,3 +717,36 @@ func (o *FrameWaitForSelectorOptions) Parse(ctx context.Context, opts goja.Value
 
 	return nil
 }
+
+// FrameDispatchEventOptions are options for Frame.dispatchEvent.
+type FrameDispatchEventOptions struct {
+	ElementHandleDispatchEventOptions
+	Strict bool `json:"strict"`
+}
+
+// NewFrameDispatchEventOptions returns a new FrameDispatchEventOptions.
+func NewFrameDispatchEventOptions(defaultTimeout time.Duration) *FrameDispatchEventOptions {
+	return &FrameDispatchEventOptions{
+		ElementHandleDispatchEventOptions: *NewElementHandleDispatchEventOptions(defaultTimeout),
+		Strict:                            false,
+	}
+}
+
+// Parse the FrameDispatchEventOptions options from a goja value.
+func (o *FrameDispatchEventOptions) Parse(ctx context.Context, opts goja.Value) error {
+	if err := o.ElementHandleDispatchEventOptions.Parse(ctx, opts); err != nil {
+		return err
+	}
+	if !isGojaValueExists(opts) {
+		return nil
+	}
+	gopts := opts.ToObject(k6ext.Runtime(ctx))
+	for _, k := range gopts.Keys() {
+		if k == "strict" {
+			o.Strict = gopts.Get(k).ToBoolean()
+			break
+		}
+	}
+
+	return nil
+}

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -737,7 +737,7 @@ func (o *FrameDispatchEventOptions) Parse(ctx context.Context, opts goja.Value) 
 	if err := o.ElementHandleDispatchEventOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if !isGojaValueExists(opts) {
+	if !gojaValueExists(opts) {
 		return nil
 	}
 	gopts := opts.ToObject(k6ext.Runtime(ctx))

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -720,33 +720,12 @@ func (o *FrameWaitForSelectorOptions) Parse(ctx context.Context, opts goja.Value
 
 // FrameDispatchEventOptions are options for Frame.dispatchEvent.
 type FrameDispatchEventOptions struct {
-	ElementHandleDispatchEventOptions
-	Strict bool `json:"strict"`
+	*FrameBaseOptions
 }
 
 // NewFrameDispatchEventOptions returns a new FrameDispatchEventOptions.
 func NewFrameDispatchEventOptions(defaultTimeout time.Duration) *FrameDispatchEventOptions {
 	return &FrameDispatchEventOptions{
-		ElementHandleDispatchEventOptions: *NewElementHandleDispatchEventOptions(defaultTimeout),
-		Strict:                            false,
+		FrameBaseOptions: NewFrameBaseOptions(defaultTimeout),
 	}
-}
-
-// Parse the FrameDispatchEventOptions options from a goja value.
-func (o *FrameDispatchEventOptions) Parse(ctx context.Context, opts goja.Value) error {
-	if err := o.ElementHandleDispatchEventOptions.Parse(ctx, opts); err != nil {
-		return err
-	}
-	if !gojaValueExists(opts) {
-		return nil
-	}
-	gopts := opts.ToObject(k6ext.Runtime(ctx))
-	for _, k := range gopts.Keys() {
-		if k == "strict" {
-			o.Strict = gopts.Get(k).ToBoolean()
-			break
-		}
-	}
-
-	return nil
 }

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -216,8 +216,8 @@ func TrimQuotes(s string) string {
 	return s
 }
 
-// isGojaValueExists returns true if a given value is not nil and exists
+// gojaValueExists returns true if a given value is not nil and exists
 // (defined and not null) in the goja runtime.
-func isGojaValueExists(v goja.Value) bool {
+func gojaValueExists(v goja.Value) bool {
 	return v != nil && !goja.IsUndefined(v) && !goja.IsNull(v)
 }

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -215,3 +215,9 @@ func TrimQuotes(s string) string {
 	}
 	return s
 }
+
+// isGojaValueExists returns true if a given value is not nil and exists
+// (defined and not null) in the goja runtime.
+func isGojaValueExists(v goja.Value) bool {
+	return v != nil && !goja.IsUndefined(v) && !goja.IsNull(v)
+}

--- a/common/locator.go
+++ b/common/locator.go
@@ -570,3 +570,28 @@ func (l *Locator) tap(opts *FrameTapOptions) error {
 	opts.Strict = true
 	return l.frame.tap(l.selector, opts)
 }
+
+// DispatchEvent dispatches an event for the element matching the
+// locator's selector with strict mode on.
+func (l *Locator) DispatchEvent(typ string, eventInit, opts goja.Value) {
+	l.log.Debugf(
+		"Locator:DispatchEvent", "fid:%s furl:%q sel:%q typ:%q eventInit:%+v opts:%+v",
+		l.frame.ID(), l.frame.URL(), l.selector, typ, eventInit, opts,
+	)
+
+	var err error
+	defer func() { panicOrSlowMo(l.ctx, err) }()
+
+	popts := NewFrameDispatchEventOptions(l.frame.defaultTimeout())
+	if err = popts.Parse(l.ctx, opts); err != nil {
+		return
+	}
+	if err = l.dispatchEvent(typ, eventInit, popts); err != nil {
+		return
+	}
+}
+
+func (l *Locator) dispatchEvent(typ string, eventInit goja.Value, opts *FrameDispatchEventOptions) error {
+	opts.Strict = true
+	return l.frame.dispatchEvent(l.selector, typ, eventInit, opts)
+}

--- a/examples/fillform.js
+++ b/examples/fillform.js
@@ -1,29 +1,30 @@
-import { check } from 'k6';
-import launcher from 'k6/x/browser';
+import { check } from "k6";
+import launcher from "k6/x/browser";
 
-export default function() {
-  const browser = launcher.launch('chromium', {
+export default function () {
+  const browser = launcher.launch("chromium", {
     headless: __ENV.XK6_HEADLESS ? true : false,
   });
   const context = browser.newContext();
   const page = context.newPage();
 
   // Goto front page, find login link and click it
-  page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+  page.goto("https://test.k6.io/", { waitUntil: "networkidle" });
   const elem = page.$('a[href="/my_messages.php"]');
   elem.click();
 
   // Enter login credentials and login
-  page.$('input[name="login"]').type('admin');
-  page.$('input[name="password"]').type('123');
+  page.$('input[name="login"]').type("admin");
+  page.$('input[name="password"]').type("123");
   page.$('input[type="submit"]').click();
+  // page.dispatchEvent('input[type="submit"]', "click", "mouseevent");
 
   // We expect the above form submission to trigger a navigation, so wait for it
   // and the page to be loaded.
   page.waitForNavigation();
 
   check(page, {
-    'header': page.$('h2').textContent() == 'Welcome, admin!',
+    header: page.$("h2").textContent() == "Welcome, admin!",
   });
 
   page.close();

--- a/examples/fillform.js
+++ b/examples/fillform.js
@@ -1,30 +1,29 @@
-import { check } from "k6";
-import launcher from "k6/x/browser";
+import { check } from 'k6';
+import launcher from 'k6/x/browser';
 
-export default function () {
-  const browser = launcher.launch("chromium", {
+export default function() {
+  const browser = launcher.launch('chromium', {
     headless: __ENV.XK6_HEADLESS ? true : false,
   });
   const context = browser.newContext();
   const page = context.newPage();
 
   // Goto front page, find login link and click it
-  page.goto("https://test.k6.io/", { waitUntil: "networkidle" });
+  page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
   const elem = page.$('a[href="/my_messages.php"]');
   elem.click();
 
   // Enter login credentials and login
-  page.$('input[name="login"]').type("admin");
-  page.$('input[name="password"]').type("123");
+  page.$('input[name="login"]').type('admin');
+  page.$('input[name="password"]').type('123');
   page.$('input[type="submit"]').click();
-  // page.dispatchEvent('input[type="submit"]', "click", "mouseevent");
 
   // We expect the above form submission to trigger a navigation, so wait for it
   // and the page to be loaded.
   page.waitForNavigation();
 
   check(page, {
-    header: page.$("h2").textContent() == "Welcome, admin!",
+    'header': page.$('h2').textContent() == 'Welcome, admin!',
   });
 
   page.close();

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -424,6 +424,8 @@ func TestLocatorDispatchEvent(t *testing.T) {
 			ok := p.Evaluate(tb.toGojaValue(`() => window.result`))
 			return ok.(goja.Value).ToBoolean() //nolint:forcetypeassert
 		}
+
+		require.False(t, result(), "should not be clicked first")
 		p.Locator("#link", nil).DispatchEvent("click", tb.toGojaValue("mouseevent"), nil)
 		require.True(t, result(), "could not dispatch event")
 	})

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -410,3 +410,24 @@ func TestLocatorTap(t *testing.T) {
 		}, "should not select multiple elements")
 	})
 }
+
+//nolint:tparallel
+func TestLocatorDispatchEvent(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	require.NotNil(t, p.Goto(tb.staticURL("/locators.html"), nil))
+
+	t.Run("ok", func(t *testing.T) {
+		result := func() bool {
+			ok := p.Evaluate(tb.toGojaValue(`() => window.result`))
+			return ok.(goja.Value).ToBoolean() //nolint:forcetypeassert
+		}
+		p.Locator("#link", nil).DispatchEvent("click", tb.toGojaValue("mouseevent"), nil)
+		require.True(t, result(), "could not dispatch event")
+	})
+	t.Run("strict", func(t *testing.T) {
+		require.Panics(t, func() { p.Locator("a", nil).DispatchEvent("click", tb.toGojaValue("mouseevent"), nil) })
+	})
+}


### PR DESCRIPTION
The `Frame` and `ElementHandle` refactoring for this feature took a little more time. It's because `Frame` and `ElementHandle` were using `DblClickOptions` instead of `DispatchEventOptions`. Please see the commits for more details.

I tested `dispatchEvent` by dispatching a click event in the `example/fillform.js` instead of calling `click`, and it worked. 

However, `Frame` and `ElementHandle` should have proper dispatch event tests in the future. The locator test only tests whether we can route the `dispatchEvent` call to `Frame`, and it does not test the event dispatching behavior to the full extent.

_PS: I forgot to name the branch `feat/335-locator-dispatchEvent` 🤦_

Closes #335.