### PR TITLE
Fix a race condition with logCache.entries

### DIFF
--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -167,10 +167,12 @@ func TestBrowserLogIterationID(t *testing.T) {
 	)
 
 	require.NotEmpty(t, iterID)
-	require.NotEmpty(t, tb.logCache.entries)
 
 	tb.logCache.mu.RLock()
 	defer tb.logCache.mu.RUnlock()
+
+	require.NotEmpty(t, tb.logCache.entries)
+
 	for _, evt := range tb.logCache.entries {
 		for k, v := range evt.Data {
 			if k == "iteration_id" {


### PR DESCRIPTION
This race condition was found in a [CI job ](https://github.com/grafana/xk6-browser/actions/runs/3395754810/jobs/5646033469)which failed.

```
==================
WARNING: DATA RACE
Read at 0x00c001048490 by goroutine 161:
  github.com/grafana/xk6-browser/tests.TestBrowserLogIterationID()
      /home/runner/work/xk6-browser/xk6-browser/tests/browser_test.go:170 +0x176
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.8/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.8/x64/src/testing/testing.go:[148](https://github.com/grafana/xk6-browser/actions/runs/3395754810/jobs/5646033469#step:5:149)6 +0x47

Previous write at 0x00c001048490 by goroutine 14:
  github.com/grafana/xk6-browser/tests.(*logCache).Fire()
      /home/runner/work/xk6-browser/xk6-browser/tests/logrus_hook.go:29 +0x1dd
  github.com/sirupsen/logrus.LevelHooks.Fire()
      /home/runner/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/hooks.go:28 +0xbb
  github.com/sirupsen/logrus.(*Entry).fireHooks()
      /home/runner/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/entry.go:280 +0x304
  github.com/sirupsen/logrus.(*Entry).log()
      /home/runner/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/entry.go:242 +0x829
  github.com/sirupsen/logrus.(*Entry).Log()
      /home/runner/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/entry.go:304 +0x8b
  github.com/sirupsen/logrus.(*Entry).Logf()
      /home/runner/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/entry.go:349 +0xc4
  github.com/grafana/xk6-browser/log.(*Logger).Logf()
      /home/runner/work/xk6-browser/xk6-browser/log/logger.go:109 +0x71e
  github.com/grafana/xk6-browser/log.(*Logger).Debugf()
      /home/runner/work/xk6-browser/xk6-browser/log/logger.go:49 +0x60a
  github.com/grafana/xk6-browser/common.(*Session).Execute()
      /home/runner/work/xk6-browser/xk6-browser/common/session.go:155 +0x4f2
  github.com/chromedp/cdproto/cdp.Execute()
      /home/runner/go/pkg/mod/github.com/chromedp/cdproto@v0.0.0-20221023212508-67ada9507fb2/cdp/types.go:48 +0xda
  github.com/chromedp/cdproto/network.(*EnableParams).Do()
      /home/runner/go/pkg/mod/github.com/chromedp/cdproto@v0.0.0-20221023212508-67ada9507fb2/network/network.go:238 +0x59
  github.com/grafana/xk6-browser/common.(*NetworkManager).initDomains()
      /home/runner/work/xk6-browser/xk6-browser/common/network_manager.go:292 +0x542
  github.com/grafana/xk6-browser/common.NewNetworkManager()
      /home/runner/work/xk6-browser/xk6-browser/common/network_manager.go:88 +0x5ea
  github.com/grafana/xk6-browser/common.NewFrameSession()
      /home/runner/work/xk6-browser/xk6-browser/common/frame_session.go:100 +0x72a
  github.com/grafana/xk6-browser/common.NewPage()
      /home/runner/work/xk6-browser/xk6-browser/common/page.go:119 +0xc0b
  github.com/grafana/xk6-browser/common.(*Browser).onAttachedToTarget()
      /home/runner/work/xk6-browser/xk6-browser/common/browser.go:274 +0xaae
  github.com/grafana/xk6-browser/common.(*Browser).initEvents.func1()
      /home/runner/work/xk6-browser/xk6-browser/common/browser.go:175 +0x40f

Goroutine 161 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.8/x64/src/testing/testing.go:1486 +0x724
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.18.8/x64/src/testing/testing.go:1839 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.8/x64/src/testing/testing.go:1439 +0x213
  testing.runTests()
      /opt/hostedtoolcache/go/1.18.8/x64/src/testing/testing.go:1837 +0x7e4
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.18.8/x64/src/testing/testing.go:1719 +0xa71
  main.main()
      _testmain.go:181 +0x2e4

Goroutine 14 (running) created at:
  github.com/grafana/xk6-browser/common.(*Browser).initEvents()
      /home/runner/work/xk6-browser/xk6-browser/common/browser.go:160 +0x33a
  github.com/grafana/xk6-browser/common.(*Browser).connect()
      /home/runner/work/xk6-browser/xk6-browser/common/browser.go:121 +0x6f1
  github.com/grafana/xk6-browser/common.NewBrowser()
      /home/runner/work/xk6-browser/xk6-browser/common/browser.go:80 +0x74
  github.com/grafana/xk6-browser/chromium.(*BrowserType).launch()
      /home/runner/work/xk6-browser/xk6-browser/chromium/browser_type.go:203 +0xb4a
  github.com/grafana/xk6-browser/chromium.(*BrowserType).Launch()
      /home/runner/work/xk6-browser/xk6-browser/chromium/browser_type.go:141 +0x3e9
  github.com/grafana/xk6-browser/tests.newTestBrowser()
      /home/runner/work/xk6-browser/xk6-browser/tests/test_browser.go:110 +0x92e
  github.com/grafana/xk6-browser/tests.TestBrowserLogIterationID()
      /home/runner/work/xk6-browser/xk6-browser/tests/browser_test.go:162 +0x95
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.8/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.8/x64/src/testing/testing.go:1486 +0x47
==================
--- FAIL: TestBrowserLogIterationID (0.18s)
```