### PR TITLE
Fix data race in frame url while logging

### DIFF
--- a/common/page.go
+++ b/common/page.go
@@ -643,7 +643,7 @@ func (p *Page) MainFrame() api.Frame {
 	} else {
 		p.logger.Debugf("Page:MainFrame",
 			"sid:%v mfid:%v mflid:%v mfurl:%v",
-			p.sessionID(), mf.id, mf.loaderID, mf.url)
+			p.sessionID(), mf.id, mf.loaderID, mf.URL())
 	}
 
 	return mf


### PR DESCRIPTION
`Page` now reads the frame url using the mutex protected method `URL()` instead of accessing the url field directly.

This was preventing us to test the locator tests in parallel. This might also help testing other tests in parallel.

Fixes: #530