### PR TITLE
Release v0.7.0

### DIFF
--- a/browser/module.go
+++ b/browser/module.go
@@ -13,7 +13,7 @@ import (
 	k6modules "go.k6.io/k6/js/modules"
 )
 
-const version = "0.6.0"
+const version = "0.7.0"
 
 type (
 	// RootModule is the global module instance that will create module

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
-	go.k6.io/k6 v0.41.1-0.20221206194017-a2ab89abfdc8
+	go.k6.io/k6 v0.42.0
 	golang.org/x/exp v0.0.0-20221106115401-f9659909a136
 	golang.org/x/net v0.1.0
 	gopkg.in/guregu/null.v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.k6.io/k6 v0.41.1-0.20221206194017-a2ab89abfdc8 h1:f+N9YUGTs4iM0PcVwJSkvLX9gYsD7GK3wJyxDtzp4C4=
-go.k6.io/k6 v0.41.1-0.20221206194017-a2ab89abfdc8/go.mod h1:tox3idIlfur6nCoqZ6kruwisLIM8J/EEguuwVw/b/5c=
+go.k6.io/k6 v0.42.0 h1:TXYyaNPI5GuX2k+r0EDqawdAkdU2Kuxl68GpBbwSkUk=
+go.k6.io/k6 v0.42.0/go.mod h1:BY6vVmsNSaetHmPqQ8D6VMJJRptzwevdSpURQmSkrMQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/release notes/v0.7.0.md
+++ b/release notes/v0.7.0.md
@@ -53,12 +53,12 @@ We've been busy preparing for big changes in the future, so this minor release i
 	
     This shouldn't change any existing behavior, but if you notice anything that doesn't work as expected, please let us know. 
 
-- Fix for CI. ([#674](https://github.com/grafana/xk6-browser/pull/674))
+- Cleanup unused dependencies. ([#674](https://github.com/grafana/xk6-browser/pull/674))
 
 ### Experimental Module Merge into k6
 
 - `xk6-browser` is now importable as an experimental module from `k6`. ([#667](https://github.com/grafana/xk6-browser/pull/667))
 
-- Disabling of `xk6-browser` in restricted environments. ([#665](https://github.com/grafana/xk6-browser/pull/665))
+- `xk6-browser` can now be disabled via configuration, e.g. in restricted environments. ([#665](https://github.com/grafana/xk6-browser/pull/665))
 
 - Fixed `k6` network `Hosts` incompatibility. ([#671](https://github.com/grafana/xk6-browser/pull/671))

--- a/release notes/v0.7.0.md
+++ b/release notes/v0.7.0.md
@@ -3,6 +3,11 @@ xk6-browser v0.7.0 is here! :tada:
 We've been busy preparing for big changes in the future, so this minor release is smaller than usual. It contains a new feature to unblock users using `dialog` boxes, and internal improvements.
 
 
+## Bugs fixed
+
+- `xk6-browser` no longer panics when it navigates to a website that contains `iframes` which themselves navigate to a different origin to the main `frame` (e.g. a website containing an embedded Youtube video). ([#677](https://github.com/grafana/xk6-browser/pull/677))
+
+
 ## New features
 
 - `xk6-browser` will now automatically dismiss dialog boxes (`alert`, `confirm`, `prompt`, and `beforeunload`). ([#663](https://github.com/grafana/xk6-browser/pull/663))

--- a/release notes/v0.7.0.md
+++ b/release notes/v0.7.0.md
@@ -1,0 +1,42 @@
+xk6-browser v0.7.0 is here! :tada:
+
+We've been busy preparing for big changes in the future, so this minor release is smaller than usual. It contains a new feature to unblock users using `dialog` boxes, and internal improvements.
+
+
+## New features
+
+- `xk6-browser` will now automatically dismiss dialog boxes (`alert`, `confirm`, `prompt`, and `beforeunload`). ([#663](https://github.com/grafana/xk6-browser/pull/663))
+
+
+## Improvements
+
+- Updated the video to match what we released in `v0.6.0`, and it's still relevant for `v0.7.0`. ([#639](https://github.com/grafana/xk6-browser/pull/639))
+- We couldn't launch a new browser without providing at least an empty object. We've fixed this so now you can launch a new browser without that empty object. ([#649](https://github.com/grafana/xk6-browser/pull/649))
+    
+    With the empty object:
+
+    ```js
+    const browser = chromium.launch({});
+    ```
+
+    Without the empty object:
+
+    ```js
+    const browser = chromium.launch();
+    ```
+
+- Made improvements to the code that handles lifecycle events. This shouldn't change any of the existing behavior, but if you notice anything that doesn't work as you expected please let us know. ([#647](https://github.com/grafana/xk6-browser/pull/647), [#644](https://github.com/grafana/xk6-browser/pull/644))
+
+- Simplified the README. You will now be redirected to the [documentation](https://k6.io/docs/javascript-api/xk6-browser/). ([#656](https://github.com/grafana/xk6-browser/pull/656))
+
+- The project roadmap has been updated. ([#658](https://github.com/grafana/xk6-browser/pull/658))
+
+- Some more internal changes that are worth talking about, which is that we're making it simpler to import so that we can make this extension an experimental module in `k6`. ([#667](https://github.com/grafana/xk6-browser/pull/667), [#665](https://github.com/grafana/xk6-browser/pull/665))
+
+
+
+## Internals
+
+- Upgraded `k6` dependency to `v0.42.0`. ([#?](https://github.com/grafana/xk6-browser/pull/?))
+
+- Several refactors and bug fixes to improve maintainability and stability. ([#671](https://github.com/grafana/xk6-browser/pull/671), [#674](https://github.com/grafana/xk6-browser/pull/674))

--- a/release notes/v0.7.0.md
+++ b/release notes/v0.7.0.md
@@ -44,7 +44,9 @@ We've been busy preparing for big changes in the future, so this minor release i
 
 - Upgraded `k6` dependency to `v0.42.0`. ([#?](https://github.com/grafana/xk6-browser/pull/?))
 
-- Refactored the code that handles the lifecycle events. This shouldn't change any of the existing behavior, but if you notice anything that doesn't work as you expected please let us know. ([#647](https://github.com/grafana/xk6-browser/pull/647), [#644](https://github.com/grafana/xk6-browser/pull/644))
+- Refactored the lifecycle events code. ([#647](https://github.com/grafana/xk6-browser/pull/647), [#644](https://github.com/grafana/xk6-browser/pull/644))
+	
+    This shouldn't change any existing behavior, but if you notice anything that doesn't work as expected, please let us know. 
 
 - Fix for CI. ([#674](https://github.com/grafana/xk6-browser/pull/674))
 

--- a/release notes/v0.7.0.md
+++ b/release notes/v0.7.0.md
@@ -10,7 +10,9 @@ We've been busy preparing for big changes in the future, so this minor release i
 
 ## Improvements
 
-- You can now launch a new browser without defining an empty options object. ([#649](https://github.com/grafana/xk6-browser/pull/649))
+- Improved launching of a browser without providing any options. ([#649](https://github.com/grafana/xk6-browser/pull/649))
+ 
+  We couldn't launch a new browser without providing an empty object. We've fixed this, so now you can launch a new browser without an empty object.
     
     With the empty object:
 
@@ -27,11 +29,15 @@ We've been busy preparing for big changes in the future, so this minor release i
 
 ### Documentation
 
-- Updated the video to match what we released in `v0.6.0`, and it's still relevant for `v0.7.0`. ([#639](https://github.com/grafana/xk6-browser/pull/639))
+- Updated the demo video on our README. ([#639](https://github.com/grafana/xk6-browser/pull/639))
 
-- Simplified the README. You will now be redirected to the [documentation](https://k6.io/docs/javascript-api/xk6-browser/). ([#656](https://github.com/grafana/xk6-browser/pull/656))
+  Now it shows the usage for xk6-browser version v0.6.0 and above.
 
-- The project roadmap has been updated. ([#658](https://github.com/grafana/xk6-browser/pull/658))
+- Simplified the README. ([#656](https://github.com/grafana/xk6-browser/pull/656))
+
+  You can now find the documentation [here](https://k6.io/docs/javascript-api/xk6-browser/).
+
+- Updated the project roadmap. ([#658](https://github.com/grafana/xk6-browser/pull/658))
 
 
 ## Internals
@@ -46,6 +52,6 @@ We've been busy preparing for big changes in the future, so this minor release i
 
 - `xk6-browser` is now importable as an experimental module from `k6`. ([#667](https://github.com/grafana/xk6-browser/pull/667))
 
-- Disable `xk6-browser` in restricted environments. ([#665](https://github.com/grafana/xk6-browser/pull/665))
+- Disabling of `xk6-browser` in restricted environments. ([#665](https://github.com/grafana/xk6-browser/pull/665))
 
 - `k6` Hosts incompatibility fix. ([#671](https://github.com/grafana/xk6-browser/pull/671))

--- a/release notes/v0.7.0.md
+++ b/release notes/v0.7.0.md
@@ -54,4 +54,4 @@ We've been busy preparing for big changes in the future, so this minor release i
 
 - Disabling of `xk6-browser` in restricted environments. ([#665](https://github.com/grafana/xk6-browser/pull/665))
 
-- `k6` Hosts incompatibility fix. ([#671](https://github.com/grafana/xk6-browser/pull/671))
+- Fixed `k6` network `Hosts` incompatibility. ([#671](https://github.com/grafana/xk6-browser/pull/671))

--- a/release notes/v0.7.0.md
+++ b/release notes/v0.7.0.md
@@ -10,8 +10,7 @@ We've been busy preparing for big changes in the future, so this minor release i
 
 ## Improvements
 
-- Updated the video to match what we released in `v0.6.0`, and it's still relevant for `v0.7.0`. ([#639](https://github.com/grafana/xk6-browser/pull/639))
-- We couldn't launch a new browser without providing at least an empty object. We've fixed this so now you can launch a new browser without that empty object. ([#649](https://github.com/grafana/xk6-browser/pull/649))
+- You can now launch a new browser without defining an empty options object. ([#649](https://github.com/grafana/xk6-browser/pull/649))
     
     With the empty object:
 
@@ -25,18 +24,28 @@ We've been busy preparing for big changes in the future, so this minor release i
     const browser = chromium.launch();
     ```
 
-- Made improvements to the code that handles lifecycle events. This shouldn't change any of the existing behavior, but if you notice anything that doesn't work as you expected please let us know. ([#647](https://github.com/grafana/xk6-browser/pull/647), [#644](https://github.com/grafana/xk6-browser/pull/644))
+
+### Documentation
+
+- Updated the video to match what we released in `v0.6.0`, and it's still relevant for `v0.7.0`. ([#639](https://github.com/grafana/xk6-browser/pull/639))
 
 - Simplified the README. You will now be redirected to the [documentation](https://k6.io/docs/javascript-api/xk6-browser/). ([#656](https://github.com/grafana/xk6-browser/pull/656))
 
 - The project roadmap has been updated. ([#658](https://github.com/grafana/xk6-browser/pull/658))
-
-- Some more internal changes that are worth talking about, which is that we're making it simpler to import so that we can make this extension an experimental module in `k6`. ([#667](https://github.com/grafana/xk6-browser/pull/667), [#665](https://github.com/grafana/xk6-browser/pull/665))
-
 
 
 ## Internals
 
 - Upgraded `k6` dependency to `v0.42.0`. ([#?](https://github.com/grafana/xk6-browser/pull/?))
 
-- Several refactors and bug fixes to improve maintainability and stability. ([#671](https://github.com/grafana/xk6-browser/pull/671), [#674](https://github.com/grafana/xk6-browser/pull/674))
+- Refactored the code that handles the lifecycle events. This shouldn't change any of the existing behavior, but if you notice anything that doesn't work as you expected please let us know. ([#647](https://github.com/grafana/xk6-browser/pull/647), [#644](https://github.com/grafana/xk6-browser/pull/644))
+
+- Fix for CI. ([#674](https://github.com/grafana/xk6-browser/pull/674))
+
+### Experimental Module Merge into k6
+
+- `xk6-browser` is now importable as an experimental module from `k6`. ([#667](https://github.com/grafana/xk6-browser/pull/667))
+
+- Disable `xk6-browser` in restricted environments. ([#665](https://github.com/grafana/xk6-browser/pull/665))
+
+- `k6` Hosts incompatibility fix. ([#671](https://github.com/grafana/xk6-browser/pull/671))

--- a/release notes/v0.7.0.md
+++ b/release notes/v0.7.0.md
@@ -7,7 +7,7 @@ We've been busy preparing for big changes in the future, so this minor release i
 
 We're excited to reveal that in an upcoming future release of `k6` you will be able to run browser tests -- we're merging `xk6-browser` into `k6`. The merge will expose the browser tests via an experimental module importable with `k6/experimental/browser`, so expect a small breaking change there. We now have a solid foundation, and to help us shape it into a better tool we need more people to use it; this is why we're doing the merge. It's worth noting that we're not merging the two code bases into a single one.
 
-In this release we made some internal changes that will help us achieve that goal in the near future, but we still have some more work to do before we can do the merge. This might mean we will eventually stop releasing new versions of `xk6-browser` binaries, and instead point people to the latest release of `k6`. When it comes to building `xk6-browser` from source, that won't change, so you will still be able to build from source the same way you have been doing so already.
+This might mean we will eventually stop releasing new versions of `xk6-browser` binaries, and instead point people to the latest release of `k6`. When it comes to building `xk6-browser` from source, that won't change, so you will still be able to build from source the same way you have been doing so already.
 
 
 ## Bugs fixed
@@ -63,6 +63,8 @@ In this release we made some internal changes that will help us achieve that goa
 - Cleanup unused dependencies. ([#674](https://github.com/grafana/xk6-browser/pull/674))
 
 ### Experimental Module Merge into k6
+
+Here are some internal changes that will help us achieve the merge goal in the near future (we still have some more work to do before we can do the merge):
 
 - `xk6-browser` will not automatically be registered under `k6/x/browser`, and in the future it will be importable from `k6/experimental/browser`. ([#667](https://github.com/grafana/xk6-browser/pull/667))
 

--- a/release notes/v0.7.0.md
+++ b/release notes/v0.7.0.md
@@ -64,7 +64,7 @@ In this release we made some internal changes that will help us achieve that goa
 
 ### Experimental Module Merge into k6
 
-- `xk6-browser` is now importable as an experimental module from `k6`. ([#667](https://github.com/grafana/xk6-browser/pull/667))
+- `xk6-browser` will not automatically be registered under `k6/x/browser`, and in the future it will be importable from `k6/experimental/browser`. ([#667](https://github.com/grafana/xk6-browser/pull/667))
 
 - `xk6-browser` can now be disabled via configuration, e.g. in restricted environments. ([#665](https://github.com/grafana/xk6-browser/pull/665))
 

--- a/release notes/v0.7.0.md
+++ b/release notes/v0.7.0.md
@@ -1,6 +1,13 @@
 xk6-browser v0.7.0 is here! :tada:
 
-We've been busy preparing for big changes in the future, so this minor release is smaller than usual. It contains a new feature to unblock users using `dialog` boxes, and internal improvements.
+We've been busy preparing for big changes in the future, so this minor release is smaller than usual. It contains a new feature to unblock users using `dialog` boxes, a fix, and internal improvements.
+
+
+## Experimental Module Merge into k6
+
+We're excited to reveal that in an upcoming future release of `k6` you will be able to run browser tests -- we're merging `xk6-browser` into `k6`. The merge will expose the browser tests via an experimental module importable with `k6/experimental/browser`, so expect a small breaking change there. We now have a solid foundation, and to help us shape it into a better tool we need more people to use it; this is why we're doing the merge. It's worth noting that we're not merging the two code bases into a single one.
+
+In this release we made some internal changes that will help us achieve that goal in the near future, but we still have some more work to do before we can do the merge. This might mean we will eventually stop releasing new versions of `xk6-browser` binaries, and instead point people to the latest release of `k6`. When it comes to building `xk6-browser` from source, that won't change, so you will still be able to build from source the same way you have been doing so already.
 
 
 ## Bugs fixed


### PR DESCRIPTION
- [X] Update version to `v0.7.0` in the `browser/module.go` file.
- [X] Add a readme.
- [x] Update the readme with the release details.
- [x] Update to released version of `k6` `v0.42.0`