### PR TITLE
dismiss dialog box automatically

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -272,6 +272,11 @@ func (fs *FrameSession) onEventJavascriptDialogOpening(event *cdppage.EventJavas
 		"sid:%v tid:%v url:%v dialogType:%s",
 		fs.session.ID(), fs.targetID, event.URL, event.Type)
 
+	// Dialog type of beforeunload needs to accept the
+	// dialog, instead of dismissing it. We're unable to
+	// dismiss beforeunload dialog boxes at the moment as
+	// it seems to pause the exec of any other action on
+	// the page. I believe this is an issue in Chromium.
 	action := cdppage.HandleJavaScriptDialog(false)
 	if event.Type == cdppage.DialogTypeBeforeunload {
 		action = cdppage.HandleJavaScriptDialog(true)

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -273,6 +273,10 @@ func (fs *FrameSession) onEventJavascriptDialogOpening(event *cdppage.EventJavas
 		fs.session.ID(), fs.targetID, event.URL, event.Type)
 
 	action := cdppage.HandleJavaScriptDialog(false)
+	if event.Type == cdppage.DialogTypeBeforeunload {
+		action = cdppage.HandleJavaScriptDialog(true)
+	}
+
 	if err := action.Do(cdp.WithExecutor(fs.ctx, fs.session)); err != nil {
 		fs.logger.Errorf("FrameSession:onEventJavascriptDialogOpening", "failed to dismiss dialog box: %v", err)
 	}

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -259,10 +259,23 @@ func (fs *FrameSession) initEvents() {
 					fs.onAttachedToTarget(ev)
 				case *target.EventDetachedFromTarget:
 					fs.onDetachedFromTarget(ev)
+				case *cdppage.EventJavascriptDialogOpening:
+					fs.onEventJavascriptDialogOpening(ev)
 				}
 			}
 		}
 	}()
