### PR TITLE
Fix press in classes to work with combo keys

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -476,7 +476,7 @@ func (h *ElementHandle) press(apiCtx context.Context, key string, opts *Keyboard
 	if err != nil {
 		return err
 	}
-	err = h.frame.page.Keyboard.press(key, opts)
+	err = h.frame.page.Keyboard.comboPress(key, opts)
 	if err != nil {
 		return err
 	}

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -359,3 +359,19 @@ func TestElementHandleWaitForSelector(t *testing.T) {
 
 	element.Dispose()
 }
+
+func TestElementHandler_Press(t *testing.T) {
+	tb := newTestBrowser(t)
+
+	p := tb.NewPage(nil)
+
+	p.SetContent(`<input>`, nil)
+
+	el := p.Query("input")
+
+	el.Press("Shift+KeyA", nil)
+	el.Press("KeyB", nil)
+	el.Press("Shift+KeyC", nil)
+
+	require.Equal(t, "AbC", el.InputValue(nil))
+}

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -360,7 +360,7 @@ func TestElementHandleWaitForSelector(t *testing.T) {
 	element.Dispose()
 }
 
-func TestElementHandler_Press(t *testing.T) {
+func TestElementHandlePress(t *testing.T) {
 	tb := newTestBrowser(t)
 
 	p := tb.NewPage(nil)

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFrame_Press(t *testing.T) {
+func TestFramePress(t *testing.T) {
 	tb := newTestBrowser(t)
 
 	p := tb.NewPage(nil)

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -1,0 +1,23 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrame_Press(t *testing.T) {
+	tb := newTestBrowser(t)
+
+	p := tb.NewPage(nil)
+
+	p.SetContent(`<input id="text1">`, nil)
+
+	f := p.Frames()[0]
+
+	f.Press("#text1", "Shift+KeyA", nil)
+	f.Press("#text1", "KeyB", nil)
+	f.Press("#text1", "Shift+KeyC", nil)
+
+	require.Equal(t, "AbC", f.InputValue("#text1", nil))
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -371,7 +371,7 @@ func TestLocatorElementState(t *testing.T) {
 	}
 }
 
-func TestLocator_Press(t *testing.T) {
+func TestLocatorPress(t *testing.T) {
 	tb := newTestBrowser(t)
 
 	p := tb.NewPage(nil)

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -370,3 +370,19 @@ func TestLocatorElementState(t *testing.T) {
 		})
 	}
 }
+
+func TestLocator_Press(t *testing.T) {
+	tb := newTestBrowser(t)
+
+	p := tb.NewPage(nil)
+
+	p.SetContent(`<input id="text1">`, nil)
+
+	l := p.Locator("#text1", nil)
+
+	l.Press("Shift+KeyA", nil)
+	l.Press("KeyB", nil)
+	l.Press("Shift+KeyC", nil)
+
+	require.Equal(t, "AbC", l.InputValue(nil))
+}

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -684,7 +684,7 @@ func TestPageWaitForNavigationShouldNotPanic(t *testing.T) {
 	require.NotPanics(t, func() { p.WaitForNavigation(nil) })
 }
 
-func TestPage_Press(t *testing.T) {
+func TestPagePress(t *testing.T) {
 	tb := newTestBrowser(t)
 
 	p := tb.NewPage(nil)

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -684,6 +684,20 @@ func TestPageWaitForNavigationShouldNotPanic(t *testing.T) {
 	require.NotPanics(t, func() { p.WaitForNavigation(nil) })
 }
 
+func TestPage_Press(t *testing.T) {
+	tb := newTestBrowser(t)
+
+	p := tb.NewPage(nil)
+
+	p.SetContent(`<input id="text1">`, nil)
+
+	p.Press("#text1", "Shift+KeyA", nil)
+	p.Press("#text1", "KeyB", nil)
+	p.Press("#text1", "Shift+KeyC", nil)
+
+	require.Equal(t, "AbC", p.InputValue("#text1", nil))
+}
+
 func assertPanicErrorContains(t *testing.T, err interface{}, expErrMsg string) {
 	t.Helper()
 


### PR DESCRIPTION
`ElementHandle`, `Page`, `Locator` and `Frame` all implement the `Press` method. In a recent fix (#326) combo keys with the `Shift` modifier key was fixed for the `Keyboard` `Press` method. The `Press` methods for the other classes should have worked with combo key presses, but didn't, which resulted in an error: `ERRO[0002] pressing "Shift+KeyH+i" on "#text1": key down: "Shift+KeyH+i" is not a valid key for layout "us"`. This fix will ensure that combo key presses work for all of them. This fix matches the behaviour in playwright.

Playwright test:

```js
const { test, chromium } = require('@playwright/test');

test.describe('editing', () => {
  test('frame press', async () => {
    const browser = await chromium.launch({ headless: false, slowMo: 500 });
    const ctx = await browser.newContext();
    const page = await ctx.newPage();

    await page.goto("https://test.k6.io/browser.php");

    const e = await page.$('#text1');
    e.press("Shift+KeyH+i");
    await clearField(page);

    page.press('#text1', "Shift+KeyH+i");
    await clearField(page);

    const l = page.locator('#text1');
    l.press("Shift+KeyH+i");
    await clearField(page);

    const f = page.frames()[0];
    f.press('#text1', "Shift+KeyH+i");
    await clearField(page);

    await new Promise(resolve => setTimeout(resolve, 2000));

    await browser.close();
  });
});

async function clearField(page) {
  await new Promise(resolve => setTimeout(resolve, 500));
  page.press('#text1', 'Backspace');
  page.press('#text1', 'Backspace');
  await new Promise(resolve => setTimeout(resolve, 500));
}
```

Equivalent xk6-browser test:

```js
import { sleep } from 'k6'
import { chromium } from 'k6/x/browser';

export default function () {
  const browser = chromium.launch({
    headless: false,
  });
  const context = browser.newContext();
  const page = context.newPage();

  page.goto('https://test.k6.io/browser.php');

  const e = page.$('#text1');
  e.press("Shift+KeyH+i");
  clearField(page);

  page.press('#text1', "Shift+KeyH+i");
  clearField(page);

  const l = page.locator('#text1');
  l.press('Shift+KeyH+i');
  clearField(page);

  const f = page.frames()[0];
  f.press('#text1', 'Shift+KeyH+i');
  clearField(page);

  sleep(2);
  browser.close();
}

function clearField(page) {
  sleep(1);
  page.press('#text1', 'Backspace');
  page.press('#text1', 'Backspace');
  sleep(1);
}
```

Closes: https://github.com/grafana/xk6-browser/issues/521