### PR TITLE
Add iteration ID field to log events

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -118,7 +118,7 @@ func (b *BrowserType) initContext() context.Context {
 	ctx := k6ext.WithVU(b.vu.Context(), b.vu)
 	ctx = k6ext.WithCustomMetrics(ctx, b.k6Metrics)
 	ctx = common.WithHooks(ctx, b.hooks)
-	ctx = common.WithTraceID(ctx, fmt.Sprintf("%x", b.randSrc.Uint64()))
+	ctx = common.WithIterationID(ctx, fmt.Sprintf("%x", b.randSrc.Uint64()))
 	return ctx
 }
 
@@ -375,7 +375,7 @@ func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*log.Log
 	var (
 		k6Logger            = k6ext.GetVU(ctx).State().Logger
 		reCategoryFilter, _ = regexp.Compile(launchOpts.LogCategoryFilter)
-		logger              = log.New(k6Logger, common.GetTraceID(ctx), launchOpts.Debug, reCategoryFilter)
+		logger              = log.New(k6Logger, common.GetIterationID(ctx), launchOpts.Debug, reCategoryFilter)
 	)
 
 	// set the log level from the launch options (usually from a script's options).

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -375,7 +375,7 @@ func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*log.Log
 	var (
 		k6Logger            = k6ext.GetVU(ctx).State().Logger
 		reCategoryFilter, _ = regexp.Compile(launchOpts.LogCategoryFilter)
-		logger              = log.New(k6Logger, launchOpts.Debug, reCategoryFilter)
+		logger              = log.New(k6Logger, common.GetTraceID(ctx), launchOpts.Debug, reCategoryFilter)
 	)
 
 	// set the log level from the launch options (usually from a script's options).

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/common"
@@ -39,6 +41,7 @@ type BrowserType struct {
 	k6Metrics *k6ext.CustomMetrics
 	execPath  string       // path to the Chromium executable
 	storage   *storage.Dir // stores temporary data for the extension and user
+	randSrc   *rand.Rand
 }
 
 // NewBrowserType registers our custom k6 metrics, creates method mappings on
@@ -57,6 +60,7 @@ func NewBrowserType(vu k6modules.VU) api.BrowserType {
 		hooks:     hooks,
 		k6Metrics: k6m,
 		storage:   &storage.Dir{},
+		randSrc:   rand.New(rand.NewSource(time.Now().UnixNano())), //nolint: gosec
 	}
 	rt.SetFieldNameMapper(common.NewFieldNameMapper())
 
@@ -114,6 +118,7 @@ func (b *BrowserType) initContext() context.Context {
 	ctx := k6ext.WithVU(b.vu.Context(), b.vu)
 	ctx = k6ext.WithCustomMetrics(ctx, b.k6Metrics)
 	ctx = common.WithHooks(ctx, b.hooks)
+	ctx = common.WithTraceID(ctx, fmt.Sprintf("%x", b.randSrc.Uint64()))
 	return ctx
 }
 

