### PR TITLE
Fix context canceled error when running more than 1 iteration

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/chromium"
 	"github.com/grafana/xk6-browser/common"
-	"github.com/grafana/xk6-browser/k6ext"
 
 	k6modules "go.k6.io/k6/js/modules"
 )
@@ -57,13 +56,9 @@ func New() *RootModule {
 // NewModuleInstance implements the k6modules.Module interface to return
 // a new instance for each VU.
 func (*RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
-	k6m := k6ext.RegisterCustomMetrics(vu.InitEnv().Registry)
-	ctx := k6ext.WithVU(vu.Context(), vu)
-	ctx = k6ext.WithCustomMetrics(ctx, k6m)
-
 	return &ModuleInstance{
 		mod: &JSModule{
-			Chromium: chromium.NewBrowserType(ctx),
+			Chromium: chromium.NewBrowserType(vu),
 			Devices:  common.GetDevices(),
 			Version:  version,
 		},

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -123,7 +123,7 @@ func newTestBrowser(tb testing.TB, opts ...interface{}) *testBrowser {
 	}
 
 	// launch the browser
-	v := chromium.NewBrowserType(vu.Context())
+	v := chromium.NewBrowserType(vu)
 	bt, ok := v.(*chromium.BrowserType)
 	if !ok {
 		panic(fmt.Errorf("testBrowser: unexpected browser type %T", v))


### PR DESCRIPTION
This was a regression introduced by #515, caused by the fact [the VU context changes after each iteration](https://github.com/grafana/k6/blob/e09bb87277865d668586429eee97158fbbfc58e5/js/runner.go#L710), so our context initialization needs to happen on each iteration (`launch()` call) as well.

I wanted to add an E2E test to cover this scenario and test multiple iterations, but the process still exits with 0 when this was broken, so we wouldn't have seen it in CI anyway. I'm not sure how to test it otherwise. We should probably dump the summary results and check them in the job, similar to [the way the test-xk6 workflow works in the k6 repo](https://github.com/grafana/k6/blob/master/.github/workflows/xk6.yml#L69-L73). But we can do that later and I didn't want to delay the fix.