### PR TITLE
Fix timeout detection (callApiWithTimeout)

### DIFF
--- a/common/helpers.go
+++ b/common/helpers.go
@@ -23,6 +23,7 @@ package common
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -121,7 +122,8 @@ func callApiWithTimeout(ctx context.Context, fn func(context.Context, chan inter
 
 	select {
 	case <-apiCtx.Done():
-		if apiCtx.Err() == context.Canceled {
+		err = apiCtx.Err()
+		if errors.Is(err, context.DeadlineExceeded) {
 			err = ErrTimedOut
 		}
 	case result = <-resultCh:

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -224,9 +224,7 @@ func TestPageInnerHTML(t *testing.T) {
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		p.SetContent(sampleHTML, nil)
-		assert.Equal(t, "", p.InnerHTML("p", tb.toGojaValue(jsFrameBaseOpts{
-			Timeout: "100",
-		})))
+		require.Panics(t, func() { p.InnerHTML("p", tb.toGojaValue(jsFrameBaseOpts{Timeout: "100"})) })
 	})
 }
 
@@ -259,9 +257,7 @@ func TestPageInnerText(t *testing.T) {
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		p.SetContent(sampleHTML, nil)
-		assert.Equal(t, "", p.InnerText("p", tb.toGojaValue(jsFrameBaseOpts{
-			Timeout: "100",
-		})))
+		require.Panics(t, func() { p.InnerText("p", tb.toGojaValue(jsFrameBaseOpts{Timeout: "100"})) })
 	})
 }
 
@@ -294,9 +290,7 @@ func TestPageTextContent(t *testing.T) {
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		p.SetContent(sampleHTML, nil)
-		assert.Equal(t, "", p.TextContent("p", tb.toGojaValue(jsFrameBaseOpts{
-			Timeout: "100",
-		})))
+		require.Panics(t, func() { p.TextContent("p", tb.toGojaValue(jsFrameBaseOpts{Timeout: "100"})) })
 	})
 }
 


### PR DESCRIPTION
Before this fix, we couldn't detect the timeouts properly (v0.3.0~now). For example, in the following test, we assert that the result of the `TextContent` method is empty even if the element we're looking for does not exist. The frame action should have timed out instead of returning an empty string (`p` tag doesn't exist in `sampleHTML`).

See the `err_wrong_selector` subtest.

https://github.com/grafana/xk6-browser/blob/eeab22ebfdc5c6d2863eab9a744ea1205d6d9309/tests/page_test.go#L256-L289

This PR fixes the problem and detects the timeout error properly by using `context.DeadlineExceeded` instead of `context.Canceled`. The current system is still unstable because this fix re-surfaced a data race bug that happens from time to time (happens on frame navigation). Previously reported on #254's description.

I've also fixed a few page tests vulnerable to this bug by requiring that they panic (one of them is above).

This bug has also prevented me from testing the locator timeout tests (#366). Then again, ~I'll send a PR~I sent #412 for the locator timeout tests ~shortly~ (based on this branch). For example, the following test wasn't panicking because of the bug that this PR fixes:

```go
tb := newTestBrowser(t)
p := tb.NewPage(nil)
p.SetContent("<html></html>", nil)
assert.Panics(t, func() { p.Locator("NOTEXIST", nil).Tap(tb.toGojaValue(jsFrameBaseOpts{Timeout: "100"})) })
```