--- a/common/context.go
+++ b/common/context.go
@@ -9,6 +9,7 @@ type ctxKey int
 const (
 	ctxKeyLaunchOptions ctxKey = iota
 	ctxKeyHooks
+	ctxKeyTraceID
 )
 
 func WithHooks(ctx context.Context, hooks *Hooks) context.Context {
@@ -21,6 +22,21 @@ func GetHooks(ctx context.Context) *Hooks {
 		return nil
 	}
 	return v.(*Hooks)
+}
+
+// WithTraceID adds a random unique hexadecimal trace ID to the context.
+func WithTraceID(ctx context.Context, traceID string) context.Context {
+	return context.WithValue(ctx, ctxKeyTraceID, traceID)
+}
+
+// GetTraceID returns the unique trace ID attached to the context.
+func GetTraceID(ctx context.Context) string {
+	v := ctx.Value(ctxKeyTraceID)
+	val, ok := v.(string)
+	if v == nil || !ok {
+		return ""
+	}
+	return val
 }
 
 func WithLaunchOptions(ctx context.Context, opts *LaunchOptions) context.Context {

--- a/common/context.go
+++ b/common/context.go
@@ -9,7 +9,7 @@ type ctxKey int
 const (
 	ctxKeyLaunchOptions ctxKey = iota
 	ctxKeyHooks
-	ctxKeyTraceID
+	ctxKeyIterationID
 )
 
 func WithHooks(ctx context.Context, hooks *Hooks) context.Context {
@@ -24,14 +24,14 @@ func GetHooks(ctx context.Context) *Hooks {
 	return v.(*Hooks)
 }
 
-// WithTraceID adds a random unique hexadecimal trace ID to the context.
-func WithTraceID(ctx context.Context, traceID string) context.Context {
-	return context.WithValue(ctx, ctxKeyTraceID, traceID)
+// WithIterationID adds an identifier for the current iteration to the context.
+func WithIterationID(ctx context.Context, iterID string) context.Context {
+	return context.WithValue(ctx, ctxKeyIterationID, iterID)
 }
 
-// GetTraceID returns the unique trace ID attached to the context.
-func GetTraceID(ctx context.Context) string {
-	v := ctx.Value(ctxKeyTraceID)
+// GetIterationID returns the iteration identifier attached to the context.
+func GetIterationID(ctx context.Context) string {
+	v := ctx.Value(ctxKeyIterationID)
 	val, ok := v.(string)
 	if v == nil || !ok {
 		return ""

--- a/common/context.go
+++ b/common/context.go
@@ -31,12 +31,8 @@ func WithIterationID(ctx context.Context, iterID string) context.Context {
 
 // GetIterationID returns the iteration identifier attached to the context.
 func GetIterationID(ctx context.Context) string {
-	v := ctx.Value(ctxKeyIterationID)
-	val, ok := v.(string)
-	if v == nil || !ok {
-		return ""
-	}
-	return val
+	s, _ := ctx.Value(ctxKeyIterationID).(string)
+	return s
 }
 
 func WithLaunchOptions(ctx context.Context, opts *LaunchOptions) context.Context {

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -18,7 +18,7 @@ import (
 
 func newExecCtx() (*ExecutionContext, context.Context, *goja.Runtime) {
 	ctx := context.Background()
-	logger := log.New(logrus.New(), false, nil)
+	logger := log.New(logrus.New(), "", false, nil)
 	execCtx := NewExecutionContext(ctx, nil, nil, runtime.ExecutionContextID(123456789), logger)
 
 	return execCtx, ctx, goja.New()

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -74,7 +74,7 @@ func NewNetworkManager(
 		ctx:              ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:           log.New(state.Logger, GetTraceID(ctx), false, nil),
+		logger:           log.New(state.Logger, GetIterationID(ctx), false, nil),
 		session:          s,
 		parent:           parent,
 		frameManager:     fm,

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -74,7 +74,7 @@ func NewNetworkManager(
 		ctx:              ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:           log.New(state.Logger, false, nil),
+		logger:           log.New(state.Logger, GetTraceID(ctx), false, nil),
 		session:          s,
 		parent:           parent,
 		frameManager:     fm,

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -63,7 +63,7 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 	vu.MoveToVUContext()
 	st := vu.State()
 	st.Options = k6opts
-	logger := log.New(st.Logger, false, nil)
+	logger := log.New(st.Logger, "", false, nil)
 	nm := &NetworkManager{
 		ctx:      vu.Context(),
 		logger:   logger,

--- a/common/response.go
+++ b/common/response.go
@@ -71,7 +71,7 @@ func NewHTTPResponse(ctx context.Context, req *Request, resp *network.Response, 
 		ctx: ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:            log.New(state.Logger, GetTraceID(ctx), false, nil),
+		logger:            log.New(state.Logger, GetIterationID(ctx), false, nil),
 		request:           req,
 		remoteAddress:     &RemoteAddress{IPAddress: resp.RemoteIPAddress, Port: resp.RemotePort},
 		securityDetails:   nil,

--- a/common/response.go
+++ b/common/response.go
@@ -71,7 +71,7 @@ func NewHTTPResponse(ctx context.Context, req *Request, resp *network.Response, 
 		ctx: ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:            log.New(state.Logger, false, nil),
+		logger:            log.New(state.Logger, GetTraceID(ctx), false, nil),
 		request:           req,
 		remoteAddress:     &RemoteAddress{IPAddress: resp.RemoteIPAddress, Port: resp.RemotePort},
 		securityDetails:   nil,

--- a/log/logger.go
+++ b/log/logger.go
@@ -19,7 +19,7 @@ type Logger struct {
 	*logrus.Logger
 	mu             sync.Mutex
 	lastLogCall    int64
-	traceID        string
+	iterID         string
 	debugOverride  bool
 	categoryFilter *regexp.Regexp
 }
@@ -34,10 +34,10 @@ func NewNullLogger() *Logger {
 }
 
 // New creates a new logger.
-func New(logger *logrus.Logger, traceID string, debugOverride bool, categoryFilter *regexp.Regexp) *Logger {
+func New(logger *logrus.Logger, iterID string, debugOverride bool, categoryFilter *regexp.Regexp) *Logger {
 	return &Logger{
 		Logger:         logger,
-		traceID:        traceID,
+		iterID:         iterID,
 		debugOverride:  debugOverride,
 		categoryFilter: categoryFilter,
 	}
@@ -102,8 +102,8 @@ func (l *Logger) Logf(level logrus.Level, category string, msg string, args ...a
 		"elapsed":   fmt.Sprintf("%d ms", elapsed),
 		"goroutine": goRoutineID(),
 	}
-	if l.traceID != "" && l.GetLevel() > logrus.InfoLevel {
-		fields["trace_id"] = l.traceID
+	if l.iterID != "" && l.GetLevel() > logrus.InfoLevel {
+		fields["iteration_id"] = l.iterID
 	}
 	entry := l.WithFields(fields)
 	if l.GetLevel() < level && l.debugOverride {

--- a/log/logger.go
+++ b/log/logger.go
@@ -19,6 +19,7 @@ type Logger struct {
 	*logrus.Logger
 	mu             sync.Mutex
 	lastLogCall    int64
+	traceID        string
 	debugOverride  bool
 	categoryFilter *regexp.Regexp
 }
@@ -29,13 +30,14 @@ func NewNullLogger() *Logger {
 	log := logrus.New()
 	log.SetOutput(ioutil.Discard)
 
-	return New(log, false, nil)
+	return New(log, "", false, nil)
 }
 
 // New creates a new logger.
-func New(logger *logrus.Logger, debugOverride bool, categoryFilter *regexp.Regexp) *Logger {
+func New(logger *logrus.Logger, traceID string, debugOverride bool, categoryFilter *regexp.Regexp) *Logger {
 	return &Logger{
 		Logger:         logger,
+		traceID:        traceID,
 		debugOverride:  debugOverride,
 		categoryFilter: categoryFilter,
 	}
@@ -95,11 +97,15 @@ func (l *Logger) Logf(level logrus.Level, category string, msg string, args ...a
 		fmt.Printf("%s [%d]: %s - %s ms\n", magenta(category), goRoutineID(), string(msg), magenta(elapsed))
 		return
 	}
-	entry := l.WithFields(logrus.Fields{
+	fields := logrus.Fields{
 		"category":  category,
 		"elapsed":   fmt.Sprintf("%d ms", elapsed),
 		"goroutine": goRoutineID(),
-	})
+	}
+	if l.traceID != "" && l.GetLevel() > logrus.InfoLevel {
+		fields["trace_id"] = l.traceID
+	}
+	entry := l.WithFields(fields)
 	if l.GetLevel() < level && l.debugOverride {
 		entry.Printf(msg, args...)
 		return

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -156,25 +156,25 @@ func TestBrowserCrashErr(t *testing.T) {
 	}, "launching browser: Invalid devtools server port")
 }
 
-func TestBrowserLogTraceID(t *testing.T) {
+func TestBrowserLogIterationID(t *testing.T) {
 	t.Parallel()
 
 	tb := newTestBrowser(t, withLogCache())
 
 	var (
-		traceID    = common.GetTraceID(tb.ctx)
+		iterID     = common.GetIterationID(tb.ctx)
 		tracedEvts int
 	)
 
-	require.NotEmpty(t, traceID)
+	require.NotEmpty(t, iterID)
 	require.NotEmpty(t, tb.logCache.entries)
 
 	tb.logCache.mu.RLock()
 	defer tb.logCache.mu.RUnlock()
 	for _, evt := range tb.logCache.entries {
 		for k, v := range evt.Data {
-			if k == "trace_id" {
-				assert.Equal(t, traceID, v)
+			if k == "iteration_id" {
+				assert.Equal(t, iterID, v)
 				tracedEvts++
 			}
 		}

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/common"
 )
 
 func TestBrowserNewPage(t *testing.T) {
@@ -152,4 +154,31 @@ func TestBrowserCrashErr(t *testing.T) {
 
 		newTestBrowser(t, lopts)
 	}, "launching browser: Invalid devtools server port")
+}
+
+func TestBrowserLogTraceID(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withLogCache())
+
+	var (
+		traceID    = common.GetTraceID(tb.ctx)
+		tracedEvts int
+	)
+
+	require.NotEmpty(t, traceID)
+	require.NotEmpty(t, tb.logCache.entries)
+
+	tb.logCache.mu.RLock()
+	defer tb.logCache.mu.RUnlock()
+	for _, evt := range tb.logCache.entries {
+		for k, v := range evt.Data {
+			if k == "trace_id" {
+				assert.Equal(t, traceID, v)
+				tracedEvts++
+			}
+		}
+	}
+
+	assert.Equal(t, len(tb.logCache.entries), tracedEvts)
 }


### PR DESCRIPTION
This adds an `iteration_id` field to all log events that uniquely identifies a k6 iteration, and thus a single browser start/stop cycle. I'm finding it relatively useful when testing issues like #566 that only happen when stress testing the entire `tests` package, and not a single test in isolation, since I can filter log events for a specific iteration.

It's only added to events when `XK6_BROWSER_LOG` is set to `debug` or `trace`.

Related to #422 