### PR TITLE
Improve handling of browser process exit and WS connection closing

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -214,10 +214,10 @@ func (b *BrowserType) allocate(
 	flags map[string]interface{}, env []string, dataDir *storage.Dir,
 	logger *log.Logger,
 ) (_ *common.BrowserProcess, rerr error) {
-	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	bProcCtx, bProcCtxCancel := context.WithTimeout(ctx, opts.Timeout)
 	defer func() {
 		if rerr != nil {
-			cancel()
+			bProcCtxCancel()
 		}
 	}()
 
@@ -231,7 +231,7 @@ func (b *BrowserType) allocate(
 		path = b.ExecutablePath()
 	}
 
-	return common.NewBrowserProcess(ctx, path, args, env, dataDir, cancel, logger) //nolint: wrapcheck
+	return common.NewBrowserProcess(bProcCtx, path, args, env, dataDir, bProcCtxCancel, logger) //nolint: wrapcheck
 }
 
 // parseArgs parses command-line arguments and returns them.

--- a/common/browser.go
+++ b/common/browser.go
@@ -441,6 +441,7 @@ func (b *Browser) Close() {
 		}
 	}
 
+	b.conn.Close()
 	// Wait for all outstanding events (e.g. Target.detachedFromTarget) to be
 	// processed, and for the process to exit gracefully. Otherwise kill it
 	// forcefully after the timeout.

--- a/common/browser.go
+++ b/common/browser.go
@@ -441,14 +441,11 @@ func (b *Browser) Close() {
 		}
 	}
 
-	// Close all sessions and try to cleanly close the WS connection, but
-	// we'll disregard any errors in the case the connection has already
-	// been closed by the browser.
-	b.conn.Close()
-
 	// Wait for all outstanding events (e.g. Target.detachedFromTarget) to be
 	// processed, and for the process to exit gracefully. Otherwise kill it
 	// forcefully after the timeout.
