### PR TITLE
Release notes v0.5.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	k6modules "go.k6.io/k6/js/modules"
 )
 
-const version = "0.4.0"
+const version = "0.5.0"
 
 type (
 	// RootModule is the global module instance that will create module

--- a/release notes/v0.5.0.md
+++ b/release notes/v0.5.0.md
@@ -1,0 +1,103 @@
+xk6-browser v0.5.0 is here! :tada:
+
+This minor release contains a new feature, a few important stability fixes, some breaking changes, improvements, and a continuation of our efforts to migrate to async APIs. Coinciding with this release, is the up-to-date documentation, which can be found at [https://k6.io/docs/javascript-api/xk6-browser/](https://k6.io/docs/javascript-api/xk6-browser/). Only a few of the most used classes like `Browser` and `BrowserContext` are currently well documented, and we're working hard on updating the rest of the API.
+
+
+## New Feature
+
+- Combining key presses when inputting text in an input field now works with the `Shift` modifier key ([#326](https://github.com/grafana/xk6-browser/pull/326), [#522](https://github.com/grafana/xk6-browser/pull/522)).
+
+  ```
+  const l = page.locator('#input-text-test');
+  l.press('Shift+KeyH+i');  // "Hi"
+  l.press('Backspace');     // "H"
+  l.press('Backspace');     // ""
+  l.press('KeyH+i');        // "hi"
+  ```
+
+
+## Bugs fixed
+
+- A couple of `Page.goto()` race conditions, where the call would timeout waiting for the navigation event. This was mainly found to occur in CI, but it could happen in real world tests as well.
+  ([#480](https://github.com/grafana/xk6-browser/pull/480), [#501](https://github.com/grafana/xk6-browser/pull/501))
+
+- A `Page.waitForNavigation()` race condition, where the call would fail with a Go nil pointer dereference error. ([#500](https://github.com/grafana/xk6-browser/pull/500))
+
+
+## Breaking changes
+
+- `chromium` is now an importable object, which changes the syntax for launching tests using Chromium (which is still the only supported browser type). ([#462](https://github.com/grafana/xk6-browser/pull/462), [#515](https://github.com/grafana/xk6-browser/pull/515))
+
+  Previously, scripts called `launch()` on the `k6/x/browser` module directly, and specified `'chromium'` as the first argument:
+  ```js
+  import launcher from 'k6/x/browser';
+
+  export default function () {
+    const browser = launcher.launch('chromium', {
+      headless: false,
+    });
+
+    ...
+  ```
+
+  Now, `chromium` must be imported separately and `chromium.launch()` should be called instead:
+  ```js
+  import { chromium } from 'k6/x/browser';
+
+  export default function () {
+    const browser = chromium.launch({
+      headless: false,
+    });
+
+    ...
+  ```
+
+  The same options are supported in the `chromium.launch()` method as in the previous `launch()` function.
+
+- `ElementHandle.click()` is now an asynchronous method that returns a Promise. ([#466](https://github.com/grafana/xk6-browser/pull/466))
+
+  Note that the `async` and `await` keywords are not yet supported (see [this k6 issue](https://github.com/grafana/k6/issues/779) for a workaround), so resolving the Promise using `then()` is required for scripts to continue to work correctly.
+
+  See the [`fillform.js` example](https://github.com/grafana/xk6-browser/blob/v0.5.0/examples/fillform.js) for how to use it.
+
+- `Page.waitForNavigation()` is now an asynchronous method that returns a Promise. ([#467](https://github.com/grafana/xk6-browser/pull/467))
+
+  When expecting a navigation triggered by a `click()`, it's important to resolve both Promises inside a `Promise.all()` call, to avoid a race condition.
+
+  See the [`fillform.js` example](https://github.com/grafana/xk6-browser/blob/v0.5.0/examples/fillform.js) for how to use it.
+
+- As part of the `Page.waitForNavigation()` async change, a timeout error won't interrupt the script iteration anymore, and the Promise will be rejected instead. ([#508](https://github.com/grafana/xk6-browser/pull/508))
+
+  This gives more flexibility, as you can handle this error however you prefer, including interrupting the iteration. For example:
+
+  ```js
+  import { fail } from 'k6';
+
+  export default function () {
+    ...
+
+    Promise.all([
+      page.waitForNavigation({ timeout: 1000 }),
+      page.locator('a').click(),
+    ]).then(() => {
+      // Everything went well, the page navigated.
+    }, (err) => {
+      console.log(err);  // "waiting for navigation: timed out after 1s"
+      fail(err);         // interrupt the iteration
+    });
+  ```
+
+
+## Improvements
+
+- We've made more changes to our log messages to make them more concise and user friendlier. ([#438](https://github.com/grafana/xk6-browser/pull/438))
+
+
+## Internals
+
+- Upgraded k6 dependency to v0.40.0. ([#523](https://github.com/grafana/xk6-browser/pull/523))
+
+- Several refactors to improve maintainability.
+  ([#452](https://github.com/grafana/xk6-browser/pull/452), [#457](https://github.com/grafana/xk6-browser/pull/457), [#464](https://github.com/grafana/xk6-browser/pull/464), [#476](https://github.com/grafana/xk6-browser/pull/476), ([#497](https://github.com/grafana/xk6-browser/pull/497)))
+
+- Add pprof server enabled by an optional environment variable. This will help us troubleshoot issues on a live xk6-browser process. ([#503](https://github.com/grafana/xk6-browser/pull/503), [#507](https://github.com/grafana/xk6-browser/pull/507))


### PR DESCRIPTION
This contains the release notes for v0.5.0. The main changes are acount
stability, asynchronous changes to click and waitForNavigation, and
exporting a new BrowserType, Chromium, that replaces the launch
function to launch a new chromium browser instance.