### PR TITLE
Add frame lifecycle event listener

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -705,6 +705,11 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 		fs.manager.frameLifecycleEvent(event.FrameID, LifecycleEventLoad)
 	case "DOMContentLoaded":
 		fs.manager.frameLifecycleEvent(event.FrameID, LifecycleEventDOMContentLoad)
+	case "networkIdle":
+		// TODO: maybe move this to the frame manager.
+		fs.manager.callForFrame(event.FrameID, func(f *Frame) {
+			f.emit(EventFrameAddLifecycle, LifecycleEventNetworkIdle)
+		})
 	}
 
 	eventToMetric := map[string]*k6metrics.Metric{


### PR DESCRIPTION
Totally experimental, probably a super dumb idea, and just for POC to concretely show what I mean [here](https://github.com/grafana/xk6-browser/pull/578#issuecomment-1282335614). I'm not expecting this to be merged.

We also need to handle shutting down the goroutine when a `Frame` is detached, etc.

We could probably do it without a goroutine, but I didn't explore that.