### PR TITLE
Fix concurrent usage of goja.Runtime in waitForNavigation

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -1850,7 +1850,7 @@ func (f *Frame) WaitForNavigation(opts goja.Value) *goja.Promise {
 		})
 
 	handleTimeoutError := func(err error) error {
-		if errors.Is(err, context.DeadlineExceeded) {
+		if err != nil {
 			e := &k6ext.UserFriendlyError{
 				Err:     err,
 				Timeout: parsedOpts.Timeout,

--- a/common/frame.go
+++ b/common/frame.go
@@ -1850,6 +1850,8 @@ func (f *Frame) WaitForNavigation(opts goja.Value) *goja.Promise {
 		})
 
 	handleTimeoutError := func(err error) error {
+		f.log.Debugf("Frame:WaitForNavigation",
+			"fid:%v furl:%s timeoutCtx done: %v", f.ID(), f.URL(), err)
 		if err != nil {
 			e := &k6ext.UserFriendlyError{
 				Err:     err,
@@ -1857,9 +1859,6 @@ func (f *Frame) WaitForNavigation(opts goja.Value) *goja.Promise {
 			}
 			return fmt.Errorf("waiting for navigation: %w", e)
 		}
-		f.log.Debugf("Frame:WaitForNavigation",
-			"fid:%v furl:%s timeoutCtx done: %v",
-			f.ID(), f.URL(), err)
 
 		return nil
 	}


### PR DESCRIPTION
This is a functional change from before, since the iteration won't be interrupted by a timeout error anymore, and the promise will be rejected instead. This might be an acceptable tradeoff for using a lock, but it would be better if there was a way of interrupting the iteration if the promise is rejected.

Fixes #506