### PR TITLE
Improve more log messages and auto detect timeout errors

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -447,8 +447,11 @@ func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*log.Log
 		_ = logger.SetLevel("debug")
 	}
 	if el, ok := os.LookupEnv("XK6_BROWSER_LOG"); ok {
-		if err := logger.SetLevel(el); err != nil {
-			return nil, fmt.Errorf("setting logger level to %q: %w", el, err)
+		if logger.SetLevel(el) != nil {
+			return nil, fmt.Errorf(
+				"invalid log level %q, should be one of: panic, fatal, error, warn, warning, info, debug, trace",
+				el,
+			)
 		}
 	}
 	if _, ok := os.LookupEnv("XK6_BROWSER_CALLER"); ok {

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -241,7 +241,7 @@ func parseArgs(flags map[string]interface{}) ([]string, error) {
 				args = append(args, fmt.Sprintf("--%s", name))
 			}
 		default:
-			return nil, fmt.Errorf(`invalid browser command line flag: "%s=%s"`, name, value)
+			return nil, fmt.Errorf(`invalid browser command line flag: "%s=%v"`, name, value)
 		}
 	}
 	if _, ok := flags["no-sandbox"]; !ok && os.Getuid() == 0 {

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -220,7 +220,7 @@ func (b *BrowserType) allocate(
 		return nil, err
 	}
 
-	wsURL, err := parseWebsocketURL(ctx, stdout)
+	wsURL, err := parseDevToolsURL(ctx, stdout)
 	if err != nil {
 		return nil, fmt.Errorf("getting DevTools URL: %w", err)
 	}
@@ -402,11 +402,11 @@ func execute(
 	return cmd, stdout, nil
 }
 
-// parseWebsocketURL grabs the websocket address from chrome's output and returns it.
-func parseWebsocketURL(ctx context.Context, rc io.Reader) (wsURL string, _ error) {
+// parseDevToolsURL grabs the websocket address from chrome's output and returns it.
+func parseDevToolsURL(ctx context.Context, rc io.Reader) (wsURL string, _ error) {
 	type result struct {
-		wsURL string
-		err   error
+		devToolsURL string
+		err         error
 	}
 	c := make(chan result, 1)
 	go func() {
@@ -428,7 +428,7 @@ func parseWebsocketURL(ctx context.Context, rc io.Reader) (wsURL string, _ error
 	}()
 	select {
 	case r := <-c:
-		return r.wsURL, r.err
+		return r.devToolsURL, r.err
 	case <-ctx.Done():
 		return "", fmt.Errorf("%w", ctx.Err())
 	}

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -129,6 +129,10 @@ func (b *BrowserType) Launch(opts goja.Value) api.Browser {
 
 	bp, err := b.launch(launchOpts)
 	if err != nil {
+		err = &k6ext.UserFriendlyError{
+			Err:     err,
+			Timeout: launchOpts.Timeout,
+		}
 		k6ext.Panic(b.Ctx, "%w", err)
 	}
 

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -152,7 +152,7 @@ func (b *BrowserType) Launch(opts goja.Value) api.Browser {
 	go func(ctx context.Context) {
 		defer func() {
 			if err := dataDir.Cleanup(); err != nil {
-				logger.Errorf("BrowserType:Launch", "%v", err)
+				logger.Errorf("BrowserType:Launch", "cleaning up the user data directory: %v", err)
 			}
 		}()
 		// There's a small chance that this might be called
@@ -383,19 +383,22 @@ func execute(
 		// TODO: How to handle these errors?
 		defer func() {
 			if err := dataDir.Cleanup(); err != nil {
-				logger.Errorf("BrowserType:execute", "%v", err)
+				logger.Errorf("BrowserType:Close", "cleaning up the user data directory: %v", err)
 			}
 		}()
 
 		if err := cmd.Wait(); err != nil {
-			log := logger.Errorf
-			if err.Error() == "signal: killed" || err.Error() == "exit status 1" {
+			logErr := logger.Errorf
+			if s := err.Error(); strings.Contains(s, "signal: killed") || strings.Contains(s, "exit status 1") {
 				// The browser process is killed when the context is cancelled
 				// after a k6 iteration ends, so silence the log message until
 				// we can stop it gracefully. See #https://github.com/grafana/xk6-browser/issues/423
-				log = logger.Debugf
+				logErr = logger.Debugf
 			}
-			log("BrowserType:execute", "browser process with PID %d ended unexpectedly: %v", cmd.Process.Pid, err)
+			logErr(
+				"browser", "process with PID %d unexpectedly ended: %v",
+				cmd.Process.Pid, err,
+			)
 		}
 	}()
 

--- a/common/browser.go
+++ b/common/browser.go
@@ -382,7 +382,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 	action := target.CreateTarget("about:blank").WithBrowserContextID(id)
 	tid, err := action.Do(cdp.WithExecutor(ctx, b.conn))
 	if err != nil {
-		return nil, fmt.Errorf("%T: %w", action, err)
+		return nil, fmt.Errorf("creating a new blank page: %w", err)
 	}
 	// let the event handler know about the new page.
 	targetID <- tid

--- a/common/browser.go
+++ b/common/browser.go
@@ -404,7 +404,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 func (b *Browser) Close() {
 	defer func() {
 		if err := b.browserProc.userDataDir.Cleanup(); err != nil {
-			b.logger.Errorf("Browser:Close", "%v", err)
+			b.logger.Errorf("Browser:Close", "cleaning up the user data directory: %v", err)
 		}
 	}()
 

--- a/common/browser.go
+++ b/common/browser.go
@@ -260,7 +260,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 					ev.SessionID, evti.TargetID, b.ctx.Err())
 				return // ignore
 			default:
-				k6ext.Panic(b.ctx, "cannot create NewPage for background_page event: %w", err)
+				k6ext.Panic(b.ctx, "creating a new background page: %w", err)
 			}
 		}
 
@@ -299,7 +299,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 					ev.SessionID, evti.TargetID, b.ctx.Err())
 				return // ignore
 			default:
-				k6ext.Panic(b.ctx, "cannot create NewPage for page event: %w", err)
+				k6ext.Panic(b.ctx, "creating a new page: %w", err)
 			}
 		}
 
@@ -457,7 +457,7 @@ func (b *Browser) NewContext(opts goja.Value) api.BrowserContext {
 	browserContextID, err := action.Do(cdp.WithExecutor(b.ctx, b.conn))
 	b.logger.Debugf("Browser:NewContext", "bctxid:%v", browserContextID)
 	if err != nil {
-		k6ext.Panic(b.ctx, "cannot create browser context (%s): %w", browserContextID, err)
+		k6ext.Panic(b.ctx, "creating browser context ID %s: %w", browserContextID, err)
 	}
 
 	browserCtxOpts := NewBrowserContextOptions()

--- a/common/browser.go
+++ b/common/browser.go
@@ -205,7 +205,7 @@ func (b *Browser) initEvents() error {
 
 	action := target.SetAutoAttach(true, true).WithFlatten(true)
 	if err := action.Do(cdp.WithExecutor(b.ctx, b.conn)); err != nil {
-		return fmt.Errorf("executing setAutoAttach: %w", err)
+		return fmt.Errorf("internal error while auto-attaching to browser pages: %w", err)
 	}
 
 	// Target.setAutoAttach has a bug where it does not wait for new Targets being attached.
@@ -213,7 +213,7 @@ func (b *Browser) initEvents() error {
 	// This can be removed after https://chromium-review.googlesource.com/c/chromium/src/+/2885888 lands in stable.
 	action2 := target.GetTargetInfo()
 	if _, err := action2.Do(cdp.WithExecutor(b.ctx, b.conn)); err != nil {
-		return fmt.Errorf("executing getTargetInfo: %w", err)
+		return fmt.Errorf("internal error while getting browser target info: %w", err)
 	}
 
 	return nil

--- a/common/browser.go
+++ b/common/browser.go
@@ -394,8 +394,11 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 		page = b.pages[tid]
 		b.pagesMu.RUnlock()
 	case <-ctx.Done():
-		b.logger.Debugf("Browser:newPageInContext:<-ctx.Done", "tid:%v bctxid:%v err:%v", tid, id, ctx.Err())
-		err = ctx.Err()
+		err = &k6ext.UserFriendlyError{
+			Err:     ctx.Err(),
+			Timeout: b.launchOpts.Timeout,
+		}
+		b.logger.Debugf("Browser:newPageInContext:<-ctx.Done", "tid:%v bctxid:%v err:%v", tid, id, err)
 	}
 	return page, err
 }

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -355,7 +355,7 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 				case "predicate":
 					predicateFn, isCallable = goja.AssertFunction(opts.Get(k))
 					if !isCallable {
-						k6ext.Panic(b.ctx, "expected callable predicate")
+						k6ext.Panic(b.ctx, "predicate function is not callable")
 					}
 				case "timeout":
 					timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
@@ -364,7 +364,7 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 		default:
 			predicateFn, isCallable = goja.AssertFunction(optsOrPredicate)
 			if !isCallable {
-				k6ext.Panic(b.ctx, "expected callable predicate")
+				k6ext.Panic(b.ctx, "predicate function is not callable")
 			}
 		}
 	}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -214,7 +214,7 @@ func (b *BrowserContext) GrantPermissions(permissions []string, opts goja.Value)
 
 	action := cdpbrowser.GrantPermissions(perms).WithOrigin(origin).WithBrowserContextID(b.id)
 	if err := action.Do(cdp.WithExecutor(b.ctx, b.browser.conn)); err != nil {
-		k6ext.Panic(b.ctx, "override permissions: %w", err)
+		k6ext.Panic(b.ctx, "internal error while overriding browser permissions: %w", err)
 	}
 }
 

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -214,7 +214,7 @@ func (b *BrowserContext) GrantPermissions(permissions []string, opts goja.Value)
 
 	action := cdpbrowser.GrantPermissions(perms).WithOrigin(origin).WithBrowserContextID(b.id)
 	if err := action.Do(cdp.WithExecutor(b.ctx, b.browser.conn)); err != nil {
-		k6ext.Panic(b.ctx, "internal error while overriding browser permissions: %w", err)
+		k6ext.Panic(b.ctx, "internal error while granting browser permissions: %w", err)
 	}
 }
 

