### PR TITLE
Release notes v0.6.0

### DIFF
--- a/release notes/v0.6.0.md
+++ b/release notes/v0.6.0.md
@@ -1,0 +1,99 @@
+xk6-browser v0.6.0 is here! :tada:
+
+This minor release contains essential stability fixes, bug fixes that we found while stress testing the application, improvements, and a continuation of our efforts to migrate to async APIs.
+
+
+## Bugs fixed
+
+- Fixed `ignoreDefaultArgs`. ([#547](https://github.com/grafana/xk6-browser/pull/547))
+
+  We're now not hiding scrollbars while running in headless mode. This issue was [causing](https://github.com/grafana/xk6-browser/issues/536) the browser viewport width to be larger than it should be.
+
+- Fixed data race while logging. ([#531](https://github.com/grafana/xk6-browser/pull/531))
+
+- Fixed sending metrics with incorrect timestamp to the Cloud. ([#551](https://github.com/grafana/xk6-browser/pull/551))
+
+  The issue was preventing users from analyzing performance metrics in the Cloud.
+
+- Fixed the `waitUntil` option for `Page.goto`, `Page.reload` and `Page.waitForLoadState`. ([#578](https://github.com/grafana/xk6-browser/pull/578), [#623](https://github.com/grafana/xk6-browser/pull/623), [#628](https://github.com/grafana/xk6-browser/pull/628))
+
+  This now works as expected with the `load`, `domcontentloaded` and `networkidle` lifecycle events. `networkidle` might not work so well with websites that are very chatty and so the wait eventually could timeout.
+
+- Fixed a possible deadlock that can happen while navigating frames. ([#539](https://github.com/grafana/xk6-browser/pull/539))
+
+- Fixed two possible data races which could occur during a navigation. ([#630](https://github.com/grafana/xk6-browser/pull/630))
+
+## Breaking changes
+
+- `Page.goto` is now an asynchronous method that returns a `Promise`. ([#583](https://github.com/grafana/xk6-browser/pull/583), [#591](https://github.com/grafana/xk6-browser/pull/591))
+
+  All our examples have been updated to work with async `Page.goto`. For example, you can look at the [`browser_args.js` example](https://github.com/grafana/xk6-browser/blob/v0.6.0/examples/browser_args.js) for how to use it.
+
+  Note that the `async` and `await` keywords are not yet supported (see [this k6 issue](https://github.com/grafana/k6/issues/779) for a workaround), so resolving the `Promise` using `then()` is required for scripts to continue to work correctly.
+
+- Setting a browser launch property to `null` will be ignored and the default will be used; take a look at the [BrowserType.launch](https://k6.io/docs/javascript-api/xk6-browser/browsertype/launch/) documentation for the defaults. ([#616](https://github.com/grafana/xk6-browser/pull/616), [#620](https://github.com/grafana/xk6-browser/pull/620))
+
+  For example:
+  ```js
+  const browser = chromium.launch({
+    headless: null,          // will be set to true
+    logCategoryFilter: null, // will be set to '.*'
+    timeout: null,           // will be set to 30s
+  });
+  ```
+- Setting some browser launch options will be ignored on Cloud. ([#627](https://github.com/grafana/xk6-browser/pull/627))
+
+  Setting the following options will be ignored, and they take their default values as follows:
+
+  option | default | note
+  ------ | ------- | -----
+  devtools | false
+  executablePath | "" | will be determined by xk6-browser
+  headless | true |
+
+## Improvements
+
+- Added an example of how to use `xk6-browser` alongside `k6`. ([#529](https://github.com/grafana/xk6-browser/pull/529))
+
+- Improved handling of browser process exit and WS connection closing. ([#535](https://github.com/grafana/xk6-browser/pull/535))
+
+  We're now waiting for the browser process to exit before ending the iteration. Previously, we would cancel the browser context prematurely, which caused the _process unexpectedly ended_ and _signal: killed_ errors.
+
+- Improved the internal event handling mechanism. ([#555](https://github.com/grafana/xk6-browser/pull/555))
+
+  Now we're handling events in the order we receive them. This change has drastically improved the extension's stability.
+
+- Improved emitting errors from the browser. ([#598](https://github.com/grafana/xk6-browser/pull/598))
+
+  Now we're returning the error that can occur while launching a browser. Previously, we would log a _file already closed error_ if the browser process exits prematurely.
+
+- Added a Docker example. ([#556](https://github.com/grafana/xk6-browser/pull/556), [#631](https://github.com/grafana/xk6-browser/pull/631))
+
+  You can now use xk6-browser [using Docker](https://github.com/grafana/xk6-browser#running-examples-in-a-docker-container). For example:
+
+  ```bash
+  docker-compose run -T xk6-browser run - <examples/browser_on.js
+  ```
+
+- Upgraded the project to be compatible with Go 1.19. ([#568](https://github.com/grafana/xk6-browser/pull/568))
+
+- Added a troubleshooting document. ([#569](https://github.com/grafana/xk6-browser/pull/569))
+
+  This document is a good place to start when you have issues installing or running xk6-browser.
+
+- Added a GitHub issues template. ([#584](https://github.com/grafana/xk6-browser/pull/584))
+
+  It makes it easier for you to send us the details of the problems you're facing.
+
+- Return an error on invalid `BrowserType.launch` options. ([#608](https://github.com/grafana/xk6-browser/pull/608))
+
+- Fixed the example test script `browser_args.js` on macOS. ([#629](https://github.com/grafana/xk6-browser/pull/629))
+
+
+## Internals
+
+- Upgraded `k6` dependency to `v0.41.0`. ([#633](https://github.com/grafana/xk6-browser/pull/633))
+
+- Several refactors and bug fixes to improve maintainability and stability.
+  ([#525](https://github.com/grafana/xk6-browser/pull/525), [#526](https://github.com/grafana/xk6-browser/pull/526), [#532](https://github.com/grafana/xk6-browser/pull/532), [#534](https://github.com/grafana/xk6-browser/pull/534), [#540](https://github.com/grafana/xk6-browser/pull/540), [#541](https://github.com/grafana/xk6-browser/pull/541), [#510](https://github.com/grafana/xk6-browser/issues/510), [#548](https://github.com/grafana/xk6-browser/pull/548), [#564](https://github.com/grafana/xk6-browser/pull/564), [#565](https://github.com/grafana/xk6-browser/pull/565), [#570](https://github.com/grafana/xk6-browser/pull/570), [#572](https://github.com/grafana/xk6-browser/pull/572), [#574](https://github.com/grafana/xk6-browser/pull/574), [#576](https://github.com/grafana/xk6-browser/pull/576), [#581](https://github.com/grafana/xk6-browser/pull/581), [#585](https://github.com/grafana/xk6-browser/pull/585), [#586](https://github.com/grafana/xk6-browser/pull/586), [#587](https://github.com/grafana/xk6-browser/pull/587), [#588](https://github.com/grafana/xk6-browser/pull/588), [#589](https://github.com/grafana/xk6-browser/pull/589), [#595](https://github.com/grafana/xk6-browser/pull/595), [#596](https://github.com/grafana/xk6-browser/pull/596), [#599](https://github.com/grafana/xk6-browser/pull/599), [#604](https://github.com/grafana/xk6-browser/pull/604), [#606](https://github.com/grafana/xk6-browser/pull/606), [#607](https://github.com/grafana/xk6-browser/pull/607), [#615](https://github.com/grafana/xk6-browser/pull/615), [#617](https://github.com/grafana/xk6-browser/pull/617), [#634](https://github.com/grafana/xk6-browser/pull/634), [#636](https://github.com/grafana/xk6-browser/pull/636))
+


### PR DESCRIPTION
This contains the release notes for v0.6.0. We've primarily worked on making xk6-browser more stable. There are many bug fixes which users may or may not have run into, but we did while we were testing the application. `page.goto` is no async, which is a breaking change.