+	// We don't bother closing the WS connection, since it will be closed by
+	// the browser.
 	timeout := time.Second
 	select {
 	case <-b.browserProc.processDone:

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -174,23 +174,15 @@ func execute(
 		// TODO: How to handle these errors?
 		defer func() {
 			if err := dataDir.Cleanup(); err != nil {
-				logger.Errorf("BrowserType:Close", "cleaning up the user data directory: %v", err)
+				logger.Errorf("browser", "cleaning up the user data directory: %v", err)
 			}
 			close(done)
 		}()
 
 		if err := cmd.Wait(); err != nil {
-			logErr := logger.Errorf
-			if s := err.Error(); strings.Contains(s, "signal: killed") || strings.Contains(s, "exit status 1") {
-				// The browser process is killed when the context is cancelled
-				// after a k6 iteration ends, so silence the log message until
-				// we can stop it gracefully. See #https://github.com/grafana/xk6-browser/issues/423
-				logErr = logger.Debugf
-			}
-			logErr(
-				"browser", "process with PID %d unexpectedly ended: %v",
-				cmd.Process.Pid, err,
-			)
+			logger.Errorf("browser",
+				"process with PID %d unexpectedly ended: %v",
+				cmd.Process.Pid, err)
 		}
 	}()
 

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -43,6 +43,7 @@ type BrowserProcess struct {
 	// Channels for managing termination.
 	lostConnection             chan struct{}
 	processIsGracefullyClosing chan struct{}
+	processDone                chan struct{}
 
 	// Browser's WebSocket URL to speak CDP
 	wsURL string
@@ -55,9 +56,9 @@ type BrowserProcess struct {
 
 func NewBrowserProcess(
 	ctx context.Context, path string, args, env []string, dataDir *storage.Dir,
-	cancel context.CancelFunc, logger *log.Logger,
+	ctxCancel context.CancelFunc, logger *log.Logger,
 ) (*BrowserProcess, error) {
-	cmd, stdout, err := execute(ctx, path, args, env, dataDir, logger)
+	cmd, stdout, procDone, err := execute(ctx, path, args, env, dataDir, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -69,10 +70,11 @@ func NewBrowserProcess(
 
 	p := BrowserProcess{
 		ctx:                        ctx,
-		cancel:                     cancel,
+		cancel:                     ctxCancel,
 		process:                    cmd.Process,
 		lostConnection:             make(chan struct{}),
 		processIsGracefullyClosing: make(chan struct{}),
+		processDone:                procDone,
 		wsURL:                      wsURL,
 		userDataDir:                dataDir,
 	}
@@ -139,13 +141,13 @@ func (p *BrowserProcess) AttachLogger(logger *log.Logger) {
 func execute(
 	ctx context.Context, path string, args, env []string, dataDir *storage.Dir,
 	logger *log.Logger,
-) (*exec.Cmd, io.Reader, error) {
+) (*exec.Cmd, io.Reader, chan struct{}, error) {
 	cmd := exec.CommandContext(ctx, path, args...)
 	killAfterParent(cmd)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, nil, fmt.Errorf("%w", err)
+		return nil, nil, nil, fmt.Errorf("%w", err)
 	}
 	cmd.Stderr = cmd.Stdout
 
@@ -158,21 +160,23 @@ func execute(
 	// can run into a data race.
 	err = cmd.Start()
 	if os.IsNotExist(err) {
-		return nil, nil, fmt.Errorf("file does not exist: %s", path)
+		return nil, nil, nil, fmt.Errorf("file does not exist: %s", path)
 	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("%w", err)
+		return nil, nil, nil, fmt.Errorf("%w", err)
 	}
 	if ctx.Err() != nil {
-		return nil, nil, fmt.Errorf("%w", ctx.Err())
+		return nil, nil, nil, fmt.Errorf("%w", ctx.Err())
 	}
 
+	done := make(chan struct{})
 	go func() {
 		// TODO: How to handle these errors?
 		defer func() {
 			if err := dataDir.Cleanup(); err != nil {
 				logger.Errorf("BrowserType:Close", "cleaning up the user data directory: %v", err)
 			}
+			close(done)
 		}()
 
 		if err := cmd.Wait(); err != nil {
@@ -190,7 +194,7 @@ func execute(
 		}
 	}()
 
-	return cmd, stdout, nil
+	return cmd, stdout, done, nil
 }
 
 // parseDevToolsURL grabs the websocket address from chrome's output and returns it.

--- a/common/connection.go
+++ b/common/connection.go
@@ -251,8 +251,6 @@ func (c *Connection) createSession(info *target.Info) (*Session, error) {
 }
 
 func (c *Connection) handleIOError(err error) {
-	// It's either a normal closure initiated by the browser, or we stopped the
-	// connection. In either case, disregard the error.
 	if closing := c.isClosing(); websocket.IsCloseError(
 		err, websocket.CloseNormalClosure, websocket.CloseGoingAway,
 	) || closing {


### PR DESCRIPTION
This was initially an effort for #510, but since that became difficult to reproduce even in EC2, it pivoted to fixing #232 and some related issues.

See the commits for details, but in summary, this:
- Ensures we wait for the browser process to exit before ending the iteration.
  Previously, we would cancel the browser context prematurely, which caused `process with PID 282373 unexpectedly ended: signal: killed` errors.
  Now, we wait for the browser process to exit on its own, since the CDP `Browser.close` command does that implicitly, and only forcefully kill it if it exceeds a specific timeout (1s).
- Fixes, or rather _hides_, the `close 1006 (abnormal closure): unexpected EOF` error from #232.
  See, Chrom{e,ium} doesn't close the WS connection cleanly (they don't send a [Close control frame](https://www.rfc-editor.org/rfc/rfc6455#section-1.4)) after we send `Browser.close`, or even the TCP socket for that matter; they just end the process. :facepalm: So in the case this happens as a result of us sending `Browser.close`, we just disregard the error, though still log it as Debug for troubleshooting purposes.