### PR TITLE
Force browser opts in cloud

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -132,7 +132,7 @@ func (b *BrowserType) Launch(opts goja.Value) api.Browser {
 		k6ext.Panic(ctx, "setting up logger: %w", err)
 	}
 
-	launchOpts := common.NewLaunchOptions()
+	launchOpts := common.NewLaunchOptions(false)
 	if err := launchOpts.Parse(ctx, opts, b.logger); err != nil {
 		k6ext.Panic(ctx, "parsing launch options: %w", err)
 	}

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -132,7 +132,7 @@ func (b *BrowserType) Launch(opts goja.Value) api.Browser {
 		k6ext.Panic(ctx, "setting up logger: %w", err)
 	}
 
-	launchOpts := common.NewLaunchOptions(false)
+	launchOpts := common.NewLaunchOptions(k6ext.OnCloud())
 	if err := launchOpts.Parse(ctx, opts, b.logger); err != nil {
 		k6ext.Panic(ctx, "parsing launch options: %w", err)
 	}

--- a/common/browser_options.go
+++ b/common/browser_options.go
@@ -44,12 +44,13 @@ type LaunchPersistentContextOptions struct {
 }
 
 // NewLaunchOptions returns a new LaunchOptions.
-func NewLaunchOptions() *LaunchOptions {
+func NewLaunchOptions(onCloud bool) *LaunchOptions {
 	return &LaunchOptions{
 		Env:               make(map[string]string),
 		Headless:          true,
 		LogCategoryFilter: ".*",
 		Timeout:           DefaultTimeout,
+		onCloud:           onCloud,
 	}
 }
 

--- a/common/browser_options.go
+++ b/common/browser_options.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
+	"golang.org/x/exp/slices"
 
 	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/log"
@@ -32,6 +33,8 @@ type LaunchOptions struct {
 	Proxy             ProxyOptions
 	SlowMo            time.Duration
 	Timeout           time.Duration
+
+	onCloud bool // some options will be ignored when running in the cloud
 }
 
 // LaunchPersistentContextOptions stores browser launch options for persistent context.
@@ -66,6 +69,10 @@ func (l *LaunchOptions) Parse(ctx context.Context, opts goja.Value, logger *log.
 		}
 	)
 	for _, k := range o.Keys() {
+		if l.shouldIgnoreOnCloud(k) {
+			logger.Warnf("LaunchOptions", "setting %s option is disallowed on cloud.", k)
+			continue
+		}
 		v := o.Get(k)
 		if v.Export() == nil {
 			if dv, ok := defaults[k]; ok {
@@ -104,4 +111,11 @@ func (l *LaunchOptions) Parse(ctx context.Context, opts goja.Value, logger *log.
 	}
 
 	return nil
+}
+
+func (l *LaunchOptions) shouldIgnoreOnCloud(opt string) bool {
+	if !l.onCloud {
+		return false
+	}
+	return slices.Contains([]string{"devtools", "executablePath", "headless"}, opt)
 }

--- a/common/browser_options_test.go
+++ b/common/browser_options_test.go
@@ -212,7 +212,7 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 			t.Parallel()
 			var (
 				vu = k6test.NewVU(t)
-				lo = NewLaunchOptions()
+				lo = NewLaunchOptions(false)
 			)
 			err := lo.Parse(vu.Context(), vu.ToGojaValue(tt.opts), log.NewNullLogger())
 			if tt.err != "" {

--- a/common/browser_options_test.go
+++ b/common/browser_options_test.go
@@ -15,9 +15,10 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 	t.Parallel()
 
 	for name, tt := range map[string]struct {
-		opts   map[string]any
-		assert func(testing.TB, *LaunchOptions)
-		err    string
+		opts    map[string]any
+		assert  func(testing.TB, *LaunchOptions)
+		err     string
+		onCloud bool
 	}{
 		"defaults": {
 			opts: map[string]any{},
@@ -28,6 +29,24 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 					Headless:          true,
 					LogCategoryFilter: ".*",
 					Timeout:           DefaultTimeout,
+				}, lo)
+			},
+		},
+		"defaults_on_cloud": {
+			onCloud: true,
+			opts: map[string]any{
+				"headless":       false,
+				"devtools":       true,
+				"executablePath": "something else",
+			},
+			assert: func(tb testing.TB, lo *LaunchOptions) {
+				tb.Helper()
+				assert.Equal(t, &LaunchOptions{
+					Env:               make(map[string]string),
+					Headless:          true,
+					LogCategoryFilter: ".*",
+					Timeout:           DefaultTimeout,
+					onCloud:           true,
 				}, lo)
 			},
 		},
@@ -212,7 +231,7 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 			t.Parallel()
 			var (
 				vu = k6test.NewVU(t)
-				lo = NewLaunchOptions(false)
+				lo = NewLaunchOptions(tt.onCloud)
 			)
 			err := lo.Parse(vu.Context(), vu.ToGojaValue(tt.opts), log.NewNullLogger())
 			if tt.err != "" {

--- a/common/browser_options_test.go
+++ b/common/browser_options_test.go
@@ -35,18 +35,38 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 		"defaults_on_cloud": {
 			onCloud: true,
 			opts: map[string]any{
+				// disallow changing the following opts
 				"headless":       false,
 				"devtools":       true,
 				"executablePath": "something else",
+				// allow changing the following opts
+				"args":              []string{"any"},
+				"debug":             true,
+				"env":               map[string]string{"some": "thing"},
+				"ignoreDefaultArgs": []string{"any"},
+				"logCategoryFilter": "...",
+				"proxy":             ProxyOptions{Server: "srv"},
+				"slowMo":            time.Second,
+				"timeout":           time.Second,
 			},
 			assert: func(tb testing.TB, lo *LaunchOptions) {
 				tb.Helper()
 				assert.Equal(t, &LaunchOptions{
-					Env:               make(map[string]string),
-					Headless:          true,
-					LogCategoryFilter: ".*",
-					Timeout:           DefaultTimeout,
-					onCloud:           true,
+					// disallowed:
+					Headless:       true,
+					Devtools:       false,
+					ExecutablePath: "",
+					// allowed:
+					Args:              []string{"any"},
+					Debug:             true,
+					Env:               map[string]string{"some": "thing"},
+					IgnoreDefaultArgs: []string{"any"},
+					LogCategoryFilter: "...",
+					Proxy:             ProxyOptions{Server: "srv"},
+					SlowMo:            time.Second,
+					Timeout:           time.Second,
+
+					onCloud: true,
 				}, lo)
 			},
 		},

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -24,7 +24,7 @@ func TestBrowserNewPageInContext(t *testing.T) {
 	newTestCase := func(id cdp.BrowserContextID) *testCase {
 		ctx, cancel := context.WithCancel(context.Background())
 		logger := log.NewNullLogger()
-		b := newBrowser(ctx, cancel, nil, NewLaunchOptions(), logger)
+		b := newBrowser(ctx, cancel, nil, NewLaunchOptions(false), logger)
 		// set a new browser context in the browser with `id`, so that newPageInContext can find it.
 		b.contexts[id] = NewBrowserContext(ctx, b, id, nil, nil)
 		return &testCase{

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
 	go.k6.io/k6 v0.41.0
+	golang.org/x/exp v0.0.0-20221106115401-f9659909a136
 	golang.org/x/net v0.1.0
 	gopkg.in/guregu/null.v3 v3.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -138,7 +138,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -282,6 +282,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221106115401-f9659909a136 h1:Fq7F/w7MAa1KJ5bt2aJ62ihqp9HDcRuyILskkpIAurw=
+golang.org/x/exp v0.0.0-20221106115401-f9659909a136/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -479,7 +481,6 @@ golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/k6ext/cloud.go
+++ b/k6ext/cloud.go
@@ -1,0 +1,9 @@
+package k6ext
+
+import "os"
+
+// OnCloud returns true if xk6-browser runs in the cloud.
+func OnCloud() bool {
+	_, ok := os.LookupEnv("K6_CLOUDRUN_INSTANCE_ID")
+	return ok
+}

--- a/k6ext/doc.go
+++ b/k6ext/doc.go
@@ -1,0 +1,2 @@
+// Package k6ext acts as an encapsulation layer between the k6 core and xk6-browser.
+package k6ext


### PR DESCRIPTION
This PR ignores cloud-only options and logs a message when xk6-browser is running in the cloud.

The cloud-only options are: `devtools`, `executablePath`, and `headless`.

* The `k6ext.OnCloud` detects the cloud run and returns `true` if the [`K6_CLOUDRUN_INSTANCE_ID`](https://k6.io/docs/cloud/creating-and-running-a-test/cloud-tests-from-the-cli/#cloud-environment-variables) environment variable exists.
* `LaunchOptions.Parse` ignores the cloud-only options if we're running in the cloud.

Closes #414.