### PR TITLE
Fix `Page.goto()` race condition

### DIFF
--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -591,15 +590,27 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, opts goja.Value) 
 	timeoutCtx, timeoutCancelFn := context.WithTimeout(m.ctx, parsedOpts.Timeout)
 	defer timeoutCancelFn()
 
-	chSameDoc, evCancelFn := createWaitForEventHandler(timeoutCtx, frame, []string{EventFrameNavigation}, func(data interface{}) bool {
-		return data.(*NavigationEvent).newDocument == nil
-	})
-	defer evCancelFn() // Remove event handler
+	newDocIDCh := make(chan string, 1)
+	navEvtCh, navEvtCancel := createWaitForEventHandler(
+		timeoutCtx, frame, []string{EventFrameNavigation},
+		func(data interface{}) bool {
+			newDocID := <-newDocIDCh
+			if evt, ok := data.(*NavigationEvent); ok {
+				return evt.newDocument.documentID == newDocID
+			}
+			return false
+		})
+	defer navEvtCancel()
 
-	chWaitUntilCh, evCancelFn2 := createWaitForEventHandler(timeoutCtx, frame, []string{EventFrameAddLifecycle}, func(data interface{}) bool {
-		return data.(LifecycleEvent) == parsedOpts.WaitUntil
-	})
-	defer evCancelFn2() // Remove event handler
+	lifecycleEvtCh, lifecycleEvtCancel := createWaitForEventPredicateHandler(
+		timeoutCtx, frame, []string{EventFrameAddLifecycle},
+		func(data interface{}) bool {
+			if le, ok := data.(LifecycleEvent); ok {
+				return le == parsedOpts.WaitUntil
+			}
+			return false
+		})
+	defer lifecycleEvtCancel()
 
 	fs := frame.page.getFrameSession(cdp.FrameID(frame.ID()))
 	if fs == nil {
@@ -617,85 +628,49 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, opts goja.Value) 
 		k6ext.Panic(m.ctx, "navigating to %q: %v", url, err)
 	}
 
-	var event *NavigationEvent
-	if newDocumentID != "" {
-		m.logger.Debugf("FrameManager:NavigateFrame",
-			"fmid:%d fid:%v furl:%s url:%s newDocID:%s",
-			fmid, fid, furl, url, newDocumentID)
+	if newDocumentID == "" {
+		// It's a navigation within the same document (e.g. via anchor links or
+		// the History API), so don't wait for a response nor any lifecycle
+		// events.
+		return nil
+	}
 
-		data, err := waitForEvent(m.ctx, frame, []string{EventFrameNavigation}, func(data interface{}) bool {
-			ev := data.(*NavigationEvent)
+	// unblock the waiter goroutine
+	newDocIDCh <- newDocumentID
 
-			// We are interested either in this specific document, or any other document that
-			// did commit and replaced the expected document.
-			if ev.newDocument != nil && (ev.newDocument.documentID == newDocumentID || ev.err == nil) {
-				return true
-			}
-			return false
-		}, parsedOpts.Timeout)
-		if err != nil {
+	handleTimeoutError := func(err error) {
+		if errors.Is(err, context.DeadlineExceeded) {
 			err = &k6ext.UserFriendlyError{
 				Err:     err,
 				Timeout: parsedOpts.Timeout,
 			}
-			k6ext.Panic(m.ctx, "navigating to %q: %v", url, err)
+			k6ext.Panic(m.ctx, "navigating to %q: %w", url, err)
 		}
-
-		event = data.(*NavigationEvent)
-		if event.newDocument.documentID != newDocumentID {
-			m.logger.Debugf("FrameManager:NavigateFrame:interrupted",
-				"fmid:%d fid:%v furl:%s url:%s docID:%s newDocID:%s",
-				fmid, fid, furl, url, event.newDocument.documentID, newDocumentID)
-		} else if event.err != nil &&
-			// TODO: A more graceful way of avoiding Throw()?
-			!(netMgr.userReqInterceptionEnabled &&
-				strings.Contains(event.err.Error(), "ERR_BLOCKED_BY_CLIENT")) {
-			k6ext.Panic(m.ctx, "%w", event.err)
-		}
-	} else {
 		m.logger.Debugf("FrameManager:NavigateFrame",
-			"fmid:%d fid:%v furl:%s url:%s newDocID:0",
-			fmid, fid, furl, url)
-
-		select {
-		case <-timeoutCtx.Done():
-			if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
-				err = &k6ext.UserFriendlyError{
-					Err:     err,
-					Timeout: parsedOpts.Timeout,
-				}
-				k6ext.Panic(m.ctx, "navigating to %q: %w", url, err)
-			}
-		case data := <-chSameDoc:
-			event = data.(*NavigationEvent)
-		}
-	}
-
-	if !frame.hasSubtreeLifecycleEventFired(parsedOpts.WaitUntil) {
-		m.logger.Debugf("FrameManager:NavigateFrame",
-			"fmid:%d fid:%v furl:%s url:%s hasSubtreeLifecycleEventFired:false",
-			fmid, fid, furl, url)
-
-		select {
-		case <-timeoutCtx.Done():
-			if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
-				err = &k6ext.UserFriendlyError{
-					Err:     err,
-					Timeout: parsedOpts.Timeout,
-				}
-				k6ext.Panic(m.ctx, "navigating to %q: %w", url, err)
-			}
-		case <-chWaitUntilCh:
-		}
+			"fmid:%d fid:%v furl:%s url:%s timeoutCtx done: %v",
+			fmid, fid, furl, url, err)
 	}
 
 	var resp *Response
