### PR TITLE
Log when a launch option is set to null

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -133,7 +133,7 @@ func (b *BrowserType) Launch(opts goja.Value) api.Browser {
 	}
 
 	launchOpts := common.NewLaunchOptions()
-	if err := launchOpts.Parse(ctx, opts); err != nil {
+	if err := launchOpts.Parse(ctx, opts, b.logger); err != nil {
 		k6ext.Panic(ctx, "parsing launch options: %w", err)
 	}
 	ctx = common.WithLaunchOptions(ctx, launchOpts)

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -375,7 +375,7 @@ func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*log.Log
 	var (
 		k6Logger            = k6ext.GetVU(ctx).State().Logger
 		reCategoryFilter, _ = regexp.Compile(launchOpts.LogCategoryFilter)
-		logger              = log.New(k6Logger, common.GetIterationID(ctx), launchOpts.Debug, reCategoryFilter)
+		logger              = log.New(k6Logger, common.GetIterationID(ctx), reCategoryFilter)
 	)
 
 	// set the log level from the launch options (usually from a script's options).

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -373,11 +372,12 @@ func setFlagsFromK6Options(flags map[string]any, k6opts *k6lib.Options) {
 // makeLogger makes and returns an extension wide logger.
 func makeLogger(ctx context.Context, launchOpts *common.LaunchOptions) (*log.Logger, error) {
 	var (
-		k6Logger            = k6ext.GetVU(ctx).State().Logger
-		reCategoryFilter, _ = regexp.Compile(launchOpts.LogCategoryFilter)
-		logger              = log.New(k6Logger, common.GetIterationID(ctx), reCategoryFilter)
+		k6Logger = k6ext.GetVU(ctx).State().Logger
+		logger   = log.New(k6Logger, common.GetIterationID(ctx))
 	)
-
+	if err := logger.SetCategoryFilter(launchOpts.LogCategoryFilter); err != nil {
+		return nil, fmt.Errorf("making logger: %w", err)
+	}
 	// set the log level from the launch options (usually from a script's options).
 	if launchOpts.Debug {
 		_ = logger.SetLevel("debug")

--- a/common/browser_options.go
+++ b/common/browser_options.go
@@ -56,13 +56,22 @@ func (l *LaunchOptions) Parse(ctx context.Context, opts goja.Value, logger *log.
 		return errors.New("LaunchOptions does not exist in the runtime")
 	}
 	var (
-		rt = k6ext.Runtime(ctx)
-		o  = opts.ToObject(rt)
+		rt       = k6ext.Runtime(ctx)
+		o        = opts.ToObject(rt)
+		defaults = map[string]any{
+			"env":               l.Env,
+			"headless":          l.Headless,
+			"logCategoryFilter": l.LogCategoryFilter,
+			"timeout":           l.Timeout,
+		}
 	)
 	for _, k := range o.Keys() {
 		v := o.Get(k)
 		if v.Export() == nil {
-			continue // don't override the defaults on `null``
+			if dv, ok := defaults[k]; ok {
+				logger.Warnf("LaunchOptions", "%s was null and set to its default: %v", k, dv)
+			}
+			continue
 		}
 		var err error
 		switch k {

--- a/common/browser_options.go
+++ b/common/browser_options.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dop251/goja"
 
 	"github.com/grafana/xk6-browser/k6ext"
+	"github.com/grafana/xk6-browser/log"
 )
 
 // ProxyOptions allows configuring a proxy server.
@@ -41,17 +42,16 @@ type LaunchPersistentContextOptions struct {
 
 // NewLaunchOptions returns a new LaunchOptions.
 func NewLaunchOptions() *LaunchOptions {
-	launchOpts := LaunchOptions{
+	return &LaunchOptions{
 		Env:               make(map[string]string),
 		Headless:          true,
 		LogCategoryFilter: ".*",
 		Timeout:           DefaultTimeout,
 	}
-	return &launchOpts
 }
 
 // Parse parses launch options from a JS object.
-func (l *LaunchOptions) Parse(ctx context.Context, opts goja.Value) error { //nolint:cyclop
+func (l *LaunchOptions) Parse(ctx context.Context, opts goja.Value, logger *log.Logger) error { //nolint:cyclop
 	if !gojaValueExists(opts) {
 		return errors.New("LaunchOptions does not exist in the runtime")
 	}

--- a/common/browser_options_test.go
+++ b/common/browser_options_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/xk6-browser/k6ext/k6test"
+	"github.com/grafana/xk6-browser/log"
 )
 
 func TestBrowserLaunchOptionsParse(t *testing.T) {
@@ -213,7 +214,7 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 				vu = k6test.NewVU(t)
 				lo = NewLaunchOptions()
 			)
-			err := lo.Parse(vu.Context(), vu.ToGojaValue(tt.opts))
+			err := lo.Parse(vu.Context(), vu.ToGojaValue(tt.opts), log.NewNullLogger())
 			if tt.err != "" {
 				require.ErrorContains(t, err, tt.err)
 			} else {

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -23,7 +23,8 @@ func TestBrowserNewPageInContext(t *testing.T) {
 	}
 	newTestCase := func(id cdp.BrowserContextID) *testCase {
 		ctx, cancel := context.WithCancel(context.Background())
-		b := newBrowser(ctx, cancel, nil, NewLaunchOptions(), log.NewNullLogger())
+		logger := log.NewNullLogger()
+		b := newBrowser(ctx, cancel, nil, NewLaunchOptions(), logger)
 		// set a new browser context in the browser with `id`, so that newPageInContext can find it.
 		b.contexts[id] = NewBrowserContext(ctx, b, id, nil, nil)
 		return &testCase{

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -18,7 +18,7 @@ import (
 
 func newExecCtx() (*ExecutionContext, context.Context, *goja.Runtime) {
 	ctx := context.Background()
-	logger := log.New(logrus.New(), "", nil)
+	logger := log.New(logrus.New(), "")
 	execCtx := NewExecutionContext(ctx, nil, nil, runtime.ExecutionContextID(123456789), logger)
 
 	return execCtx, ctx, goja.New()

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/xk6-browser/log"
@@ -18,7 +17,7 @@ import (
 
 func newExecCtx() (*ExecutionContext, context.Context, *goja.Runtime) {
 	ctx := context.Background()
-	logger := log.New(logrus.New(), "")
+	logger := log.NewNullLogger()
 	execCtx := NewExecutionContext(ctx, nil, nil, runtime.ExecutionContextID(123456789), logger)
 
 	return execCtx, ctx, goja.New()

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -18,7 +18,7 @@ import (
 
 func newExecCtx() (*ExecutionContext, context.Context, *goja.Runtime) {
 	ctx := context.Background()
-	logger := log.New(logrus.New(), "", false, nil)
+	logger := log.New(logrus.New(), "", nil)
 	execCtx := NewExecutionContext(ctx, nil, nil, runtime.ExecutionContextID(123456789), logger)
 
 	return execCtx, ctx, goja.New()

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -74,7 +74,7 @@ func NewNetworkManager(
 		ctx:              ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:           log.New(state.Logger, GetIterationID(ctx), nil),
+		logger:           log.New(state.Logger, GetIterationID(ctx)),
 		session:          s,
 		parent:           parent,
 		frameManager:     fm,

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -74,7 +74,7 @@ func NewNetworkManager(
 		ctx:              ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:           log.New(state.Logger, GetIterationID(ctx), false, nil),
+		logger:           log.New(state.Logger, GetIterationID(ctx), nil),
 		session:          s,
 		parent:           parent,
 		frameManager:     fm,

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -63,7 +63,7 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 	vu.MoveToVUContext()
 	st := vu.State()
 	st.Options = k6opts
-	logger := log.New(st.Logger, "", false, nil)
+	logger := log.New(st.Logger, "", nil)
 	nm := &NetworkManager{
 		ctx:      vu.Context(),
 		logger:   logger,

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -63,7 +63,7 @@ func newTestNetworkManager(t *testing.T, k6opts k6lib.Options) (*NetworkManager,
 	vu.MoveToVUContext()
 	st := vu.State()
 	st.Options = k6opts
-	logger := log.New(st.Logger, "", nil)
+	logger := log.New(st.Logger, "")
 	nm := &NetworkManager{
 		ctx:      vu.Context(),
 		logger:   logger,

--- a/common/response.go
+++ b/common/response.go
@@ -71,7 +71,7 @@ func NewHTTPResponse(ctx context.Context, req *Request, resp *network.Response, 
 		ctx: ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:            log.New(state.Logger, GetIterationID(ctx), nil),
+		logger:            log.New(state.Logger, GetIterationID(ctx)),
 		request:           req,
 		remoteAddress:     &RemoteAddress{IPAddress: resp.RemoteIPAddress, Port: resp.RemotePort},
 		securityDetails:   nil,

--- a/common/response.go
+++ b/common/response.go
@@ -71,7 +71,7 @@ func NewHTTPResponse(ctx context.Context, req *Request, resp *network.Response, 
 		ctx: ctx,
 		// TODO: Pass an internal logger instead of basing it on k6's logger?
 		// See https://github.com/grafana/xk6-browser/issues/54
-		logger:            log.New(state.Logger, GetIterationID(ctx), false, nil),
+		logger:            log.New(state.Logger, GetIterationID(ctx), nil),
 		request:           req,
 		remoteAddress:     &RemoteAddress{IPAddress: resp.RemoteIPAddress, Port: resp.RemotePort},
 		securityDetails:   nil,

--- a/log/logger.go
+++ b/log/logger.go
@@ -20,7 +20,6 @@ type Logger struct {
 	mu             sync.Mutex
 	lastLogCall    int64
 	iterID         string
-	debugOverride  bool
 	categoryFilter *regexp.Regexp
 }
 
@@ -30,15 +29,14 @@ func NewNullLogger() *Logger {
 	log := logrus.New()
 	log.SetOutput(ioutil.Discard)
 
-	return New(log, "", false, nil)
+	return New(log, "", nil)
 }
 
 // New creates a new logger.
-func New(logger *logrus.Logger, iterID string, debugOverride bool, categoryFilter *regexp.Regexp) *Logger {
+func New(logger *logrus.Logger, iterID string, categoryFilter *regexp.Regexp) *Logger {
 	return &Logger{
 		Logger:         logger,
 		iterID:         iterID,
-		debugOverride:  debugOverride,
 		categoryFilter: categoryFilter,
 	}
 }
@@ -106,7 +104,7 @@ func (l *Logger) Logf(level logrus.Level, category string, msg string, args ...a
 		fields["iteration_id"] = l.iterID
 	}
 	entry := l.WithFields(fields)
-	if l.GetLevel() < level && l.debugOverride {
+	if l.GetLevel() < level {
 		entry.Printf(msg, args...)
 		return
 	}


### PR DESCRIPTION
It logs when one of the default browser launch options is set to either `null` or `undefined` and overridden by its default option. I needed to move `makeLogger` from `launch` to `Launch` so we could log something in `BrowserType.Launch`.

Currently, `Parse` doesn't mind the `logCategoryFilter` and `debug` options. There was a chicken-egg situation: `Parse` needs a logger, but we don't know about the `logCategoryFilter` and `debug` options until `Parse` finishes. And, `Parse` needs to log!

This should [allow](https://github.com/grafana/xk6-browser/pull/608#discussion_r1008050172) merging #608 and #619.

PS: I can squash this after the review if you want.