### PR TITLE
Fix waituntil for page.reload

### DIFF
--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -1,17 +1,9 @@
 package tests
 
 import (
-	"fmt"
-	"net/http"
-	"sync"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/common"
 )
 
 func TestFramePress(t *testing.T) {
@@ -28,131 +20,4 @@ func TestFramePress(t *testing.T) {
 	f.Press("#text1", "Shift+KeyC", nil)
 
 	require.Equal(t, "AbC", f.InputValue("#text1", nil))
-}
-
-func TestLifecycleNetworkIdle(t *testing.T) {
-	t.Parallel()
-
-	assertHome := func(tb *testBrowser, p api.Page, check func()) {
-		var resolved, rejected bool
-		err := tb.await(func() error {
-			opts := tb.toGojaValue(common.FrameGotoOptions{
-				WaitUntil: common.LifecycleEventNetworkIdle,
-				Timeout:   30 * time.Second,
-			})
-			tb.promise(p.Goto(tb.URL("/home"), opts)).then(
-				func() {
-					check()
-					resolved = true
-				},
-				func() {
-					rejected = true
-				},
-			)
-
-			return nil
-		})
-		require.NoError(t, err)
-
-		assert.True(t, resolved)
-		assert.False(t, rejected)
-	}
-
-	t.Run("doesn't timeout waiting for networkIdle", func(t *testing.T) {
-		t.Parallel()
-
-		tb := newTestBrowser(t, withHTTPServer())
-		p := tb.NewPage(nil)
-		tb.withHandler("/home", func(w http.ResponseWriter, _ *http.Request) {
-			fmt.Fprintf(w, `
-			<html>
-				<head></head>
-				<body>
-					<div id="serverMsg">Waiting...</div>
-					<script src="/ping.js" async></script>
-				</body>
-			</html>
-			`)
-		})
-
-		tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
-			fmt.Fprintf(w, `
-				var serverMsgOutput = document.getElementById("serverMsg");
-				serverMsgOutput.innerText = "ping.js loaded from server";
-			`)
-		})
-
-		assertHome(tb, p, func() {
-			result := p.TextContent("#serverMsg", nil)
-			assert.EqualValues(t, "ping.js loaded from server", result)
-		})
-	})
-
-	t.Run("doesn't unblock wait for networkIdle too early", func(t *testing.T) {
-		t.Parallel()
-
-		tb := newTestBrowser(t, withFileServer())
-		p := tb.NewPage(nil)
-		tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, tb.staticURL("prolonged_network_idle.html"), http.StatusMovedPermanently)
-		})
-
-		var counter int64
-		ch := make(chan bool)
-		tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
-			<-ch
-
-			var counterMu sync.Mutex
-			counterMu.Lock()
-			defer counterMu.Unlock()
-
-			time.Sleep(time.Millisecond * 50)
-
-			counter++
-			fmt.Fprintf(w, "pong %d", counter)
-		})
-
-		tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
-			fmt.Fprintf(w, `
-				var serverMsgOutput = document.getElementById("serverMsg");
-				serverMsgOutput.innerText = "ping.js loaded from server";
-			`)
-			close(ch)
-		})
-
-		assertHome(tb, p, func() {
-			result := p.TextContent("#prolongNetworkIdleLoad", nil)
-			assert.EqualValues(t, "Waiting... pong 4 - for loop complete", result)
-
-			result = p.TextContent("#serverMsg", nil)
-			assert.EqualValues(t, "ping.js loaded from server", result)
-		})
-	})
-
-	t.Run("doesn't unblock wait on networkIdle early when load and domcontentloaded complete at once", func(t *testing.T) {
-		t.Parallel()
-
-		tb := newTestBrowser(t, withFileServer())
-		p := tb.NewPage(nil)
-		tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, tb.staticURL("prolonged_network_idle_10.html"), http.StatusMovedPermanently)
-		})
-
-		var counterMu sync.Mutex
-		var counter int64
-		tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
-			counterMu.Lock()
-			defer counterMu.Unlock()
-
-			time.Sleep(time.Millisecond * 50)
-
-			counter++
-			fmt.Fprintf(w, "pong %d", counter)
-		})
-
-		assertHome(tb, p, func() {
-			result := p.TextContent("#prolongNetworkIdleLoad", nil)
-			assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
-		})
-	})
 }

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -1,0 +1,143 @@
+package tests
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLifecycleNetworkIdle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("doesn't timeout waiting for networkIdle", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t, withHTTPServer())
+		p := tb.NewPage(nil)
+		tb.withHandler("/home", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprintf(w, `
+			<html>
+				<head></head>
+				<body>
+					<div id="pingJSText">Waiting...</div>
+					<script src="/ping.js" async></script>
+				</body>
+			</html>
+			`)
+		})
+
+		tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprintf(w, `
+				var pingJSTextOutput = document.getElementById("pingJSText");
+				pingJSTextOutput.innerText = "ping.js loaded from server";
+			`)
+		})
+
+		assertHome(t, tb, p, "/home", common.LifecycleEventNetworkIdle, func() {
+			result := p.TextContent("#pingJSText", nil)
+			assert.EqualValues(t, "ping.js loaded from server", result)
+		})
+	})
+
+	t.Run("doesn't unblock wait for networkIdle too early", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t, withFileServer())
+		p := tb.NewPage(nil)
+		tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, tb.staticURL("prolonged_network_idle.html"), http.StatusMovedPermanently)
+		})
+
+		var counter int64
+		ch := make(chan bool)
+		tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
+			<-ch
+
+			var counterMu sync.Mutex
+			counterMu.Lock()
+			defer counterMu.Unlock()
+
+			time.Sleep(time.Millisecond * 50)
+
+			counter++
+			fmt.Fprintf(w, "pong %d", counter)
+		})
+
+		tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprintf(w, `
+				var pingJSTextOutput = document.getElementById("pingJSText");
+				pingJSTextOutput.innerText = "ping.js loaded from server";
+			`)
+			close(ch)
+		})
+
+		assertHome(t, tb, p, "/home", common.LifecycleEventNetworkIdle, func() {
+			result := p.TextContent("#pingRequestText", nil)
+			assert.EqualValues(t, "Waiting... pong 4 - for loop complete", result)
+
+			result = p.TextContent("#pingJSText", nil)
+			assert.EqualValues(t, "ping.js loaded from server", result)
+		})
+	})
+
+	t.Run("doesn't unblock wait on networkIdle early when load and domcontentloaded complete at once", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t, withFileServer())
+		p := tb.NewPage(nil)
+		tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, tb.staticURL("prolonged_network_idle_10.html"), http.StatusMovedPermanently)
+		})
+
+		var counterMu sync.Mutex
+		var counter int64
+		tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
+			counterMu.Lock()
+			defer counterMu.Unlock()
+
+			time.Sleep(time.Millisecond * 50)
+
+			counter++
+			fmt.Fprintf(w, "pong %d", counter)
+		})
+
+		assertHome(t, tb, p, "/home", common.LifecycleEventNetworkIdle, func() {
+			result := p.TextContent("#pingRequestText", nil)
+			assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
+		})
+	})
+}
+
+func assertHome(t *testing.T, tb *testBrowser, p api.Page, gotoURL string, waitUntil common.LifecycleEvent, check func()) {
+	t.Helper()
+
+	var resolved, rejected bool
+	err := tb.await(func() error {
+		opts := tb.toGojaValue(common.FrameGotoOptions{
+			WaitUntil: waitUntil,
+			Timeout:   30 * time.Second,
+		})
+		tb.promise(p.Goto(tb.URL(gotoURL), opts)).then(
+			func() {
+				check()
+				resolved = true
+			},
+			func() {
+				rejected = true
+			},
+		)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.True(t, resolved)
+	assert.False(t, rejected)
+}

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -7,11 +7,162 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/common"
 )
+
+func TestLifecycleReloadLoad(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tb.staticURL("reload_lifecycle.html"), http.StatusMovedPermanently)
+	})
+
+	var counter int64
+	var counterMu sync.Mutex
+	tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		counterMu.Lock()
+		defer counterMu.Unlock()
+
+		time.Sleep(time.Millisecond * 100)
+
+		counter++
+		fmt.Fprintf(w, "pong %d", counter)
+	})
+
+	tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `
+				var pingJSTextOutput = document.getElementById("pingJSText");
+				pingJSTextOutput.innerText = "ping.js loaded from server";
+			`)
+	})
+
+	waitUntil := common.LifecycleEventLoad
+	assertHome(t, tb, p, waitUntil, func() {
+		result := p.TextContent("#pingRequestText", nil)
+		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "ping.js loaded from server", result)
+
+		opts := tb.toGojaValue(common.PageReloadOptions{
+			WaitUntil: waitUntil,
+			Timeout:   30 * time.Second,
+		})
+		p.Reload(opts)
+
+		result = p.TextContent("#pingRequestText", nil)
+		assert.NotEqualValues(t, "Waiting... pong 20 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "ping.js loaded from server", result)
+	})
+}
+
+func TestLifecycleReloadDOMContentLoaded(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tb.staticURL("reload_lifecycle.html"), http.StatusMovedPermanently)
+	})
+
+	var counter int64
+	var counterMu sync.Mutex
+	tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		counterMu.Lock()
+		defer counterMu.Unlock()
+
+		time.Sleep(time.Millisecond * 100)
+
+		counter++
+		fmt.Fprintf(w, "pong %d", counter)
+	})
+
+	tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `
+				await new Promise(resolve => setTimeout(resolve, 1000));
+
+				var pingJSTextOutput = document.getElementById("pingJSText");
+				pingJSTextOutput.innerText = "ping.js loaded from server";
+			`)
+	})
+
+	waitUntil := common.LifecycleEventDOMContentLoad
+	assertHome(t, tb, p, waitUntil, func() {
+		result := p.TextContent("#pingRequestText", nil)
+		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "Waiting...", result)
+
+		opts := tb.toGojaValue(common.PageReloadOptions{
+			WaitUntil: waitUntil,
+			Timeout:   30 * time.Second,
+		})
+		p.Reload(opts)
+
+		result = p.TextContent("#pingRequestText", nil)
+		assert.NotEqualValues(t, "Waiting... pong 20 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "Waiting...", result)
+	})
+}
+
+func TestLifecycleReloadNetworkIdle(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tb.staticURL("reload_lifecycle.html"), http.StatusMovedPermanently)
+	})
+
+	var counter int64
+	var counterMu sync.Mutex
+	tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		counterMu.Lock()
+		defer counterMu.Unlock()
+
+		counter++
+		fmt.Fprintf(w, "pong %d", counter)
+	})
+
+	tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `
+				var pingJSTextOutput = document.getElementById("pingJSText");
+				pingJSTextOutput.innerText = "ping.js loaded from server";
+			`)
+	})
+
+	waitUntil := common.LifecycleEventNetworkIdle
+	assertHome(t, tb, p, waitUntil, func() {
+		result := p.TextContent("#pingRequestText", nil)
+		assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "ping.js loaded from server", result)
+
+		opts := tb.toGojaValue(common.PageReloadOptions{
+			WaitUntil: waitUntil,
+			Timeout:   30 * time.Second,
+		})
+		p.Reload(opts)
+
+		result = p.TextContent("#pingRequestText", nil)
+		assert.EqualValues(t, "Waiting... pong 20 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "ping.js loaded from server", result)
+	})
+}
 
 func TestLifecycleNetworkIdle(t *testing.T) {
 	t.Parallel()
@@ -40,7 +191,7 @@ func TestLifecycleNetworkIdle(t *testing.T) {
 			`)
 		})
 
-		assertHome(t, tb, p, "/home", common.LifecycleEventNetworkIdle, func() {
+		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() {
 			result := p.TextContent("#pingJSText", nil)
 			assert.EqualValues(t, "ping.js loaded from server", result)
 		})
@@ -57,10 +208,10 @@ func TestLifecycleNetworkIdle(t *testing.T) {
 
 		var counter int64
 		ch := make(chan bool)
+		var counterMu sync.Mutex
 		tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
 			<-ch
 
-			var counterMu sync.Mutex
 			counterMu.Lock()
 			defer counterMu.Unlock()
 
@@ -78,7 +229,7 @@ func TestLifecycleNetworkIdle(t *testing.T) {
 			close(ch)
 		})
 
-		assertHome(t, tb, p, "/home", common.LifecycleEventNetworkIdle, func() {
+		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() {
 			result := p.TextContent("#pingRequestText", nil)
 			assert.EqualValues(t, "Waiting... pong 4 - for loop complete", result)
 
@@ -108,14 +259,20 @@ func TestLifecycleNetworkIdle(t *testing.T) {
 			fmt.Fprintf(w, "pong %d", counter)
 		})
 
-		assertHome(t, tb, p, "/home", common.LifecycleEventNetworkIdle, func() {
+		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() {
 			result := p.TextContent("#pingRequestText", nil)
 			assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
 		})
 	})
 }
 
-func assertHome(t *testing.T, tb *testBrowser, p api.Page, gotoURL string, waitUntil common.LifecycleEvent, check func()) {
+func assertHome(
+	t *testing.T,
+	tb *testBrowser,
+	p api.Page,
+	waitUntil common.LifecycleEvent,
+	check func(),
+) {
 	t.Helper()
 
 	var resolved, rejected bool
@@ -124,7 +281,7 @@ func assertHome(t *testing.T, tb *testBrowser, p api.Page, gotoURL string, waitU
 			WaitUntil: waitUntil,
 			Timeout:   30 * time.Second,
 		})
-		tb.promise(p.Goto(tb.URL(gotoURL), opts)).then(
+		tb.promise(p.Goto(tb.URL("/home"), opts)).then(
 			func() {
 				check()
 				resolved = true

--- a/tests/static/prolonged_network_idle.html
+++ b/tests/static/prolonged_network_idle.html
@@ -9,12 +9,12 @@
     <script>
         var pingRequestTextOutput = document.getElementById("pingRequestText");
 
-        var p = pingRequestText();
+        var p = requestPings();
         p.then(() => {
             pingRequestTextOutput.innerText += ' - for loop complete';
         })
 
-        async function pingRequestText() {
+        async function requestPings() {
             for (var i = 0; i < 4; i++) {
                 await fetch('/ping')
                     .then(response => response.text())

--- a/tests/static/prolonged_network_idle.html
+++ b/tests/static/prolonged_network_idle.html
@@ -3,23 +3,23 @@
 <head></head>
 
 <body>
-    <div id="prolongNetworkIdleLoad">Waiting...</div>
-    <div id="serverMsg">Waiting...</div>
+    <div id="pingRequestText">Waiting...</div>
+    <div id="pingJSText">Waiting...</div>
 
     <script>
-        var prolongNetworkIdleLoadOutput = document.getElementById("prolongNetworkIdleLoad");
+        var pingRequestTextOutput = document.getElementById("pingRequestText");
 
-        var p = prolongNetworkIdleLoad();
+        var p = pingRequestText();
         p.then(() => {
-            prolongNetworkIdleLoadOutput.innerText += ' - for loop complete';
+            pingRequestTextOutput.innerText += ' - for loop complete';
         })
 
-        async function prolongNetworkIdleLoad() {
+        async function pingRequestText() {
             for (var i = 0; i < 4; i++) {
                 await fetch('/ping')
                     .then(response => response.text())
                     .then((data) => {
-                        prolongNetworkIdleLoadOutput.innerText = 'Waiting... ' + data;
+                        pingRequestTextOutput.innerText = 'Waiting... ' + data;
                     });
             }
         }

--- a/tests/static/prolonged_network_idle_10.html
+++ b/tests/static/prolonged_network_idle_10.html
@@ -3,22 +3,22 @@
 <head></head>
 
 <body>
-    <div id="prolongNetworkIdleLoad">Waiting...</div>
+    <div id="pingRequestText">Waiting...</div>
 
     <script>
-        var prolongNetworkIdleLoadOutput = document.getElementById("prolongNetworkIdleLoad");
+        var pingRequestTextOutput = document.getElementById("pingRequestText");
 
-        var p = prolongNetworkIdleLoad();
+        var p = pingRequestText();
         p.then(() => {
-            prolongNetworkIdleLoadOutput.innerText += ' - for loop complete';
+            pingRequestTextOutput.innerText += ' - for loop complete';
         })
 
-        async function prolongNetworkIdleLoad() {
+        async function pingRequestText() {
             for (var i = 0; i < 10; i++) {
                 await fetch('/ping')
                     .then(response => response.text())
                     .then((data) => {
-                        prolongNetworkIdleLoadOutput.innerText = 'Waiting... ' + data;
+                        pingRequestTextOutput.innerText = 'Waiting... ' + data;
                     });
             }
         }

--- a/tests/static/reload_lifecycle.html
+++ b/tests/static/reload_lifecycle.html
@@ -4,6 +4,7 @@
 
 <body>
     <div id="pingRequestText">Waiting...</div>
+    <div id="pingJSText">Waiting...</div>
 
     <script>
         var pingRequestTextOutput = document.getElementById("pingRequestText");
@@ -23,6 +24,7 @@
             }
         }
     </script>
+    <script src="/ping.js" async></script>
 </body>
 
 </html>


### PR DESCRIPTION
Closes: https://github.com/grafana/xk6-browser/issues/622

The logic to `waitUntil` has been copied from `FrameManager.NavigateFrame`. The issue was that `waitUntil` when used with `networkIdle` wasn't working as expected -- the wait would end too early.

I've also refactored the previous lifecycle event tests into a new file. There will be a lot more lifecycle event tests coming in future PRs, so it's best to keep them all in one place.