### PR TITLE
chore: remove static chromium version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,8 @@ RUN  xk6 build --output "/tmp/k6" --with github.com/grafana/xk6-browser
 
 FROM debian:bullseye
 
-ARG CHROMIUM_VERSION=106.0.5249.61-1~deb11u1
-
 RUN apt-get update && \
-    apt-get install -y chromium=${CHROMIUM_VERSION}
+    apt-get install -y chromium
 
 COPY --from=builder /tmp/k6 /usr/bin/k6
 


### PR DESCRIPTION
# What?

Removing the fixed version of the chromium because it's not available in the repositories after a while. 

# Why?

It was reported in [community forums](https://community.k6.io/t/issue-with-building-xk6-browser-as-docker-image/5109). 

```
$ docker-compose build --no-cache xk6-browser
....
Step 5/9 : ARG CHROMIUM_VERSION=106.0.5249.61-1~deb11u1
 ---> Running in bc2110352dd6
Removing intermediate container bc2110352dd6
 ---> 5b4bee2c903b
Step 6/9 : RUN apt-get update &&     apt-get install -y chromium=${CHROMIUM_VERSION}
 ---> Running in 3537960e2093
Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [48.4 kB]
Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB]
Get:4 http://deb.debian.org/debian bullseye/main amd64 Packages [8184 kB]
Get:5 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [194 kB]
Get:6 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [14.6 kB]
Fetched 8600 kB in 2s (5221 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '106.0.5249.61-1~deb11u1' for 'chromium' was not found
The command '/bin/sh -c apt-get update &&     apt-get install -y chromium=${CHROMIUM_VERSION}' returned a non-zero code: 100
ERROR: Service 'xk6-browser' failed to build : Build failed
```