### PR TITLE
add example on how to use xk6-browser with k6

### DIFF
--- a/examples/multiple-scenario.js
+++ b/examples/multiple-scenario.js
@@ -1,0 +1,49 @@
+import { chromium } from 'k6/x/browser'
+
+export const options = {
+  scenarios: {
+    messages: {
+      executor: 'constant-vus',
+      exec: 'messages',
+      vus: 2,
+      duration: '2s',
+    },
+    news: {
+      executor: 'per-vu-iterations',
+      exec: 'news',
+      vus: 2,
+      iterations: 4,
+      maxDuration: '5s',
+    },
+  },
+  thresholds: {
+    browser_dom_content_loaded: ['p(90) < 1000'],
+    browser_first_contentful_paint: ['max < 1000']
+  }
+}
+
+export function messages() {
+  const browser = chromium.launch({
+    headless: __ENV.XK6_HEADLESS ? true : false,
+  });
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' })
+
+  page.close();
+  browser.close();
+}
+
+export function news() {
+  const browser = chromium.launch({
+    headless: __ENV.XK6_HEADLESS ? true : false,
+  });
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  page.goto('https://test.k6.io/news.php', { waitUntil: 'networkidle' })
+
+  page.close();
+  browser.close();
+}

--- a/examples/multiple-scenario.js
+++ b/examples/multiple-scenario.js
@@ -26,8 +26,7 @@ export function messages() {
   const browser = chromium.launch({
     headless: __ENV.XK6_HEADLESS ? true : false,
   });
-  const context = browser.newContext();
-  const page = context.newPage();
+  const page = browser.newPage();
 
   page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' })
 
@@ -39,8 +38,7 @@ export function news() {
   const browser = chromium.launch({
     headless: __ENV.XK6_HEADLESS ? true : false,
   });
-  const context = browser.newContext();
-  const page = context.newPage();
+  const page = browser.newPage();
 
   page.goto('https://test.k6.io/news.php', { waitUntil: 'networkidle' })
 


### PR DESCRIPTION
This PR adds a new test to demo how xk6-browser can be used together with k6. This includes:

- creating multiple scenarios where each scenario executes a different function
- different executor used for each scenario
- use of thresholds