### PR TITLE
Refactor cleanup temp dir to remove cleanupFunc

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -51,10 +51,6 @@ const (
 	BrowserStateClosed
 )
 
-// CleanupFunc is the function signature that a upstream cleanup
-// function must match for Close() to successfully call.
-type CleanupFunc func()
-
 // Browser stores a Browser context.
 type Browser struct {
 	BaseEventEmitter
@@ -89,11 +85,6 @@ type Browser struct {
 	vu k6modules.VU
 
 	logger *log.Logger
-
-	// This is called when Close() is called. This allows us to hook into
-	// the browser close function to cleanup anything that was created
-	// upstream.
-	cleanupFunc CleanupFunc
 }
 
 // NewBrowser creates a new browser, connects to it, then returns it.
@@ -103,9 +94,8 @@ func NewBrowser(
 	browserProc *BrowserProcess,
 	launchOpts *LaunchOptions,
 	logger *log.Logger,
-	cleanupFunc CleanupFunc,
 ) (*Browser, error) {
-	b := newBrowser(ctx, cancel, browserProc, launchOpts, logger, cleanupFunc)
+	b := newBrowser(ctx, cancel, browserProc, launchOpts, logger)
 	if err := b.connect(); err != nil {
 		return nil, err
 	}
@@ -119,7 +109,6 @@ func newBrowser(
 	browserProc *BrowserProcess,
 	launchOpts *LaunchOptions,
 	logger *log.Logger,
-	cleanupFunc CleanupFunc,
 ) *Browser {
 	return &Browser{
 		BaseEventEmitter:    NewBaseEventEmitter(ctx),
@@ -133,7 +122,6 @@ func newBrowser(
 		sessionIDtoTargetID: make(map[target.SessionID]target.ID),
 		vu:                  k6ext.GetVU(ctx),
 		logger:              logger,
-		cleanupFunc:         cleanupFunc,
 	}
 }
 
@@ -415,8 +403,8 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 // Close shuts down the browser.
 func (b *Browser) Close() {
 	defer func() {
-		if b.cleanupFunc != nil {
-			b.cleanupFunc()
+		if err := b.browserProc.userDataDir.Cleanup(); err != nil {
+			b.logger.Errorf("Browser:Close", "%v", err)
 		}
 	}()
 

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -25,6 +25,7 @@ import (
 	"os"
 
 	"github.com/grafana/xk6-browser/log"
+	"github.com/grafana/xk6-browser/storage"
 )
 
 type BrowserProcess struct {
@@ -42,16 +43,13 @@ type BrowserProcess struct {
 	wsURL string
 
 	// The directory where user data for the browser is stored.
-	userDataDir string
+	userDataDir *storage.Dir
 
 	logger *log.Logger
 }
 
 func NewBrowserProcess(
-	ctx context.Context,
-	cancel context.CancelFunc,
-	process *os.Process,
-	wsURL, userDataDir string,
+	ctx context.Context, cancel context.CancelFunc, process *os.Process, wsURL string, dataDir *storage.Dir,
 ) *BrowserProcess {
 	p := BrowserProcess{
 		ctx:                        ctx,
@@ -60,7 +58,7 @@ func NewBrowserProcess(
 		lostConnection:             make(chan struct{}),
 		processIsGracefullyClosing: make(chan struct{}),
 		wsURL:                      wsURL,
-		userDataDir:                userDataDir,
+		userDataDir:                dataDir,
 	}
 	go func() {
 		// If we lose connection to the browser and we're not in-progress with clean

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -23,7 +23,7 @@ func TestBrowserNewPageInContext(t *testing.T) {
 	}
 	newTestCase := func(id cdp.BrowserContextID) *testCase {
 		ctx := context.Background()
-		b := newBrowser(ctx, nil, nil, NewLaunchOptions(), log.NewNullLogger(), nil)
+		b := newBrowser(ctx, nil, nil, NewLaunchOptions(), log.NewNullLogger())
 		// set a new browser context in the browser with `id`, so that newPageInContext can find it.
 		b.contexts[id] = NewBrowserContext(ctx, b, id, nil, nil)
 		return &testCase{


### PR DESCRIPTION
Browser doesn't own or should really care about the cleanup of the temp
dir. For now we want to avoid using cleanupFunc, but still call cleanup
from Browser.
Closes: #402