### PR TITLE
Add mutex to prevent data race on pendingDoc and use mutex when reading frame.inflightRequests

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -148,6 +148,18 @@ func (f *Frame) inflightRequestsLen() int {
 	return len(f.inflightRequests)
 }
 
+func (f *Frame) getInflightRequest() map[network.RequestID]bool {
+	f.inflightRequestsMu.Lock()
+	defer f.inflightRequestsMu.Unlock()
+
+	ifr := make(map[network.RequestID]bool)
+	for k, v := range f.inflightRequests {
+		ifr[k] = v
+	}
+
+	return ifr
+}
+
 func (f *Frame) clearLifecycle() {
 	f.log.Debugf("Frame:clearLifecycle", "fid:%s furl:%q", f.ID(), f.URL())
 

--- a/common/frame.go
+++ b/common/frame.go
@@ -149,8 +149,8 @@ func (f *Frame) inflightRequestsLen() int {
 }
 
 func (f *Frame) getInflightRequest() map[network.RequestID]bool {
-	f.inflightRequestsMu.Lock()
-	defer f.inflightRequestsMu.Unlock()
+	f.inflightRequestsMu.RLock()
+	defer f.inflightRequestsMu.RUnlock()
 
 	ifr := make(map[network.RequestID]bool)
 	for k, v := range f.inflightRequests {

--- a/common/frame.go
+++ b/common/frame.go
@@ -148,7 +148,7 @@ func (f *Frame) inflightRequestsLen() int {
 	return len(f.inflightRequests)
 }
 
-func (f *Frame) getInflightRequest() map[network.RequestID]bool {
+func (f *Frame) cloneInflightRequests() map[network.RequestID]bool {
 	f.inflightRequestsMu.RLock()
 	defer f.inflightRequestsMu.RUnlock()
 

--- a/common/frame.go
+++ b/common/frame.go
@@ -70,8 +70,9 @@ type Frame struct {
 	inflightRequestsMu sync.RWMutex
 	inflightRequests   map[network.RequestID]bool
 
-	currentDocument *DocumentInfo
-	pendingDocument *DocumentInfo
+	currentDocument   *DocumentInfo
+	pendingDocumentMu sync.RWMutex
+	pendingDocument   *DocumentInfo
 
 	log *log.Logger
 }

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -446,7 +446,7 @@ func (m *FrameManager) requestFailed(req *Request, canceled bool) {
 	}
 	frame.deleteRequest(req.getID())
 
-	ifr := frame.getInflightRequest()
+	ifr := frame.cloneInflightRequests()
 	switch rc := len(ifr); {
 	case rc == 0:
 		frame.startNetworkIdleTimer()

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -454,6 +454,13 @@ func (m *FrameManager) requestFailed(req *Request, canceled bool) {
 		for reqID := range ifr {
 			req := frame.requestByID(reqID)
 
+			if req == nil {
+				m.logger.Debugf("FrameManager:requestFailed:rc<=10 request is nil",
+					"reqID:%s frameID:%s",
+					reqID, frame.ID())
+				continue
+			}
+
 			m.logger.Debugf("FrameManager:requestFailed:rc<=10",
 				"reqID:%s inflightURL:%s frameID:%s",
 				reqID, req.URL(), frame.ID())

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -446,11 +446,12 @@ func (m *FrameManager) requestFailed(req *Request, canceled bool) {
 	}
 	frame.deleteRequest(req.getID())
 
-	switch rc := frame.inflightRequestsLen(); {
+	ifr := frame.getInflightRequest()
+	switch rc := len(ifr); {
 	case rc == 0:
 		frame.startNetworkIdleTimer()
 	case rc <= 10:
-		for reqID := range frame.inflightRequests {
+		for reqID := range ifr {
 			req := frame.requestByID(reqID)
 
 			m.logger.Debugf("FrameManager:requestFailed:rc<=10",

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -122,12 +122,13 @@ func (m *FrameManager) frameAbortedNavigation(frameID cdp.FrameID, errorText, do
 	}
 
 	frame.pendingDocumentMu.Lock()
-	defer frame.pendingDocumentMu.Unlock()
 
 	if frame.pendingDocument == nil {
+		frame.pendingDocumentMu.Unlock()
 		return
 	}
 	if documentID != "" && frame.pendingDocument.documentID != documentID {
+		frame.pendingDocumentMu.Unlock()
 		return
 	}
 
@@ -142,6 +143,9 @@ func (m *FrameManager) frameAbortedNavigation(frameID cdp.FrameID, errorText, do
 		err:         errors.New(errorText),
 	}
 	frame.pendingDocument = nil
+
+	frame.pendingDocumentMu.Unlock()
+
 	frame.emit(EventFrameNavigation, ne)
 }
 


### PR DESCRIPTION
Two race conditions were found while stress testing some lifecycle event tests. The resulting log is:

```
WARNING: DATA RACE
Read at 0x00c0008f9328 by goroutine 254:
  github.com/grafana/xk6-browser/common.(*FrameManager).requestFailed()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_manager.go:449 +0x2cc
  github.com/grafana/xk6-browser/common.(*NetworkManager).onLoadingFailed()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/network_manager.go:357 +0x234
  github.com/grafana/xk6-browser/common.(*NetworkManager).handleEvents()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/network_manager.go:330 +0x144
  github.com/grafana/xk6-browser/common.(*NetworkManager).initEvents.func1()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/network_manager.go:313 +0x3c

Previous write at 0x00c0008f9328 by goroutine 427:
  github.com/grafana/xk6-browser/common.(*FrameManager).frameNavigated()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_manager.go:292 +0x9b0
  github.com/grafana/xk6-browser/common.(*FrameSession).onFrameNavigated()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_session.go:628 +0x24c
  github.com/grafana/xk6-browser/common.(*FrameSession).initEvents.func1()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_session.go:237 +0x52c

Goroutine 254 (running) created at:
  github.com/grafana/xk6-browser/common.(*NetworkManager).initEvents()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/network_manager.go:312 +0x358
  github.com/grafana/xk6-browser/common.NewNetworkManager()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/network_manager.go:87 +0x46c
  github.com/grafana/xk6-browser/common.NewFrameSession()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_session.go:100 +0x510
  github.com/grafana/xk6-browser/common.NewPage()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/page.go:119 +0x878
  github.com/grafana/xk6-browser/common.(*Browser).onAttachedToTarget()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/browser.go:274 +0x810
  github.com/grafana/xk6-browser/common.(*Browser).initEvents.func1()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/browser.go:175 +0x2fc

Goroutine 427 (running) created at:
  github.com/grafana/xk6-browser/common.(*FrameSession).initEvents()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_session.go:208 +0x280
  github.com/grafana/xk6-browser/common.NewFrameSession()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_session.go:117 +0x914
  github.com/grafana/xk6-browser/common.NewPage()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/page.go:119 +0x878
  github.com/grafana/xk6-browser/common.(*Browser).onAttachedToTarget()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/browser.go:274 +0x810
  github.com/grafana/xk6-browser/common.(*Browser).initEvents.func1()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/browser.go:175 +0x2fc
==================
==================
WARNING: DATA RACE
Write at 0x00c0008f9318 by goroutine 427:
  github.com/grafana/xk6-browser/common.(*Frame).clearLifecycle()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame.go:175 +0x2bc
  github.com/grafana/xk6-browser/common.(*FrameManager).frameNavigated()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_manager.go:305 +0xbe4
  github.com/grafana/xk6-browser/common.(*FrameSession).onFrameNavigated()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_session.go:628 +0x24c
  github.com/grafana/xk6-browser/common.(*FrameSession).initEvents.func1()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_session.go:237 +0x52c

Previous read at 0x00c0008f9318 by goroutine 254:
  github.com/grafana/xk6-browser/common.(*FrameManager).requestFailed()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_manager.go:440 +0x210
  github.com/grafana/xk6-browser/common.(*NetworkManager).onLoadingFailed()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/network_manager.go:357 +0x234
  github.com/grafana/xk6-browser/common.(*NetworkManager).handleEvents()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/network_manager.go:330 +0x144
  github.com/grafana/xk6-browser/common.(*NetworkManager).initEvents.func1()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/network_manager.go:313 +0x3c

Goroutine 427 (running) created at:
  github.com/grafana/xk6-browser/common.(*FrameSession).initEvents()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_session.go:208 +0x280
  github.com/grafana/xk6-browser/common.NewFrameSession()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_session.go:117 +0x914
  github.com/grafana/xk6-browser/common.NewPage()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/page.go:119 +0x878
  github.com/grafana/xk6-browser/common.(*Browser).onAttachedToTarget()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/browser.go:274 +0x810
  github.com/grafana/xk6-browser/common.(*Browser).initEvents.func1()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/browser.go:175 +0x2fc

Goroutine 254 (running) created at:
  github.com/grafana/xk6-browser/common.(*NetworkManager).initEvents()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/network_manager.go:312 +0x358
  github.com/grafana/xk6-browser/common.NewNetworkManager()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/network_manager.go:87 +0x46c
  github.com/grafana/xk6-browser/common.NewFrameSession()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/frame_session.go:100 +0x510
  github.com/grafana/xk6-browser/common.NewPage()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/page.go:119 +0x878
  github.com/grafana/xk6-browser/common.(*Browser).onAttachedToTarget()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/browser.go:274 +0x810
  github.com/grafana/xk6-browser/common.(*Browser).initEvents.func1()
      /Users/ankuragarwal/go/src/github.com/grafana/xk6-browser/common/browser.go:175 +0x2fc
==================
```

The fix for this is two fold:
1. Protect the access to `pendingDocument` with a new `pendingDocumentMu` mutex.
2. Ensure that we work with a clone of `frame.inflightRequests` when logging `frame.inflightRequests` -- `frame.inflightRequests` is already accessed in a secure way in `frame` with `inflightRequestsMu`.