### PR TITLE
Fix parallel locator tests

### DIFF
--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -179,6 +179,7 @@ func TestLocator(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -254,6 +255,7 @@ func TestLocator(t *testing.T) {
 		},
 	}
 	for _, tt := range sanityTests {
+		tt := tt
 		t.Run("timeout/"+tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -309,6 +311,7 @@ func TestLocatorElementState(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.state, func(t *testing.T) {
 			t.Parallel()
 
@@ -351,6 +354,7 @@ func TestLocatorElementState(t *testing.T) {
 		},
 	}
 	for _, tt := range sanityTests {
+		tt := tt
 		t.Run("timeout/"+tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -56,7 +56,7 @@ func TestLocator(t *testing.T) {
 		},
 		{
 			"DblClick", func(tb *testBrowser, p api.Page) {
-				p.Locator("#link", nil).Dblclick(nil)
+				p.Locator("#linkdbl", nil).Dblclick(nil)
 				v := p.Evaluate(tb.toGojaValue(`() => window.dblclick`))
 				require.True(t, tb.asGojaBool(v), "cannot not double click the link")
 			},

--- a/tests/static/locators.html
+++ b/tests/static/locators.html
@@ -7,6 +7,7 @@
 
 <body>
     <a id="link" href="#" onclick="event.preventDefault()">Click</a>
+    <a id="linkdbl" href="#" ondblclick="event.preventDefault()">Dblclick</a>
     <a href="#" onclick="event.preventDefault()">Click</a>
     <input id="inputCheckbox" type="checkbox" />
     <input type="checkbox" />
@@ -24,7 +25,7 @@
         document.querySelector('#link').addEventListener(
             'click', e => { window.result = true; }, false
         );
-        document.querySelector('#link').addEventListener(
+        document.querySelector('#linkdbl').addEventListener(
             'dblclick', e => { window.dblclick = true; }, false
         );
         document.querySelector('#inputCheckbox').addEventListener(


### PR DESCRIPTION
The `dblclick` test was wrong. It was listening for the `click` event instead of the `dblclick` event.

And the other tests were wrong too. We missed preventing capturing the loop variables in parallel tests in #389. So we weren't testing the existing locator features so far. The `dblclick` test started to fail when I fix the locator tests (so I fixed it afterward).

Somewhat related: #469