### PR TITLE
Add POC code to inject web vital js script

### DIFF
--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -232,6 +232,10 @@ func (b *BrowserContext) NewPage() api.Page {
 	}
 	b.logger.Debugf("BrowserContext:NewPage:return", "bctxid:%v ptid:%s", bctxid, ptid)
 
+	for _, s := range b.evaluateOnNewDocumentSources {
+		p.evaluateOnNewDocument(s)
+	}
+
 	return p
 }
 

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -543,6 +543,7 @@ type WebVitalMetric struct {
 	Delta          json.Number
 	NumEntries     json.Number
 	NavigationType string
+	URL            string
 }
 
 func (fs *FrameSession) parseAndRecordWebVitalMetric(robj *cdpruntime.RemoteObject) (bool, error) {
@@ -581,6 +582,7 @@ func (fs *FrameSession) parseAndRecordWebVitalMetric(robj *cdpruntime.RemoteObje
 			fs.k6Metrics.WebVitals[w.Name],
 			fs.k6Metrics.WebVitals[w.Name+":"+w.Rating],
 			w.Value,
+			w.URL,
 		)
 	default:
 		err = Error(fmt.Sprintf("web vital type not found '%s'", bb))
@@ -589,8 +591,8 @@ func (fs *FrameSession) parseAndRecordWebVitalMetric(robj *cdpruntime.RemoteObje
 	return err == nil, err
 }
 
-func (fs *FrameSession) emitMetric(m *k6metrics.Metric, mRating *k6metrics.Metric, n json.Number) error {
-	fs.logger.Debugf("FrameSession:emitMetric", "m:%s v:%f", m.Name, n)
+func (fs *FrameSession) emitMetric(m *k6metrics.Metric, mRating *k6metrics.Metric, n json.Number, url string) error {
+	fs.logger.Debugf("FrameSession:emitMetric", "m:%s v:%s url:%s", m.Name, n.String(), url)
 
 	f, err := n.Float64()
 	if err != nil {
@@ -599,7 +601,7 @@ func (fs *FrameSession) emitMetric(m *k6metrics.Metric, mRating *k6metrics.Metri
 
 	state := fs.vu.State()
 	tags := state.Tags.GetCurrentValues().Tags
-
+	tags = tags.With("url", url)
 	now := time.Now()
 	k6metrics.PushIfNotDone(fs.ctx, state.Samples, k6metrics.ConnectedSamples{
 		Samples: []k6metrics.Sample{

--- a/common/page.go
+++ b/common/page.go
@@ -17,6 +17,7 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
 	"github.com/chromedp/cdproto/emulation"
+	"github.com/chromedp/cdproto/page"
 	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
@@ -167,8 +168,16 @@ func (p *Page) didCrash() {
 	p.emit(EventPageCrash, p)
 }
 
-func (p *Page) evaluateOnNewDocument(source string) {
-	// TODO: implement
+func (p *Page) evaluateOnNewDocument(source string) error {
+	p.logger.Debugf("Page:evaluateOnNewDocument", "sid:%v frame:nil", p.sessionID())
+
+	action := page.AddScriptToEvaluateOnNewDocument(source)
+	_, err := action.Do(cdp.WithExecutor(p.ctx, p.session))
+	if err != nil {
+		return fmt.Errorf("failed to add script to page: %w", err)
+	}
+
+	return nil
 }
 
 func (p *Page) getFrameElement(f *Frame) (handle *ElementHandle, _ error) {

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -6,24 +6,52 @@ import k6metrics "go.k6.io/k6/metrics"
 type CustomMetrics struct {
 	BrowserDOMContentLoaded     *k6metrics.Metric
 	BrowserFirstPaint           *k6metrics.Metric
-	BrowserFirstContentfulPaint *k6metrics.Metric
 	BrowserFirstMeaningfulPaint *k6metrics.Metric
 	BrowserLoaded               *k6metrics.Metric
+
+	WebVitals map[string]*k6metrics.Metric
 }
 
 // RegisterCustomMetrics creates and registers our custom metrics with the k6
 // VU Registry and returns our internal struct pointer.
 func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
+	wvs := map[string]string{
+		"LCP":  "browser_largest_content_paint",
+		"FID":  "browser_first_input_delay",
+		"CLS":  "browser_cumulative_layout_shift",
+		"FCP":  "browser_first_contentful_paint",
+		"TTFB": "browser_time_to_first_byte",
+		"INP":  "browser_interaction_to_next_paint",
+	}
+	webVitals := make(map[string]*k6metrics.Metric)
+
+	for k, v := range wvs {
+		t := k6metrics.Time
+		if k == "CLS" {
+			t = k6metrics.Default
+		}
+
+		webVitals[k] = registry.MustNewMetric(
+			v, k6metrics.Trend, t)
+
+		webVitals[k+":good"] = registry.MustNewMetric(
+			v+"_good", k6metrics.Counter)
+		webVitals[k+":needs-improvement"] = registry.MustNewMetric(
+			v+"_needs_improvement", k6metrics.Counter)
+		webVitals[k+":poor"] = registry.MustNewMetric(
+			v+"_poor", k6metrics.Counter)
+	}
+
 	return &CustomMetrics{
 		BrowserDOMContentLoaded: registry.MustNewMetric(
 			"browser_dom_content_loaded", k6metrics.Trend, k6metrics.Time),
 		BrowserFirstPaint: registry.MustNewMetric(
 			"browser_first_paint", k6metrics.Trend, k6metrics.Time),
-		BrowserFirstContentfulPaint: registry.MustNewMetric(
-			"browser_first_contentful_paint", k6metrics.Trend, k6metrics.Time),
 		BrowserFirstMeaningfulPaint: registry.MustNewMetric(
 			"browser_first_meaningful_paint", k6metrics.Trend, k6metrics.Time),
 		BrowserLoaded: registry.MustNewMetric(
 			"browser_loaded", k6metrics.Trend, k6metrics.Time),
+
+		WebVitals: webVitals,
 	}
 }


### PR DESCRIPTION
Closes: #653 

This POC tests to see how viable it is to inject Google's Web Vital JS script into each website that is navigated to.

## Result

When testing the following test:

```js
import { chromium } from 'k6/x/browser';
import { sleep } from 'k6';

export default function () {
  const browser = chromium.launch({
    headless: false,
  });
  const context = browser.newContext();
  context.addInitScript(`{
    function print(metric) {
      const m = {
        id: metric.id,
        name: metric.name,
        value: metric.value,
        rating: metric.rating,
        delta: metric.delta,
        numEntries: metric.entries.length,
        navigationType: metric.navigationType,
        url: window.location.href,
      }
      console.log('xk6-browser.web.vital.metric=' + JSON.stringify(m))
    }

    async function load() {
      let {
        onCLS, onFID, onLCP, onFCP, onINP, onTTFB
      } = await import('https://unpkg.com/web-vitals@3?module');

      onCLS(print);
      onFID(print);
      onLCP(print);
  
      onFCP(print);
      onINP(print);
      onTTFB(print);
    }

    load();
  }`);
  const page = context.newPage();

  page.goto('https://test.k6.io', { waitUntil: 'networkidle' })
  .then(() => {
    console.log("done")
  })
  .finally(()=> {
    sleep(6);
    page.close();
    browser.close();
  });
}
```

This is the output that we're interested in:

```bash
browser_cumulative_layout_shift..........: avg=0.000057 min=0.000057 med=0.000057 max=0.000057 p(90)=0.000057 p(95)=0.000057
browser_cumulative_layout_shift_good.....: 1      0.125174/s
browser_first_contentful_paint...........: avg=466.3ms  min=466.3ms  med=466.3ms  max=466.3ms  p(90)=466.3ms  p(95)=466.3ms 
browser_first_contentful_paint_good......: 1      0.125174/s
browser_first_input_delay................: avg=7.79ms   min=7.79ms   med=7.79ms   max=7.79ms   p(90)=7.79ms   p(95)=7.79ms  
browser_first_input_delay_good...........: 1      0.125174/s
browser_interaction_to_next_paint........: avg=8ms      min=8ms      med=8ms      max=8ms      p(90)=8ms      p(95)=8ms     
browser_interaction_to_next_paint_good...: 1      0.125174/s
browser_largest_content_paint............: avg=466.39ms min=466.39ms med=466.39ms max=466.39ms p(90)=466.39ms p(95)=466.39ms
browser_largest_content_paint_good.......: 1      0.125174/s
browser_time_to_first_byte...............: avg=326.7ms  min=326.7ms  med=326.7ms  max=326.7ms  p(90)=326.7ms  p(95)=326.7ms 
browser_time_to_first_byte_good..........: 1      0.125174/s
```

## Analysis

The results are positive as we can retrieve the measurements for all of the [Core Web Vitals](https://web.dev/vitals/), as well as three others which could be useful now or in the future. We should probably concentrate on the core Web Vitals and get a good understanding of those.

Some areas that need further investigation and input from product/users:
1. We probably need our own metric type, instead of using `metrics.Trend`.
    1. How do we display the rating in the summary in a concise way?
    1. We should concentrate on the 75th percentile as suggested by Google: ["to ensure you're hitting the recommended target for most of your users, a good threshold to measure is the 75th percentile of page loads, segmented across mobile and desktop devices."](https://web.dev/vitals/#:~:text=to%20ensure%20you%27re%20hitting%20the%20recommended%20target%20for%20most%20of%20your%20users%2C%20a%20good%20threshold%20to%20measure%20is%20the%2075th%20percentile%20of%20page%20loads%2C%20segmented%20across%20mobile%20and%20desktop%20devices.")
1. We need to tidy up and move this JS injection code within the code somewhere, possibly with the other [injected script](https://github.com/grafana/xk6-browser/blob/16c0b8cef2b85c096a13ead97d5c57fe3533baf4/common/execution_context.go#L243).
1. We probably don't want to aggregate the web vitals for all pages that are navigated, but instead split them up based on the frame and sub frame.
1. There's a limitation to this library in that it doesn't work for sub frames, so we would have to inject this library into the sub frame and display them separately. I don't think aggregating the root frames and the sub frames is going to be straight forward.
1. Can we use the Web Vitals with SPAs?
1. We will face the same problem we do with aggregated HTTP metrics - they're not all that useful until you split them out per page/group. But that obviously depends on the user to implement grouping.
    1. Grouping doesn't work with async APIs -- https://github.com/grafana/k6/issues/2728.
1. We would likely need to bundle this script with the binary:
    1. Allows us to use this library in a locked down test environment that may not have access to all of the internet.
    2. Avoids XSS issues.
1. [Grafana Faro](https://grafana.com/oss/faro/) also uses this.

### Measurement Results And Comparison



## Conclusion

I believe that this is likely to be the solution we go with, at least in the short term. It gives us what we need for now, we just need to fine tune it so that it's concise, simple to understand and all the information they need is displayed.