### PR TITLE
Add tests to lock in the waitUntil lifecycle event behaviour

### DIFF
--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -14,6 +14,71 @@ import (
 	"github.com/grafana/xk6-browser/common"
 )
 
+func TestLifecycleWaitForNavigationDOMContentLoaded(t *testing.T) {
+	// Test description
+	//
+	// 1. goto /home and wait for the domcontentloaded lifecycle event.
+	// 2. click on a link that navigates to a page, at the same time
+	//    set WaitForNavigation with domcontentloaded.
+	//
+	// Success criteria: The initial navigation must succeed followed
+	//                   by the second navigation where we also set a
+	//                   WaitForNavigation on domcontentloaded; this
+	//                   should also succeed and unblock.
+
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tb.staticURL("wait_for_nav_lifecycle.html"), http.StatusMovedPermanently)
+	})
+
+	var counter int64
+	var counterMu sync.Mutex
+	tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		counterMu.Lock()
+		defer counterMu.Unlock()
+
+		time.Sleep(time.Millisecond * 100)
+
+		counter++
+		fmt.Fprintf(w, "pong %d", counter)
+	})
+
+	tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `
+				await new Promise(resolve => setTimeout(resolve, 1000));
+				
+				var pingJSTextOutput = document.getElementById("pingJSText");
+				pingJSTextOutput.innerText = "ping.js loaded from server";
+			`)
+	})
+
+	waitUntil := common.LifecycleEventDOMContentLoad
+	assertHome(t, tb, p, waitUntil, func() testPromise {
+		result := p.TextContent("#pingRequestText", nil)
+		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "Waiting...", result)
+
+		waitForNav := p.WaitForNavigation(tb.toGojaValue(&common.FrameWaitForNavigationOptions{
+			Timeout:   30000,
+			WaitUntil: waitUntil,
+		}))
+		click := p.Click("#homeLink", nil)
+
+		return tb.promiseAll(waitForNav, click)
+	}, func() {
+		result := p.TextContent("#pingRequestText", nil)
+		assert.NotEqualValues(t, "Waiting... pong 20 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "Waiting...", result)
+	})
+}
+
 func TestLifecycleWaitForNavigationNetworkIdle(t *testing.T) {
 	// Test description
 	//

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -14,6 +14,67 @@ import (
 	"github.com/grafana/xk6-browser/common"
 )
 
+func TestLifecycleWaitForNavigationNetworkIdle(t *testing.T) {
+	// Test description
+	//
+	// 1. goto /home and wait for the networkidle lifecycle event.
+	// 2. click on a link that navigates to a page, at the same time
+	//    set WaitForNavigation with networkidle.
+	//
+	// Success criteria: The initial navigation must succeed followed
+	//                   by the second navigation where we also set a
+	//                   WaitForNavigation on networkidle; this should
+	//                   also succeed and unblock.
+
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tb.staticURL("wait_for_nav_lifecycle.html"), http.StatusMovedPermanently)
+	})
+
+	var counter int64
+	var counterMu sync.Mutex
+	tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		counterMu.Lock()
+		defer counterMu.Unlock()
+
+		counter++
+		fmt.Fprintf(w, "pong %d", counter)
+	})
+
+	tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `
+				var pingJSTextOutput = document.getElementById("pingJSText");
+				pingJSTextOutput.innerText = "ping.js loaded from server";
+			`)
+	})
+
+	waitUntil := common.LifecycleEventNetworkIdle
+	assertHome(t, tb, p, waitUntil, func() testPromise {
+		result := p.TextContent("#pingRequestText", nil)
+		assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "ping.js loaded from server", result)
+
+		waitForNav := p.WaitForNavigation(tb.toGojaValue(&common.FrameWaitForNavigationOptions{
+			Timeout:   30000,
+			WaitUntil: waitUntil,
+		}))
+		click := p.Click("#homeLink", nil)
+
+		return tb.promiseAll(waitForNav, click)
+	}, func() {
+		result := p.TextContent("#pingRequestText", nil)
+		assert.EqualValues(t, "Waiting... pong 20 - for loop complete", result)
+
+		result = p.TextContent("#pingJSText", nil)
+		assert.EqualValues(t, "ping.js loaded from server", result)
+	})
+}
+
 func TestLifecycleWaitForNavigationTimeout(t *testing.T) {
 	// Test description
 	//

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -120,7 +120,7 @@ func TestLifecycleWaitForLoadStateLoad(t *testing.T) {
 	})
 
 	waitUntil := common.LifecycleEventLoad
