### PR TITLE
Make `fillform.js` example less racy

### DIFF
--- a/examples/fillform.js
+++ b/examples/fillform.js
@@ -1,7 +1,7 @@
 import { check } from 'k6';
 import { chromium } from 'k6/x/browser';
 
-export default function() {
+export default function () {
   const browser = chromium.launch({
     headless: __ENV.XK6_HEADLESS ? true : false,
   });
@@ -10,21 +10,23 @@ export default function() {
 
   // Goto front page, find login link and click it
   page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
-  const elem = page.$('a[href="/my_messages.php"]');
-  elem.click().then(() => {
+  Promise.all([
+    page.waitForNavigation(),
+    page.locator('a[href="/my_messages.php"]').click(),
+  ]).then(() => {
     // Enter login credentials and login
-    page.$('input[name="login"]').type('admin');
-    page.$('input[name="password"]').type('123');
+    page.locator('input[name="login"]').type('admin');
+    page.locator('input[name="password"]').type('123');
     // We expect the form submission to trigger a navigation, so to prevent a
     // race condition, setup a waiter concurrently while waiting for the click
     // to resolve.
     return Promise.all([
       page.waitForNavigation(),
-      page.$('input[type="submit"]').click(),
+      page.locator('input[type="submit"]').click(),
     ]);
   }).then(() => {
     check(page, {
-      'header': page.$('h2').textContent() == 'Welcome, admin!',
+      'header': page.locator('h2').textContent() == 'Welcome, admin!',
     });
   }).finally(() => {
     page.close();


### PR DESCRIPTION
This ensures we use `Promise.all()` wherever `click()`/`waitForNavigation()` is used, which is also [suggested by Playwright](https://playwright.dev/docs/api/class-page#page-wait-for-navigation) to avoid a race condition.

And also change the example to use the Locator API, which handles navigations better.

From my local and Cloud tests, this helped resolve the errors in #495.