### PR TITLE
Refactor to NewRequestParams

### DIFF
--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -460,7 +460,13 @@ func (m *NetworkManager) onRequest(event *network.EventRequestWillBeSent, interc
 			event.Request.URL, event.Request.Method, event.Initiator.Type, event.FrameID)
 	}
 
-	req, err := NewRequest(m.ctx, event, frame, redirectChain, interceptionID, m.userReqInterceptionEnabled)
+	req, err := NewRequest(m.ctx, NewRequestParams{
+		event:             event,
+		frame:             frame,
+		redirectChain:     redirectChain,
+		interceptionID:    interceptionID,
+		allowInterception: m.userReqInterceptionEnabled,
+	})
 	if err != nil {
 		m.logger.Errorf("NetworkManager", "creating request: %s", err)
 		return

--- a/common/request_test.go
+++ b/common/request_test.go
@@ -50,7 +50,10 @@ func TestRequest(t *testing.T) {
 		WallTime:  &wt,
 	}
 	vu := k6test.NewVU(t)
-	req, err := NewRequest(vu.Context(), evt, nil, nil, "intercept", false)
+	req, err := NewRequest(vu.Context(), NewRequestParams{
+		event:          evt,
+		interceptionID: "intercept",
+	})
 	require.NoError(t, err)
 
 	t.Run("error_parse_url", func(t *testing.T) {
@@ -67,7 +70,10 @@ func TestRequest(t *testing.T) {
 			WallTime:  &wt,
 		}
 		vu := k6test.NewVU(t)
-		req, err := NewRequest(vu.Context(), evt, nil, nil, "intercept", false)
+		req, err := NewRequest(vu.Context(), NewRequestParams{
+			event:          evt,
+			interceptionID: "intercept",
+		})
 		require.EqualError(t, err, `parsing URL ":": missing protocol scheme`)
 		require.Nil(t, req)
 	})


### PR DESCRIPTION
Using a relatively long list of primitive types makes it hard to initialize `Request` and can bring uninvited bugs. I noticed this when testing `Request`/`Response` metric emissions for Issue #533. I needed to pass `nil` and false values for unwanted fields:

```go
req, err := NewRequest(vu.Context(), evt, nil, nil, "intercept", false)
```

Now:

```go
req, err := NewRequest(vu.Context(), NewRequestParams{
	event:          evt,
	interceptionID: "intercept",
})
```

I'm using this approach in #551 and will keep doing so if this PR is accepted.