--- a/common/connection.go
+++ b/common/connection.go
@@ -392,7 +392,7 @@ func (c *Connection) send(ctx context.Context, msg *cdproto.Message, recvCh chan
 		return fmt.Errorf("closing communication with browser: %w", &websocket.CloseError{Code: code})
 	case <-ctx.Done():
 		c.logger.Debugf("Connection:send:<-ctx.Done", "wsURL:%q sid:%v err:%v", c.wsURL, msg.SessionID, c.ctx.Err())
-		return fmt.Errorf("%w", ctx.Err())
+		return nil
 	case <-c.done:
 		c.logger.Debugf("Connection:send:<-c.done", "wsURL:%q sid:%v", c.wsURL, msg.SessionID)
 		return nil

--- a/common/connection.go
+++ b/common/connection.go
@@ -24,11 +24,14 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/grafana/xk6-browser/log"
 
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
@@ -38,8 +41,6 @@ import (
 	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jlexer"
 	"github.com/mailru/easyjson/jwriter"
-
-	"github.com/grafana/xk6-browser/log"
 )
 
 const wsWriteBufferSize = 1 << 20
@@ -82,13 +83,14 @@ func (f ActionFunc) Do(ctx context.Context) error {
 }
 
 /*
-	Connection represents a WebSocket connection and the root "Browser Session".
+		Connection represents a WebSocket connection and the root "Browser Session".
 
-	                                      ┌───────────────────────────────────────────────────────────────────┐
-                                          │                                                                   │
-                                          │                          Browser Process                          │
-                                          │                                                                   │
-                                          └───────────────────────────────────────────────────────────────────┘
+		                                      ┌───────────────────────────────────────────────────────────────────┐
+	                                          │                                                                   │
+	                                          │                          Browser Process                          │
+	                                          │                                                                   │
+	                                          └───────────────────────────────────────────────────────────────────┘
+
 ┌───────────────────────────┐                                           │      ▲
 │Reads JSON-RPC CDP messages│                                           │      │
 │from WS connection and puts│                                           ▼      │
@@ -106,8 +108,10 @@ func (f ActionFunc) Do(ctx context.Context) error {
 │   messages on outgoing    │             │                    │                         │                    │
 │ channel of WS connection. │             └────────────────────┘                         └────────────────────┘
 └───────────────────────────┘                    │      ▲                                       │      ▲
-                                                 │      │                                       │      │
-                                                 ▼      │                                       ▼      │
+
+	│      │                                       │      │
+	▼      │                                       ▼      │
+
 ┌───────────────────────────┐             ┌────────────────────┐                         ┌────────────────────┐
 │Registers with session as a├─────────────■                    │                         │                    │
 │handler for a specific CDP │             │   Event Listener   │      *  *  *  *  *      │   Event Listener   │
@@ -234,7 +238,7 @@ func (c *Connection) createSession(info *target.Info) (*Session, error) {
 }
 
 func (c *Connection) handleIOError(err error) {
-	c.logger.Errorf("Connection:handleIOError", "err:%v", err)
+	c.logger.Errorf("cdp", "communicating with browser: %v", err)
 
 	if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 		// Report an unexpected closure
@@ -244,15 +248,18 @@ func (c *Connection) handleIOError(err error) {
 			return
 		}
 	}
-	code := websocket.CloseGoingAway
-	if e, ok := err.(*websocket.CloseError); ok {
-		code = e.Code
+	var (
+		cerr *websocket.CloseError
+		code = websocket.CloseGoingAway
+	)
+	if errors.As(err, &cerr) {
+		code = cerr.Code
 	}
 	select {
 	case c.closeCh <- code:
-		c.logger.Debugf("Connection:handleIOError:c.closeCh <-", "code:%d", code)
+		c.logger.Debugf("cdp", "ending browser communication with code %d", code)
 	case <-c.done:
-		c.logger.Debugf("Connection:handleIOError:<-c.done", "")
+		c.logger.Debugf("cdp", "ending browser communication")
 	}
 }
 
@@ -378,20 +385,17 @@ func (c *Connection) send(ctx context.Context, msg *cdproto.Message, recvCh chan
 	case c.sendCh <- msg:
 	case err := <-c.errorCh:
 		c.logger.Debugf("Connection:send:<-c.errorCh", "wsURL:%q sid:%v, err:%v", c.wsURL, msg.SessionID, err)
-		return err
+		return fmt.Errorf("sending a message to browser: %w", err)
 	case code := <-c.closeCh:
 		c.logger.Debugf("Connection:send:<-c.closeCh", "wsURL:%q sid:%v, websocket code:%v", c.wsURL, msg.SessionID, code)
 		_ = c.closeConnection(code)
-		return &websocket.CloseError{Code: code}
+		return fmt.Errorf("closing communication with browser: %w", &websocket.CloseError{Code: code})
+	case <-ctx.Done():
+		c.logger.Debugf("Connection:send:<-ctx.Done", "wsURL:%q sid:%v err:%v", c.wsURL, msg.SessionID, c.ctx.Err())
+		return fmt.Errorf("%w", ctx.Err())
 	case <-c.done:
 		c.logger.Debugf("Connection:send:<-c.done", "wsURL:%q sid:%v", c.wsURL, msg.SessionID)
 		return nil
-	case <-ctx.Done():
-		c.logger.Errorf("Connection:send:<-ctx.Done()", "wsURL:%q sid:%v err:%v", c.wsURL, msg.SessionID, c.ctx.Err())
-		return ctx.Err()
-	case <-c.ctx.Done():
-		c.logger.Errorf("Connection:send:<-c.ctx.Done()", "wsURL:%q sid:%v err:%v", c.wsURL, msg.SessionID, c.ctx.Err())
-		return ctx.Err()
 	}
 
 	// Block waiting for response.

--- a/common/connection_test.go
+++ b/common/connection_test.go
@@ -64,7 +64,7 @@ func TestConnectionClosureAbnormal(t *testing.T) {
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
 			err := action.Do(cdp.WithExecutor(ctx, conn))
-			require.EqualError(t, err, "websocket: close 1006 (abnormal closure): unexpected EOF")
+			require.ErrorContains(t, err, "websocket: close 1006 (abnormal closure): unexpected EOF")
 		}
 	})
 }

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -75,7 +75,7 @@ func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, point Position)
 			return false, err
 		}
 		if box == nil {
-			return false, errors.New("getting bounding box of element")
+			return false, errors.New("missing bounding box of element")
 		}
 		// Translate from viewport coordinates to frame coordinates.
 		point.X -= box.X

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -146,7 +146,7 @@ func (h *ElementHandle) checkElementState(_ context.Context, state string) (*boo
 	}
 
 	return nil, fmt.Errorf(
-		"checking state %q of element: %q", state, reflect.TypeOf(result))
+		"checking state %q of element %q", state, reflect.TypeOf(result))
 }
 
 func (h *ElementHandle) click(p *Position, opts *MouseClickOptions) error {
@@ -687,7 +687,7 @@ func (h *ElementHandle) waitForElementState(
 	}
 
 	return false, fmt.Errorf(
-		"checking states %v of element: %q", states, reflect.TypeOf(result))
+		"waiting for states %v of element %q", states, reflect.TypeOf(result))
 }
 
 func (h *ElementHandle) waitForSelector(apiCtx context.Context, selector string, opts *FrameWaitForSelectorOptions) (*ElementHandle, error) {
@@ -915,7 +915,7 @@ func (h *ElementHandle) InputValue(opts goja.Value) string {
 func (h *ElementHandle) IsChecked() bool {
 	result, err := h.isChecked(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "element isChecked: %w", err)
+		k6ext.Panic(h.ctx, "checking element is checked: %w", err)
 	}
 	return result
 }
@@ -924,7 +924,7 @@ func (h *ElementHandle) IsChecked() bool {
 func (h *ElementHandle) IsDisabled() bool {
 	result, err := h.isDisabled(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "element isDisabled: %w", err)
+		k6ext.Panic(h.ctx, "checking element is disabled: %w", err)
 	}
 	return result
 }
@@ -933,7 +933,7 @@ func (h *ElementHandle) IsDisabled() bool {
 func (h *ElementHandle) IsEditable() bool {
 	result, err := h.isEditable(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "element isEditable: %w", err)
+		k6ext.Panic(h.ctx, "checking element is editable: %w", err)
 	}
 	return result
 }
@@ -942,7 +942,7 @@ func (h *ElementHandle) IsEditable() bool {
 func (h *ElementHandle) IsEnabled() bool {
 	result, err := h.isEnabled(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "element isEnabled: %w", err)
+		k6ext.Panic(h.ctx, "checking element is enabled: %w", err)
 	}
 	return result
 }
@@ -951,7 +951,7 @@ func (h *ElementHandle) IsEnabled() bool {
 func (h *ElementHandle) IsHidden() bool {
 	result, err := h.isHidden(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "element isHidden: %w", err)
+		k6ext.Panic(h.ctx, "checking element is hidden: %w", err)
 	}
 	return result
 }
@@ -960,7 +960,7 @@ func (h *ElementHandle) IsHidden() bool {
 func (h *ElementHandle) IsVisible() bool {
 	result, err := h.isVisible(h.ctx, 0)
 	if err != nil && err != ErrTimedOut { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "element isVisible: %w", err)
+		k6ext.Panic(h.ctx, "checking element is visible: %w", err)
 	}
 	return result
 }
@@ -1061,7 +1061,7 @@ func (h *ElementHandle) QueryAll(selector string) []api.ElementHandle {
 
 	handles, err := h.queryAll(selector, h.evalWithScript)
 	if err != nil {
-		k6ext.Panic(h.ctx, "QueryAll: %w", err)
+		k6ext.Panic(h.ctx, "querying all selector %q: %w", selector, err)
 	}
 
 	return handles
@@ -1079,7 +1079,7 @@ func (h *ElementHandle) queryAll(selector string, eval evalFunc) ([]api.ElementH
 		parsedSelector,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("querying selector %q: %w", selector, err)
+		return nil, fmt.Errorf("querying all selectors %q: %w", selector, err)
 	}
 	if result == nil {
 		// it is ok to return a nil slice because it means we didn't find any elements.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -648,11 +648,9 @@ func (h *ElementHandle) waitAndScrollIntoViewIfNeeded(apiCtx context.Context, fo
 		return h.eval(apiCtx, opts, fn)
 	}
 	actFn := h.newAction([]string{"visible", "stable"}, fn, force, noWaitAfter, timeout)
-	_, err := callApiWithTimeout(h.ctx, actFn, timeout)
-	if err != nil {
-		return err
-	}
-	return nil
+	_, err := call(h.ctx, actFn, timeout)
+
+	return err
 }
 
 func (h *ElementHandle) waitForElementState(
@@ -745,7 +743,7 @@ func (h *ElementHandle) Click(opts goja.Value) {
 		return nil, handle.click(p, actionOpts.ToMouseClickOptions())
 	}
 	pointerFn := h.newPointerAction(fn, &actionOpts.ElementHandleBasePointerOptions)
-	_, err := callApiWithTimeout(h.ctx, pointerFn, actionOpts.Timeout)
+	_, err := call(h.ctx, pointerFn, actionOpts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "clicking on element: %v", err)
 	}
@@ -777,7 +775,7 @@ func (h *ElementHandle) Dblclick(opts goja.Value) {
 		return nil, handle.dblClick(p, actionOpts.ToMouseClickOptions())
 	}
 	pointerFn := h.newPointerAction(fn, &actionOpts.ElementHandleBasePointerOptions)
-	_, err := callApiWithTimeout(h.ctx, pointerFn, actionOpts.Timeout)
+	_, err := call(h.ctx, pointerFn, actionOpts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "double clicking on element: %w", err)
 	}
@@ -790,7 +788,7 @@ func (h *ElementHandle) DispatchEvent(typ string, eventInit goja.Value) {
 	}
 	opts := NewElementHandleBaseOptions(h.defaultTimeout())
 	actFn := h.newAction([]string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
-	_, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
+	_, err := call(h.ctx, actFn, opts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "dispatching element event: %w", err)
 	}
@@ -807,7 +805,7 @@ func (h *ElementHandle) Fill(value string, opts goja.Value) {
 	}
 	actFn := h.newAction([]string{"visible", "enabled", "editable"},
 		fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
-	_, err := callApiWithTimeout(h.ctx, actFn, actionOpts.Timeout)
+	_, err := call(h.ctx, actFn, actionOpts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "handling element fill action: %w", err)
 	}
@@ -821,7 +819,7 @@ func (h *ElementHandle) Focus() {
 	}
 	opts := NewElementHandleBaseOptions(h.defaultTimeout())
 	actFn := h.newAction([]string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
-	_, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
+	_, err := call(h.ctx, actFn, opts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "focusing on element: %w", err)
 	}
@@ -835,7 +833,7 @@ func (h *ElementHandle) GetAttribute(name string) goja.Value {
 	}
 	opts := NewElementHandleBaseOptions(h.defaultTimeout())
 	actFn := h.newAction([]string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
-	v, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
+	v, err := call(h.ctx, actFn, opts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "getting attribute of %q: %q", name, err)
 	}
@@ -854,7 +852,7 @@ func (h *ElementHandle) Hover(opts goja.Value) {
 		return nil, handle.hover(apiCtx, p)
 	}
 	pointerFn := h.newPointerAction(fn, &actionOpts.ElementHandleBasePointerOptions)
-	_, err := callApiWithTimeout(h.ctx, pointerFn, actionOpts.Timeout)
+	_, err := call(h.ctx, pointerFn, actionOpts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "hovering on element: %w", err)
 	}
@@ -868,7 +866,7 @@ func (h *ElementHandle) InnerHTML() string {
 	}
 	opts := NewElementHandleBaseOptions(h.defaultTimeout())
 	actFn := h.newAction([]string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
-	v, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
+	v, err := call(h.ctx, actFn, opts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "getting element's inner HTML: %w", err)
 	}
@@ -884,7 +882,7 @@ func (h *ElementHandle) InnerText() string {
 	}
 	opts := NewElementHandleBaseOptions(h.defaultTimeout())
 	actFn := h.newAction([]string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
-	v, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
+	v, err := call(h.ctx, actFn, opts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "getting element's inner text: %w", err)
 	}
@@ -902,7 +900,7 @@ func (h *ElementHandle) InputValue(opts goja.Value) string {
 		return handle.inputValue(apiCtx)
 	}
 	actFn := h.newAction([]string{}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
-	v, err := callApiWithTimeout(h.ctx, actFn, actionOpts.Timeout)
+	v, err := call(h.ctx, actFn, actionOpts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "getting element's input value: %w", err)
 	}
@@ -1011,7 +1009,7 @@ func (h *ElementHandle) Press(key string, opts goja.Value) {
 		return nil, handle.press(apiCtx, key, NewKeyboardOptions())
 	}
 	actFn := h.newAction([]string{}, fn, false, parsedOpts.NoWaitAfter, parsedOpts.Timeout)
-	_, err := callApiWithTimeout(h.ctx, actFn, parsedOpts.Timeout)
+	_, err := call(h.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "pressing %q: %v", key, err)
 	}
@@ -1118,7 +1116,7 @@ func (h *ElementHandle) SetChecked(checked bool, opts goja.Value) {
 		return nil, handle.setChecked(apiCtx, checked, p)
 	}
 	pointerFn := h.newPointerAction(fn, &parsedOpts.ElementHandleBasePointerOptions)
-	_, err = callApiWithTimeout(h.ctx, pointerFn, parsedOpts.Timeout)
+	_, err = call(h.ctx, pointerFn, parsedOpts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "checking element: %w", err)
 	}
@@ -1199,7 +1197,7 @@ func (h *ElementHandle) SelectOption(values goja.Value, opts goja.Value) []strin
 		return handle.selectOption(apiCtx, values)
 	}
 	actFn := h.newAction([]string{}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
-	selectedOptions, err := callApiWithTimeout(h.ctx, actFn, actionOpts.Timeout)
+	selectedOptions, err := call(h.ctx, actFn, actionOpts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "selecting options: %w", err)
 	}
@@ -1222,7 +1220,7 @@ func (h *ElementHandle) SelectText(opts goja.Value) {
 		return nil, handle.selectText(apiCtx)
 	}
 	actFn := h.newAction([]string{}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
-	_, err := callApiWithTimeout(h.ctx, actFn, actionOpts.Timeout)
+	_, err := call(h.ctx, actFn, actionOpts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "selecting text: %w", err)
 	}
@@ -1245,7 +1243,7 @@ func (h *ElementHandle) Tap(opts goja.Value) {
 		return nil, handle.tap(apiCtx, p)
 	}
 	pointerFn := h.newPointerAction(fn, &parsedOpts.ElementHandleBasePointerOptions)
-	_, err = callApiWithTimeout(h.ctx, pointerFn, parsedOpts.Timeout)
+	_, err = call(h.ctx, pointerFn, parsedOpts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "tapping element: %w", err)
 	}
@@ -1258,7 +1256,7 @@ func (h *ElementHandle) TextContent() string {
 	}
 	opts := NewElementHandleBaseOptions(h.defaultTimeout())
 	actFn := h.newAction([]string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
-	v, err := callApiWithTimeout(h.ctx, actFn, opts.Timeout)
+	v, err := call(h.ctx, actFn, opts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "getting text content of element: %w", err)
 	}
@@ -1277,7 +1275,7 @@ func (h *ElementHandle) Type(text string, opts goja.Value) {
 		return nil, handle.typ(apiCtx, text, NewKeyboardOptions())
 	}
 	actFn := h.newAction([]string{}, fn, false, parsedOpts.NoWaitAfter, parsedOpts.Timeout)
-	_, err := callApiWithTimeout(h.ctx, actFn, parsedOpts.Timeout)
+	_, err := call(h.ctx, actFn, parsedOpts.Timeout)
 	if err != nil {
 		k6ext.Panic(h.ctx, "typing text %q: %w", text, err)
 	}

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -152,7 +152,7 @@ func (e *ExecutionContext) adoptElementHandle(eh *ElementHandle) (*ElementHandle
 		efid, esid)
 
 	if eh.execCtx == e {
-		return nil, errors.New("already belongs to the execution context")
+		return nil, errors.New("already belongs to the same execution context")
 	}
 	if e.frame == nil {
 		return nil, errors.New("does not have a frame owner")
@@ -224,7 +224,7 @@ func (e *ExecutionContext) eval(
 	if remoteObject, exceptionDetails, err = action.Do(cdp.WithExecutor(apiCtx, e.session)); err != nil {
 		var cdpe *cdproto.Error
 		if errors.As(err, &cdpe) && cdpe.Code == -32000 {
-			err = fmt.Errorf("execution context with ID %d not found", e.id)
+			err = errors.New("execution context changed; most likely because of a navigation")
 		}
 		return nil, err
 	}
@@ -256,6 +256,7 @@ func (e *ExecutionContext) eval(
 }
 
 // Based on: https://github.com/microsoft/playwright/blob/master/src/server/injected/injectedScript.ts
+//
 //go:embed js/injected_script.js
 var injectedScriptSource string
 

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -152,10 +152,10 @@ func (e *ExecutionContext) adoptElementHandle(eh *ElementHandle) (*ElementHandle
 		efid, esid)
 
 	if eh.execCtx == e {
-		panic("cannot adopt handle that already belongs to this execution context")
+		return nil, errors.New("already belongs to the execution context")
 	}
 	if e.frame == nil {
-		panic("cannot adopt handle without frame owner")
+		return nil, errors.New("does not have a frame owner")
 	}
 
 	var node *cdp.Node

--- a/common/frame.go
+++ b/common/frame.go
@@ -932,7 +932,7 @@ func (f *Frame) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (handle 
 	{
 		ec := f.executionContexts[mainWorld]
 		if ec == nil {
-			k6ext.Panic(f.ctx, "execution context %q not found", mainWorld)
+			k6ext.Panic(f.ctx, "evaluating handle: execution context %q not found", mainWorld)
 		}
 		handle, err = ec.EvalHandle(f.ctx, pageFunc, args...)
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -714,7 +714,7 @@ func (f *Frame) click(selector string, opts *FrameClickOptions) error {
 		selector, DOMElementStateAttached, opts.Strict, click, &opts.ElementHandleBasePointerOptions,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err.Error())
+		return errorFromDOMError(err)
 	}
 
 	return nil
@@ -742,7 +742,7 @@ func (f *Frame) check(selector string, opts *FrameCheckOptions) error {
 		selector, DOMElementStateAttached, opts.Strict, check, &opts.ElementHandleBasePointerOptions,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err.Error())
+		return errorFromDOMError(err)
 	}
 
 	return nil
@@ -770,7 +770,7 @@ func (f *Frame) uncheck(selector string, opts *FrameUncheckOptions) error {
 		selector, DOMElementStateAttached, opts.Strict, uncheck, &opts.ElementHandleBasePointerOptions,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err.Error())
+		return errorFromDOMError(err)
 	}
 
 	return nil
@@ -806,7 +806,7 @@ func (f *Frame) isChecked(selector string, opts *FrameIsCheckedOptions) (bool, e
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return false, errorFromDOMError(err.Error())
+		return false, errorFromDOMError(err)
 	}
 
 	bv, ok := v.(bool)
@@ -860,7 +860,7 @@ func (f *Frame) dblclick(selector string, opts *FrameDblclickOptions) error {
 		selector, DOMElementStateAttached, opts.Strict, dblclick, &opts.ElementHandleBasePointerOptions,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err.Error())
+		return errorFromDOMError(err)
 	}
 
 	return nil
@@ -895,7 +895,7 @@ func (f *Frame) dispatchEvent(selector, typ string, eventInit goja.Value, opts *
 		force, noWaitAfter, opts.Timeout,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err.Error())
+		return errorFromDOMError(err)
 	}
 
 	return nil
@@ -969,7 +969,7 @@ func (f *Frame) fill(selector, value string, opts *FrameFillOptions) error {
 		opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err.Error())
+		return errorFromDOMError(err)
 	}
 
 	return nil
@@ -998,7 +998,7 @@ func (f *Frame) focus(selector string, opts *FrameBaseOptions) error {
 		[]string{}, false, true, opts.Timeout,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err.Error())
+		return errorFromDOMError(err)
 	}
 
 	return nil
@@ -1042,7 +1042,7 @@ func (f *Frame) getAttribute(selector, name string, opts *FrameBaseOptions) (goj
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return nil, errorFromDOMError(err.Error())
+		return nil, errorFromDOMError(err)
 	}
 	gv, ok := v.(goja.Value)
 	if !ok {
@@ -1082,7 +1082,7 @@ func (f *Frame) hover(selector string, opts *FrameHoverOptions) error {
 		selector, DOMElementStateAttached, opts.Strict, hover, &opts.ElementHandleBasePointerOptions,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err.Error())
+		return errorFromDOMError(err)
 	}
 
 	return nil
@@ -1117,7 +1117,7 @@ func (f *Frame) innerHTML(selector string, opts *FrameInnerHTMLOptions) (string,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return "", errorFromDOMError(err.Error())
+		return "", errorFromDOMError(err)
 	}
 	if v == nil {
 		return "", nil
@@ -1159,7 +1159,7 @@ func (f *Frame) innerText(selector string, opts *FrameInnerTextOptions) (string,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return "", errorFromDOMError(err.Error())
+		return "", errorFromDOMError(err)
 	}
 	if v == nil {
 		return "", nil
@@ -1199,7 +1199,7 @@ func (f *Frame) inputValue(selector string, opts *FrameInputValueOptions) (strin
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return "", errorFromDOMError(err.Error())
+		return "", errorFromDOMError(err)
 	}
 	gv, ok := v.(goja.Value)
 	if !ok {
@@ -1255,7 +1255,7 @@ func (f *Frame) isEditable(selector string, opts *FrameIsEditableOptions) (bool,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return false, errorFromDOMError(err.Error())
+		return false, errorFromDOMError(err)
 	}
 
 	bv, ok := v.(bool)
@@ -1296,7 +1296,7 @@ func (f *Frame) isEnabled(selector string, opts *FrameIsEnabledOptions) (bool, e
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return false, errorFromDOMError(err.Error())
+		return false, errorFromDOMError(err)
 	}
 
 	bv, ok := v.(bool)
@@ -1337,7 +1337,7 @@ func (f *Frame) isDisabled(selector string, opts *FrameIsDisabledOptions) (bool,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return false, errorFromDOMError(err.Error())
+		return false, errorFromDOMError(err)
 	}
 
 	bv, ok := v.(bool)
@@ -1378,7 +1378,7 @@ func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, err
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return false, errorFromDOMError(err.Error())
+		return false, errorFromDOMError(err)
 	}
 
 	bv, ok := v.(bool)
@@ -1419,7 +1419,7 @@ func (f *Frame) isVisible(selector string, opts *FrameIsVisibleOptions) (bool, e
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return false, errorFromDOMError(err.Error())
+		return false, errorFromDOMError(err)
 	}
 
 	bv, ok := v.(bool)
@@ -1525,7 +1525,7 @@ func (f *Frame) press(selector, key string, opts *FramePressOptions) error {
 		[]string{}, false, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err.Error())
+		return errorFromDOMError(err)
 	}
 
 	return nil
@@ -1560,7 +1560,7 @@ func (f *Frame) selectOption(selector string, values goja.Value, opts *FrameSele
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return nil, errorFromDOMError(err.Error())
+		return nil, errorFromDOMError(err)
 	}
 	selectHandle, ok := v.(jsHandle)
 	if !ok {
@@ -1644,7 +1644,7 @@ func (f *Frame) tap(selector string, opts *FrameTapOptions) error {
 		selector, DOMElementStateAttached, opts.Strict, tap, &opts.ElementHandleBasePointerOptions,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err.Error())
+		return errorFromDOMError(err)
 	}
 
 	return nil
@@ -1679,7 +1679,7 @@ func (f *Frame) textContent(selector string, opts *FrameTextContentOptions) (str
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
-		return "", errorFromDOMError(err.Error())
+		return "", errorFromDOMError(err)
 	}
 	if v == nil {
 		return "", nil
@@ -1723,7 +1723,7 @@ func (f *Frame) typ(selector, text string, opts *FrameTypeOptions) error {
 		[]string{}, false, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err.Error())
+		return errorFromDOMError(err)
 	}
 
 	return nil

--- a/common/frame.go
+++ b/common/frame.go
@@ -647,7 +647,7 @@ func (f *Frame) waitForSelector(selector string, opts *FrameWaitForSelectorOptio
 		return nil, err
 	}
 	if handle == nil {
-		return nil, fmt.Errorf("wait for selector %q did not result in any nodes", selector)
+		return nil, fmt.Errorf("waiting for selector %q did not result in any nodes", selector)
 	}
 
 	// We always return ElementHandles in the main execution context (aka "DOM world")
@@ -656,14 +656,14 @@ func (f *Frame) waitForSelector(selector string, opts *FrameWaitForSelectorOptio
 
 	ec := f.executionContexts[mainWorld]
 	if ec == nil {
-		return nil, fmt.Errorf("wait for selector %q cannot find execution context: %q", selector, mainWorld)
+		return nil, fmt.Errorf("waiting for selector %q: execution context %q not found", selector, mainWorld)
 	}
 	// an element should belong to the current execution context.
 	// otherwise, we should adopt it to this execution context.
 	if ec != handle.execCtx {
 		defer handle.Dispose()
 		if handle, err = ec.adoptElementHandle(handle); err != nil {
-			return nil, fmt.Errorf("wait for selector %q cannot adopt element handle: %w", selector, err)
+			return nil, fmt.Errorf("adopting element handle while waiting for selector %q: %w", selector, err)
 		}
 	}
 

--- a/common/frame.go
+++ b/common/frame.go
@@ -713,7 +713,7 @@ func (f *Frame) click(selector string, opts *FrameClickOptions) error {
 	act := f.newPointerAction(
 		selector, DOMElementStateAttached, opts.Strict, click, &opts.ElementHandleBasePointerOptions,
 	)
-	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err.Error())
 	}
 
@@ -741,7 +741,7 @@ func (f *Frame) check(selector string, opts *FrameCheckOptions) error {
 	act := f.newPointerAction(
 		selector, DOMElementStateAttached, opts.Strict, check, &opts.ElementHandleBasePointerOptions,
 	)
-	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err.Error())
 	}
 
@@ -769,7 +769,7 @@ func (f *Frame) uncheck(selector string, opts *FrameUncheckOptions) error {
 	act := f.newPointerAction(
 		selector, DOMElementStateAttached, opts.Strict, uncheck, &opts.ElementHandleBasePointerOptions,
 	)
-	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err.Error())
 	}
 
@@ -804,7 +804,7 @@ func (f *Frame) isChecked(selector string, opts *FrameIsCheckedOptions) (bool, e
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, isChecked, []string{}, false, true, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return false, errorFromDOMError(err.Error())
 	}
@@ -859,7 +859,7 @@ func (f *Frame) dblclick(selector string, opts *FrameDblclickOptions) error {
 	act := f.newPointerAction(
 		selector, DOMElementStateAttached, opts.Strict, dblclick, &opts.ElementHandleBasePointerOptions,
 	)
-	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err.Error())
 	}
 
@@ -894,7 +894,7 @@ func (f *Frame) dispatchEvent(selector, typ string, eventInit goja.Value, opts *
 		selector, DOMElementStateAttached, opts.Strict, dispatchEvent, []string{},
 		force, noWaitAfter, opts.Timeout,
 	)
-	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err.Error())
 	}
 
@@ -968,7 +968,7 @@ func (f *Frame) fill(selector, value string, opts *FrameFillOptions) error {
 		fill, []string{"visible", "enabled", "editable"},
 		opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
-	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err.Error())
 	}
 
@@ -997,7 +997,7 @@ func (f *Frame) focus(selector string, opts *FrameBaseOptions) error {
 		selector, DOMElementStateAttached, opts.Strict, focus,
 		[]string{}, false, true, opts.Timeout,
 	)
-	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err.Error())
 	}
 
@@ -1040,7 +1040,7 @@ func (f *Frame) getAttribute(selector, name string, opts *FrameBaseOptions) (goj
 		selector, DOMElementStateAttached, opts.Strict, getAttribute,
 		[]string{}, false, true, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return nil, errorFromDOMError(err.Error())
 	}
@@ -1081,7 +1081,7 @@ func (f *Frame) hover(selector string, opts *FrameHoverOptions) error {
 	act := f.newPointerAction(
 		selector, DOMElementStateAttached, opts.Strict, hover, &opts.ElementHandleBasePointerOptions,
 	)
-	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err.Error())
 	}
 
@@ -1115,7 +1115,7 @@ func (f *Frame) innerHTML(selector string, opts *FrameInnerHTMLOptions) (string,
 		selector, DOMElementStateAttached, opts.Strict, innerHTML,
 		[]string{}, false, true, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return "", errorFromDOMError(err.Error())
 	}
@@ -1157,7 +1157,7 @@ func (f *Frame) innerText(selector string, opts *FrameInnerTextOptions) (string,
 		selector, DOMElementStateAttached, opts.Strict, innerText,
 		[]string{}, false, true, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return "", errorFromDOMError(err.Error())
 	}
@@ -1197,7 +1197,7 @@ func (f *Frame) inputValue(selector string, opts *FrameInputValueOptions) (strin
 		selector, DOMElementStateAttached, opts.Strict, inputValue,
 		[]string{}, false, true, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return "", errorFromDOMError(err.Error())
 	}
@@ -1253,7 +1253,7 @@ func (f *Frame) isEditable(selector string, opts *FrameIsEditableOptions) (bool,
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, isEditable, []string{}, false, true, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return false, errorFromDOMError(err.Error())
 	}
@@ -1294,7 +1294,7 @@ func (f *Frame) isEnabled(selector string, opts *FrameIsEnabledOptions) (bool, e
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, isEnabled, []string{}, false, true, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return false, errorFromDOMError(err.Error())
 	}
@@ -1335,7 +1335,7 @@ func (f *Frame) isDisabled(selector string, opts *FrameIsDisabledOptions) (bool,
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, isDisabled, []string{}, false, true, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return false, errorFromDOMError(err.Error())
 	}
@@ -1376,7 +1376,7 @@ func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, err
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, isHidden, []string{}, false, true, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return false, errorFromDOMError(err.Error())
 	}
@@ -1417,7 +1417,7 @@ func (f *Frame) isVisible(selector string, opts *FrameIsVisibleOptions) (bool, e
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, isVisible, []string{}, false, true, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return false, errorFromDOMError(err.Error())
 	}
@@ -1524,7 +1524,7 @@ func (f *Frame) press(selector, key string, opts *FramePressOptions) error {
 		selector, DOMElementStateAttached, opts.Strict, press,
 		[]string{}, false, opts.NoWaitAfter, opts.Timeout,
 	)
-	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err.Error())
 	}
 
@@ -1558,7 +1558,7 @@ func (f *Frame) selectOption(selector string, values goja.Value, opts *FrameSele
 		selector, DOMElementStateAttached, opts.Strict, selectOption,
 		[]string{}, opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return nil, errorFromDOMError(err.Error())
 	}
@@ -1643,7 +1643,7 @@ func (f *Frame) tap(selector string, opts *FrameTapOptions) error {
 	act := f.newPointerAction(
 		selector, DOMElementStateAttached, opts.Strict, tap, &opts.ElementHandleBasePointerOptions,
 	)
-	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err.Error())
 	}
 
@@ -1677,7 +1677,7 @@ func (f *Frame) textContent(selector string, opts *FrameTextContentOptions) (str
 		selector, DOMElementStateAttached, opts.Strict, TextContent,
 		[]string{}, false, true, opts.Timeout,
 	)
-	v, err := callApiWithTimeout(f.ctx, act, opts.Timeout)
+	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
 		return "", errorFromDOMError(err.Error())
 	}
@@ -1722,7 +1722,7 @@ func (f *Frame) typ(selector, text string, opts *FrameTypeOptions) error {
 		selector, DOMElementStateAttached, opts.Strict, typeText,
 		[]string{}, false, opts.NoWaitAfter, opts.Timeout,
 	)
-	if _, err := callApiWithTimeout(f.ctx, act, opts.Timeout); err != nil {
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err.Error())
 	}
 

--- a/common/frame.go
+++ b/common/frame.go
@@ -318,7 +318,7 @@ func (f *Frame) document() (*ElementHandle, error) {
 
 	dh, err := f.newDocumentHandle()
 	if err != nil {
-		return nil, fmt.Errorf("newDocumentHandle: %w", err)
+		return nil, fmt.Errorf("getting new document handle: %w", err)
 	}
 
 	// each execution context switch modifies documentHandle.
@@ -389,7 +389,7 @@ func (f *Frame) newDocumentHandle() (*ElementHandle, error) {
 	}
 	dh, ok := result.(*ElementHandle)
 	if !ok {
-		return nil, fmt.Errorf("invalid document handle type: %T", result)
+		return nil, fmt.Errorf("unexpected document handle type: %T", result)
 	}
 
 	return dh, nil
@@ -567,7 +567,7 @@ func (f *Frame) waitForFunction(
 
 	execCtx := f.executionContexts[world]
 	if execCtx == nil {
-		return nil, fmt.Errorf("execution context %q not found", world)
+		return nil, fmt.Errorf("waiting for function: execution context %q not found", world)
 	}
 	injected, err := execCtx.getInjectedScript(apiCtx)
 	if err != nil {
@@ -590,7 +590,7 @@ func (f *Frame) waitForFunction(
 		handle, err := execCtx.eval(apiCtx, opts, js)
 		if err != nil {
 			cb(func() error {
-				reject(fmt.Errorf("waitForFunction promise rejected: %w", err))
+				reject(fmt.Errorf("waiting for function promise rejected: %w", err))
 				return nil
 			})
 			return
@@ -608,7 +608,7 @@ func (f *Frame) waitForFunction(
 			}, args...)...)
 		if err != nil {
 			cb(func() error {
-				reject(fmt.Errorf("waitForFunction promise rejected: %w", err))
+				reject(fmt.Errorf("waiting for function promise rejected: %w", err))
 				return nil
 			})
 			return
@@ -698,10 +698,10 @@ func (f *Frame) Click(selector string, opts goja.Value) {
 
 	popts := NewFrameClickOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
+		k6ext.Panic(f.ctx, "parsing click options %q: %w", selector, err)
 	}
 	if err := f.click(selector, popts); err != nil {
-		k6ext.Panic(f.ctx, "click %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "clicking on %q: %w", selector, err)
 	}
 	applySlowMo(f.ctx)
 }
@@ -726,10 +726,10 @@ func (f *Frame) Check(selector string, opts goja.Value) {
 
 	popts := NewFrameCheckOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
+		k6ext.Panic(f.ctx, "parsing new frame check options: %w", err)
 	}
 	if err := f.check(selector, popts); err != nil {
-		k6ext.Panic(f.ctx, "check %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "checking %q: %w", selector, err)
 	}
 	applySlowMo(f.ctx)
 }
@@ -754,10 +754,10 @@ func (f *Frame) Uncheck(selector string, opts goja.Value) {
 
 	popts := NewFrameUncheckOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
+		k6ext.Panic(f.ctx, "parsing frame uncheck options %q: %w", selector, err)
 	}
 	if err := f.uncheck(selector, popts); err != nil {
-		k6ext.Panic(f.ctx, "uncheck %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "unchecking %q: %w", selector, err)
 	}
 	applySlowMo(f.ctx)
 }
@@ -783,11 +783,11 @@ func (f *Frame) IsChecked(selector string, opts goja.Value) bool {
 
 	popts := NewFrameIsCheckedOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
+		k6ext.Panic(f.ctx, "parsing is checked options: %w", err)
 	}
 	checked, err := f.isChecked(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "isChecked %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "checking element is checked %q: %w", selector, err)
 	}
 
 	return checked
@@ -811,7 +811,7 @@ func (f *Frame) isChecked(selector string, opts *FrameIsCheckedOptions) (bool, e
 
 	bv, ok := v.(bool)
 	if !ok {
-		return false, fmt.Errorf("isChecked returned %T; want bool", v)
+		return false, fmt.Errorf("checking is %q checked: unexpected type %T", selector, v)
 	}
 
 	return bv, nil
@@ -842,10 +842,10 @@ func (f *Frame) Dblclick(selector string, opts goja.Value) {
 
 	popts := NewFrameDblClickOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
+		k6ext.Panic(f.ctx, "parsing double click options: %w", err)
 	}
 	if err := f.dblclick(selector, popts); err != nil {
-		k6ext.Panic(f.ctx, "dblclick %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "double clicking on %q: %w", selector, err)
 	}
 	applySlowMo(f.ctx)
 }
@@ -872,10 +872,10 @@ func (f *Frame) DispatchEvent(selector, typ string, eventInit, opts goja.Value) 
 
 	popts := NewFrameDispatchEventOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "Frame.dispatchEvent options: %w", err)
+		k6ext.Panic(f.ctx, "parsing dispatch event options: %w", err)
 	}
 	if err := f.dispatchEvent(selector, typ, eventInit, popts); err != nil {
-		k6ext.Panic(f.ctx, "dispatchEvent %q to %q: %w", typ, selector, err)
+		k6ext.Panic(f.ctx, "dispatching event %q to %q: %w", typ, selector, err)
 	}
 	applySlowMo(f.ctx)
 }
@@ -951,10 +951,10 @@ func (f *Frame) Fill(selector, value string, opts goja.Value) {
 
 	popts := NewFrameFillOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
+		k6ext.Panic(f.ctx, "parsing fill options: %w", err)
 	}
 	if err := f.fill(selector, value, popts); err != nil {
-		k6ext.Panic(f.ctx, "fill %q with %q: %w", selector, value, err)
+		k6ext.Panic(f.ctx, "filling %q with %q: %w", selector, value, err)
 	}
 	applySlowMo(f.ctx)
 }
@@ -981,10 +981,10 @@ func (f *Frame) Focus(selector string, opts goja.Value) {
 
 	popts := NewFrameBaseOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
+		k6ext.Panic(f.ctx, "parsing focus options: %w", err)
 	}
 	if err := f.focus(selector, popts); err != nil {
-		k6ext.Panic(f.ctx, "focus %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "focusing %q: %w", selector, err)
 	}
 	applySlowMo(f.ctx)
 }
@@ -1024,7 +1024,7 @@ func (f *Frame) GetAttribute(selector, name string, opts goja.Value) goja.Value 
 	}
 	v, err := f.getAttribute(selector, name, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "getAttribute %q of %q: %w", name, selector, err)
+		k6ext.Panic(f.ctx, "getting attribute %q of %q: %w", name, selector, err)
 	}
 
 	applySlowMo(f.ctx)
@@ -1046,7 +1046,7 @@ func (f *Frame) getAttribute(selector, name string, opts *FrameBaseOptions) (goj
 	}
 	gv, ok := v.(goja.Value)
 	if !ok {
-		return nil, fmt.Errorf("unexpected type %T", v)
+		return nil, fmt.Errorf("getting %q attribute of %q: unexpected type %T", name, selector, v)
 	}
 
 	return gv, nil
@@ -1065,10 +1065,10 @@ func (f *Frame) Hover(selector string, opts goja.Value) {
 
 	popts := NewFrameHoverOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parse: %w", err)
+		k6ext.Panic(f.ctx, "parsing hover options: %w", err)
 	}
 	if err := f.hover(selector, popts); err != nil {
-		k6ext.Panic(f.ctx, "hover %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "hovering %q: %w", selector, err)
 	}
 
 	applySlowMo(f.ctx)
@@ -1095,11 +1095,11 @@ func (f *Frame) InnerHTML(selector string, opts goja.Value) string {
 
 	popts := NewFrameInnerHTMLOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parse: %w", err)
+		k6ext.Panic(f.ctx, "parsing inner HTML options: %w", err)
 	}
 	v, err := f.innerHTML(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "innerHTML of %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "getting inner HTML of %q: %w", selector, err)
 	}
 
 	applySlowMo(f.ctx)
@@ -1124,7 +1124,7 @@ func (f *Frame) innerHTML(selector string, opts *FrameInnerHTMLOptions) (string,
 	}
 	gv, ok := v.(goja.Value)
 	if !ok {
-		return "", fmt.Errorf("unexpected type %T", v)
+		return "", fmt.Errorf("getting inner html of %q: unexpected type %T", selector, v)
 	}
 
 	return gv.String(), nil
@@ -1137,11 +1137,11 @@ func (f *Frame) InnerText(selector string, opts goja.Value) string {
 
 	popts := NewFrameInnerTextOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parse: %w", err)
+		k6ext.Panic(f.ctx, "parsing inner text options: %w", err)
 	}
 	v, err := f.innerText(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "innerText of %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "getting inner text of %q: %w", selector, err)
 	}
 
 	applySlowMo(f.ctx)
@@ -1166,7 +1166,7 @@ func (f *Frame) innerText(selector string, opts *FrameInnerTextOptions) (string,
 	}
 	gv, ok := v.(goja.Value)
 	if !ok {
-		return "", fmt.Errorf("unexpected type %T", v)
+		return "", fmt.Errorf("getting inner text of %q: unexpected type %T", selector, v)
 	}
 
 	return gv.String(), nil
@@ -1179,11 +1179,11 @@ func (f *Frame) InputValue(selector string, opts goja.Value) string {
 
 	popts := NewFrameInputValueOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parse: %w", err)
+		k6ext.Panic(f.ctx, "parsing input value options: %w", err)
 	}
 	v, err := f.inputValue(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "inputValue of %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "getting input value of %q: %w", selector, err)
 	}
 
 	return v
@@ -1203,7 +1203,7 @@ func (f *Frame) inputValue(selector string, opts *FrameInputValueOptions) (strin
 	}
 	gv, ok := v.(goja.Value)
 	if !ok {
-		return "", fmt.Errorf("unexpected type %T", v)
+		return "", fmt.Errorf("getting input value of %q: unexpected type %T", selector, v)
 	}
 
 	return gv.String(), nil
@@ -1236,7 +1236,7 @@ func (f *Frame) IsEditable(selector string, opts goja.Value) bool {
 	}
 	editable, err := f.isEditable(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "isEditable %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "checking is %q editable: %w", selector, err)
 	}
 
 	return editable
@@ -1260,7 +1260,7 @@ func (f *Frame) isEditable(selector string, opts *FrameIsEditableOptions) (bool,
 
 	bv, ok := v.(bool)
 	if !ok {
-		return false, fmt.Errorf("isEditable returned %T; want bool", v)
+		return false, fmt.Errorf("checking is %q editable: unexpected type %T", selector, v)
 	}
 
 	return bv, nil
@@ -1273,11 +1273,11 @@ func (f *Frame) IsEnabled(selector string, opts goja.Value) bool {
 
 	popts := NewFrameIsEnabledOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
+		k6ext.Panic(f.ctx, "parsing is enabled options: %w", err)
 	}
 	enabled, err := f.isEnabled(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "isEnabled %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "checking is %q enabled: %w", selector, err)
 	}
 
 	return enabled
@@ -1301,7 +1301,7 @@ func (f *Frame) isEnabled(selector string, opts *FrameIsEnabledOptions) (bool, e
 
 	bv, ok := v.(bool)
 	if !ok {
-		return false, fmt.Errorf("isEnabled returned %T; want bool", v)
+		return false, fmt.Errorf("checking is %q enabled: unexpected type %T", selector, v)
 	}
 
 	return bv, nil
@@ -1314,11 +1314,11 @@ func (f *Frame) IsDisabled(selector string, opts goja.Value) bool {
 
 	popts := NewFrameIsDisabledOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
+		k6ext.Panic(f.ctx, "parsing is disabled options: %w", err)
 	}
 	disabled, err := f.isDisabled(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "isDisabled %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "checking is %q disabled: %w", selector, err)
 	}
 
 	return disabled
@@ -1342,7 +1342,7 @@ func (f *Frame) isDisabled(selector string, opts *FrameIsDisabledOptions) (bool,
 
 	bv, ok := v.(bool)
 	if !ok {
-		return false, fmt.Errorf("isDisabled returned %T; want bool", v)
+		return false, fmt.Errorf("checking is %q disabled: unexpected type %T", selector, v)
 	}
 
 	return bv, nil
@@ -1355,11 +1355,11 @@ func (f *Frame) IsHidden(selector string, opts goja.Value) bool {
 
 	popts := NewFrameIsHiddenOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
+		k6ext.Panic(f.ctx, "parsing is hidden options: %w", err)
 	}
 	hidden, err := f.isHidden(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "isHidden %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "checking is %q hidden: %w", selector, err)
 	}
 
 	return hidden
@@ -1383,7 +1383,7 @@ func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, err
 
 	bv, ok := v.(bool)
 	if !ok {
-		return false, fmt.Errorf("isHidden returned %T; want bool", v)
+		return false, fmt.Errorf("checking is %q hidden: unexpected type %T", selector, v)
 	}
 
 	return bv, nil
@@ -1396,11 +1396,11 @@ func (f *Frame) IsVisible(selector string, opts goja.Value) bool {
 
 	popts := NewFrameIsVisibleOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "%w", err)
+		k6ext.Panic(f.ctx, "parsing is visible options: %w", err)
 	}
 	visible, err := f.isVisible(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "isVisible %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "checking is %q visible: %w", selector, err)
 	}
 
 	return visible
@@ -1424,7 +1424,7 @@ func (f *Frame) isVisible(selector string, opts *FrameIsVisibleOptions) (bool, e
 
 	bv, ok := v.(bool)
 	if !ok {
-		return false, fmt.Errorf("isVisible returned %T; want bool", v)
+		return false, fmt.Errorf("checking is %q visible: unexpected type %T", selector, v)
 	}
 
 	return bv, nil
@@ -1507,10 +1507,10 @@ func (f *Frame) Press(selector, key string, opts goja.Value) {
 
 	popts := NewFramePressOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parse: %w", err)
+		k6ext.Panic(f.ctx, "parsing press options: %w", err)
 	}
 	if err := f.press(selector, key, popts); err != nil {
-		k6ext.Panic(f.ctx, "press %q on %q: %w", key, selector, err)
+		k6ext.Panic(f.ctx, "pressing %q on %q: %w", key, selector, err)
 	}
 
 	applySlowMo(f.ctx)
@@ -1538,11 +1538,11 @@ func (f *Frame) SelectOption(selector string, values goja.Value, opts goja.Value
 
 	popts := NewFrameSelectOptionOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parse: %w", err)
+		k6ext.Panic(f.ctx, "parsing select option options: %w", err)
 	}
 	v, err := f.selectOption(selector, values, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "selectOption on %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "selecting option on %q: %w", selector, err)
 	}
 
 	applySlowMo(f.ctx)
@@ -1592,7 +1592,7 @@ func (f *Frame) SetContent(html string, opts goja.Value) {
 
 	parsedOpts := NewFrameSetContentOptions(f.defaultTimeout())
 	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parsing setContent options: %w", err)
+		k6ext.Panic(f.ctx, "parsing set content options: %w", err)
 	}
 
 	js := `(html) => {
@@ -1627,10 +1627,10 @@ func (f *Frame) Tap(selector string, opts goja.Value) {
 
 	popts := NewFrameTapOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parse: %w", err)
+		k6ext.Panic(f.ctx, "parsing tap options: %w", err)
 	}
 	if err := f.tap(selector, popts); err != nil {
-		k6ext.Panic(f.ctx, "tap %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "tapping on %q: %w", selector, err)
 	}
 
 	applySlowMo(f.ctx)
@@ -1657,11 +1657,11 @@ func (f *Frame) TextContent(selector string, opts goja.Value) string {
 
 	popts := NewFrameTextContentOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parse: %w", err)
+		k6ext.Panic(f.ctx, "parsing text content options: %w", err)
 	}
 	v, err := f.textContent(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "textContent of %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "getting text content of %q: %w", selector, err)
 	}
 
 	applySlowMo(f.ctx)
@@ -1686,7 +1686,7 @@ func (f *Frame) textContent(selector string, opts *FrameTextContentOptions) (str
 	}
 	gv, ok := v.(goja.Value)
 	if !ok {
-		return "", fmt.Errorf("unexpected type %T", v)
+		return "", fmt.Errorf("getting text content of %q: unexpected type %T", selector, v)
 	}
 
 	return gv.String(), nil
@@ -1705,10 +1705,10 @@ func (f *Frame) Type(selector, text string, opts goja.Value) {
 
 	popts := NewFrameTypeOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parse: %w", err)
+		k6ext.Panic(f.ctx, "parsing type options: %w", err)
 	}
 	if err := f.typ(selector, text, popts); err != nil {
-		k6ext.Panic(f.ctx, "type %q in %q: %w", text, selector, err)
+		k6ext.Panic(f.ctx, "typing %q in %q: %w", text, selector, err)
 	}
 
 	applySlowMo(f.ctx)
@@ -1801,7 +1801,7 @@ func (f *Frame) WaitForLoadState(state string, opts goja.Value) {
 	waitUntil := LifecycleEventLoad
 	if state != "" {
 		if err = waitUntil.UnmarshalText([]byte(state)); err != nil {
-			k6ext.Panic(f.ctx, "waitForLoadState: %v", err)
+			k6ext.Panic(f.ctx, "waiting for load state: %v", err)
 		}
 	}
 
@@ -1813,7 +1813,7 @@ func (f *Frame) WaitForLoadState(state string, opts goja.Value) {
 		return data.(LifecycleEvent) == waitUntil
 	}, parsedOpts.Timeout)
 	if err != nil {
-		k6ext.Panic(f.ctx, "waitForLoadState %q: %v", state, err)
+		k6ext.Panic(f.ctx, "waiting for load state %q: %v", state, err)
 	}
 }
 
@@ -1826,11 +1826,11 @@ func (f *Frame) WaitForNavigation(opts goja.Value) api.Response {
 func (f *Frame) WaitForSelector(selector string, opts goja.Value) api.ElementHandle {
 	parsedOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
 	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parsing waitForSelector %q options: %w", selector, err)
+		k6ext.Panic(f.ctx, "parsing wait for selector %q options: %w", selector, err)
 	}
 	handle, err := f.waitForSelectorRetry(selector, parsedOpts, maxRetry)
 	if err != nil {
-		k6ext.Panic(f.ctx, "waitForSelector %q: %w", selector, err)
+		k6ext.Panic(f.ctx, "waiting for selector %q: %w", selector, err)
 	}
 	return handle
 }

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -33,7 +33,6 @@ import (
 	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/log"
 
-	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
 
 	"github.com/chromedp/cdproto/cdp"
@@ -582,7 +581,6 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, opts goja.Value) 
 	defer m.logger.Debugf("FrameManager:NavigateFrame:return",
 		"fmid:%d fid:%v furl:%s url:%s", fmid, fid, furl, url)
 
-	rt := m.vu.Runtime()
 	netMgr := m.page.mainFrameSession.getNetworkManager()
 	defaultReferer := netMgr.extraHTTPHeaders["referer"]
 	parsedOpts := NewFrameGotoOptions(defaultReferer, time.Duration(m.timeoutSettings.navigationTimeout())*time.Second)
@@ -636,6 +634,10 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, opts goja.Value) 
 			return false
 		}, parsedOpts.Timeout)
 		if err != nil {
+			err = &k6ext.UserFriendlyError{
+				Err:     err,
+				Timeout: parsedOpts.Timeout,
+			}
 			k6ext.Panic(m.ctx, "navigating to %q: %v", url, err)
 		}
 
@@ -648,7 +650,7 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, opts goja.Value) 
 			// TODO: A more graceful way of avoiding Throw()?
 			!(netMgr.userReqInterceptionEnabled &&
 				strings.Contains(event.err.Error(), "ERR_BLOCKED_BY_CLIENT")) {
-			k6common.Throw(rt, event.err)
+			k6ext.Panic(m.ctx, "%w", event.err)
 		}
 	} else {
 		m.logger.Debugf("FrameManager:NavigateFrame",
@@ -657,8 +659,12 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, opts goja.Value) 
 
 		select {
 		case <-timeoutCtx.Done():
-			if timeoutCtx.Err() == context.DeadlineExceeded {
-				k6ext.Panic(m.ctx, "navigating to %q: %s after %s", url, ErrTimedOut, parsedOpts.Timeout)
+			if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
+				err = &k6ext.UserFriendlyError{
+					Err:     err,
+					Timeout: parsedOpts.Timeout,
+				}
+				k6ext.Panic(m.ctx, "navigating to %q: %w", url, err)
 			}
 		case data := <-chSameDoc:
 			event = data.(*NavigationEvent)
@@ -672,8 +678,12 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, opts goja.Value) 
 
 		select {
 		case <-timeoutCtx.Done():
-			if timeoutCtx.Err() == context.DeadlineExceeded {
-				k6ext.Panic(m.ctx, "navigating to %q: %s after %s", url, ErrTimedOut, parsedOpts.Timeout)
+			if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
+				err = &k6ext.UserFriendlyError{
+					Err:     err,
+					Timeout: parsedOpts.Timeout,
+				}
+				k6ext.Panic(m.ctx, "navigating to %q: %w", url, err)
 			}
 		case <-chWaitUntilCh:
 		}

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -708,7 +708,7 @@ func (m *FrameManager) WaitForFrameNavigation(frame *Frame, opts goja.Value) api
 
 	parsedOpts := NewFrameWaitForNavigationOptions(time.Duration(m.timeoutSettings.timeout()) * time.Second)
 	if err := parsedOpts.Parse(m.ctx, opts); err != nil {
-		k6ext.Panic(m.ctx, "cannot parse waitForNavigation options: %v", err)
+		k6ext.Panic(m.ctx, "parsing wait for frame navigation options: %v", err)
 	}
 
 	ch, evCancelFn := createWaitForEventHandler(m.ctx, frame, []string{EventFrameNavigation},
@@ -726,7 +726,7 @@ func (m *FrameManager) WaitForFrameNavigation(frame *Frame, opts goja.Value) api
 			m.ID(), frame.URL(), m.ctx.Err())
 		return nil
 	case <-time.After(parsedOpts.Timeout):
-		k6ext.Panic(m.ctx, "waitForFrameNavigation timed out after %s", parsedOpts.Timeout)
+		k6ext.Panic(m.ctx, "waiting for frame navigation timed out after %s", parsedOpts.Timeout)
 	case data := <-ch:
 		event = data.(*NavigationEvent)
 	}
@@ -747,7 +747,7 @@ func (m *FrameManager) WaitForFrameNavigation(frame *Frame, opts goja.Value) api
 			return data.(LifecycleEvent) == parsedOpts.WaitUntil
 		}, parsedOpts.Timeout)
 		if err != nil {
-			k6ext.Panic(m.ctx, "waitForFrameNavigation cannot wait for event (EventFrameAddLifecycle): %v", err)
+			k6ext.Panic(m.ctx, "waiting for frame navigation until %q: %v", parsedOpts.WaitUntil, err)
 		}
 	}
 

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -130,7 +130,7 @@ func NewFrameSession(
 			"sid:%v tid:%v err:%v",
 			s.ID(), tid, err)
 
-		return nil, fmt.Errorf("getting window ID: %w", err)
+		return nil, fmt.Errorf("getting browser window ID: %w", err)
 	}
 
 	fs.initEvents()

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -53,9 +53,9 @@ import (
 const utilityWorldName = "__k6_browser_utility_world__"
 
 /*
-   FrameSession is used for managing a frame's life-cycle, or in other words its full session.
-   It manages all the event listening while deferring the state storage to the Frame and FrameManager
-   structs.
+FrameSession is used for managing a frame's life-cycle, or in other words its full session.
+It manages all the event listening while deferring the state storage to the Frame and FrameManager
+structs.
 */
 type FrameSession struct {
 	ctx            context.Context
@@ -88,6 +88,7 @@ type FrameSession struct {
 }
 
 // NewFrameSession initializes and returns a new FrameSession.
+//
 //nolint:funlen
 func NewFrameSession(
 	ctx context.Context, s session, p *Page, parent *FrameSession, tid target.ID, l *log.Logger,
@@ -500,7 +501,11 @@ func (fs *FrameSession) navigateFrame(frame *Frame, url, referrer string) (strin
 	action := cdppage.Navigate(url).WithReferrer(referrer).WithFrameID(cdp.FrameID(frame.ID()))
 	_, documentID, errorText, err := action.Do(cdp.WithExecutor(fs.ctx, fs.session))
 	if err != nil {
-		err = fmt.Errorf("%s at %q: %w", errorText, url, err)
+		if errorText == "" {
+			err = fmt.Errorf("%w", err)
+		} else {
+			err = fmt.Errorf("%q: %w", errorText, err)
+		}
 	}
 	return documentID.String(), err
 }

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -933,7 +933,7 @@ func (fs *FrameSession) updateGeolocation(initial bool) error {
 			WithLongitude(geolocation.Longitude).
 			WithAccuracy(geolocation.Accurracy)
 		if err := action.Do(cdp.WithExecutor(fs.ctx, fs.session)); err != nil {
-			return fmt.Errorf("overriding geolocation: %w", err)
+			return fmt.Errorf("%w", err)
 		}
 	}
 	return nil

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -206,7 +206,7 @@ func (fs *FrameSession) initDomains() error {
 	}
 	for _, action := range actions {
 		if err := action.Do(cdp.WithExecutor(fs.ctx, fs.session)); err != nil {
-			return fmt.Errorf("executing %T: %w", action, err)
+			return fmt.Errorf("internal error while enabling %T: %w", action, err)
 		}
 	}
 	return nil
@@ -438,7 +438,7 @@ func (fs *FrameSession) initOptions() error {
 
 	for _, action := range optActions {
 		if err := action.Do(cdp.WithExecutor(fs.ctx, fs.session)); err != nil {
-			return fmt.Errorf("executing %T: %w", action, err)
+			return fmt.Errorf("internal error while initializing frame %T: %w", action, err)
 		}
 	}
 
@@ -902,7 +902,7 @@ func (fs *FrameSession) updateEmulateMedia(initial bool) error {
 		WithMedia(string(fs.page.mediaType)).
 		WithFeatures(features)
 	if err := action.Do(cdp.WithExecutor(fs.ctx, fs.session)); err != nil {
-		return fmt.Errorf("executing %T: %w", action, err)
+		return fmt.Errorf("internal error while updating emulated media: %w", err)
 	}
 	return nil
 }

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -52,7 +52,7 @@ func convertBaseJSHandleTypes(ctx context.Context, execCtx *ExecutionContext, ob
 	return &cdpruntime.CallArgument{ObjectID: objHandle.remoteObject.ObjectID}, nil
 }
 
-//nolint: cyclop
+// nolint: cyclop
 func convertArgument(
 	ctx context.Context, execCtx *ExecutionContext, arg interface{},
 ) (*cdpruntime.CallArgument, error) {
@@ -105,21 +105,23 @@ func convertArgument(
 	}
 }
 
-func callApiWithTimeout(ctx context.Context, fn func(context.Context, chan interface{}, chan error), timeout time.Duration) (interface{}, error) {
-	var result interface{}
-	var err error
-	var cancelFn context.CancelFunc
-	resultCh := make(chan interface{})
-	errCh := make(chan error)
-
-	apiCtx := ctx
+func call(
+	ctx context.Context, fn func(context.Context, chan interface{}, chan error), timeout time.Duration,
+) (interface{}, error) {
+	var (
+		result   interface{}
+		err      error
+		cancelFn context.CancelFunc
+		resultCh = make(chan interface{})
+		errCh    = make(chan error)
+		apiCtx   = ctx
+	)
 	if timeout > 0 {
 		apiCtx, cancelFn = context.WithTimeout(ctx, timeout)
 		defer cancelFn()
 	}
 
 	go fn(apiCtx, resultCh, errCh)
-
 	select {
 	case <-apiCtx.Done():
 		err = apiCtx.Err()

--- a/common/locator.go
+++ b/common/locator.go
@@ -39,11 +39,11 @@ func (l *Locator) Click(opts goja.Value) {
 
 	copts := NewFrameClickOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parse: %w", err)
+		err = fmt.Errorf("parsing click options: %w", err)
 		return
 	}
 	if err = l.click(copts); err != nil {
-		err = fmt.Errorf("click %q: %w", l.selector, err)
+		err = fmt.Errorf("clicking on %q: %w", l.selector, err)
 		return
 	}
 }
@@ -64,11 +64,11 @@ func (l *Locator) Dblclick(opts goja.Value) {
 
 	copts := NewFrameDblClickOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parse: %w", err)
+		err = fmt.Errorf("parsing double click options: %w", err)
 		return
 	}
 	if err = l.dblclick(copts); err != nil {
-		err = fmt.Errorf("dblclick %q: %w", l.selector, err)
+		err = fmt.Errorf("double clicking on %q: %w", l.selector, err)
 		return
 	}
 }
@@ -89,11 +89,11 @@ func (l *Locator) Check(opts goja.Value) {
 
 	copts := NewFrameCheckOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parse: %w", err)
+		err = fmt.Errorf("parsing check options: %w", err)
 		return
 	}
 	if err = l.check(copts); err != nil {
-		err = fmt.Errorf("check %q: %w", l.selector, err)
+		err = fmt.Errorf("checking %q: %w", l.selector, err)
 		return
 	}
 }
@@ -114,11 +114,11 @@ func (l *Locator) Uncheck(opts goja.Value) {
 
 	copts := NewFrameUncheckOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parse: %w", err)
+		err = fmt.Errorf("parsing uncheck options: %w", err)
 		return
 	}
 	if err = l.uncheck(copts); err != nil {
-		err = fmt.Errorf("uncheck %q: %w", l.selector, err)
+		err = fmt.Errorf("unchecking %q: %w", l.selector, err)
 		return
 	}
 }
@@ -137,11 +137,11 @@ func (l *Locator) IsChecked(opts goja.Value) bool {
 
 	copts := NewFrameIsCheckedOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parse: %w", err)
+		k6ext.Panic(l.ctx, "parsing is checked options: %w", err)
 	}
 	checked, err := l.isChecked(copts)
 	if err != nil {
-		k6ext.Panic(l.ctx, "isChecked: %w", err)
+		k6ext.Panic(l.ctx, "checking is %q checked: %w", l.selector, err)
 	}
 
 	return checked
@@ -161,11 +161,11 @@ func (l *Locator) IsEditable(opts goja.Value) bool {
 
 	copts := NewFrameIsEditableOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parse: %w", err)
+		k6ext.Panic(l.ctx, "parsing is editable options: %w", err)
 	}
 	editable, err := l.isEditable(copts)
 	if err != nil {
-		k6ext.Panic(l.ctx, "isEditable %q: %w", l.selector, err)
+		k6ext.Panic(l.ctx, "checking is %q editable: %w", l.selector, err)
 	}
 
 	return editable
@@ -185,11 +185,11 @@ func (l *Locator) IsEnabled(opts goja.Value) bool {
 
 	copts := NewFrameIsEnabledOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parse: %w", err)
+		k6ext.Panic(l.ctx, "parsing is enabled options: %w", err)
 	}
 	enabled, err := l.isEnabled(copts)
 	if err != nil {
-		k6ext.Panic(l.ctx, "isEnabled %q: %w", l.selector, err)
+		k6ext.Panic(l.ctx, "checking is %q enabled: %w", l.selector, err)
 	}
 
 	return enabled
@@ -209,11 +209,11 @@ func (l *Locator) IsDisabled(opts goja.Value) bool {
 
 	copts := NewFrameIsDisabledOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parse: %w", err)
+		k6ext.Panic(l.ctx, "parsing is disabled options: %w", err)
 	}
 	disabled, err := l.isDisabled(copts)
 	if err != nil {
-		k6ext.Panic(l.ctx, "isDisabled %q: %w", l.selector, err)
+		k6ext.Panic(l.ctx, "checking is %q disabled: %w", l.selector, err)
 	}
 
 	return disabled
@@ -233,11 +233,11 @@ func (l *Locator) IsVisible(opts goja.Value) bool {
 
 	copts := NewFrameIsVisibleOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parse: %w", err)
+		k6ext.Panic(l.ctx, "parsing is visible options: %w", err)
 	}
 	visible, err := l.isVisible(copts)
 	if err != nil {
-		k6ext.Panic(l.ctx, "isVisible %q: %w", l.selector, err)
+		k6ext.Panic(l.ctx, "checking is %q visible: %w", l.selector, err)
 	}
 
 	return visible
@@ -257,11 +257,11 @@ func (l *Locator) IsHidden(opts goja.Value) bool {
 
 	copts := NewFrameIsHiddenOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parse: %w", err)
+		k6ext.Panic(l.ctx, "parsing is hidden options: %w", err)
 	}
 	hidden, err := l.isHidden(copts)
 	if err != nil {
-		k6ext.Panic(l.ctx, "isHidden %q: %w", l.selector, err)
+		k6ext.Panic(l.ctx, "checking is %q hidden: %w", l.selector, err)
 	}
 
 	return hidden
@@ -286,11 +286,11 @@ func (l *Locator) Fill(value string, opts goja.Value) {
 
 	copts := NewFrameFillOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parse: %w", err)
+		err = fmt.Errorf("parsing fill options: %w", err)
 		return
 	}
 	if err = l.fill(value, copts); err != nil {
-		err = fmt.Errorf("fill %q with %q: %w", l.selector, value, err)
+		err = fmt.Errorf("filling %q with %q: %w", l.selector, value, err)
 		return
 	}
 }
@@ -309,11 +309,11 @@ func (l *Locator) Focus(opts goja.Value) {
 
 	copts := NewFrameBaseOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parse: %w", err)
+		err = fmt.Errorf("parsing focus options: %w", err)
 		return
 	}
 	if err = l.focus(copts); err != nil {
-		err = fmt.Errorf("focus %q: %w", l.selector, err)
+		err = fmt.Errorf("focusing on %q: %w", l.selector, err)
 		return
 	}
 }
@@ -335,12 +335,12 @@ func (l *Locator) GetAttribute(name string, opts goja.Value) goja.Value {
 
 	copts := NewFrameBaseOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parse: %w", err)
+		err = fmt.Errorf("parsing get attribute options: %w", err)
 		return nil
 	}
 	var v goja.Value
 	if v, err = l.getAttribute(name, copts); err != nil {
-		err = fmt.Errorf("getAttribute %q of %q: %w", name, l.selector, err)
+		err = fmt.Errorf("getting attribute %q of %q: %w", name, l.selector, err)
 		return nil
 	}
 
@@ -362,12 +362,12 @@ func (l *Locator) InnerHTML(opts goja.Value) string {
 
 	copts := NewFrameInnerHTMLOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parse: %w", err)
+		err = fmt.Errorf("parsing inner HTML options: %w", err)
 		return ""
 	}
 	var s string
 	if s, err = l.innerHTML(copts); err != nil {
-		err = fmt.Errorf("innerHTML of %q: %w", l.selector, err)
+		err = fmt.Errorf("getting inner HTML of %q: %w", l.selector, err)
 		return ""
 	}
 
@@ -389,12 +389,12 @@ func (l *Locator) InnerText(opts goja.Value) string {
 
 	copts := NewFrameInnerTextOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parse: %w", err)
+		err = fmt.Errorf("parsing inner text options: %w", err)
 		return ""
 	}
 	var s string
 	if s, err = l.innerText(copts); err != nil {
-		err = fmt.Errorf("innerText of %q: %w", l.selector, err)
+		err = fmt.Errorf("getting inner text of %q: %w", l.selector, err)
 		return ""
 	}
 
@@ -416,12 +416,12 @@ func (l *Locator) TextContent(opts goja.Value) string {
 
 	copts := NewFrameTextContentOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parse: %w", err)
+		err = fmt.Errorf("parsing text context options: %w", err)
 		return ""
 	}
 	var s string
 	if s, err = l.textContent(copts); err != nil {
-		err = fmt.Errorf("textContent of %q: %w", l.selector, err)
+		err = fmt.Errorf("getting text content of %q: %w", l.selector, err)
 		return ""
 	}
 
@@ -440,11 +440,11 @@ func (l *Locator) InputValue(opts goja.Value) string {
 
 	copts := NewFrameInputValueOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parse: %w", err)
+		k6ext.Panic(l.ctx, "parsing input value options: %w", err)
 	}
 	v, err := l.inputValue(copts)
 	if err != nil {
-		k6ext.Panic(l.ctx, "inputValue of %q: %w", l.selector, err)
+		k6ext.Panic(l.ctx, "getting input value of %q: %w", l.selector, err)
 	}
 
 	return v
@@ -463,11 +463,11 @@ func (l *Locator) SelectOption(values goja.Value, opts goja.Value) []string {
 
 	copts := NewFrameSelectOptionOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parse: %w", err)
+		k6ext.Panic(l.ctx, "parsing select option options: %w", err)
 	}
 	v, err := l.selectOption(values, copts)
 	if err != nil {
-		k6ext.Panic(l.ctx, "selectOption on %q: %w", l.selector, err)
+		k6ext.Panic(l.ctx, "selecting option on %q: %w", l.selector, err)
 	}
 
 	return v
@@ -491,10 +491,11 @@ func (l *Locator) Press(key string, opts goja.Value) {
 
 	copts := NewFramePressOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
+		err = fmt.Errorf("parsing press options: %w", err)
 		return
 	}
 	if err = l.press(key, copts); err != nil {
-		err = fmt.Errorf("press %q on %q: %w", key, l.selector, err)
+		err = fmt.Errorf("pressing %q on %q: %w", key, l.selector, err)
 		return
 	}
 }
