### PR TITLE
Add a queue per handler to keep events in order

### DIFF
--- a/common/event_emitter.go
+++ b/common/event_emitter.go
@@ -181,13 +181,14 @@ func (e *BaseEventEmitter) emit(event string, data interface{}) {
 		eh.queue.readMutex.Lock()
 		defer eh.queue.readMutex.Unlock()
 
-		// We try to read from the current queue (curQueue)
-		// If there isn't anything on curQueue then there must
+		// We try to read from the read queue (queue.read).
+		// If there isn't anything on the read queue, then there must
 		// be something being populated by the synched emitTo
-		// func below. Swap around curQueue with queue. Queue
-		// is now being populated again by emitTo, and all
+		// func below.
+		// Swap around the read queue with the write queue.
+		// Queue is now being populated again by emitTo, and all
 		// emitEvent goroutines can continue to consume from
-		// curQueue until that is again depleted.
+		// the read queue until that is again depleted.
 		if len(eh.queue.read) == 0 {
 			eh.queue.writeMutex.Lock()
 			eh.queue.read, eh.queue.write = eh.queue.write, eh.queue.read

--- a/common/event_emitter.go
+++ b/common/event_emitter.go
@@ -100,9 +100,9 @@ type NavigationEvent struct {
 type eventHandler struct {
 	ctx           context.Context
 	ch            chan Event
-	queueMutex    *sync.Mutex
+	queueMutex    sync.Mutex
 	queue         []Event
-	curQueueMutex *sync.Mutex
+	curQueueMutex sync.Mutex
 	curQueue      []Event
 }
 
@@ -222,19 +222,7 @@ func (e *BaseEventEmitter) emit(event string, data interface{}) {
 func (e *BaseEventEmitter) on(ctx context.Context, events []string, ch chan Event) {
 	e.sync(func() {
 		for _, event := range events {
-			_, ok := e.handlers[event]
-			if !ok {
-				e.handlers[event] = make([]*eventHandler, 0)
-			}
-			eh := eventHandler{
-				ctx,
-				ch,
-				&sync.Mutex{},
-				make([]Event, 0),
-				&sync.Mutex{},
-				make([]Event, 0),
-			}
-			e.handlers[event] = append(e.handlers[event], &eh)
+			e.handlers[event] = append(e.handlers[event], &eventHandler{ctx: ctx, ch: ch})
 		}
 	})
 }
@@ -242,14 +230,6 @@ func (e *BaseEventEmitter) on(ctx context.Context, events []string, ch chan Even
 // OnAll registers a handler for all events.
 func (e *BaseEventEmitter) onAll(ctx context.Context, ch chan Event) {
 	e.sync(func() {
-		e.handlersAll = append(e.handlersAll,
-			&eventHandler{
-				ctx,
-				ch,
-				&sync.Mutex{},
-				make([]Event, 0),
-				&sync.Mutex{},
-				make([]Event, 0),
-			})
+		e.handlersAll = append(e.handlersAll, &eventHandler{ctx: ctx, ch: ch})
 	})
 }

--- a/common/event_emitter_test.go
+++ b/common/event_emitter_test.go
@@ -175,7 +175,6 @@ func TestBaseEventEmitter(t *testing.T) {
 
 		emitWorker := func() {
 			for i := 0; i < maxInt; i++ {
-				i := i
 				emitter.emit(eventName, i)
 			}
 		}
@@ -236,7 +235,6 @@ func TestBaseEventEmitter(t *testing.T) {
 
 		emitWorker := func() {
 			for i := 0; i < maxInt; i += 4 {
-				i := i
 				emitter.emit(eventName1, i)
 				emitter.emit(eventName2, i+1)
 				emitter.emit(eventName3, i+2)
@@ -301,7 +299,6 @@ func TestBaseEventEmitter(t *testing.T) {
 
 		emitWorker := func() {
 			for i := 0; i < maxInt; i++ {
-				i := i
 				emitter.emit(eventName1, i)
 			}
 		}

--- a/common/event_emitter_test.go
+++ b/common/event_emitter_test.go
@@ -208,7 +208,10 @@ func TestBaseEventEmitter(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		emitter := NewBaseEventEmitter(ctx)
 		ch := make(chan Event)
-		emitter.on(ctx, []string{eventName1, eventName2, eventName3, eventName4}, ch)
+		// Calling on twice to ensure that the same queue is used
+		// internally for the same channel and handler.
+		emitter.on(ctx, []string{eventName1, eventName2}, ch)
+		emitter.on(ctx, []string{eventName3, eventName4}, ch)
 
 		var expectedI int
 		handler := func() {


### PR DESCRIPTION
Events are sometimes out of order due to use using a goroutine to publish events to the handler concurrently as there's no guarantee when the goroutines will run (the first goroutine to be created isn't necessarily going to be the first to run). To overcome this, a `queue` has been added per handler to synchronise all publishes of events to that handler as well as a `mutex` so that only one `emitEvent` goroutine can read from the `queue` **and** write to the handler's channel at any one time.

We tried working with a buffered channel instead of a `queue` (which is a slice). Unfortunately it's difficult to determine how large the channel needs to be to work with the test -- the more complex the test, the more events that will be emitted. For now we think it is easier to work with a `queue` that can grow when needed.

After creating the unit tests, we found that although we were receiving events in order we had created a deadlock when a handler was receiving events **and** emitting new events. To overcome this we had to create a "double `queue`" system whereby new emitted events can be stored on one `queue`, while the `emitEvent` goroutines can read off of a separate `queue`. When the read `queue` is depleted, the queues are swapped around.

Closes: https://github.com/grafana/xk6-browser/issues/553