### PR TITLE
docs: simplify README

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,20 @@
+## FAQ
+
+- **Is this production ready?**<br>
+    No, not yet. We're focused on making the extension stable and reliable, as that's our top priority, before adding more features.
+
+- **Is this extension supported in k6 Cloud?**<br>
+    No, not yet. Once the codebase is deemed production ready we'll add support for browser-based testing in k6 Cloud.
+
+- **It doesn't work with my Chromium/Chrome version, why?**<br>
+    CDP evolves and there are differences between different versions of Chromium, sometimes quite subtle. The codebase is continuously tested with the two latest major releases of Google Chrome.
+
+- **Are Firefox or WebKit-based browsers supported?**<br>
+    Not yet. There are differences in CDP coverage between Chromium, Firefox, and WebKit-based browsers. xk6-browser is initially only targetting Chromium-based browsers.
+
+- **Are all features of Playwright supported?**<br>
+    No. Playwright's API is pretty large and some of the functionality only makes sense if it's implemented using async operations: event listening, request interception, waiting for events, etc. This requires the existence of an event loop per VU in k6, which was only [recently added](https://github.com/grafana/k6/issues/882). Most of the current xk6-browser API is synchronous and thus lacks some of the functionality that requires asynchronicity, but we're gradually migrating existing methods to return a `Promise`, and adding new ones that will follow the same API.
+
+    Expect many breaking changes during this transition, which we'll point out in the release notes.
+
+    Note that `async`/`await` is still not natively supported in k6 scripts, because of the outdated Babel version it uses. If you wish to use this syntax you'll have to transform your script beforehand with an updated Babel version. See the [k6-template-es6 project](https://github.com/grafana/k6-template-es6) and [this comment](https://github.com/grafana/k6/issues/779#issuecomment-964027280) for details.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 <p align="center">
     <a href="https://github.com/grafana/xk6-browser/releases">Download</a> ·
-    <a href="#install">Install</a> ·
+    <a href="https://k6.io/docs/javascript-api/xk6-browser/get-started/installation/">Install</a> ·
     <a href="https://k6.io/docs/javascript-api/k6-x-browser/">Documentation</a> ·
     <a href="https://community.k6.io/c/xk6-browser/14">Community Forum</a>
 </p>
@@ -22,7 +22,7 @@
 <img src="assets/github-hr.svg" height="32" alt="---" />
 <br/>
 
-**xk6-browser** is a [k6](https://k6.io/) extension adding support for automation of browsers via the [Chrome Devtools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP).
+**xk6-browser** is a [k6](https://k6.io/) extension adding support for automation of browsers via the [Chrome Devtools Protocol](https://chromedevtools.github.io/devtools-protocol/) (CDP). It adds browser-level APIs to interact with browsers and collect frontend performance metrics as part of your k6 tests.
 
 https://user-images.githubusercontent.com/10811379/200350050-f346931f-6402-487e-bf4d-eff808ac2190.mp4
 
@@ -37,411 +37,41 @@ Special acknowledgment to the authors of [Playwright](https://playwright.dev/) a
 
 See our [project roadmap](ROADMAP.md) for more details.
 
-
-## FAQ
-
-- **Is this production ready?**<br>
-    No, not yet. We're focused on making the extension stable and reliable, as that's our top priority, before adding more features.
-
-- **Is this extension supported in k6 Cloud?**<br>
-    No, not yet. Once the codebase is deemed production ready we'll add support for browser-based testing in k6 Cloud.
-
-- **It doesn't work with my Chromium/Chrome version, why?**<br>
-    CDP evolves and there are differences between different versions of Chromium, sometimes quite subtle. The codebase is continuously tested with the two latest major releases of Google Chrome.
-
-- **Are Firefox or WebKit-based browsers supported?**<br>
-    Not yet. There are differences in CDP coverage between Chromium, Firefox, and WebKit-based browsers. xk6-browser is initially only targetting Chromium-based browsers.
-
-- **Are all features of Playwright supported?**<br>
-    No. Playwright's API is pretty large and some of the functionality only makes sense if it's implemented using async operations: event listening, request interception, waiting for events, etc. This requires the existence of an event loop per VU in k6, which was only [recently added](https://github.com/grafana/k6/issues/882). Most of the current xk6-browser API is synchronous and thus lacks some of the functionality that requires asynchronicity, but we're gradually migrating existing methods to return a `Promise`, and adding new ones that will follow the same API.
-
-    Expect many breaking changes during this transition, which we'll point out in the release notes.
-
-    Note that `async`/`await` is still not natively supported in k6 scripts, because of the outdated Babel version it uses. If you wish to use this syntax you'll have to transform your script beforehand with an updated Babel version. See the [k6-template-es6 project](https://github.com/grafana/k6-template-es6) and [this comment](https://github.com/grafana/k6/issues/779#issuecomment-964027280) for details.
-
-## Install
-
-### Pre-built binaries
-
-The easiest way to install xk6-browser is to grab a pre-built binary from the [GitHub Releases](https://github.com/grafana/xk6-browser/releases) page. Once you download and unpack the release, you can optionally copy the xk6-browser binary it contains somewhere in your `PATH`, so you are able to run xk6-browser from any location on your system.
-
-Note that you **cannot** use the plain k6 binary released by the k6 project and must run any scripts that import `k6/x/browser` with this separate binary.
-
-### Build from source
-
-To build a `k6` binary with this extension, first ensure you have the prerequisites:
-
-- Make sure that you're running [the latest Go version](https://go.dev/dl/)
-- [Go toolchain](https://go101.org/article/go-toolchain.html)
-- Git
-
-Then:
-
-1. Install `xk6`:
-  ```shell
-  go install go.k6.io/xk6/cmd/xk6@latest
-  ```
-
-2. Build the binary:
-  ```shell
-  xk6 build --output xk6-browser --with github.com/grafana/xk6-browser
-  ```
-
-  This will create a `xk6-browser` binary file in the current working directory. This file can be used exactly the same as the main `k6` binary, with the addition of being able to run xk6-browser scripts.
-
-3. Run scripts that import `k6/x/browser` with the new `xk6-browser` binary. On Linux and macOS make sure this is done by referencing the file in the current directory:
-   ```shell
-   ./xk6-browser run <script>
-   ```
-
-   Note: You can place it somewhere in your `PATH` so that it can be run from anywhere on your system.
-
-### Troubleshooting
-
-If you're having issues installing or running xk6-browser, please see the [troubleshooting document](/TROUBLESHOOTING.md).
-
-## Examples
-
-#### Launch options
-
-```js
-import { chromium } from 'k6/x/browser';
-
-export default function() {
-    const browser = chromium.launch({
-        args: [],                   // Extra commandline arguments to include when launching browser process
-        debug: true,                // Log all CDP messages to k6 logging subsystem
-        devtools: true,             // Open up developer tools in the browser by default
-        env: {},                    // Environment variables to set before launching browser process
-        executablePath: null,       // Override search for browser executable in favor of specified absolute path
-        headless: false,            // Show browser UI or not
-        ignoreDefaultArgs: [],      // Ignore any of the default arguments included when launching browser process
-        proxy: {},                  // Specify to set browser's proxy config
-        slowMo: '500ms',            // Slow down input actions and navigations by specified time
-        timeout: '30s',             // Default timeout to use for various actions and navigations
-    });
-    browser.close();
-}
-```
-
-#### New browser context options
-
-```js
-import { chromium } from 'k6/x/browser';
-
-export default function() {
-    const browser = chromium.launch();
-    const context = browser.newContext({
-        acceptDownloads: false,             // Whether to accept downloading of files by default
-        bypassCSP: false,                   // Whether to bypass content-security-policy rules
-        colorScheme: 'light',               // Preferred color scheme of browser ('light', 'dark' or 'no-preference')
-        deviceScaleFactor: 1.0,             // Device scaling factor
-        extraHTTPHeaders: {name: "value"},  // HTTP headers to always include in HTTP requests
-        geolocation: {latitude: 0.0, longitude: 0.0},       // Geolocation to use
-        hasTouch: false,                    // Simulate device with touch or not
-        httpCredentials: {username: null, password: null},  // Credentials to use if encountering HTTP authentication
-        ignoreHTTPSErrors: false,           // Ignore HTTPS certificate issues
-        isMobile: false,                    // Simulate mobile device or not
-        javaScriptEnabled: true,            // Should JavaScript be enabled or not
-        locale: 'en-US',                    // The locale to set
-        offline: false,                     // Whether to put browser in offline mode or not
-        permissions: ['midi'],              // Permisions to grant by default
-        reducedMotion: 'no-preference',     // Indicate to browser whether it should try to reduce motion/animations
-        screen: {width: 800, height: 600},  // Set default screen size
-        timezoneID: '',                     // Set default timezone to use
-        userAgent: '',                      // Set default user-agent string to use
-        viewport: {width: 800, height: 600},// Set default viewport to use
-    });
-    browser.close();
-}
-```
-
-#### Page screenshot
-
-```js
-import { chromium } from 'k6/x/browser';
-
-export default function() {
-    const browser = chromium.launch({ headless: false });
-    const context = browser.newContext();
-    const page = context.newPage();
-    page.goto('http://whatsmyuseragent.org/');
-    page.screenshot({ path: `example-chromium.png` });
-    page.close();
-    browser.close();
-}
-```
-
-#### Query DOM for element using CSS, XPath or Text based selectors
-
-```js
-import { chromium } from 'k6/x/browser';
-
-export default function() {
-    const browser = chromium.launch({ headless: false });
-    const context = browser.newContext();
-    const page = context.newPage();
-    page.goto('http://whatsmyuseragent.org/');
-
-    // Find element using CSS selector
-    let ip = page.$('.ip-address p').textContent();
-    console.log("CSS selector: ", ip);
-
-    // Find element using XPath expression
-    ip = page.$("//div[@class='ip-address']/p").textContent();
-    console.log("Xpath expression: ", ip);
-
-    // Find element using Text search (TODO: support coming soon!)
-    //ip = page.$("My IP Address").textContent();
-    //console.log("Text search: ", ip);
-
-    page.close();
-    browser.close();
-}
-```
-
-#### Evaluate JS in browser
-
-```js
-import { chromium } from 'k6/x/browser';
-
-export default function() {
-    const browser = chromium.launch({ headless: false });
-    const context = browser.newContext();
-    const page = context.newPage();
-    page.goto('http://whatsmyuseragent.org/', { waitUntil: 'load' });
-    const dimensions = page.evaluate(() => {
-        return {
-            width: document.documentElement.clientWidth,
-            height: document.documentElement.clientHeight,
-            deviceScaleFactor: window.devicePixelRatio
-        };
-    });
-    console.log(JSON.stringify(dimensions));
-    page.close();
-    browser.close();
-}
-```
-
-#### Set preferred color scheme of browser
-
-```js
-import { chromium } from 'k6/x/browser';
-import { sleep } from "k6";
-
-export default function() {
-    const browser = chromium.launch({
-        headless: false
-    });
-    const context = browser.newContext({
-        colorScheme: 'dark', // Valid values are "light", "dark" or "no-preference"
-    });
-    const page = context.newPage();
-    page.goto('http://whatsmyuseragent.org/');
-
-    sleep(5);
-
-    page.close();
-    browser.close();
-}
-```
-
-#### Fill out a form
-
-```js
-import { chromium } from 'k6/x/browser';
-
-export default function() {
-    const browser = chromium.launch({
-        headless: false,
-        slowMo: '500ms' // slow down by 500ms
-    });
-    const context = browser.newContext();
-    const page = context.newPage();
-
-    // Goto front page, find login link and click it
-    page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
-    const elem = page.$('a[href="/my_messages.php"]');
-    elem.click().then(() => {
-        // Enter login credentials and login
-        page.$('input[name="login"]').type('admin');
-        page.$('input[name="password"]').type('123');
-        return page.$('input[type="submit"]').click();
-    }).then(() => {
-        // Wait for next page to load
-        page.waitForLoadState('networkidle');
-    }).finally(() => {
-        // Release the page and browser.
-        page.close();
-        browser.close();
-    });
-}
-```
-
-#### Check element state
-
-```js
-import { chromium } from 'k6/x/browser';
-import { check } from "k6";
-
-export default function() {
-    const browser = chromium.launch({
-        headless: false
-    });
-    const context = browser.newContext();
-    const page = context.newPage();
-
-    // Inject page content
-    page.setContent(`
-        <div class="visible">Hello world</div>
-        <div style="display:none" class="hidden"></div>
-        <div class="editable" editable>Edit me</div>
-        <input type="checkbox" enabled class="enabled">
-        <input type="checkbox" disabled class="disabled">
-        <input type="checkbox" checked class="checked">
-        <input type="checkbox" class="unchecked">
-    `);
-
-    // Check state
-    check(page, {
-        'visible': p => p.$('.visible').isVisible(),
-        'hidden': p => p.$('.hidden').isHidden(),
-        'editable': p => p.$('.editable').isEditable(),
-        'enabled': p => p.$('.enabled').isEnabled(),
-        'disabled': p => p.$('.disabled').isDisabled(),
-        'checked': p => p.$('.checked').isChecked(),
-        'unchecked': p => p.$('.unchecked').isChecked() === false,
-    });
-
-    page.close();
-    browser.close();
-}
-```
-
-#### Locator API
-
-We suggest using the Locator API instead of the low-level
-`ElementHandle` methods. An element handle can go stale if
-the element's underlying frame is navigated. However,
-with the Locator API, even if the underlying frame
-navigates, locators will continue to work.
-
-The Locator API can also help you abstract a page to simplify testing.
-To do that, you can use a pattern called the Page Object Model.
-You can see an example [here](examples/locator_pom.js).
-
-```js
-import { chromium } from 'k6/x/browser';
-
-export default function () {
-  const browser = chromium.launch({
-    headless: false,
-  });
-  const context = browser.newContext();
-  const page = context.newPage();
-
-  page.goto("https://test.k6.io/flip_coin.php", {
-    waitUntil: "networkidle",
-  });
-
-  /*
-  In this example, we will use two locators, matching a
-  different betting button on the page. If you were to query
-  the buttons once and save them as below, you would see an
-  error after the initial navigation. Try it!
-
-    const heads = page.$("input[value='Bet on heads!']");
-    const tails = page.$("input[value='Bet on tails!']");
-
-  The Locator API allows you to get a fresh element handle each
-  time you use one of the locator methods. And, you can carry a
-  locator across frame navigations. Let's create two locators;
-  each locates a button on the page.
-  */
-  const heads = page.locator("input[value='Bet on heads!']");
-  const tails = page.locator("input[value='Bet on tails!']");
-
-  const currentBet = page.locator("//p[starts-with(text(),'Your bet: ')]");
-
-  // In the following Promise.all the tails locator clicks
-  // on the tails button by using the locator's selector.
-  // Since clicking on each button causes page navigation,
-  // waitForNavigation is needed -- this is because the page
-  // won't be ready until the navigation completes.
-  // Setting up the waitForNavigation first before the click
-  // is important to avoid race conditions.
-  Promise.all([
-    page.waitForNavigation(),
-    tails.click(),
-  ]).then(() => {
-    console.log(currentBet.innerText());
-    // the heads locator clicks on the heads button
-    // by using the locator's selector.
-    return Promise.all([
-      page.waitForNavigation(),
-      heads.click(),
-    ]);
-  }).then(() => {
-    console.log(currentBet.innerText());
-    return Promise.all([
-      page.waitForNavigation(),
-      tails.click(),
-    ]);
-  }).finally(() => {
-    console.log(currentBet.innerText());
-    page.close();
-    browser.close();
-  })
-}
-```
-
-### Running examples in a Docker container
-
-The examples above are also available as standalone files in the [`examples` directory](/examples). You can run them in a Docker container using Docker Compose with:
+## Getting Started
+
+- [Getting Started](https://k6.io/docs/javascript-api/xk6-browser/)
+- [Installing xk6-browser](https://k6.io/docs/javascript-api/xk6-browser/get-started/installation/)
+- [Running xk6-browser](https://k6.io/docs/javascript-api/xk6-browser/get-started/running-xk6-browser/)
+- [Browser Metrics](https://k6.io/docs/javascript-api/xk6-browser/get-started/browser-metrics/)
+- [Selecting Elements](https://k6.io/docs/javascript-api/xk6-browser/get-started/selecting-elements/)
+
+## Documentation
+
+- [Releases](https://github.com/grafana/xk6-browser/releases)
+- [API Documentation](https://k6.io/docs/javascript-api/xk6-browser/api/) - This documents how to use our API and its current state with xk6-browser.
+- [Examples](/examples) - The examples from our API documentation are also available as standalone files. You can run them in a Docker container using Docker Compose with:
 
 ```bash
 docker-compose run -T xk6-browser run - <examples/browser_on.js
 ```
 
-## Status
+## Getting Help
 
-Currently only Chromium is supported, and the [Playwright API](https://playwright.dev/docs/api/class-playwright) coverage is as follows:
+- Go to our [FAQ](/FAQ.md) to answer your most asked questions about xk6-browser.
+- If you're having issues installing or running xk6-browser, please see the [troubleshooting document](/TROUBLESHOOTING.md).
+- To get help about usage, report bugs, suggest features and discuss xk6-browser with other users see [SUPPORT.md](SUPPORT.md).
 
-| Class | Support | Missing APIs |
-|   :---   | :--- | :--- |
-| [Accessibility](https://playwright.dev/docs/api/class-accessibility) | :warning: | [`snapshot()`](https://playwright.dev/docs/api/class-accessibility#accessibilitysnapshotoptions) |
-| [Browser](https://playwright.dev/docs/api/class-browser) | :white_check_mark: | [`startTracing()`](https://playwright.dev/docs/api/class-browser#browser-start-tracing), [`stopTracing()`](https://playwright.dev/docs/api/class-browser#browser-stop-tracing) |
-| [BrowserContext](https://playwright.dev/docs/api/class-browsercontext) | :white_check_mark: | [`addCookies()`](https://playwright.dev/docs/api/class-browsercontext#browsercontextaddcookiescookies), [`backgroundPages()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-background-pages), [`cookies()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-cookies), [`exposeBinding()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-expose-binding), [`exposeFunction()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-expose-function), [`newCDPSession()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-new-cdp-session), [`on()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-event-background-page), [`route()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-route), [`serviceWorkers()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-service-workers), [`storageState()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state), [`unroute()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-unroute), [`waitForEvent()`](https://playwright.dev/docs/api/class-browsercontext#browser-context-wait-for-event), [`tracing`](https://playwright.dev/docs/api/class-browsercontext#browser-context-tracing) |
-| [BrowserServer](https://playwright.dev/docs/api/class-browserserver) | :warning: | All |
-| [BrowserType](https://playwright.dev/docs/api/class-browsertype) | :white_check_mark: | [`connect()`](https://playwright.dev/docs/api/class-browsertype#browser-type-connect), [`connectOverCDP()`](https://playwright.dev/docs/api/class-browsertype#browser-type-connect-over-cdp), [`launchPersistentContext()`](https://playwright.dev/docs/api/class-browsertype#browsertypelaunchpersistentcontextuserdatadir-options), [`launchServer()`](https://playwright.dev/docs/api/class-browsertype#browsertypelaunchserveroptions) |
-| [CDPSession](https://playwright.dev/docs/api/class-cdpsession) | :warning: | All |
-| [ConsoleMessage](https://playwright.dev/docs/api/class-consolemessage) | :warning: | All |
-| [Coverage](https://playwright.dev/docs/api/class-coverage) | :warning: | All |
-| [Dialog](https://playwright.dev/docs/api/class-dialog) | :warning: | All |
-| [Download](https://playwright.dev/docs/api/class-download) | :warning: | All |
-| [ElementHandle](https://playwright.dev/docs/api/class-elementhandle) | :white_check_mark: | [`$eval()`](https://playwright.dev/docs/api/class-elementhandle#element-handle-eval-on-selector), [`$$eval()`](https://playwright.dev/docs/api/class-elementhandle#element-handle-eval-on-selector-all), [`setInputFiles()`](https://playwright.dev/docs/api/class-elementhandle#element-handle-set-input-files) |
-| [FetchRequest](https://playwright.dev/docs/api/class-fetchrequest) | :warning: | All |
-| [FetchResponse](https://playwright.dev/docs/api/class-fetchresponse) | :warning: | All |
-| [FileChooser](https://playwright.dev/docs/api/class-filechooser) | :warning: | All |
-| [Frame](https://playwright.dev/docs/api/class-frame) | :white_check_mark: | [`$eval()`](https://playwright.dev/docs/api/class-frame#frame-eval-on-selector), [`$$eval()`](https://playwright.dev/docs/api/class-frame#frame-eval-on-selector-all), [`addScriptTag()`](https://playwright.dev/docs/api/class-frame#frame-add-script-tag), [`addStyleTag()`](https://playwright.dev/docs/api/class-frame#frame-add-style-tag), [`dragAndDrop()`](https://playwright.dev/docs/api/class-frame#frame-drag-and-drop), [`locator()`](https://playwright.dev/docs/api/class-frame#frame-locator), [`setInputFiles()`](https://playwright.dev/docs/api/class-frame#frame-set-input-files) |
-| [JSHandle](https://playwright.dev/docs/api/class-jshandle) | :white_check_mark: | - |
-| [Keyboard](https://playwright.dev/docs/api/class-keyboard) | :white_check_mark: | - |
-| [Locator](https://playwright.dev/docs/api/class-locator) | :white_check_mark: | [`allInnerTexts()`](https://playwright.dev/docs/api/class-locator#locator-all-inner-texts), [`allTextContents()`](https://playwright.dev/docs/api/class-locator#locator-all-text-contents), [`boundingBox([options])`](https://playwright.dev/docs/api/class-locator#locator-bounding-box), [`count()`](https://playwright.dev/docs/api/class-locator#locator-count), [`dragTo(target[, options])`](https://playwright.dev/docs/api/class-locator#locator-drag-to), [`elementHandle([options]) (state: attached)`](https://playwright.dev/docs/api/class-locator#locator-element-handle), [`elementHandles()`](https://playwright.dev/docs/api/class-locator#locator-element-handles), [`evaluate(pageFunction[, arg, options])`](https://playwright.dev/docs/api/class-locator#locator-evaluate), [`evaluateAll(pageFunction[, arg])`](https://playwright.dev/docs/api/class-locator#locator-evaluate-all), [`evaluateHandle(pageFunction[, arg, options])`](https://playwright.dev/docs/api/class-locator#locator-evaluate-handle), [`first()`](https://playwright.dev/docs/api/class-locator#locator-first), [`frameLocator(selector)`](https://playwright.dev/docs/api/class-locator#locator-frame-locator), [`frameLocator(selector)`](https://playwright.dev/docs/api/class-page#page-frame-locator), [`highlight()`](https://playwright.dev/docs/api/class-locator#locator-highlight), [`last()`](https://playwright.dev/docs/api/class-locator#locator-last), [`nth(index)`](https://playwright.dev/docs/api/class-locator#locator-nth), [`page()`](https://playwright.dev/docs/api/class-locator#locator-page), [`screenshot([options])`](https://playwright.dev/docs/api/class-locator#locator-screenshot), [`scrollIntoViewIfNeeded([options])`](https://playwright.dev/docs/api/class-locator#locator-scroll-into-view-if-needed), [`selectText([options])`](https://playwright.dev/docs/api/class-locator#locator-select-text), [`setChecked(checked[, options])`](https://playwright.dev/docs/api/class-locator#locator-set-checked), [`setInputFiles(files[, options])`](https://playwright.dev/docs/api/class-locator#locator-set-input-files) |
-| [Logger](https://playwright.dev/docs/api/class-logger) | :warning: | All |
-| [Mouse](https://playwright.dev/docs/api/class-mouse) | :white_check_mark: | - |
-| [Page](https://playwright.dev/docs/api/class-page) | :white_check_mark: | [`$eval()`](https://playwright.dev/docs/api/class-page#page-eval-on-selector), [`$$eval()`](https://playwright.dev/docs/api/class-page#page-eval-on-selector-all), [`addInitScript()`](https://playwright.dev/docs/api/class-page#page-add-init-script), [`addScriptTag()`](https://playwright.dev/docs/api/class-page#page-add-script-tag), [`addStyleTag()`](https://playwright.dev/docs/api/class-page#page-add-style-tag), [`dragAndDrop()`](https://playwright.dev/docs/api/class-page#page-drag-and-drop), [`exposeBinding()`](https://playwright.dev/docs/api/class-page#page-expose-binding), [`exposeFunction()`](https://playwright.dev/docs/api/class-page#page-expose-function), [`frame()`](https://playwright.dev/docs/api/class-page#page-frame), [`goBack()`](https://playwright.dev/docs/api/class-page#page-go-back), [`goForward()`](https://playwright.dev/docs/api/class-page#page-go-forward), [`on()`](https://playwright.dev/docs/api/class-page#page-event-close), [`pause()`](https://playwright.dev/docs/api/class-page#page-pause), [`pdf()`](https://playwright.dev/docs/api/class-page#page-pdf), [`route()`](https://playwright.dev/docs/api/class-page#page-route), [`unroute()`](https://playwright.dev/docs/api/class-page#page-unroute), [`video()`](https://playwright.dev/docs/api/class-page#page-video), [`waitForEvent()`](https://playwright.dev/docs/api/class-page#page-wait-for-event), [`waitForResponse()`](https://playwright.dev/docs/api/class-page#page-wait-for-response), [`waitForURL()`](https://playwright.dev/docs/api/class-page#page-wait-for-url), [`workers()`](https://playwright.dev/docs/api/class-page#page-workers) |
-| [Request](https://playwright.dev/docs/api/class-request) | :white_check_mark: | [`failure()`](https://playwright.dev/docs/api/class-request#request-failure), [`postDataJSON()`](https://playwright.dev/docs/api/class-request#request-post-data-json), [`redirectFrom()`](https://playwright.dev/docs/api/class-request#request-redirected-from), [`redirectTo()`](https://playwright.dev/docs/api/class-request#request-redirected-to) |
-| [Response](https://playwright.dev/docs/api/class-response) | :white_check_mark: | [`finished()`](https://playwright.dev/docs/api/class-response#response-finished) |
-| [Route](https://playwright.dev/docs/api/class-route) | :warning: | All |
-| [Selectors](https://playwright.dev/docs/api/class-selectors) | :warning: | All |
-| [Touchscreen](https://playwright.dev/docs/api/class-touchscreen) | :white_check_mark: | - |
-| [Tracing](https://playwright.dev/docs/api/class-tracing) | :warning: | All |
-| [Video](https://playwright.dev/docs/api/class-video) | :warning: | All |
-| [WebSocket](https://playwright.dev/docs/api/class-websocket) | :warning: | All |
-| [Worker](https://playwright.dev/docs/api/class-worker) | :warning: | All |
+## Additional Resources
 
+To find out more about xk6-browser or browser testing in general, check out the following links. 
 
-Support
--------
+**Note:** since our API is still transitioning, some of the code snippets from the links below may not be as accurate, though the concept should remain similar. Please refer to our up-to-date [API documentation](https://k6.io/docs/javascript-api/xk6-browser/api/) for details.
 
-To get help about usage, report bugs, suggest features and discuss xk6-browser with other users see [SUPPORT.md](SUPPORT.md).
+- [Introducing browser automation and end-to-end web testing with k6](https://k6.io/blog/announcing-xk6-browser-testing/) - A blog post from our CEO, Robin Gustafsson, where he introduced xk6-browser.
+- [Real Browser Testing with xk6-browser](https://youtu.be/y04wavsZxSs) - A video tutorial from our Developer Advocate, Nicole van der Hoeven, where she demonstrated how to get started with xk6-browser.
+- [Browser testing and API load testing in the same script with k6](https://youtu.be/Y4qDAaJgxV0) - Office Hours episode where we first introduced xk6-browser.
+- [What is Browser Testing](https://youtu.be/ieQwRy9UVo4) - An introductory chat with our DevRel team about what browser testing is and why do we need to test with browsers.
+- [Getting started with xk6-browser](https://youtu.be/CRSTQ6n05hM) - Office Hours episode where our DevRel team shared insights on how to get started with xk6-browser and the state of browser testing with k6
+- [Hybrid Performance Testing with k6](https://www.youtube.com/watch?v=nZlleGaf5Ro) - Office Hours episode where our DevRel team talked about what a hybrid performance testing is and how xk6-browser can help.
+- [A Medley of Frontend and Backend Performance Testing](https://youtu.be/Pa2FBI2k1qc) - A talk from our Developer Advocate, Marie Cruz, where she explained what frontend and backend performance testing and also features xk6-browser.
+


### PR DESCRIPTION
This simplifies our README and links our users to our documentation instead. This also addresses [Update xk6-browser documentation#632](https://github.com/grafana/xk6-browser/issues/632)