@@ -517,10 +518,11 @@ func (l *Locator) Type(text string, opts goja.Value) {
 
 	copts := NewFrameTypeOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
+		err = fmt.Errorf("parsing type options: %w", err)
 		return
 	}
 	if err = l.typ(text, copts); err != nil {
-		err = fmt.Errorf("type %q in %q: %w", text, l.selector, err)
+		err = fmt.Errorf("typing %q in %q: %w", text, l.selector, err)
 		return
 	}
 }
@@ -540,10 +542,11 @@ func (l *Locator) Hover(opts goja.Value) {
 
 	copts := NewFrameHoverOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
+		err = fmt.Errorf("parsing hover options: %w", err)
 		return
 	}
 	if err = l.hover(copts); err != nil {
-		err = fmt.Errorf("hover %q: %w", l.selector, err)
+		err = fmt.Errorf("hovering on %q: %w", l.selector, err)
 		return
 	}
 }
@@ -562,10 +565,11 @@ func (l *Locator) Tap(opts goja.Value) {
 
 	copts := NewFrameTapOptions(l.frame.defaultTimeout())
 	if err = copts.Parse(l.ctx, opts); err != nil {
+		err = fmt.Errorf("parsing tap options: %w", err)
 		return
 	}
 	if err = l.tap(copts); err != nil {
-		err = fmt.Errorf("tap %q: %w", l.selector, err)
+		err = fmt.Errorf("tapping on %q: %w", l.selector, err)
 		return
 	}
 }