-	assertHome(t, tb, p, waitUntil, func() {
+	assertHome(t, tb, p, waitUntil, func() testPromise {
 		result := p.TextContent("#pingRequestText", nil)
 		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
@@ -129,7 +129,9 @@ func TestLifecycleWaitForLoadStateLoad(t *testing.T) {
 
 		// This shouldn't block and return after calling hasLifecycleEventFired.
 		p.WaitForLoadState(waitUntil.String(), nil)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleWaitForLoadStateDOMContentLoaded(t *testing.T) {
@@ -176,7 +178,7 @@ func TestLifecycleWaitForLoadStateDOMContentLoaded(t *testing.T) {
 	})
 
 	waitUntil := common.LifecycleEventDOMContentLoad
-	assertHome(t, tb, p, waitUntil, func() {
+	assertHome(t, tb, p, waitUntil, func() testPromise {
 		result := p.TextContent("#pingRequestText", nil)
 		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
@@ -185,7 +187,9 @@ func TestLifecycleWaitForLoadStateDOMContentLoaded(t *testing.T) {
 
 		// This shouldn't block and return after calling hasLifecycleEventFired.
 		p.WaitForLoadState(waitUntil.String(), nil)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleWaitForLoadStateNetworkIdle(t *testing.T) {
@@ -226,7 +230,7 @@ func TestLifecycleWaitForLoadStateNetworkIdle(t *testing.T) {
 	})
 
 	waitUntil := common.LifecycleEventNetworkIdle
-	assertHome(t, tb, p, waitUntil, func() {
+	assertHome(t, tb, p, waitUntil, func() testPromise {
 		result := p.TextContent("#pingRequestText", nil)
 		assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
@@ -235,7 +239,9 @@ func TestLifecycleWaitForLoadStateNetworkIdle(t *testing.T) {
 
 		// This shouldn't block and return after calling hasLifecycleEventFired.
 		p.WaitForLoadState(waitUntil.String(), nil)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleWaitForLoadStateDOMContentLoadedThenNetworkIdle(t *testing.T) {
@@ -276,7 +282,7 @@ func TestLifecycleWaitForLoadStateDOMContentLoadedThenNetworkIdle(t *testing.T) 
 			`)
 	})
 
-	assertHome(t, tb, p, common.LifecycleEventDOMContentLoad, func() {
+	assertHome(t, tb, p, common.LifecycleEventDOMContentLoad, func() testPromise {
 		p.WaitForLoadState(common.LifecycleEventNetworkIdle.String(), nil)
 
 		result := p.TextContent("#pingRequestText", nil)
@@ -284,7 +290,9 @@ func TestLifecycleWaitForLoadStateDOMContentLoadedThenNetworkIdle(t *testing.T) 
 
 		result = p.TextContent("#pingJSText", nil)
 		assert.EqualValues(t, "ping.js loaded from server", result)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleReloadLoad(t *testing.T) {
@@ -316,7 +324,7 @@ func TestLifecycleReloadLoad(t *testing.T) {
 	})
 
 	waitUntil := common.LifecycleEventLoad
-	assertHome(t, tb, p, waitUntil, func() {
+	assertHome(t, tb, p, waitUntil, func() testPromise {
 		result := p.TextContent("#pingRequestText", nil)
 		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
@@ -334,7 +342,9 @@ func TestLifecycleReloadLoad(t *testing.T) {
 
 		result = p.TextContent("#pingJSText", nil)
 		assert.EqualValues(t, "ping.js loaded from server", result)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleReloadDOMContentLoaded(t *testing.T) {
@@ -368,7 +378,7 @@ func TestLifecycleReloadDOMContentLoaded(t *testing.T) {
 	})
 
 	waitUntil := common.LifecycleEventDOMContentLoad
-	assertHome(t, tb, p, waitUntil, func() {
+	assertHome(t, tb, p, waitUntil, func() testPromise {
 		result := p.TextContent("#pingRequestText", nil)
 		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
@@ -386,7 +396,9 @@ func TestLifecycleReloadDOMContentLoaded(t *testing.T) {
 
 		result = p.TextContent("#pingJSText", nil)
 		assert.EqualValues(t, "Waiting...", result)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleReloadNetworkIdle(t *testing.T) {
@@ -416,7 +428,7 @@ func TestLifecycleReloadNetworkIdle(t *testing.T) {
 	})
 
 	waitUntil := common.LifecycleEventNetworkIdle
-	assertHome(t, tb, p, waitUntil, func() {
+	assertHome(t, tb, p, waitUntil, func() testPromise {
 		result := p.TextContent("#pingRequestText", nil)
 		assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
@@ -434,7 +446,9 @@ func TestLifecycleReloadNetworkIdle(t *testing.T) {
 
 		result = p.TextContent("#pingJSText", nil)
 		assert.EqualValues(t, "ping.js loaded from server", result)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleLoadWithSubFrame(t *testing.T) {
@@ -482,13 +496,15 @@ func TestLifecycleLoadWithSubFrame(t *testing.T) {
 			`)
 	})
 
-	assertHome(t, tb, p, common.LifecycleEventLoad, func() {
+	assertHome(t, tb, p, common.LifecycleEventLoad, func() testPromise {
 		result := p.TextContent("#subFramePingRequestText", nil)
 		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
 		result = p.TextContent("#subFramePingJSText", nil)
 		assert.EqualValues(t, "ping.js loaded from server", result)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleDOMContentLoadedWithSubFrame(t *testing.T) {
@@ -539,13 +555,15 @@ func TestLifecycleDOMContentLoadedWithSubFrame(t *testing.T) {
 			`)
 	})
 
-	assertHome(t, tb, p, common.LifecycleEventDOMContentLoad, func() {
+	assertHome(t, tb, p, common.LifecycleEventDOMContentLoad, func() testPromise {
 		result := p.TextContent("#subFramePingRequestText", nil)
 		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
 		result = p.TextContent("#subFramePingJSText", nil)
 		assert.EqualValues(t, "Waiting...", result)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleNetworkIdleWithSubFrame(t *testing.T) {
@@ -591,13 +609,15 @@ func TestLifecycleNetworkIdleWithSubFrame(t *testing.T) {
 			`)
 	})
 
-	assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() {
+	assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() testPromise {
 		result := p.TextContent("#subFramePingRequestText", nil)
 		assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
 		result = p.TextContent("#subFramePingJSText", nil)
 		assert.EqualValues(t, "ping.js loaded from server", result)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleLoad(t *testing.T) {
@@ -637,13 +657,15 @@ func TestLifecycleLoad(t *testing.T) {
 			`)
 	})
 
-	assertHome(t, tb, p, common.LifecycleEventLoad, func() {
+	assertHome(t, tb, p, common.LifecycleEventLoad, func() testPromise {
 		result := p.TextContent("#pingRequestText", nil)
 		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
 		result = p.TextContent("#pingJSText", nil)
 		assert.EqualValues(t, "ping.js loaded from server", result)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleDOMContentLoaded(t *testing.T) {
@@ -683,13 +705,15 @@ func TestLifecycleDOMContentLoaded(t *testing.T) {
 			`)
 	})
 
-	assertHome(t, tb, p, common.LifecycleEventDOMContentLoad, func() {
+	assertHome(t, tb, p, common.LifecycleEventDOMContentLoad, func() testPromise {
 		result := p.TextContent("#pingRequestText", nil)
 		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
 		result = p.TextContent("#pingJSText", nil)
 		assert.EqualValues(t, "Waiting...", result)
-	})
+
+		return testPromise{}
+	}, nil)
 }
 
 func TestLifecycleNetworkIdle(t *testing.T) {
@@ -719,10 +743,12 @@ func TestLifecycleNetworkIdle(t *testing.T) {
 			`)
 		})
 
-		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() {
+		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() testPromise {
 			result := p.TextContent("#pingJSText", nil)
 			assert.EqualValues(t, "ping.js loaded from server", result)
-		})
+
+			return testPromise{}
+		}, nil)
 	})
 
 	t.Run("doesn't unblock wait for networkIdle too early", func(t *testing.T) {
@@ -757,13 +783,15 @@ func TestLifecycleNetworkIdle(t *testing.T) {
 			close(ch)
 		})
 
-		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() {
+		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() testPromise {
 			result := p.TextContent("#pingRequestText", nil)
 			assert.EqualValues(t, "Waiting... pong 4 - for loop complete", result)
 
 			result = p.TextContent("#pingJSText", nil)
 			assert.EqualValues(t, "ping.js loaded from server", result)
-		})
+
+			return testPromise{}
+		}, nil)
 	})
 
 	t.Run("doesn't unblock wait on networkIdle early when load and domcontentloaded complete at once", func(t *testing.T) {
@@ -787,10 +815,12 @@ func TestLifecycleNetworkIdle(t *testing.T) {
 			fmt.Fprintf(w, "pong %d", counter)
 		})
 
-		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() {
+		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() testPromise {
 			result := p.TextContent("#pingRequestText", nil)
 			assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
-		})
+
+			return testPromise{}
+		}, nil)
 	})
 }
 
@@ -799,7 +829,8 @@ func assertHome(
 	tb *testBrowser,
 	p api.Page,
 	waitUntil common.LifecycleEvent,
-	check func(),
+	check func() testPromise,
+	secondCheck func(),
 ) {
 	t.Helper()
 
@@ -809,15 +840,20 @@ func assertHome(
 			WaitUntil: waitUntil,
 			Timeout:   30 * time.Second,
 		})
-		tb.promise(p.Goto(tb.URL("/home"), opts)).then(
-			func() {
-				check()
+		prm := tb.promise(p.Goto(tb.URL("/home"), opts)).then(
+			func() testPromise {
 				resolved = true
+				return check()
 			},
 			func() {
 				rejected = true
 			},
 		)
+		if secondCheck != nil {
+			prm.then(func() {
+				secondCheck()
+			})
+		}
 
 		return nil
 	})

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -373,6 +373,60 @@ func TestLifecycleReloadNetworkIdle(t *testing.T) {
 	})
 }
 
+func TestLifecycleLoadWithSubFrame(t *testing.T) {
+	// Test description
+	//
+	// 1. goto /home (which also has a iframe) and wait for the
+	//    load lifecycle event.
+	//
+	// Success criteria: Once main and subframe (iframe) have both
+	//                   loaded the html and the async scripts it
+	//                   should unblock. We don't wait for the
+	//                   other network requests to complete. We assert
+	//                   that the sub frame has amended the main
+	//                   frame's DOM.
+
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tb.staticURL("lifecycle_main_frame.html"), http.StatusMovedPermanently)
+	})
+	tb.withHandler("/sub", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tb.staticURL("lifecycle_subframe.html"), http.StatusMovedPermanently)
+	})
+
+	var counter int64
+	var counterMu sync.Mutex
+	tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		counterMu.Lock()
+		defer counterMu.Unlock()
+
+		time.Sleep(time.Millisecond * 100)
+
+		counter++
+		fmt.Fprintf(w, "pong %d", counter)
+	})
+
+	tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `
+				var pingJSTextOutput = document.getElementById("pingJSText");
+				var parentOutputServerMsg = window.parent.document.getElementById('subFramePingJSText');
+				pingJSTextOutput.innerText = "ping.js loaded from server";
+				parentOutputServerMsg.innerText = pingJSTextOutput.innerText;
+			`)
+	})
+
+	assertHome(t, tb, p, common.LifecycleEventLoad, func() {
+		result := p.TextContent("#subFramePingRequestText", nil)
+		assert.NotEqualValues(t, "Waiting... pong 10 - for loop complete", result)
+
+		result = p.TextContent("#subFramePingJSText", nil)
+		assert.EqualValues(t, "ping.js loaded from server", result)
+	})
+}
+
 func TestLifecycleDOMContentLoadedWithSubFrame(t *testing.T) {
 	// Test description
 	//

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -373,6 +373,58 @@ func TestLifecycleReloadNetworkIdle(t *testing.T) {
 	})
 }
 
+func TestLifecycleNetworkIdleWithSubFrame(t *testing.T) {
+	// Test description
+	//
+	// 1. goto /home (which also has a iframe) and wait for the
+	//    networkidle lifecycle event.
+	//
+	// Success criteria: Once main and subframe (iframe) have both
+	//                   loaded the html, async scripts and all other
+	//                   network requests, it should unblock. We
+	//                   assert that the sub frame has amended the
+	//                   main frame's DOM.
+
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+	tb.withHandler("/home", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tb.staticURL("lifecycle_main_frame.html"), http.StatusMovedPermanently)
+	})
+	tb.withHandler("/sub", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, tb.staticURL("lifecycle_subframe.html"), http.StatusMovedPermanently)
+	})
+
+	var counter int64
+	var counterMu sync.Mutex
+	tb.withHandler("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		counterMu.Lock()
+		defer counterMu.Unlock()
+
+		counter++
+		fmt.Fprintf(w, "pong %d", counter)
+	})
+
+	tb.withHandler("/ping.js", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `
+				var pingJSTextOutput = document.getElementById("pingJSText");
+				pingJSTextOutput.innerText = "ping.js loaded from server";
+
+				var parentOutputServerMsg = window.parent.document.getElementById('subFramePingJSText');
+				parentOutputServerMsg.innerText = pingJSTextOutput.innerText;
+			`)
+	})
+
+	assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() {
+		result := p.TextContent("#subFramePingRequestText", nil)
+		assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
+
+		result = p.TextContent("#subFramePingJSText", nil)
+		assert.EqualValues(t, "ping.js loaded from server", result)
+	})
+}
+
 func TestLifecycleLoad(t *testing.T) {
 	// Test description
 	//

--- a/tests/static/lifecycle_main_frame.html
+++ b/tests/static/lifecycle_main_frame.html
@@ -1,0 +1,12 @@
+<html>
+
+<head></head>
+
+<body>
+    <div id="frameType">main</div>
+    <div id="subFramePingRequestText">Waiting...</div>
+    <div id="subFramePingJSText">Waiting...</div>
+    <iframe src="/sub"></iframe>
+</body>
+
+</html>

--- a/tests/static/lifecycle_subframe.html
+++ b/tests/static/lifecycle_subframe.html
@@ -1,0 +1,37 @@
+<html>
+
+<head></head>
+
+<body>
+    <div id="pingRequestText">Waiting...</div>
+    <div id="pingJSText">Waiting...</div>
+
+    <script>
+        var pingRequestTextOutput = document.getElementById("pingRequestText");
+        var parentOutput = window.parent.document.getElementById('subFramePingRequestText');
+
+        var p = pingRequestText();
+        p.then(() => {
+            pingRequestTextOutput.innerText += ' - for loop complete';
+            if (parentOutput) {
+                parentOutput.innerText = pingRequestTextOutput.innerText;
+            }
+        })
+
+        async function pingRequestText() {
+            for (var i = 0; i < 10; i++) {
+                await fetch('/ping')
+                    .then(response => response.text())
+                    .then((data) => {
+                        pingRequestTextOutput.innerText = 'Waiting... ' + data;
+                        if (parentOutput) {
+                            parentOutput.innerText = pingRequestTextOutput.innerText;
+                        }
+                    });
+            }
+        }
+    </script>
+    <script src="/ping.js" async></script>
+</body>
+
+</html>


### PR DESCRIPTION
Before we attempt to cleanup the lifecycle event code (#593) we need to lock in the current behaviour so that any refactoring does not affect the behaviour.

The tests are:
- test that `waitUntil` on `load` and `DOMContentLoaded` work as expected when used in `goto`.
- test that `waitUntil` on `load`, `DOMContentLoaded` and `networkidle` work as expected when we navigate to a page with a main and sub frame when used in `goto`.
- test that `waitUntil` on `load`, `DOMContentLoaded` and `networkidle` work as expected when used as an option on `WaitForNavigation`.
- test that `waitUntil` on `networkidle` timesout if we set it too late after the navigation has completed.

Linked issue: https://github.com/grafana/xk6-browser/issues/593