### PR TITLE
Add helpers for Async APIs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,17 @@ issues:
       linters:
       - wrapcheck
       - funlen
+      - cyclop
+    - path: k6ext/k6test
+      linters:
+      - wrapcheck
+      - funlen
+      - cyclop
+    - path: tests
+      linters:
+      - wrapcheck
+      - funlen
+      - cyclop
 
 linters:
   disable-all: true

--- a/k6ext/k6test/vu.go
+++ b/k6ext/k6test/vu.go
@@ -2,7 +2,6 @@ package k6test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/grafana/xk6-browser/k6ext"
@@ -31,10 +30,7 @@ func (v *VU) ToGojaValue(i interface{}) goja.Value { return v.Runtime().ToValue(
 
 // RunLoop is a convenience method for running fn in the event loop.
 func (v *VU) RunLoop(fn func() error) error {
-	if err := v.Loop.Start(fn); err != nil {
-		return fmt.Errorf("%w", err)
-	}
-	return nil
+	return v.Loop.Start(fn)
 }
 
 // NewVU returns a mock VU.

--- a/k6ext/k6test/vu.go
+++ b/k6ext/k6test/vu.go
@@ -2,6 +2,7 @@ package k6test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/grafana/xk6-browser/k6ext"
@@ -25,8 +26,16 @@ type VU struct {
 	Loop *k6eventloop.EventLoop
 }
 
-// ToGojaValue is a convenient method for converting any value to a goja value.
+// ToGojaValue is a convenience method for converting any value to a goja value.
 func (v *VU) ToGojaValue(i interface{}) goja.Value { return v.Runtime().ToValue(i) }
+
+// RunLoop is a convenience method for running fn in the event loop.
+func (v *VU) RunLoop(fn func() error) error {
+	if err := v.Loop.Start(fn); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	return nil
+}
 
 // NewVU returns a mock VU.
 func NewVU(tb testing.TB) *VU {

--- a/k6ext/promise.go
+++ b/k6ext/promise.go
@@ -1,0 +1,54 @@
+package k6ext
+
+import (
+	"context"
+
+	"github.com/dop251/goja"
+)
+
+// eventLoopDirective determines whether the event
+// loop should be aborted if the promise is rejected.
+type eventLoopDirective int
+
+const (
+	continueEventLoop eventLoopDirective = iota + 1
+	abortEventLoop
+)
+
+// PromisifiedFunc is a type of the function to run as a promise.
+type PromisifiedFunc func() (result interface{}, reason error)
+
+// Promise runs fn in a goroutine and returns a new goja.Promise.
+//   - If fn returns a nil error, resolves the promise with the
+//     first result value fn returns.
+//   - Otherwise, rejects the promise with the error fn returns.
+func Promise(ctx context.Context, fn PromisifiedFunc) *goja.Promise {
+	return promise(ctx, fn, continueEventLoop)
+}
+
+// AbortingPromise is like Promise, but it aborts the event loop if an error occurs.
+func AbortingPromise(ctx context.Context, fn PromisifiedFunc) *goja.Promise {
+	return promise(ctx, fn, abortEventLoop)
+}
+
+func promise(ctx context.Context, fn PromisifiedFunc, d eventLoopDirective) *goja.Promise {
+	var (
+		vu                 = GetVU(ctx)
+		cb                 = vu.RegisterCallback()
+		p, resolve, reject = vu.Runtime().NewPromise()
+	)
+	go cb(func() error {
+		v, err := fn()
+		if err != nil {
+			reject(err)
+		} else {
+			resolve(v)
+		}
+		if d == continueEventLoop {
+			err = nil
+		}
+		return err
+	})
+
+	return p
+}

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -87,7 +87,7 @@ func TestBrowserOn(t *testing.T) {
 		b := newTestBrowser(t)
 		require.NoError(t, b.vu.Runtime().Set("b", b.Browser))
 
-		err := b.vu.RunLoop(func() error {
+		err := b.await(func() error {
 			_, err := b.runString(script, "wrongevent")
 			return err
 		})
@@ -107,7 +107,7 @@ func TestBrowserOn(t *testing.T) {
 		require.NoError(t, rt.Set("b", b.Browser))
 		require.NoError(t, rt.Set("log", func(s string) { log = append(log, s) }))
 
-		err := b.vu.RunLoop(func() error {
+		err := b.await(func() error {
 			time.AfterFunc(100*time.Millisecond, b.Browser.Close)
 			_, err := b.runString(script, "disconnected")
 			return err
@@ -129,7 +129,7 @@ func TestBrowserOn(t *testing.T) {
 		require.NoError(t, rt.Set("b", b.Browser))
 		require.NoError(t, rt.Set("log", func(s string) { log = append(log, s) }))
 
-		err := b.vu.RunLoop(func() error {
+		err := b.await(func() error {
 			time.AfterFunc(100*time.Millisecond, cancel)
 			_, err := b.runString(script, "disconnected")
 			return err

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -22,7 +22,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -80,64 +79,63 @@ func TestTmpDirCleanup(t *testing.T) {
 func TestBrowserOn(t *testing.T) {
 	t.Parallel()
 
-	script := `
-		b.on('%s').then((val) => {
-			log('ok: '+val);
-		}, (val) => {
-			log('err: '+val);
-		});`
+	script := `b.on('%s').then(log).catch(log);`
 
 	t.Run("err_wrong_event", func(t *testing.T) {
 		t.Parallel()
 
 		b := newTestBrowser(t)
-		rt := b.vu.Runtime()
-		require.NoError(t, rt.Set("b", b.Browser))
+		require.NoError(t, b.vu.Runtime().Set("b", b.Browser))
 
-		err := b.vu.Loop.Start(func() error {
-			_, err := rt.RunString(fmt.Sprintf(script, "wrongevent"))
+		err := b.vu.RunLoop(func() error {
+			_, err := b.runString(script, "wrongevent")
 			return err
 		})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(),
-			`unknown browser event: "wrongevent", must be "disconnected"`)
+		assert.ErrorContains(t, err, `unknown browser event: "wrongevent", must be "disconnected"`)
 	})
 
 	t.Run("ok_promise_resolved", func(t *testing.T) {
 		t.Parallel()
 
-		b := newTestBrowser(t, withSkipClose())
-		rt := b.vu.Runtime()
+		var (
+			b   = newTestBrowser(t, withSkipClose())
+			rt  = b.vu.Runtime()
+			log []string
+		)
+
 		require.NoError(t, rt.Set("b", b.Browser))
-		var log []string
 		require.NoError(t, rt.Set("log", func(s string) { log = append(log, s) }))
 
-		err := b.vu.Loop.Start(func() error {
-			time.AfterFunc(100*time.Millisecond, func() { b.Browser.Close() })
-			_, err := rt.RunString(fmt.Sprintf(script, "disconnected"))
+		err := b.vu.RunLoop(func() error {
+			time.AfterFunc(100*time.Millisecond, b.Browser.Close)
+			_, err := b.runString(script, "disconnected")
 			return err
 		})
 		require.NoError(t, err)
-		assert.Contains(t, log, "ok: true")
+		assert.Contains(t, log, "true")
 	})
 
 	t.Run("ok_promise_rejected", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		b := newTestBrowser(t, ctx)
-		rt := b.vu.Runtime()
+		var (
+			ctx, cancel = context.WithCancel(context.Background())
+			b           = newTestBrowser(t, ctx)
+			rt          = b.vu.Runtime()
+			log         []string
+		)
+
 		require.NoError(t, rt.Set("b", b.Browser))
-		var log []string
 		require.NoError(t, rt.Set("log", func(s string) { log = append(log, s) }))
 
-		err := b.vu.Loop.Start(func() error {
-			time.AfterFunc(100*time.Millisecond, func() { cancel() })
-			_, err := rt.RunString(fmt.Sprintf(script, "disconnected"))
+		err := b.vu.RunLoop(func() error {
+			time.AfterFunc(100*time.Millisecond, cancel)
+			_, err := b.runString(script, "disconnected")
 			return err
 		})
 		require.NoError(t, err)
-		assert.Contains(t, log, "err: browser.on promise rejected: context canceled")
+		assert.Contains(t, log, "browser.on promise rejected: context canceled")
 	})
 }
 

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -88,7 +88,7 @@ func TestBrowserOn(t *testing.T) {
 		require.NoError(t, b.vu.Runtime().Set("b", b.Browser))
 
 		err := b.await(func() error {
-			_, err := b.runString(script, "wrongevent")
+			_, err := b.runJavaScript(script, "wrongevent")
 			return err
 		})
 		require.Error(t, err)
@@ -109,7 +109,7 @@ func TestBrowserOn(t *testing.T) {
 
 		err := b.await(func() error {
 			time.AfterFunc(100*time.Millisecond, b.Browser.Close)
-			_, err := b.runString(script, "disconnected")
+			_, err := b.runJavaScript(script, "disconnected")
 			return err
 		})
 		require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestBrowserOn(t *testing.T) {
 
 		err := b.await(func() error {
 			time.AfterFunc(100*time.Millisecond, cancel)
-			_, err := b.runString(script, "disconnected")
+			_, err := b.runJavaScript(script, "disconnected")
 			return err
 		})
 		require.NoError(t, err)

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -251,7 +251,7 @@ func (b *testBrowser) asGojaBool(v interface{}) bool {
 }
 
 // runString in the goja runtime.
-func (b *testBrowser) runString(s string, args ...interface{}) (goja.Value, error) {
+func (b *testBrowser) runString(s string, args ...interface{}) (goja.Value, error) { //nolint:unparam
 	b.t.Helper()
 	v, err := b.runtime().RunString(fmt.Sprintf(s, args...))
 	if err != nil {

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -58,8 +58,6 @@ type testBrowser struct {
 //
 // opts provides a way to customize the newTestBrowser.
 // see: withLaunchOptions for an example.
-//
-//nolint:funlen,cyclop
 func newTestBrowser(tb testing.TB, opts ...interface{}) *testBrowser {
 	tb.Helper()
 
@@ -251,20 +249,16 @@ func (b *testBrowser) asGojaBool(v interface{}) bool {
 }
 
 // runString in the goja runtime.
-func (b *testBrowser) runString(s string, args ...interface{}) (goja.Value, error) { //nolint:unparam
+func (b *testBrowser) runString(s string, args ...interface{}) (goja.Value, error) {
 	b.t.Helper()
-	v, err := b.runtime().RunString(fmt.Sprintf(s, args...))
-	if err != nil {
-		err = fmt.Errorf("%w", err)
-	}
-	return v, err
+	return b.runtime().RunString(fmt.Sprintf(s, args...))
 }
 
 // await runs fn in the event loop and awaits its return.
 // Note: Do not confuse the method name with await in JavaScript.
 func (b *testBrowser) await(fn func() error) error {
 	b.t.Helper()
-	return b.vu.RunLoop(fn) //nolint:wrapcheck
+	return b.vu.RunLoop(fn)
 }
 
 // launchOptions provides a way to customize browser type

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -248,8 +248,8 @@ func (b *testBrowser) asGojaBool(v interface{}) bool {
 	return gv.ToBoolean()
 }
 
-// runString in the goja runtime.
-func (b *testBrowser) runString(s string, args ...interface{}) (goja.Value, error) {
+// runJavaScript in the goja runtime.
+func (b *testBrowser) runJavaScript(s string, args ...interface{}) (goja.Value, error) {
 	b.t.Helper()
 	return b.runtime().RunString(fmt.Sprintf(s, args...))
 }

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -58,6 +58,7 @@ type testBrowser struct {
 //
 // opts provides a way to customize the newTestBrowser.
 // see: withLaunchOptions for an example.
+//
 //nolint:funlen,cyclop
 func newTestBrowser(tb testing.TB, opts ...interface{}) *testBrowser {
 	tb.Helper()
@@ -249,6 +250,16 @@ func (b *testBrowser) asGojaBool(v interface{}) bool {
 	return gv.ToBoolean()
 }
 
+// runString in the goja runtime.
+func (b *testBrowser) runString(s string, args ...interface{}) (goja.Value, error) {
+	b.t.Helper()
+	v, err := b.runtime().RunString(fmt.Sprintf(s, args...))
+	if err != nil {
+		err = fmt.Errorf("%w", err)
+	}
+	return v, err
+}
+
 // launchOptions provides a way to customize browser type
 // launch options in tests.
 type launchOptions struct {
@@ -263,10 +274,10 @@ type launchOptions struct {
 //
 // example:
 //
-//    b := TestBrowser(t, withLaunchOptions{
-//        SlowMo:  "100s",
-//        Timeout: "30s",
-//    })
+//	b := TestBrowser(t, withLaunchOptions{
+//	    SlowMo:  "100s",
+//	    Timeout: "30s",
+//	})
 type withLaunchOptions = launchOptions
 
 // defaultLaunchOptions returns defaults for browser type launch options.
@@ -292,7 +303,7 @@ type httpServerOption struct{}
 //
 // example:
 //
-//    b := TestBrowser(t, withHTTPServer())
+//	b := TestBrowser(t, withHTTPServer())
 func withHTTPServer() httpServerOption {
 	return struct{}{}
 }
@@ -308,7 +319,7 @@ type fileServerOption struct{}
 //
 // example:
 //
-//    b := TestBrowser(t, withFileServer())
+//	b := TestBrowser(t, withFileServer())
 func withFileServer() fileServerOption {
 	return struct{}{}
 }
@@ -324,7 +335,7 @@ type logCacheOption struct{}
 //
 // example:
 //
-//    b := TestBrowser(t, withLogCache())
+//	b := TestBrowser(t, withLogCache())
 func withLogCache() logCacheOption {
 	return struct{}{}
 }
@@ -337,7 +348,7 @@ type skipCloseOption struct{}
 //
 // example:
 //
-//    b := TestBrowser(t, withSkipClose())
+//	b := TestBrowser(t, withSkipClose())
 func withSkipClose() skipCloseOption {
 	return struct{}{}
 }

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -260,6 +260,13 @@ func (b *testBrowser) runString(s string, args ...interface{}) (goja.Value, erro
 	return v, err
 }
 
+// await runs fn in the event loop and awaits its return.
+// Note: Do not confuse the method name with await in JavaScript.
+func (b *testBrowser) await(fn func() error) error {
+	b.t.Helper()
+	return b.vu.RunLoop(fn) //nolint:wrapcheck
+}
+
 // launchOptions provides a way to customize browser type
 // launch options in tests.
 type launchOptions struct {


### PR DESCRIPTION
This PR closes #463.

* `k6ext.Promise` makes it easier to work with promisified code.
* `k6ext.AbortingPromise` is like `Promise`, allowing the event loop's abortion.
* `VU.RunLoop` makes it easier to run an event loop.
* `testBrowser.await` is a convenience function for `VU.RunLoop`. Awaits the given function until the event loop returns.
* `testBrowser.runString` makes it easy to run strings with a `fmt.Sprintf` like behavior.

An example of refactoring can be seen in `Browser.on` and its tests.