### PR TITLE
Fix #533 wrong metric sample pushed to cloud

### DIFF
--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -181,7 +181,7 @@ func (m *NetworkManager) emitRequestMetrics(req *Request) {
 			{
 				TimeSeries: k6metrics.TimeSeries{Metric: state.BuiltinMetrics.DataSent, Tags: tags},
 				Value:      float64(req.Size().Total()),
-				Time:       req.timestamp,
+				Time:       req.wallTime,
 			},
 		},
 	})

--- a/common/response.go
+++ b/common/response.go
@@ -76,7 +76,7 @@ type Response struct {
 	fromServiceWorker bool
 	fromPrefetchCache bool
 	timestamp         time.Time
-	responseTime      time.Time
+	wallTime          time.Time
 	timing            *network.ResourceTiming
 	vu                k6modules.VU
 
@@ -105,7 +105,7 @@ func NewHTTPResponse(ctx context.Context, req *Request, resp *network.Response, 
 		fromServiceWorker: resp.FromServiceWorker,
 		fromPrefetchCache: resp.FromPrefetchCache,
 		timestamp:         timestamp.Time(),
-		responseTime:      time.Time{},
+		wallTime:          timestamp.Time().Add(req.offset),
 		timing:            resp.Timing,
 		vu:                vu,
 	}
@@ -119,10 +119,6 @@ func NewHTTPResponse(ctx context.Context, req *Request, resp *network.Response, 
 				r.headers[n] = append(r.headers[n], v)
 			}
 		}
-	}
-
-	if resp.ResponseTime != nil {
-		r.responseTime = resp.ResponseTime.Time()
 	}
 
 	if resp.SecurityDetails != nil {


### PR DESCRIPTION

Please take a look at Issue #533 to see my findings and why I wanted to use walltime here.

## Notes:
* **Test runs on staging**: Before the fix -> `141373`, After the fix -> `141372`.
* I can move `AssertSamples` and expose VU samples in separate PRs, please let me know.
* I put the request/response timing skew issue in a single test. Again, please let me know if you want me to separate them.

---

- [ ] What to do about `Frame.emitMetric`?
- [x] Retry in the cloud.
- [x] Research.
- [x] Diagnose the issue.
- [x] Locally produce the issue with a test (request metrics side).
- [x] Fix the issue (request metrics side).
- [x] Locally produce the issue with a test (response metrics side).
- [x] Fix the issue (response metrics side).
- [x] Send initial refactoring PRs for review first.
  - [x] `requestParams`
- [x] Fix the conflicts.
- [x] Refactor.
- [x] Properly arrange commits.

Closes #533.