### PR TITLE
Fix waitForExecutionContext with NewTicker

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -537,7 +537,7 @@ func (f *Frame) waitForExecutionContext(world executionWorld) {
 	f.log.Debugf("Frame:waitForExecutionContext", "fid:%s furl:%q world:%s",
 		f.ID(), f.URL(), world)
 
-	t := time.NewTimer(50 * time.Millisecond)
+	t := time.NewTicker(50 * time.Millisecond)
 	defer t.Stop()
 	for {
 		select {


### PR DESCRIPTION
In `waitForExecutionContext` it is using a for loop to wait for the context to be set. `NewTimer` only fires once, and if the context isn't set it will deadlock. Changed to working with `NewTicker` so that it can periodically check to see if the context has been set.