### PR TITLE
Fix type assertions and remove nolint directives for good

### DIFF
--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -52,13 +52,17 @@ func TestBrowserNewPageInContext(t *testing.T) {
 				ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler,
 			) error {
 				require.Equal(t, target.CommandCreateTarget, method)
-				tp := params.(*target.CreateTargetParams) //nolint:forcetypeassert
+				require.IsType(t, params, &target.CreateTargetParams{})
+				tp, _ := params.(*target.CreateTargetParams)
 				require.Equal(t, "about:blank", tp.URL)
 				require.Equal(t, browserContextID, tp.BrowserContextID)
 
 				// newPageInContext event handler will catch this target ID, and compare it to
-				// the new page's target ID to detect whether the page is loaded.
-				res.(*target.CreateTargetReturns).TargetID = targetID //nolint:forcetypeassert
+				// the new page's target ID to detect whether the page
+				// is loaded.
+				require.IsType(t, res, &target.CreateTargetReturns{})
+				v, _ := res.(*target.CreateTargetReturns)
+				v.TargetID = targetID
 
 				// for the event handler to work, there needs to be an event called
 				// EventBrowserContextPage to be fired. this normally happens when the browser's

--- a/common/frame.go
+++ b/common/frame.go
@@ -817,23 +817,17 @@ func (f *Frame) Content() string {
 
 	rt := f.vu.Runtime()
 	js := `() => {
-			let content = '';
-			if (document.doctype) {
-				content = new XMLSerializer().serializeToString(document.doctype);
-			}
-			if (document.documentElement) {
-				content += document.documentElement.outerHTML;
-			}
-			return content;
-		}`
+		let content = '';
+		if (document.doctype) {
+			content = new XMLSerializer().serializeToString(document.doctype);
+		}
+		if (document.documentElement) {
+			content += document.documentElement.outerHTML;
+		}
+		return content;
+	}`
 
-	c := f.Evaluate(rt.ToValue(js))
-	content, ok := c.(goja.Value)
-	if !ok {
-		k6ext.Panic(f.ctx, "unexpected content() value type: %T", c)
-	}
-
-	return content.ToString().String()
+	return gojaValueToString(f.ctx, f.Evaluate(rt.ToValue(js)))
 }
 
 // Dblclick double clicks an element matching provided selector.
@@ -1113,7 +1107,7 @@ func (f *Frame) innerHTML(selector string, opts *FrameInnerHTMLOptions) (string,
 		return "", fmt.Errorf("unexpected type %T", v)
 	}
 
-	return gv.ToString().String(), nil
+	return gv.String(), nil
 }
 
 // InnerText returns the inner text of the first element found
@@ -1155,7 +1149,7 @@ func (f *Frame) innerText(selector string, opts *FrameInnerTextOptions) (string,
 		return "", fmt.Errorf("unexpected type %T", v)
 	}
 
-	return gv.ToString().String(), nil
+	return gv.String(), nil
 }
 
 // InputValue returns the input value of the first element found
@@ -1192,7 +1186,7 @@ func (f *Frame) inputValue(selector string, opts *FrameInputValueOptions) (strin
 		return "", fmt.Errorf("unexpected type %T", v)
 	}
 
-	return gv.ToString().String(), nil
+	return gv.String(), nil
 }
 
 // IsDetached returns whether the frame is detached or not.
@@ -1669,7 +1663,7 @@ func (f *Frame) textContent(selector string, opts *FrameTextContentOptions) (str
 		return "", fmt.Errorf("unexpected type %T", v)
 	}
 
-	return gv.ToString().String(), nil
+	return gv.String(), nil
 }
 
 func (f *Frame) Title() string {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -866,7 +866,11 @@ func (fs *FrameSession) onTargetCrashed(event *inspector.EventTargetCrashed) {
 	fs.logger.Debugf("FrameSession:onTargetCrashed", "sid:%v tid:%v", fs.session.ID(), fs.targetID)
 
 	// TODO:?
-	fs.session.(*Session).markAsCrashed() //nolint:forcetypeassert
+	s, ok := fs.session.(*Session)
+	if !ok {
+		k6ext.Panic(fs.ctx, "unexpected type %T", fs.session)
+	}
+	s.markAsCrashed()
 	fs.page.didCrash()
 }
 

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -223,3 +223,19 @@ func TrimQuotes(s string) string {
 func gojaValueExists(v goja.Value) bool {
 	return v != nil && !goja.IsUndefined(v) && !goja.IsNull(v)
 }
+
+// asGojaValue return v as a goja value.
+// panics if v is not a goja value.
+func asGojaValue(ctx context.Context, v interface{}) goja.Value {
+	gv, ok := v.(goja.Value)
+	if !ok {
+		k6ext.Panic(ctx, "unexpected type %T", v)
+	}
+	return gv
+}
+
+// gojaValueToString returns v as string.
+// panics if v is not a goja value.
+func gojaValueToString(ctx context.Context, v interface{}) string {
+	return asGojaValue(ctx, v).String()
+}

--- a/common/page.go
+++ b/common/page.go
@@ -814,9 +814,8 @@ func (p *Page) TextContent(selector string, opts goja.Value) string {
 func (p *Page) Title() string {
 	p.logger.Debugf("Page:Title", "sid:%v", p.sessionID())
 
-	rt := p.vu.Runtime()
-	js := `() => document.title`
-	return p.Evaluate(rt.ToValue(js)).(goja.Value).String()
+	v := p.vu.Runtime().ToValue(`() => document.title`)
+	return gojaValueToString(p.ctx, p.Evaluate(v))
 }
 
 func (p *Page) Type(selector string, text string, opts goja.Value) {

--- a/common/page_test.go
+++ b/common/page_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestPageLocator can be removed later on when we add integration
@@ -23,7 +24,9 @@ func TestPageLocator(t *testing.T) {
 			mainFrame: &Frame{id: wantMainFrameID, ctx: ctx},
 		},
 	}
-	l := p.Locator(wantSelector, nil).(*Locator) //nolint:forcetypeassert
+	v := p.Locator(wantSelector, nil)
+	require.IsType(t, v, &Locator{})
+	l, _ := v.(*Locator)
 	assert.Equal(t, wantSelector, l.selector)
 	assert.Equal(t, wantMainFrameID, string(l.frame.id))
 

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -71,11 +71,12 @@ func (s *screenshotter) fullPageSize(p *Page) (*Size, error) {
 	if err != nil {
 		return nil, err
 	}
-	r, ok := result.(goja.Value)
+	v, ok := result.(goja.Value)
 	if !ok {
-		return nil, fmt.Errorf("cannot convert result to goja value")
+		return nil, fmt.Errorf("unexpected type %T", result)
 	}
-	o := r.ToObject(rt)
+	o := v.ToObject(rt)
+
 	return &Size{
 		Width:  o.Get("width").ToFloat(),
 		Height: o.Get("height").ToFloat(),

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -189,7 +189,7 @@ func TestElementHandleClickConcealedLink(t *testing.T) {
 			() => window.clickResult
 		`
 		cr := p.Evaluate(tb.toGojaValue(cmd))
-		return cr.(goja.Value).String() //nolint:forcetypeassert
+		return tb.asGojaValue(cr).String()
 	}
 	require.NotNil(t, p.Goto(tb.staticURL("/concealed_link.html"), nil))
 	require.Equal(t, wantBefore, clickResult())

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -172,9 +172,11 @@ func TestPageGotoWaitUntilLoad(t *testing.T) {
 		WaitUntil string `js:"waitUntil"`
 	}{WaitUntil: "load"}))
 