@@ -588,10 +592,11 @@ func (l *Locator) DispatchEvent(typ string, eventInit, opts goja.Value) {
 
 	popts := NewFrameDispatchEventOptions(l.frame.defaultTimeout())
 	if err = popts.Parse(l.ctx, opts); err != nil {
+		err = fmt.Errorf("parsing dispatch event options: %w", err)
 		return
 	}
 	if err = l.dispatchEvent(typ, eventInit, popts); err != nil {
-		err = fmt.Errorf("dispatchEvent %q to %q: %w", typ, l.selector, err)
+		err = fmt.Errorf("dispatching event %q to %q: %w", typ, l.selector, err)
 		return
 	}
 }
@@ -607,10 +612,10 @@ func (l *Locator) WaitFor(opts goja.Value) {
 
 	popts := NewFrameWaitForSelectorOptions(l.frame.defaultTimeout())
 	if err := popts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parse: %w", err)
+		k6ext.Panic(l.ctx, "parsing wait for options: %w", err)
 	}
 	if err := l.waitFor(popts); err != nil {
-		k6ext.Panic(l.ctx, "waitFor: %w", err)
+		k6ext.Panic(l.ctx, "waiting for %q: %w", l.selector, err)
 	}
 }
 

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -153,20 +153,20 @@ func (m *Mouse) up(x float64, y float64, opts *MouseDownUpOptions) error {
 func (m *Mouse) Click(x float64, y float64, opts goja.Value) {
 	mouseOpts := NewMouseClickOptions()
 	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
-		k6ext.Panic(m.ctx, "parsing click options: %w", err)
+		k6ext.Panic(m.ctx, "parsing mouse click options: %w", err)
 	}
 	if err := m.click(x, y, mouseOpts); err != nil {
-		k6ext.Panic(m.ctx, "mouse click: %w", err)
+		k6ext.Panic(m.ctx, "clicking on x:%f y:%f: %w", x, y, err)
 	}
 }
 
 func (m *Mouse) DblClick(x float64, y float64, opts goja.Value) {
 	mouseOpts := NewMouseDblClickOptions()
 	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
-		k6ext.Panic(m.ctx, "parsing dblclick options: %w", err)
+		k6ext.Panic(m.ctx, "parsing double click options: %w", err)
 	}
 	if err := m.dblClick(x, y, mouseOpts); err != nil {
-		k6ext.Panic(m.ctx, "mouse double click: %w", err)
+		k6ext.Panic(m.ctx, "double clicking on x:%f y:%f: %w", x, y, err)
 	}
 }
 
