### PR TITLE
Fix deadlock with executionContextMu

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -1789,9 +1789,6 @@ func (f *Frame) WaitForFunction(fn goja.Value, opts goja.Value, jsArgs ...goja.V
 		k6ext.Panic(f.ctx, "parsing waitForFunction options: %w", err)
 	}
 
-	f.executionContextMu.RLock()
-	defer f.executionContextMu.RUnlock()
-
 	js := fn.ToString().String()
 	_, isCallable := goja.AssertFunction(fn)
 	if !isCallable {


### PR DESCRIPTION
executionContextMu isn't needed to be locked and unlocked in this (WaitForFunction) method as it doesn't r/w to executionContext or documentHandle. This function later calls an unexported method with the same name, which does require access to executionContext.

A deadlock was occurring later in waitForExecutionContext since this method was holding on to the lock.

Closes: https://github.com/grafana/xk6-browser/issues/635