### PR TITLE
Add mutex to sync the clearing of the context

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -503,7 +503,7 @@ func (f *Frame) requestByID(reqID network.RequestID) *Request {
 	return frameSession.networkManager.requestFromID(reqID)
 }
 
-func (f *Frame) setContext(world executionWorld, execCtx frameExecutionContext) {
+func (f *Frame) setContext(world executionWorld, execCtx frameExecutionContext) error {
 	f.executionContextMu.Lock()
 	defer f.executionContextMu.Unlock()
 
@@ -518,12 +518,14 @@ func (f *Frame) setContext(world executionWorld, execCtx frameExecutionContext) 
 	if f.executionContexts[world] != nil {
 		f.log.Debugf("Frame:setContext", "fid:%s furl:%q ectxid:%d world:%s, world exists",
 			f.ID(), f.URL(), execCtx.ID(), world)
-		return
+		return errors.New("context already set")
 	}
 
 	f.executionContexts[world] = execCtx
 	f.log.Debugf("Frame:setContext", "fid:%s furl:%q ectxid:%d world:%s, world set",
 		f.ID(), f.URL(), execCtx.ID(), world)
+
+	return nil
 }
 
 func (f *Frame) setID(id cdp.FrameID) {
@@ -537,7 +539,7 @@ func (f *Frame) waitForExecutionContext(world executionWorld) {
 	f.log.Debugf("Frame:waitForExecutionContext", "fid:%s furl:%q world:%s",
 		f.ID(), f.URL(), world)
 
-	t := time.NewTimer(50 * time.Millisecond)
+	t := time.NewTicker(50 * time.Millisecond)
 	defer t.Stop()
 	for {
 		select {


### PR DESCRIPTION
Closes: https://github.com/grafana/xk6-browser/issues/482

This tries to synchronize the navigation internal actions by forcing
the system to wait for the context to be cleared before carrying on
with the other actions i.e. handling the response and allowing the
creation of the new contexts.

[Diagram](https://drive.google.com/file/d/17na5TdRjrkZ2aExT-hdb6r-il8uAx8cW/view?usp=sharing).
![xk6-browser - Deadlock issue #482   #496 drawio](https://user-images.githubusercontent.com/1112428/191000880-833cfbc1-b6a7-4a2a-8cb8-57f71664c56c.png)


This has been tested in the cloud and after several tests, xk6-browser
has not deadlocked 🎉 

I have another solution which i prefer as it's closer to the root cause
of the issue -- https://github.com/grafana/xk6-browser/pull/524 (which is still WIP).