### PR TITLE
Draft: Remove the nulling of the context

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -515,11 +515,11 @@ func (f *Frame) setContext(world executionWorld, execCtx frameExecutionContext) 
 		panic(err)
 	}
 
-	if f.executionContexts[world] != nil {
-		f.log.Debugf("Frame:setContext", "fid:%s furl:%q ectxid:%d world:%s, world exists",
-			f.ID(), f.URL(), execCtx.ID(), world)
-		return
-	}
+	// if f.executionContexts[world] != nil {
+	// 	f.log.Debugf("Frame:setContext", "fid:%s furl:%q ectxid:%d world:%s, world exists",
+	// 		f.ID(), f.URL(), execCtx.ID(), world)
+	// 	return
+	// }
 
 	f.executionContexts[world] = execCtx
 	f.log.Debugf("Frame:setContext", "fid:%s furl:%q ectxid:%d world:%s, world set",

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -605,20 +605,21 @@ func (fs *FrameSession) onExecutionContextDestroyed(execCtxID cdpruntime.Executi
 }
 
 func (fs *FrameSession) onExecutionContextsCleared() {
-	fs.logger.Debugf("FrameSession:onExecutionContextsCleared",
-		"sid:%v tid:%v", fs.session.ID(), fs.targetID)
+	return
+	// fs.logger.Debugf("FrameSession:onExecutionContextsCleared",
+	// 	"sid:%v tid:%v", fs.session.ID(), fs.targetID)
 
-	fs.contextIDToContextMu.Lock()
-	defer fs.contextIDToContextMu.Unlock()
+	// fs.contextIDToContextMu.Lock()
+	// defer fs.contextIDToContextMu.Unlock()
 
-	for _, context := range fs.contextIDToContext {
-		if context.Frame() != nil {
-			context.Frame().nullContext(context.id)
-		}
-	}
-	for k := range fs.contextIDToContext {
-		delete(fs.contextIDToContext, k)
-	}
+	// for _, context := range fs.contextIDToContext {
+	// 	if context.Frame() != nil {
+	// 		context.Frame().nullContext(context.id)
+	// 	}
+	// }
+	// for k := range fs.contextIDToContext {
+	// 	delete(fs.contextIDToContext, k)
+	// }
 }
 
 func (fs *FrameSession) onFrameAttached(frameID cdp.FrameID, parentFrameID cdp.FrameID) {


### PR DESCRIPTION
This should mean that we do not need to rely on the context being
cleared when a navigation occurs. This also means that we're not being
affected by the race condition where the new contexts are added before
a clear context CDP message is received.

Although the race condition has been resolved, a new error now occurs (TODO: Add the details for the new error)

Closes: https://github.com/grafana/xk6-browser/issues/482