### PR TITLE
Take context Done into considerations in a bunch of places

### DIFF
--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -80,7 +80,11 @@ func NewBrowserProcess(
 	go func() {
 		// If we lose connection to the browser and we're not in-progress with clean
 		// browser-initiated termination then cancel the context to clean up.
-		<-p.lostConnection
+		select {
+		case <-p.lostConnection:
+		case <-ctx.Done():
+		}
+
 		select {
 		case <-p.processIsGracefullyClosing:
 		default:

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -22,8 +22,8 @@ func TestBrowserNewPageInContext(t *testing.T) {
 		bc *BrowserContext
 	}
 	newTestCase := func(id cdp.BrowserContextID) *testCase {
-		ctx := context.Background()
-		b := newBrowser(ctx, nil, nil, NewLaunchOptions(), log.NewNullLogger())
+		ctx, cancel := context.WithCancel(context.Background())
+		b := newBrowser(ctx, cancel, nil, NewLaunchOptions(), log.NewNullLogger())
 		// set a new browser context in the browser with `id`, so that newPageInContext can find it.
 		b.contexts[id] = NewBrowserContext(ctx, b, id, nil, nil)
 		return &testCase{

--- a/common/frame.go
+++ b/common/frame.go
@@ -2024,11 +2024,17 @@ func (f *Frame) newAction(
 		waitOpts.Strict = strict
 		handle, err := f.waitForSelector(selector, waitOpts)
 		if err != nil {
-			errCh <- err
+			select {
+			case <-apiCtx.Done():
+			case errCh <- err:
+			}
 			return
 		}
 		if handle == nil {
-			resultCh <- nil
+			select {
+			case <-apiCtx.Done():
+			case resultCh <- nil:
+			}
 			return
 		}
 		f := handle.newAction(states, fn, false, false, timeout)
@@ -2051,11 +2057,17 @@ func (f *Frame) newPointerAction(
 		waitOpts.Strict = strict
 		handle, err := f.waitForSelector(selector, waitOpts)
 		if err != nil {
-			errCh <- err
+			select {
+			case <-apiCtx.Done():
+			case errCh <- err:
+			}
 			return
 		}
 		if handle == nil {
-			resultCh <- nil
+			select {
+			case <-apiCtx.Done():
+			case resultCh <- nil:
+			}
 			return
 		}
 		f := handle.newPointerAction(fn, opts)


### PR DESCRIPTION
This was leaving hanging goroutines all over the place. 

Not certain whether any of those are relevant for real running, but in tests it was both making stack traces harder to read (as you have a bunch of blocked goroutines), but it also likely was taking some CPU/MEM away from tests. The later likely isn't all that much, but still better to not have goroutines that hang around forever ;)