### PR TITLE
Browser should not override defaults with null values

### DIFF
--- a/common/browser_options.go
+++ b/common/browser_options.go
@@ -60,10 +60,11 @@ func (l *LaunchOptions) Parse(ctx context.Context, opts goja.Value) error { //no
 		o  = opts.ToObject(rt)
 	)
 	for _, k := range o.Keys() {
-		var (
-			err error
-			v   = o.Get(k)
-		)
+		v := o.Get(k)
+		if v.Export() == nil {
+			continue // don't override the defaults on `null``
+		}
+		var err error
 		switch k {
 		case "args":
 			err = exportOpt(rt, k, v, &l.Args)

--- a/common/browser_options_test.go
+++ b/common/browser_options_test.go
@@ -30,6 +30,23 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 				}, lo)
 			},
 		},
+		"nulls": { // don't override the defaults on `null`
+			opts: map[string]any{
+				"env":               nil,
+				"headless":          nil,
+				"logCategoryFilter": nil,
+				"timeout":           nil,
+			},
+			assert: func(tb testing.TB, lo *LaunchOptions) {
+				tb.Helper()
+				assert.Equal(tb, &LaunchOptions{
+					Env:               make(map[string]string),
+					Headless:          true,
+					LogCategoryFilter: ".*",
+					Timeout:           DefaultTimeout,
+				}, lo)
+			},
+		},
 		"args": {
 			opts: map[string]any{
 				"args": []any{"browser-arg1='value1", "browser-arg2=value2", "browser-flag"},


### PR DESCRIPTION
Fixes #407 by ignoring **any options** with `null` or `undefined` values given by a test script.

For example:
* Setting `executablePath` to `null` will be ignored, and its default value will be used.
* Or, setting `headless` to `undefined` will be ignored, and `headless` will stay as `true` ([its default value](https://github.com/grafana/xk6-browser/blob/4a47b35e132d6d188e80c7543686c3665f4c942b/common/browser_options.go#L46)).
* Setting `args` to `null` will be ignored, and `args` will stay `nil` (its default).

---

WDYT about returning an error when an option is set to `null` or `undefined`?

**Current approach.**
* Pros: Allows defaults to be used when one of the options is set to `null`. This can also be a double-edged sword (cons-es below). Slightly faster parsing (since it skips the `null`/unset properties).
* Cons: It can be confusing for users to get default behavior even if they deliberately want to set an option to `null`. IDK when this can happen, though.

**Returning an error on null**
* Pros: Strict behavior and lets users know an option should not be set to `null`. One way of doing things.
* Cons: Users can't set an option to `null`. Might there edge cases exist where users want to intentionally set an option to `null` (not only specific to `BrowserType.Launch`)?