### PR TITLE
Remove go and use chan to keep CDP msg order

### DIFF
--- a/common/barrier_test.go
+++ b/common/barrier_test.go
@@ -41,7 +41,7 @@ func TestBarrier(t *testing.T) {
 
 	barrier := NewBarrier()
 	barrier.AddFrameNavigation(frame)
-	frame.emit(EventFrameNavigation, "some data")
+	frame.emit(log, EventFrameNavigation, "some data")
 
 	err := barrier.Wait(ctx)
 	require.Nil(t, err)

--- a/common/browser.go
+++ b/common/browser.go
@@ -168,7 +168,7 @@ func (b *Browser) getPages() []*Page {
 func (b *Browser) initEvents() error {
 	var cancelCtx context.Context
 	cancelCtx, b.evCancelFn = context.WithCancel(b.ctx)
-	chHandler := make(chan Event)
+	chHandler := make(chan Event, EventListenerDefaultChanBufferSize)
 
 	b.conn.on(cancelCtx, []string{
 		cdproto.EventTargetAttachedToTarget,
@@ -313,7 +313,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 		b.sessionIDtoTargetID[ev.SessionID] = evti.TargetID
 		b.sessionIDtoTargetIDMu.Unlock()
 
-		browserCtx.emit(EventBrowserContextPage, p)
+		browserCtx.emit(b.logger, EventBrowserContextPage, p)
 	default:
 		b.logger.Warnf(
 			"Browser:onAttachedToTarget", "sid:%v tid:%v bctxid:%v bctx nil:%t, unknown target type: %q",

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -370,7 +370,7 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 	}
 
 	evCancelCtx, evCancelFn := context.WithCancel(b.ctx)
-	chEvHandler := make(chan Event)
+	chEvHandler := make(chan Event, EventListenerDefaultChanBufferSize)
 	ch := make(chan interface{})
 
 	go func() {

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -47,6 +47,8 @@ func TestBrowserNewPageInContext(t *testing.T) {
 		// newPageInContext will return this page by searching it by its targetID in the wait event handler.
 		tc.b.pages[targetID] = &Page{targetID: targetID}
 
+		log := log.NewNullLogger()
+
 		tc.b.conn = fakeConn{
 			execute: func(
 				ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler,
@@ -68,7 +70,7 @@ func TestBrowserNewPageInContext(t *testing.T) {
 				// EventBrowserContextPage to be fired. this normally happens when the browser's
 				// onAttachedToTarget event is fired. here, we imitate as if the browser created a target for
 				// the page.
-				tc.bc.emit(EventBrowserContextPage, &Page{targetID: targetID})
+				tc.bc.emit(log, EventBrowserContextPage, &Page{targetID: targetID})
 
 				return nil
 			},

--- a/common/event_emitter_test.go
+++ b/common/event_emitter_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/chromedp/cdproto"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/log"
 )
 
 func TestEventEmitterSpecificEvent(t *testing.T) {
@@ -51,10 +53,11 @@ func TestEventEmitterSpecificEvent(t *testing.T) {
 		cancelCtx, cancelFn := context.WithCancel(ctx)
 		emitter := NewBaseEventEmitter(cancelCtx)
 		ch := make(chan Event)
+		log := log.NewNullLogger()
 
 		emitter.on(cancelCtx, []string{cdproto.EventTargetTargetCreated}, ch)
 		cancelFn()
-		emitter.emit(cdproto.EventTargetTargetCreated, nil) // Event handlers are removed as part of event emission
+		emitter.emit(log, cdproto.EventTargetTargetCreated, nil) // Event handlers are removed as part of event emission
 
 		emitter.sync(func() {
 			require.Contains(t, emitter.handlers, cdproto.EventTargetTargetCreated)
@@ -66,9 +69,10 @@ func TestEventEmitterSpecificEvent(t *testing.T) {
 		ctx := context.Background()
 		emitter := NewBaseEventEmitter(ctx)
 		ch := make(chan Event, 1)
+		log := log.NewNullLogger()
 
 		emitter.on(ctx, []string{cdproto.EventTargetTargetCreated}, ch)
-		emitter.emit(cdproto.EventTargetTargetCreated, "hello world")
+		emitter.emit(log, cdproto.EventTargetTargetCreated, "hello world")
 		msg := <-ch
 
 		emitter.sync(func() {
@@ -100,10 +104,11 @@ func TestEventEmitterAllEvents(t *testing.T) {
 		emitter := NewBaseEventEmitter(ctx)
 		cancelCtx, cancelFn := context.WithCancel(ctx)
 		ch := make(chan Event)
+		log := log.NewNullLogger()
 
 		emitter.onAll(cancelCtx, ch)
 		cancelFn()
-		emitter.emit(cdproto.EventTargetTargetCreated, nil) // Event handlers are removed as part of event emission
+		emitter.emit(log, cdproto.EventTargetTargetCreated, nil) // Event handlers are removed as part of event emission
 
 		emitter.sync(func() {
 			require.Len(t, emitter.handlersAll, 0)
@@ -114,9 +119,10 @@ func TestEventEmitterAllEvents(t *testing.T) {
 		ctx := context.Background()
 		emitter := NewBaseEventEmitter(ctx)
 		ch := make(chan Event, 1)
+		log := log.NewNullLogger()
 
 		emitter.onAll(ctx, ch)
-		emitter.emit(cdproto.EventTargetTargetCreated, "hello world")
+		emitter.emit(log, cdproto.EventTargetTargetCreated, "hello world")
 		msg := <-ch
 
 		emitter.sync(func() {

--- a/common/frame.go
+++ b/common/frame.go
@@ -224,16 +224,16 @@ func (f *Frame) recalculateLifecycle() {
 		if f.hasSubtreeLifecycleEventFired(k) {
 			continue
 		}
-		f.emit(EventFrameAddLifecycle, k)
+		f.emit(f.log, EventFrameAddLifecycle, k)
 
 		if f != mainFrame {
 			continue
 		}
 		switch k {
 		case LifecycleEventLoad:
-			f.page.emit(EventPageLoad, nil)
+			f.page.emit(f.log, EventPageLoad, nil)
 		case LifecycleEventDOMContentLoad:
-			f.page.emit(EventPageDOMContentLoaded, nil)
+			f.page.emit(f.log, EventPageDOMContentLoaded, nil)
 		}
 	}
 
@@ -242,7 +242,7 @@ func (f *Frame) recalculateLifecycle() {
 	{
 		for k := range f.subtreeLifecycleEvents {
 			if ok := events[k]; !ok {
-				f.emit(EventFrameRemoveLifecycle, k)
+				f.emit(f.log, EventFrameRemoveLifecycle, k)
 			}
 		}
 	}
@@ -424,7 +424,7 @@ func (f *Frame) navigated(name string, url string, loaderID string) {
 	f.name = name
 	f.url = url
 	f.loaderID = loaderID
-	f.page.emit(EventPageFrameNavigated, f)
+	f.page.emit(f.log, EventPageFrameNavigated, f)
 }
 
 func (f *Frame) nullContext(execCtxID runtime.ExecutionContextID) {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -105,7 +105,7 @@ func NewFrameSession(
 		contextIDToContextMu: sync.Mutex{},
 		contextIDToContext:   make(map[cdpruntime.ExecutionContextID]*ExecutionContext),
 		isolatedWorlds:       make(map[string]bool),
-		eventCh:              make(chan Event),
+		eventCh:              make(chan Event, EventListenerDefaultChanBufferSize),
 		childSessions:        make(map[cdp.FrameID]*FrameSession),
 		vu:                   k6ext.GetVU(ctx),
 		k6Metrics:            k6ext.GetCustomMetrics(ctx),
@@ -543,7 +543,7 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 }
 
 func (fs *FrameSession) onExceptionThrown(event *cdpruntime.EventExceptionThrown) {
-	fs.page.emit(EventPageError, event.ExceptionDetails)
+	fs.page.emit(fs.logger, EventPageError, event.ExceptionDetails)
 }
 
 func (fs *FrameSession) onExecutionContextCreated(event *cdpruntime.EventExecutionContextCreated) {

--- a/common/frame_test.go
+++ b/common/frame_test.go
@@ -76,7 +76,7 @@ func TestFrameManagerFrameAbortedNavigationShouldEmitANonNilPendingDocument(t *t
 	fm.frames[frame.id] = frame
 
 	// listen for frame navigation events
-	recv := make(chan Event)
+	recv := make(chan Event, EventListenerDefaultChanBufferSize)
 	frame.on(ctx, []string{EventFrameNavigation}, recv)
 
 	// emit the navigation event

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -151,7 +151,7 @@ func createWaitForEventHandler(
 	chan interface{}, context.CancelFunc,
 ) {
 	evCancelCtx, evCancelFn := context.WithCancel(ctx)
-	chEvHandler := make(chan Event)
+	chEvHandler := make(chan Event, EventListenerDefaultChanBufferSize)
 	ch := make(chan interface{})
 
 	go func() {
@@ -193,7 +193,7 @@ func createWaitForEventPredicateHandler(
 	chan interface{}, context.CancelFunc,
 ) {
 	evCancelCtx, evCancelFn := context.WithCancel(ctx)
-	chEvHandler := make(chan Event)
+	chEvHandler := make(chan Event, EventListenerDefaultChanBufferSize)
 	ch := make(chan interface{})
 
 	go func() {

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -317,8 +317,8 @@ func (m *NetworkManager) handleRequestRedirect(req *Request, redirectResponse *n
 		delete(m.attemptedAuth, req.interceptionID);
 	*/
 
-	m.emit(cdproto.EventNetworkResponseReceived, resp)
-	m.emit(cdproto.EventNetworkLoadingFinished, req)
+	m.emit(m.logger, cdproto.EventNetworkResponseReceived, resp)
+	m.emit(m.logger, cdproto.EventNetworkLoadingFinished, req)
 }
 
 func (m *NetworkManager) initDomains() error {
@@ -340,7 +340,7 @@ func (m *NetworkManager) initDomains() error {
 }
 
 func (m *NetworkManager) initEvents() {
-	chHandler := make(chan Event)
+	chHandler := make(chan Event, EventListenerDefaultChanBufferSize)
 	m.session.on(m.ctx, []string{
 		cdproto.EventNetworkLoadingFailed,
 		cdproto.EventNetworkLoadingFinished,

--- a/common/page.go
+++ b/common/page.go
@@ -159,7 +159,7 @@ func (p *Page) closeWorker(sessionID target.SessionID) {
 	p.logger.Debugf("Page:closeWorker", "sid:%v", sessionID)
 
 	if worker, ok := p.workers[sessionID]; ok {
-		worker.didClose()
+		worker.didClose(p.logger)
 		delete(p.workers, sessionID)
 	}
 }
@@ -177,14 +177,14 @@ func (p *Page) didClose() {
 	}
 	p.closedMu.Unlock()
 
-	p.emit(EventPageClose, p)
+	p.emit(p.logger, EventPageClose, p)
 }
 
 func (p *Page) didCrash() {
 	p.logger.Debugf("Page:didCrash", "sid:%v", p.sessionID())
 
 	p.frameManager.dispose()
-	p.emit(EventPageCrash, p)
+	p.emit(p.logger, EventPageCrash, p)
 }
 
 func (p *Page) evaluateOnNewDocument(source string) {

--- a/common/worker.go
+++ b/common/worker.go
@@ -25,9 +25,10 @@ import (
 	"fmt"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/log"
 
 	"github.com/chromedp/cdproto/cdp"
-	"github.com/chromedp/cdproto/log"
+	clog "github.com/chromedp/cdproto/log"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
@@ -64,13 +65,13 @@ func NewWorker(ctx context.Context, s session, id target.ID, url string) (*Worke
 	return &w, nil
 }
 
-func (w *Worker) didClose() {
-	w.emit(EventWorkerClose, w)
+func (w *Worker) didClose(logger *log.Logger) {
+	w.emit(logger, EventWorkerClose, w)
 }
 
 func (w *Worker) initEvents() error {
 	actions := []Action{
-		log.Enable(),
+		clog.Enable(),
 		network.Enable(),
 		runtime.RunIfWaitingForDebugger(),
 	}


### PR DESCRIPTION
Closes: https://github.com/grafana/xk6-browser/issues/482

The order of the CDP messages can quite easily be lost after being received and handed to the handlers that are listening in on the events. To alleviate this ordering issue, remove the `goroutine` that is used to place the event on the listening handlers, and instead use a `buffered channel`. The `buffered channel` avoids a deadlock where by an event handler could be busy emitting another event, while the emit method is busy trying to pass an event to the same handler.

[Diagram](https://drive.google.com/file/d/1l8GFLqTe3KiyHQGtOYgVhIKyV1izOEAg/view?usp=sharing).
![CDP event loop break ordering drawio](https://user-images.githubusercontent.com/1112428/191000727-53f336ae-5b71-4697-af27-a4bc1ce7d11a.png)

This has been tested in the cloud and after several tests, xk6-browser has not deadlocked 🎉 

I have another solution but I prefer this solution as it's closer to the root cause of the issue -- https://github.com/grafana/xk6-browser/pull/512 (which is still WIP).
