### PR TITLE
Export Chromium `BrowserType` implementation directly

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	k6modules "go.k6.io/k6/js/modules"
 )
 
-const version = "v0.4.0"
+const version = "0.4.0"
 
 type (
 	// RootModule is the global module instance that will create module


### PR DESCRIPTION
Closes #485 

This also exposes the xk6-browser version to JS scripts, which is useful for troubleshooting user scripts until https://github.com/grafana/k6/issues/1741 is implemented.