+}
+
+func (fs *FrameSession) onEventJavascriptDialogOpening(event *cdppage.EventJavascriptDialogOpening) {
+	fs.logger.Debugf("FrameSession:onEventJavascriptDialogOpening",
+		"sid:%v tid:%v url:%v dialogType:%s",
+		fs.session.ID(), fs.targetID, event.URL, event.Type)
+
+	action := cdppage.HandleJavaScriptDialog(false)
+	if err := action.Do(cdp.WithExecutor(fs.ctx, fs.session)); err != nil {
+		fs.logger.Errorf("FrameSession:onEventJavascriptDialogOpening", "failed to dismiss dialog box: %v", err)
+	}
 }
 
 func (fs *FrameSession) initFrameTree() error {

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -56,8 +56,8 @@ func TestFrameDismissDialogBox(t *testing.T) {
 					WaitUntil: "networkidle",
 				})
 				b.promise(p.Goto(b.staticURL("dialog.html?dialogType="+tt.name), opts)).then(func() {
-					result := p.TextContent("#text", nil)
-					assert.EqualValues(t, "Hello World", result)
+					result := p.TextContent("#textField", nil)
+					assert.EqualValues(t, tt.name+" dismissed", result)
 				})
 
 				return nil

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -27,25 +27,15 @@ func TestFramePress(t *testing.T) {
 func TestFrameDismissDialogBox(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name string
-	}{
-		{
-			name: "alert",
-		},
-		{
-			name: "confirm",
-		},
-		{
-			name: "prompt",
-		},
-		{
-			name: "beforeunload",
-		},
+	tests := []string{
+		"alert",
+		"confirm",
+		"prompt",
+		"beforeunload",
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test, func(t *testing.T) {
 			t.Parallel()
 
 			b := newTestBrowser(t, withFileServer())
@@ -59,21 +49,21 @@ func TestFrameDismissDialogBox(t *testing.T) {
 					WaitUntil: "networkidle",
 				})
 				pageGoto := p.Goto(
-					b.staticURL("dialog.html?dialogType="+tt.name),
+					b.staticURL("dialog.html?dialogType="+test),
 					opts,
 				)
 				b.promise(pageGoto).then(func() *goja.Promise {
-					if tt.name == "beforeunload" {
+					if test == "beforeunload" {
 						return p.Click("#clickHere", nil)
 					}
 
 					result := p.TextContent("#textField", nil)
-					assert.EqualValues(t, tt.name+" dismissed", result)
+					assert.EqualValues(t, test+" dismissed", result)
 
 					return nil
 				}).then(func() {
 					result := p.TextContent("#textField", nil)
-					assert.EqualValues(t, tt.name+" dismissed", result)
+					assert.EqualValues(t, test+" dismissed", result)
 				})
 
 				return nil

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,4 +21,42 @@ func TestFramePress(t *testing.T) {
 	f.Press("#text1", "Shift+KeyC", nil)
 
 	require.Equal(t, "AbC", f.InputValue("#text1", nil))
+}
+
+func TestFrameDismissDialogBox(t *testing.T) {
+
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "alert",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := newTestBrowser(t, withFileServer())
+
+			p := b.NewPage(nil)
+
+			err := b.await(func() error {
+				opts := b.toGojaValue(struct {
+					WaitUntil string `js:"waitUntil"`
+				}{
+					WaitUntil: "networkidle",
+				})
+				b.promise(p.Goto(b.staticURL("dialog.html?dialogType="+tt.name), opts)).then(func() {
+					result := p.TextContent("#text", nil)
+					assert.EqualValues(t, "Hello World", result)
+				})
+
+				return nil
+			})
+			require.NoError(t, err)
+		})
+	}
 }

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +25,6 @@ func TestFramePress(t *testing.T) {
 }
 
 func TestFrameDismissDialogBox(t *testing.T) {
-
 	t.Parallel()
 
 	tests := []struct {
@@ -38,6 +38,9 @@ func TestFrameDismissDialogBox(t *testing.T) {
 		},
 		{
 			name: "prompt",
+		},
+		{
+			name: "beforeunload",
 		},
 	}
 
@@ -55,7 +58,16 @@ func TestFrameDismissDialogBox(t *testing.T) {
 				}{
 					WaitUntil: "networkidle",
 				})
-				b.promise(p.Goto(b.staticURL("dialog.html?dialogType="+tt.name), opts)).then(func() {
+				b.promise(p.Goto(b.staticURL("dialog.html?dialogType="+tt.name), opts)).then(func() *goja.Promise {
+					if tt.name == "beforeunload" {
+						return p.Click("#clickHere", nil)
+					}
+
+					result := p.TextContent("#textField", nil)
+					assert.EqualValues(t, tt.name+" dismissed", result)
+
+					return nil
+				}).then(func() {
 					result := p.TextContent("#textField", nil)
 					assert.EqualValues(t, tt.name+" dismissed", result)
 				})

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -36,6 +36,9 @@ func TestFrameDismissDialogBox(t *testing.T) {
 		{
 			name: "confirm",
 		},
+		{
+			name: "prompt",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -58,7 +58,11 @@ func TestFrameDismissDialogBox(t *testing.T) {
 				}{
 					WaitUntil: "networkidle",
 				})
-				b.promise(p.Goto(b.staticURL("dialog.html?dialogType="+tt.name), opts)).then(func() *goja.Promise {
+				pageGoto := p.Goto(
+					b.staticURL("dialog.html?dialogType="+tt.name),
+					opts,
+				)
+				b.promise(pageGoto).then(func() *goja.Promise {
 					if tt.name == "beforeunload" {
 						return p.Click("#clickHere", nil)
 					}

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -33,6 +33,9 @@ func TestFrameDismissDialogBox(t *testing.T) {
 		{
 			name: "alert",
 		},
+		{
+			name: "confirm",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/static/dialog.html
+++ b/tests/static/dialog.html
@@ -3,7 +3,7 @@
     <body>
         <div id='textField'>Hello World</div>
         <br />
-        <a href="/">click here</a>
+        <button id="clickHere" onclick="window.location.reload();">click here</button>
 
         <script>
             const queryString = window.location.search;
@@ -23,6 +23,12 @@
                 case "prompt":
                     prompt("Add text and then click accept");
                     div.textContent = 'prompt dismissed';
+                    break;
+                case "beforeunload":
+                    window.addEventListener('beforeunload', (event) => {
+                        event.returnValue = "Are you sure you want to leave?";
+                    });
+                    div.textContent = 'beforeunload dismissed';
                     break;
             }
         </script>

--- a/tests/static/dialog.html
+++ b/tests/static/dialog.html
@@ -9,6 +9,8 @@
                 case "alert":
                     alert("Click accept");
                     break;
+                case "confirm":
+                    confirm("Click accept")
             }
         </script>
     </head>

--- a/tests/static/dialog.html
+++ b/tests/static/dialog.html
@@ -11,6 +11,8 @@
                     break;
                 case "confirm":
                     confirm("Click accept")
+                case "prompt":
+                    prompt("Add text and then click accept")
             }
         </script>
     </head>

--- a/tests/static/dialog.html
+++ b/tests/static/dialog.html
@@ -1,22 +1,30 @@
 <html lang="en">
-    <head>
+    <head></head>
+    <body>
+        <div id='textField'>Hello World</div>
+        <br />
+        <a href="/">click here</a>
+
         <script>
             const queryString = window.location.search;
             const urlParams = new URLSearchParams(queryString);
-            const dialogType = urlParams.get('dialogType')
+            const dialogType = urlParams.get('dialogType');
+            const div = document.getElementById('textField');
 
             switch(dialogType) {
                 case "alert":
                     alert("Click accept");
+                    div.textContent = 'alert dismissed';
                     break;
                 case "confirm":
-                    confirm("Click accept")
+                    confirm("Click accept");
+                    div.textContent = 'confirm dismissed';
+                    break;
                 case "prompt":
-                    prompt("Add text and then click accept")
+                    prompt("Add text and then click accept");
+                    div.textContent = 'prompt dismissed';
+                    break;
             }
         </script>
-    </head>
-    <body>
-        <div id='text'>Hello World</div>
     </body>
 </html>

--- a/tests/static/dialog.html
+++ b/tests/static/dialog.html
@@ -1,0 +1,18 @@
+<html lang="en">
+    <head>
+        <script>
+            const queryString = window.location.search;
+            const urlParams = new URLSearchParams(queryString);
+            const dialogType = urlParams.get('dialogType')
+
+            switch(dialogType) {
+                case "alert":
+                    alert("Click accept");
+                    break;
+            }
+        </script>
+    </head>
+    <body>
+        <div id='text'>Hello World</div>
+    </body>
+</html>


### PR DESCRIPTION
Partly closes: https://github.com/grafana/xk6-browser/issues/655

We have had a feature request recently as well as seen dialog boxes being used elsewhere. There currently isn't a work around to removing dialog boxes in the path of a test. This change will automatically dismiss the dialog boxes (and accept it for `beforeunload` type dialogs).