### PR TITLE
Fix races around touching state.Group outside of the event loop

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -515,9 +515,11 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 		WithTime(event.Timestamp.Time()).
 		WithField("source", "browser-console-api")
 
-	if s := fs.vu.State(); s.Group.Path != "" {
-		l = l.WithField("group", s.Group.Path)
-	}
+		/* accessing the state Group while not on the eventloop is racy
+		if s := fs.vu.State(); s.Group.Path != "" {
+			l = l.WithField("group", s.Group.Path)
+		}
+		*/
 
 	var parsedObjects []interface{}
 	for _, robj := range event.Args {
@@ -688,9 +690,11 @@ func (fs *FrameSession) onLogEntryAdded(event *cdplog.EventEntryAdded) {
 		WithField("url", event.Entry.URL).
 		WithField("browser_source", event.Entry.Source.String()).
 		WithField("line_number", event.Entry.LineNumber)
-	if s := fs.vu.State(); s.Group.Path != "" {
-		l = l.WithField("group", s.Group.Path)
-	}
+		/* accessing the state Group while not on the eventloop is racy
+		if s := fs.vu.State(); s.Group.Path != "" {
+			l = l.WithField("group", s.Group.Path)
+		}
+		*/
 	switch event.Entry.Level {
 	case "info":
 		l.Info(event.Entry.Text)

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -166,9 +166,6 @@ func (m *NetworkManager) emitRequestMetrics(req *Request) {
 	state := m.vu.State()
 
 	tags := state.Tags.GetCurrentValues()
-	if state.Options.SystemTags.Has(k6metrics.TagGroup) {
-		tags = tags.With("group", state.Group.Path)
-	}
 	if state.Options.SystemTags.Has(k6metrics.TagMethod) {
 		tags = tags.With("method", req.method)
 	}
@@ -216,9 +213,6 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 	}
 
 	tags := state.Tags.GetCurrentValues()
-	if state.Options.SystemTags.Has(k6metrics.TagGroup) {
-		tags = tags.With("group", state.Group.Path)
-	}
 	if state.Options.SystemTags.Has(k6metrics.TagMethod) {
 		tags = tags.With("method", req.method)
 	}


### PR DESCRIPTION
There is no locking around the `state.Group` and it is modified by calls to `group()` while on the event loop. So for the time being to modify it - it is needed to be on the event loop.

Also the adding of the tag isn't needed as that is done automatically by `group()`