-	results := p.Evaluate(b.toGojaValue("() => window.results"))
-	var actual []string
-	_ = b.runtime().ExportTo(results.(goja.Value), &actual) //nolint:forcetypeassert
+	var (
+		results = p.Evaluate(b.toGojaValue("() => window.results"))
+		actual  []string
+	)
+	_ = b.runtime().ExportTo(b.asGojaValue(results), &actual)
 
 	assert.EqualValues(t, []string{"DOMContentLoaded", "load"}, actual, `expected "load" event to have fired`)
 }
@@ -188,9 +190,11 @@ func TestPageGotoWaitUntilDOMContentLoaded(t *testing.T) {
 		WaitUntil string `js:"waitUntil"`
 	}{WaitUntil: "domcontentloaded"}))
 
-	results := p.Evaluate(b.toGojaValue("() => window.results"))
-	var actual []string
-	_ = b.runtime().ExportTo(results.(goja.Value), &actual) //nolint:forcetypeassert
+	var (
+		results = p.Evaluate(b.toGojaValue("() => window.results"))
+		actual  []string
+	)
+	_ = b.runtime().ExportTo(b.asGojaValue(results), &actual)
 
 	assert.EqualValues(t, "DOMContentLoaded", actual[0], `expected "DOMContentLoaded" event to have fired`)
 }

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -22,6 +22,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -123,7 +124,11 @@ func newTestBrowser(tb testing.TB, opts ...interface{}) *testBrowser {
 	}
 
 	// launch the browser
-	bt := chromium.NewBrowserType(vu.Context()).(*chromium.BrowserType) //nolint:forcetypeassert
+	v := chromium.NewBrowserType(vu.Context())
+	bt, ok := v.(*chromium.BrowserType)
+	if !ok {
+		panic(fmt.Errorf("testBrowser: unexpected browser type %T", v))
+	}
 	b := bt.Launch(rt.ToValue(launchOpts))
 	tb.Cleanup(func() {
 		select {


### PR DESCRIPTION
This commit properly type-asserts to remove `nolint:forcetypeassert` directives both from the code and tests.

There are new helpers to reduce code bloat and possible error messages refactoring work:
+ `asGojaValue(v)`: returns `v` as a `goja` value or panics.
+ `gojaValueToString(v)`: returns `v` as `string` or panics.

Fixes: #417
Related: #58