### PR TITLE
Revert "Use context cancellation for signaling that browser process is done"

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -429,7 +429,7 @@ func (b *Browser) Close() {
 	// forcefully after the timeout.
 	timeout := time.Second
 	select {
-	case <-b.browserProc.ctx.Done():
+	case <-b.browserProc.processDone:
 	case <-time.After(timeout):
 		b.logger.Debugf("Browser:Close", "killing browser process with PID %d after %s", b.browserProc.Pid(), timeout)
 		b.browserProc.Terminate()


### PR DESCRIPTION
This reverts commit e35e88c949757d56b707d88ad0f4e749f44352d8.

It seems the previous change might've been causing some flakiness issues. See https://github.com/grafana/xk6-browser/issues/566#issuecomment-1285672600 and https://github.com/grafana/xk6-browser/pull/598#issuecomment-1285750715 .

Using a context instead of a channel was cleaner, and while on the surface shouldn't have any functional differences, the context cancellation might be time sensitive, so a channel should be safer.