@@ -174,10 +174,10 @@ func (m *Mouse) DblClick(x float64, y float64, opts goja.Value) {
 func (m *Mouse) Down(x float64, y float64, opts goja.Value) {
 	mouseOpts := NewMouseDownUpOptions()
 	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
-		k6ext.Panic(m.ctx, "parsing down options: %w", err)
+		k6ext.Panic(m.ctx, "parsing mouse down options: %w", err)
 	}
 	if err := m.down(x, y, mouseOpts); err != nil {
-		k6ext.Panic(m.ctx, "mouse down: %w", err)
+		k6ext.Panic(m.ctx, "pressing the mouse button on x:%f y:%f: %w", x, y, err)
 	}
 }
 
@@ -185,10 +185,10 @@ func (m *Mouse) Down(x float64, y float64, opts goja.Value) {
 func (m *Mouse) Move(x float64, y float64, opts goja.Value) {
 	mouseOpts := NewMouseDownUpOptions()
 	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
-		k6ext.Panic(m.ctx, "parsing move options: %w", err)
+		k6ext.Panic(m.ctx, "parsing mouse move options: %w", err)
 	}
 	if err := m.down(x, y, mouseOpts); err != nil {
-		k6ext.Panic(m.ctx, "mouse move: %w", err)
+		k6ext.Panic(m.ctx, "moving the mouse pointer to x:%f y:%f: %w", x, y, err)
 	}
 }
 
