### PR TITLE
Docker example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.19-bullseye as builder
+
+RUN go install -trimpath go.k6.io/xk6/cmd/xk6@latest
+
+RUN  xk6 build --output "/tmp/k6" --with github.com/grafana/xk6-browser
+
+FROM debian:bullseye
+
+ARG CHROMIUM_VERSION=106.0.5249.61-1~deb11u1
+
+RUN apt-get update
+RUN apt-get install -y chromium=${CHROMIUM_VERSION}
+
+COPY --from=builder /tmp/k6 /usr/bin/k6
+
+ENV XK6_HEADLESS=true
+
+ENTRYPOINT ["k6"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ FROM debian:bullseye
 
 ARG CHROMIUM_VERSION=106.0.5249.61-1~deb11u1
 
-RUN apt-get update
-RUN apt-get install -y chromium=${CHROMIUM_VERSION}
+RUN apt-get update && \
+    apt-get install -y chromium=${CHROMIUM_VERSION}
 
 COPY --from=builder /tmp/k6 /usr/bin/k6
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,14 @@ export default function () {
 }
 ```
 
+### Running examples in a docker container
+
+To run examples from this directory inside a Docker container you can use `docker-compose`.
+
+```bash
+docker-compose run -T xk6-browser run - <examples/browser_on.js
+```
+
 ## Status
 
 Currently only Chromium is supported, and the [Playwright API](https://playwright.dev/docs/api/class-playwright) coverage is as follows:

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ export default function () {
 
 ### Running examples in a Docker container
 
-The examples above are also available as standalone files in the [`examples` directory][/examples]. You can run them in a Docker container using Docker Compose with:
+The examples above are also available as standalone files in the [`examples` directory](/examples). You can run them in a Docker container using Docker Compose with:
 
 ```bash
 docker-compose run -T xk6-browser run - <examples/browser_on.js

--- a/README.md
+++ b/README.md
@@ -391,9 +391,9 @@ export default function () {
 }
 ```
 
-### Running examples in a docker container
+### Running examples in a Docker container
 
-To run examples from this directory inside a Docker container you can use `docker-compose`.
+The examples above are also available as standalone files in the [`examples` directory][/examples]. You can run them in a Docker container using Docker Compose with:
 
 ```bash
 docker-compose run -T xk6-browser run - <examples/browser_on.js

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,5 @@
+version: '3.4'
+
+services:
+  xk6-browser:
+    build: .


### PR DESCRIPTION
# What?

Add the Docerfile, docker-compose to provide the possibility of running examples inside the docker.

# Why?

Docker is the easiest way to improve the developer's UX.