### PR TITLE
Fix wait for networkIdle lifecycle event

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -458,12 +458,16 @@ func (f *Frame) onLoadingStarted() {
 func (f *Frame) onLoadingStopped() {
 	f.log.Debugf("Frame:onLoadingStopped", "fid:%s furl:%q", f.ID(), f.URL())
 
-	f.lifecycleEventsMu.Lock()
-	defer f.lifecycleEventsMu.Unlock()
-
-	f.lifecycleEvents[LifecycleEventDOMContentLoad] = true
-	f.lifecycleEvents[LifecycleEventLoad] = true
-	f.lifecycleEvents[LifecycleEventNetworkIdle] = true
+	// TODO: We should start a timer here and allow the user
+	//       to set how long to wait until after onLoadingStopped
+	//       has occurred. The reason we may want a timeout here
+	//       are for websites where they perform many network
+	//       requests so it may take a long time for us to see
+	//       a networkIdle event or we may never see one if the
+	//       website never stops performing network requests.
+	//       NOTE: This is a different timeout to networkIdleTimer,
+	//              which only works once there are no more network
+	//              requests and we don't see a networkIdle event.
 }
 
 func (f *Frame) position() *Position {

--- a/common/frame.go
+++ b/common/frame.go
@@ -152,11 +152,7 @@ func (f *Frame) clearLifecycle() {
 
 	// clear lifecycle events
 	f.lifecycleEventsMu.Lock()
-	{
-		for e := range f.lifecycleEvents {
-			f.lifecycleEvents[e] = false
-		}
-	}
+	f.lifecycleEvents = make(map[LifecycleEvent]bool)
 	f.lifecycleEventsMu.Unlock()
 
 	f.page.frameManager.MainFrame().recalculateLifecycle()

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -39,7 +39,7 @@ type FrameFillOptions struct {
 type FrameGotoOptions struct {
 	Referer   string         `json:"referer"`
 	Timeout   time.Duration  `json:"timeout"`
-	WaitUntil LifecycleEvent `json:"waitUntil"`
+	WaitUntil LifecycleEvent `json:"waitUntil" js:"waitUntil"`
 }
 
 type FrameHoverOptions struct {
@@ -95,7 +95,7 @@ type FrameSelectOptionOptions struct {
 
 type FrameSetContentOptions struct {
 	Timeout   time.Duration  `json:"timeout"`
-	WaitUntil LifecycleEvent `json:"waitUntil"`
+	WaitUntil LifecycleEvent `json:"waitUntil" js:"waitUntil"`
 }
 
 type FrameTapOptions struct {
@@ -130,7 +130,7 @@ type FrameWaitForLoadStateOptions struct {
 
 type FrameWaitForNavigationOptions struct {
 	URL       string         `json:"url"`
-	WaitUntil LifecycleEvent `json:"waitUntil"`
+	WaitUntil LifecycleEvent `json:"waitUntil" js:"waitUntil"`
 	Timeout   time.Duration  `json:"timeout"`
 }
 

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -475,8 +475,8 @@ func (fs *FrameSession) handleFrameTree(frameTree *cdppage.FrameTree) {
 
 func (fs *FrameSession) navigateFrame(frame *Frame, url, referrer string) (string, error) {
 	fs.logger.Debugf("FrameSession:navigateFrame",
-		"sid:%v tid:%v url:%q referrer:%q",
-		fs.session.ID(), fs.targetID, url, referrer)
+		"sid:%v fid:%s tid:%v url:%q referrer:%q",
+		fs.session.ID(), frame.ID(), fs.targetID, url, referrer)
 
 	action := cdppage.Navigate(url).WithReferrer(referrer).WithFrameID(cdp.FrameID(frame.ID()))
 	_, documentID, errorText, err := action.Do(cdp.WithExecutor(fs.ctx, fs.session))

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -705,6 +705,8 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 		fs.manager.frameLifecycleEvent(event.FrameID, LifecycleEventLoad)
 	case "DOMContentLoaded":
 		fs.manager.frameLifecycleEvent(event.FrameID, LifecycleEventDOMContentLoad)
+	case "networkIdle":
+		fs.manager.frameLifecycleEvent(event.FrameID, LifecycleEventNetworkIdle)
 	}
 
 	eventToMetric := map[string]*k6metrics.Metric{

--- a/common/page_options.go
+++ b/common/page_options.go
@@ -19,7 +19,7 @@ type PageEmulateMediaOptions struct {
 }
 
 type PageReloadOptions struct {
-	WaitUntil LifecycleEvent `json:"waitUntil"`
+	WaitUntil LifecycleEvent `json:"waitUntil" js:"waitUntil"`
 	Timeout   time.Duration  `json:"timeout"`
 }
 

--- a/tests/static/prolonged_network_idle.html
+++ b/tests/static/prolonged_network_idle.html
@@ -1,0 +1,30 @@
+<html>
+
+<head></head>
+
+<body>
+    <div id="prolongNetworkIdleLoad">Waiting...</div>
+    <div id="serverMsg">Waiting...</div>
+
+    <script>
+        var prolongNetworkIdleLoadOutput = document.getElementById("prolongNetworkIdleLoad");
+
+        var p = prolongNetworkIdleLoad();
+        p.then(() => {
+            prolongNetworkIdleLoadOutput.innerText += ' - for loop complete';
+        })
+
+        async function prolongNetworkIdleLoad() {
+            for (var i = 0; i < 4; i++) {
+                await fetch('/ping')
+                    .then(response => response.text())
+                    .then((data) => {
+                        prolongNetworkIdleLoadOutput.innerText = 'Waiting... ' + data;
+                    });
+            }
+        }
+    </script>
+    <script src="/ping.js" async></script>
+</body>
+
+</html>

--- a/tests/static/prolonged_network_idle_10.html
+++ b/tests/static/prolonged_network_idle_10.html
@@ -1,0 +1,28 @@
+<html>
+
+<head></head>
+
+<body>
+    <div id="prolongNetworkIdleLoad">Waiting...</div>
+
+    <script>
+        var prolongNetworkIdleLoadOutput = document.getElementById("prolongNetworkIdleLoad");
+
+        var p = prolongNetworkIdleLoad();
+        p.then(() => {
+            prolongNetworkIdleLoadOutput.innerText += ' - for loop complete';
+        })
+
+        async function prolongNetworkIdleLoad() {
+            for (var i = 0; i < 10; i++) {
+                await fetch('/ping')
+                    .then(response => response.text())
+                    .then((data) => {
+                        prolongNetworkIdleLoadOutput.innerText = 'Waiting... ' + data;
+                    });
+            }
+        }
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
Fixes: https://github.com/grafana/xk6-browser/issues/597

# Details

There are three `lifecycle` types that are emitted from the browser over CDP:
- `load`
- `DOMContentLoaded`
- `networkIdle`

We should be able to to wait on any of these and proceed with the test once we receive them and action on them at an appropriate time. Currently (4485c6d0caf9276b3a772e708a23f526a23f665c) the wait for `networkIdle` waits indefinitely on some websites e.g. google.com.

IMO, we should be able to rely on the browser to send us the CDP lifecycle events, which in my tests it does do. What we seem to have (and I can only guess the reasoning behind it) are three redundancies in place incase we don't receive these events from the browser at all or within a set timeout (the timeout scenario is only for `networkIdle`) or not in the order we expect (if a webpage has a hierarchy of frames, then currently we wait for the child frames to receive and action on the lifecycle events before the main one).

The first redundancy we have is the [timeout](https://github.com/grafana/xk6-browser/blob/506bfa03c672522c6872c264a1abef40ddf08e3d/common/frame.go#L270) for `networkIdle`. This timer should fire when:
1. 500ms have passed;
2. There are 0 inflight requests (actually this condition is needed for the timer to start)
3. We've not already received the `networkIdle` lifecycle event.

Unfortunately what happens in this issue is that another event is received ([EventFrameStoppedLoading](https://github.com/grafana/xk6-browser/blob/45d91cf1f26b93370c1fc0229a260efcdfc97f7f/common/frame_session.go#L262)) which [sets](https://github.com/grafana/xk6-browser/blob/506bfa03c672522c6872c264a1abef40ddf08e3d/common/frame.go#L462) `networkIdle` in the frame's `lifecycleEvents`, and when all requests finally complete (which is after we receive `EventFrameStoppedLoading`) the time cannot be started. Therefore there is nothing in place to recalculate the frame's lifecycle, and unblock waiting actions. I also think 500ms is not long enough for a timeout and I've seen situations where the timeout has fired, but then we receive the `networkIdle` lifecycle CDP event a very short while later.

The second redundancy in place is listening to `EventFrameStoppedLoading` and setting all the lifecycle types to the frame's `lifecycleEvents`, and when a subsequent new lifecycle event is received from the browser it should [recalculateLifecycle](https://github.com/grafana/xk6-browser/blob/506bfa03c672522c6872c264a1abef40ddf08e3d/common/frame.go#L189) which would unblock any waits. The problem with this currently is that this event can be received but we then don't receive and action on any other lifecycle events after -- we actually do receive `networkIdle` after but we're not calling `recalculateLifecycle` for an unknown reason. 

The fix for unblocking when waiting on `networkIdle` is:
- Call `recalculateLifecycle` once we see `networkIdle` lifecycle events.
- Increase the timeout to 1sec so that we're not timing out too early.

After this fix, I found another issue -- if we navigate to google.com, we correctly receive `networkIdle` and `recalculateLifecycle`. If we now navigate again to google.com, we unblock the wait as soon as we receive any lifecycle event. We should be waiting on the correct `networkIdle` event before unblocking waits. The issue is in [clearLifecycle](https://github.com/grafana/xk6-browser/blob/506bfa03c672522c6872c264a1abef40ddf08e3d/common/frame.go#L150). We're looping through `lifecycleEvents` and setting the entry values to `false`. This actually doesn't help later when `recalculateLifecycle` is called as it doesn't take into account the value of the `false` entry, and instead emits all the lifecycle events it has seen so far (which were from a previous navigation) and unblocks waits too early.

The fix is:
- Completely clear the frame's `lifecycleEvents` in `clearLifecycle`. This will ensure we unblock waits when a new lifecycle event is received for the new navigation.

There is now a third redundancy and a third question that needs answering -- if we navigate to youtube.com, it contains a hierarchy of frames, and so the "main" frame currently needs to wait for its child frames to receive the lifecycle events separately before it will itself action on lifecycle events and unblock waits. Again, i've not seen evidence where the child frames don't receive the events but the main frame does or vice-a-verse. So I think having this dependency on the main/child frames is unrequired, and we should add it back in once we have a real reason to do so.

# Unanswered questions

1. The browser may send multiple lifecycle events to the same frame with the same type (e.g. `DOMContentLoaded`) when navigating to a page (e.g. youtube.com). We're currently receiving and actioning on the first event, but ignore all the same subsequent  events -- should we be doing something with all the other events? I think we can only action on the first event as we can't predicate how the browser will behave and how many times the `DOMContentLoaded` will be fired.
2. By removing all three of the redundancies, it would make the lifecycle code a lot simpler, and we would just need to rely on the CDP events to dictate when to unblock waits. I have a feeling that this was added in due to out of order CDP events, which has now been resolved. If everyone agrees then I can go ahead and remove those redundancies and make things a lot simpler.

# Issue
Test script:

```js
import { chromium } from 'k6/x/browser';

export const options = {
  vus: 1,
  iterations: 1,
};

export default function () {
  const browser = chromium.launch({
    headless: false,
  });

  const context = browser.newContext();

  const page = context.newPage();

  page.goto('https://www.google.com', { waitUntil: 'networkidle' }).then(() => {
    console.log('done')
    return page.goto('https://www.google.com', { waitUntil: 'networkidle' }).then(() => {
      console.log('done')
    });
  }).finally(() => {
    browser.close();
  });
}
```

Version of xk6-browser where this test fails with the following error: 4485c6d0caf9276b3a772e708a23f526a23f665c

```
ERRO[0030] communicating with browser: websocket: close 1006 (abnormal closure): unexpected EOF  category=cdp elapsed="0 ms" goroutine=53
ERRO[0030] process with PID 41718 unexpectedly ended: signal: killed  category=browser elapsed="0 ms" goroutine=75
ERRO[0030] Uncaught (in promise) navigating to "https://www.google.com": timed out after 30s  executor=shared-iterations scenario=default
```

After the fix we don't see this timeout and xk6-browser correctly unblocks on wait when it receives the `networkIdle` lifecycle event.