@@ -196,10 +196,10 @@ func (m *Mouse) Move(x float64, y float64, opts goja.Value) {
 func (m *Mouse) Up(x float64, y float64, opts goja.Value) {
 	mouseOpts := NewMouseDownUpOptions()
 	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
-		k6ext.Panic(m.ctx, "parsing up options: %w", err)
+		k6ext.Panic(m.ctx, "parsing mouse up options: %w", err)
 	}
 	if err := m.up(x, y, mouseOpts); err != nil {
-		k6ext.Panic(m.ctx, "mouse up: %w", err)
+		k6ext.Panic(m.ctx, "releasing the mouse button on x:%f y:%f: %w", x, y, err)
 	}
 }
 

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -656,7 +656,7 @@ func (m *NetworkManager) updateProtocolRequestInterception() error {
 	}
 	for _, action := range actions {
 		if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
-			return fmt.Errorf("cannot execute %T: %w", action, err)
+			return fmt.Errorf("internal error while updating protocol request interception %T: %w", action, err)
 		}
 	}
 

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -118,7 +118,7 @@ func NewNetworkManager(
 func newResolver(conf k6types.DNSConfig) (k6netext.Resolver, error) {
 	ttl, err := parseTTL(conf.TTL.String)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse TTL: %w", err)
+		return nil, fmt.Errorf("parsing TTL: %w", err)
 	}
 
 	dnsSel := conf.Select
@@ -458,12 +458,12 @@ func (m *NetworkManager) onRequest(event *network.EventRequestWillBeSent, interc
 
 	req, err := NewRequest(m.ctx, event, frame, redirectChain, interceptionID, m.userReqInterceptionEnabled)
 	if err != nil {
-		m.logger.Errorf("NetworkManager", "cannot create Request: %s", err)
+		m.logger.Errorf("NetworkManager", "creating request: %s", err)
 		return
 	}
 	// Skip data and blob URLs, since they're internal to the browser.
 	if isInternalURL(req.url) {
-		m.logger.Debugf("NetworkManager", "skipped request handling of %s URL", req.url.Scheme)
+		m.logger.Debugf("NetworkManager", "skipping request handling of %s URL", req.url.Scheme)
 		return
 	}
 	m.reqsMu.Lock()

--- a/common/page.go
+++ b/common/page.go
@@ -149,7 +149,7 @@ func NewPage(
 
 	action := target.SetAutoAttach(true, true).WithFlatten(true)
 	if err := action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
-		return nil, fmt.Errorf("executing CDP action %T: %w", action, err)
+		return nil, fmt.Errorf("internal error while auto attaching to browser pages: %w", err)
 	}
 
 	return &p, nil

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -42,10 +42,10 @@ func TestURLSkipRequest(t *testing.T) {
 	p := tb.NewPage(nil)
 
 	p.Goto("data:text/html,hello", nil)
-	assert.True(t, tb.logCache.contains("skipped request handling of data URL"))
+	assert.True(t, tb.logCache.contains("skipping request handling of data URL"))
 
 	p.Goto("blob:something", nil)
-	assert.True(t, tb.logCache.contains("skipped request handling of blob URL"))
+	assert.True(t, tb.logCache.contains("skipping request handling of blob URL"))
 }
 
 func TestBlockHostnames(t *testing.T) {


### PR DESCRIPTION
I added an "internal error" prefix to some messages as per @ankur22's [suggestion](https://github.com/grafana/xk6-browser/pull/429#issuecomment-1173700059). Not a category per se, but the prefix indicates that something went internally wrong. So users can hopefully see whether the problem is because of their scripts or ours.

> Is there a need to distinguish between an "internal" error vs. a "user" error? Maybe internal errors could be fatal, and user errors could be just errors?

**Update:**
This PR improves the auto-detection of timeout errors and makes them user-friendly as well.