### PR TITLE
Remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
   disable-all: true
   enable:
     - cyclop
-    - deadcode
     - dogsled
     - dupl
     - durationcheck
@@ -61,7 +60,6 @@ linters:
     - gosec
     - gosimple
     - govet
-    - ifshort
     - importas
     - ineffassign
     - lll
@@ -77,7 +75,6 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - structcheck
     - tagliatelle
     - thelper
     - tparallel
@@ -85,7 +82,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - wastedassign
     - whitespace
     - wrapcheck


### PR DESCRIPTION
This PR removes four deprecated linkers (they are now replaced with the `unused` linter except ifshort). It will remove warnings from the CI jobs (see for [an example](https://github.com/grafana/xk6-browser/actions/runs/3196929405/jobs/5220053048)):

```bash
The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
The linter 'ifshort' is deprecated (since v1.48.0) due to: The repository of the linter has been deprecated by the owner. "
The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
```

You can see [the golangci-lint issue](https://github.com/golangci/golangci-lint/issues/1841) for more information.