### PR TITLE
Fix nil panic race in `FrameManager.waitForFrameNavigation`

### DIFF
--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -756,8 +756,9 @@ func (m *FrameManager) waitForFrameNavigation(frame *Frame, opts goja.Value) (ap
 	}
 
 	// A lifecycle event won't be received when navigating within the same
-	// document, so don't wait for it.
-	if !sameDocNav {
+	// document, so don't wait for it. The event might've also already been
+	// fired once we're here, so also skip waiting in that case.
+	if !sameDocNav && !frame.hasSubtreeLifecycleEventFired(parsedOpts.WaitUntil) {
 		select {
 		case <-lifecycleEvtCh:
 		case <-timeoutCtx.Done():


### PR DESCRIPTION
This refactors `waitForFrameNavigation` in a similar way as `NavigateFrame` was in #480. Namely to setup the lifecycle event waiter ASAP, ~and to not call `hasSubtreeLifecycleEventFired()` which is buggy/racy itself, and not necessary.~ While I've found that calling `hasSubtreeLifecycleEventFired()` is not necessary, I decided to bring it back since I noticed some timeouts without it. It's difficult to say whether this was related, but we can leave it and remove it later if it's found to be a problem.

Fixes #498