### PR TITLE
Fix WaitForLoadState and add tests

### DIFF
--- a/common/helpers.go
+++ b/common/helpers.go
@@ -198,26 +198,6 @@ func createWaitForEventPredicateHandler(
 	return ch, evCancelFn
 }
 
-func waitForEvent(
-	ctx context.Context,
-	emitter EventEmitter, events []string,
-	predicateFn func(data any) bool,
-	timeout time.Duration,
-) (any, error) { //nolint:unparam
-	ch, evCancelFn := createWaitForEventHandler(ctx, emitter, events, predicateFn)
-	defer evCancelFn() // Remove event handler
-
-	select {
-	case <-ctx.Done():
-	case <-time.After(timeout):
-		return nil, fmt.Errorf("%w after %s", ErrTimedOut, timeout)
-	case evData := <-ch:
-		return evData, nil
-	}
-
-	return nil, nil
-}
-
 // panicOrSlowMo panics if err is not nil, otherwise applies slow motion.
 func panicOrSlowMo(ctx context.Context, err error) {
 	if err != nil {

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -68,6 +68,62 @@ func TestLifecycleWaitForLoadStateLoad(t *testing.T) {
 	})
 }
 
+func TestLifecycleWaitForLoadStateDOMContentLoaded(t *testing.T) {
+	// Test description
+	//
+	// 1. goto /home and wait for the domcontentloaded lifecycle event.
+	// 2. use WaitForLoadState with domcontentloaded to ensure that
+	//    domcontentloaded lifecycle event has already fired.
+	//
+	// Success criteria: We don't wait for all network requests or the
+	//                   async scripts to complete, and we're only
+	//                   interested in the html file being loaded. We
+	//                   also want to ensure that the domcontentloaded
+	//                   event is stored internally, and we don't block
+	//                   on WaitForLoadState.
+
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tb.staticURL("wait_for_nav_lifecycle.html"), http.StatusMovedPermanently)
+	})
+
+	var counter int64
+	var counterMu sync.Mutex
+	tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		counterMu.Lock()
+		defer counterMu.Unlock()
+
+		time.Sleep(time.Millisecond * 100)
+
+		counter++
+		fmt.Fprintf(w, "pong %d", counter)
+	})
+
+	tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `
+				await new Promise(resolve => setTimeout(resolve, 1000));
+
+				var pingJSTextOutput = document.getElementById("pingJSText");
+				pingJSTextOutput.innerText = "ping.js loaded from server";
+			`)
+	})
+
+	waitUntil := common.LifecycleEventDOMContentLoad
+	assertHome(t, tb, p, waitUntil, func() {
+		result := p.TextContent("#pingRequestText", nil)
+		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "Waiting...", result)
+
+		// This shouldn't block and return after calling hasLifecycleEventFired.
+		p.WaitForLoadState(waitUntil.String(), nil)
+	})
+}
+
 func TestLifecycleReloadLoad(t *testing.T) {
 	t.Parallel()
 

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -124,6 +124,56 @@ func TestLifecycleWaitForLoadStateDOMContentLoaded(t *testing.T) {
 	})
 }
 
+func TestLifecycleWaitForLoadStateNetworkIdle(t *testing.T) {
+	// Test description
+	//
+	// 1. goto /home and wait for the networkidle lifecycle event.
+	// 2. use WaitForLoadState with networkidle to ensure that
+	//    networkidle lifecycle event has already fired.
+	//
+	// Success criteria: We wait for all network requests and async
+	//                   scripts to complete. We also want to ensure
+	//                   that the networkidle event is stored internally,
+	//                   and we don't block on WaitForLoadState.
+
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tb.staticURL("wait_for_nav_lifecycle.html"), http.StatusMovedPermanently)
+	})
+
+	var counter int64
+	var counterMu sync.Mutex
+	tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		counterMu.Lock()
+		defer counterMu.Unlock()
+
+		counter++
+		fmt.Fprintf(w, "pong %d", counter)
+	})
+
+	tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `
+				var pingJSTextOutput = document.getElementById("pingJSText");
+				pingJSTextOutput.innerText = "ping.js loaded from server";
+			`)
+	})
+
+	waitUntil := common.LifecycleEventNetworkIdle
+	assertHome(t, tb, p, waitUntil, func() {
+		result := p.TextContent("#pingRequestText", nil)
+		assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "ping.js loaded from server", result)
+
+		// This shouldn't block and return after calling hasLifecycleEventFired.
+		p.WaitForLoadState(waitUntil.String(), nil)
+	})
+}
+
 func TestLifecycleReloadLoad(t *testing.T) {
 	t.Parallel()
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -662,8 +662,6 @@ func TestPageWaitForFunction(t *testing.T) {
 func TestPageWaitForLoadState(t *testing.T) {
 	t.Parallel()
 
-	// TODO: Add happy path tests once WaitForLoadState is not racy.
-
 	t.Run("err_wrong_event", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/static/wait_for_nav_lifecycle.html
+++ b/tests/static/wait_for_nav_lifecycle.html
@@ -1,0 +1,31 @@
+<html>
+
+<head></head>
+
+<body>
+    <a href="/home" id="homeLink">Home</a>
+    <div id="pingRequestText">Waiting...</div>
+    <div id="pingJSText">Waiting...</div>
+
+    <script>
+        var pingRequestTextOutput = document.getElementById("pingRequestText");
+
+        var p = requestPings();
+        p.then(() => {
+            pingRequestTextOutput.innerText += ' - for loop complete';
+        })
+
+        async function requestPings() {
+            for (var i = 0; i < 10; i++) {
+                await fetch('/ping')
+                    .then(response => response.text())
+                    .then((data) => {
+                        pingRequestTextOutput.innerText = 'Waiting... ' + data;
+                    });
+            }
+        }
+    </script>
+    <script src="/ping.js" async></script>
+</body>
+
+</html>


### PR DESCRIPTION
This PR was opened to help in part with issue https://github.com/grafana/xk6-browser/issues/593.

This PR's aim is to do two things:
1. Add missing tests for `WaitForLoadState` when using `waitUntil` options.
2. Fix an issue where `WaitForLoadState` needs to wait for new events from the browser.

https://github.com/grafana/xk6-browser/pull/623 needs to be merged into `main` first before this PR.

The tests all follow a similar setup to what is already present in `main` and in https://github.com/grafana/xk6-browser/pull/623.

The fix involved copying the `waitUntil` logic used in [FrameManager.NavigateFrame](https://github.com/grafana/xk6-browser/blob/main/common/frame_manager.go#L578).