-	if event.newDocument != nil {
-		req := event.newDocument.request
-		if req != nil && req.response != nil {
-			resp = req.response
+	select {
+	case evt := <-navEvtCh:
+		if e, ok := evt.(*NavigationEvent); ok {
+			// Request could be nil in case of navigation to e.g. about:blank
+			if e.newDocument.request != nil {
+				resp = e.newDocument.request.response
+			}
 		}
+	case <-timeoutCtx.Done():
+		handleTimeoutError(timeoutCtx.Err())
+		return nil
 	}
+
+	select {
+	case <-lifecycleEvtCh:
+	case <-timeoutCtx.Done():
+		handleTimeoutError(timeoutCtx.Err())
+	}
+
 	return resp
 }
 

--- a/common/page.go
+++ b/common/page.go
@@ -719,11 +719,13 @@ func (p *Page) Reload(opts goja.Value) api.Response {
 	var resp *Response
 	req := event.newDocument.request
 	if req != nil {
-		if req.response != nil {
-			resp = req.response
-		}
+		req.responseMu.RLock()
+		resp = req.response
+		req.responseMu.RUnlock()
 	}
+
 	applySlowMo(p.ctx)
+
 	return resp
 }
 

--- a/common/request.go
+++ b/common/request.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/grafana/xk6-browser/api"
@@ -45,6 +46,7 @@ var _ api.Request = &Request{}
 type Request struct {
 	ctx                 context.Context
 	frame               *Frame
+	responseMu          sync.RWMutex
 	response            *Response
 	redirectChain       []*Request
 	requestID           network.RequestID

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -151,6 +151,7 @@ func TestPageGoto(t *testing.T) {
 
 	url := b.staticURL("empty.html")
 	r := p.Goto(url, nil)
+	require.NotNil(t, r)
 
 	assert.Equal(t, url, r.URL(), `expected URL to be %q, result of navigation was %q`, url, r.URL())
 }


### PR DESCRIPTION
This fixes the most common race condition and reason for flaky tests we've seen in CI for a while now. See the example in #427 and the commits for details.

I stress tested `TestPageGoto` in CI with [this script](https://dave.cheney.net/2013/06/19/stress-test-your-go-packages) before and after these changes. Before, it would fail with the familiar 30s timeout a few minutes into the test (see jobs [#1191](https://github.com/grafana/xk6-browser/actions/runs/2795113893), [#1192](https://github.com/grafana/xk6-browser/actions/runs/2795199585), [#1193](https://github.com/grafana/xk6-browser/actions/runs/2795217065)). After the changes, the stress test ran for an hour before I stopped it (jobs [#1190](https://github.com/grafana/xk6-browser/actions/runs/2791086400), [#1194](https://github.com/grafana/xk6-browser/actions/runs/2795306780), [#1196](https://github.com/grafana/xk6-browser/actions/runs/2795625671)), so I'm fairly confident this is an improvement over the previous version.

Closes #272