### PR TITLE
Fix XK6_BROWSER_PPROF env var for cloud support

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ var (
 )
 
 func init() {
-	if _, ok := os.LookupEnv("XK6_BROWSER_PPROF"); ok {
+	if _, ok := os.LookupEnv("K6_BROWSER_PPROF"); ok {
 		go func() {
 			address := "localhost:6060"
 			log.Println("Starting http debug server", address)


### PR DESCRIPTION
The k6-agent will only forward env vars to the k6 binary that start
with K6_. To be able to use pprof in the cloud environment we need
to change the env var from XK6_BROWSER_PPROF to K6_BROWSER_PPROF.