### PR TITLE
Fix: panic on navigating on remote iframes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
             args[1]="1"
             export GOMAXPROCS=1
           fi
+          export XK6_HEADLESS=true
           go test "${args[@]}" -timeout 5m ./...
 
   test-tip:
@@ -71,6 +72,7 @@ jobs:
           go version
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
+          export XK6_HEADLESS=true
           go test "${args[@]}" -timeout 5m ./...
 
   test-current-cov:
@@ -99,6 +101,7 @@ jobs:
             args[1]="1"
             export GOMAXPROCS=1
           fi
+          export XK6_HEADLESS=true
           echo "mode: set" > coverage.txt
           for pkg in $(go list ./... | grep -v vendor); do
               list=$(go list -test -f  '{{ join .Deps  "\n"}}' $pkg | grep github.com/grafana/xk6-browser | grep -v vendor || true)

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -169,11 +169,8 @@ func (m *FrameManager) frameAttached(frameID cdp.FrameID, parentFrameID cdp.Fram
 func (m *FrameManager) frameDetached(frameID cdp.FrameID) {
 	m.logger.Debugf("FrameManager:frameDetached", "fmid:%d fid:%v", m.ID(), frameID)
 
-	// TODO: use getFrameByID here
-	m.framesMu.RLock()
-	frame, ok := m.frames[frameID]
-	m.framesMu.RUnlock()
-	if !ok {
+	frame := m.getFrameByID(frameID)
+	if frame == nil {
 		m.logger.Debugf("FrameManager:frameDetached:return",
 			"fmid:%d fid:%v cannot find frame",
 			m.ID(), frameID)

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
+	cdppage "github.com/chromedp/cdproto/page"
 )
 
 // FrameManager manages all frames in a page and their life-cycles, it's a purely internal component.
@@ -166,7 +167,7 @@ func (m *FrameManager) frameAttached(frameID cdp.FrameID, parentFrameID cdp.Fram
 	}
 }
 
-func (m *FrameManager) frameDetached(frameID cdp.FrameID) {
+func (m *FrameManager) frameDetached(frameID cdp.FrameID, reason cdppage.FrameDetachedReason) {
 	m.logger.Debugf("FrameManager:frameDetached", "fmid:%d fid:%v", m.ID(), frameID)
 
 	frame := m.getFrameByID(frameID)
@@ -176,7 +177,16 @@ func (m *FrameManager) frameDetached(frameID cdp.FrameID) {
 			m.ID(), frameID)
 		return
 	}
-	// TODO: possible data race? the frame may have gone.
+
+	if reason == cdppage.FrameDetachedReasonSwap {
+		// When a local frame is swapped out for a remote
+		// frame, we want to keep the current frame which is
+		// still referenced by the (incoming) remote frame, but
+		// remove all its child frames.
+		m.removeChildFramesRecursively(frame)
+		return
+	}
+
 	m.removeFramesRecursively(frame)
 }
 

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -639,7 +639,7 @@ func (fs *FrameSession) onFrameDetached(frameID cdp.FrameID, reason cdppage.Fram
 		"sid:%v tid:%v fid:%v reason:%s",
 		fs.session.ID(), fs.targetID, frameID, reason)
 
-	fs.manager.frameDetached(frameID)
+	fs.manager.frameDetached(frameID, reason)
 }
 
 func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -1,6 +1,8 @@
 package tests
 
 import (
+	"os"
+	"strconv"
 	"testing"
 
 	"github.com/dop251/goja"
@@ -74,12 +76,22 @@ func TestFrameDismissDialogBox(t *testing.T) {
 }
 
 func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
-	// This test only works when headless mode is false.
-	t.SkipNow()
+	if strValue, ok := os.LookupEnv("XK6_HEADLESS"); ok {
+		if value, err := strconv.ParseBool(strValue); err == nil && value {
+			// We're skipping this when running in headless
+			// environments since the bug that the test fixes
+			// only surfaces when in headfull mode.
+			// Remove this skip once we have headfull mode in
+			// CI: https://github.com/grafana/xk6-browser/issues/678
+			t.Skip("skipped when in headless mode")
+		}
+	}
 
 	t.Parallel()
 
-	b := newTestBrowser(t, withFileServer())
+	opts := defaultLaunchOpts()
+	opts.Headless = false
+	b := newTestBrowser(t, withFileServer(), opts)
 	p := b.NewPage(nil)
 
 	var result string

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -72,3 +72,36 @@ func TestFrameDismissDialogBox(t *testing.T) {
 		})
 	}
 }
+
+func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
+	// This test only works when headless mode is false.
+	t.SkipNow()
+
+	t.Parallel()
+
+	b := newTestBrowser(t, withFileServer())
+	p := b.NewPage(nil)
+
+	var result string
+	err := b.await(func() error {
+		opts := b.toGojaValue(struct {
+			WaitUntil string `js:"waitUntil"`
+		}{
+			WaitUntil: "load",
+		})
+		pageGoto := p.Goto(
+			b.staticURL("embedded_iframe.html"),
+			opts,
+		)
+
+		b.promise(pageGoto).
+			then(func() {
+				result = p.TextContent("#doneDiv", nil)
+			})
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.EqualValues(t, "Done!", result)
+}

--- a/tests/static/embedded_iframe.html
+++ b/tests/static/embedded_iframe.html
@@ -1,0 +1,7 @@
+<html>
+    <head></head>
+    <body>
+        <div id='doneDiv'></div>
+        <iframe src='https://www.youtube.com/embed/gwO7k5RTE54?wmode=opaque&amp;enablejsapi=1' onload='document.getElementById("doneDiv").innerText = "Done!"'></iframe>
+    </body>
+</html>


### PR DESCRIPTION
Fixes: https://github.com/grafana/xk6-browser/issues/669

# Prerequisite

This requires some background reading on how `iframe`s are rendered: https://developer.chrome.com/articles/renderingng-architecture/ -- specifically around the [blink renderer](https://developer.chrome.com/articles/renderingng-architecture/#render-process-main-thread-components) which renders frames on different processes depending on if the `iframe` is from the same/current origin (e.g. k6.io) vs from a different origin (e.g. youtube.com).

Puppeteer: https://github.com/puppeteer/puppeteer/commit/4d9dc8c0e613f22d4cdf237e8bd0b0da3c588edb
Playwright: https://github.com/microsoft/playwright/commit/38fadcaded8c337d514c10db6f1c207f11e2f532

# Investigation

Here's the example website used to debug the issue:

```html
<html>
    <head></head>
    <body>
        <iframe src="https://www.youtube.com/embed/gwO7k5RTE54?wmode=opaque&amp;enablejsapi=1"></iframe>
    </body>
</html>
```

Why is `xk6-browser` panicking when it navigates to certain websites? Using the logs and the specified website, it showed that the new frame with an embedded youtube video couldn't be attached to its parent frame since `xk6-browser` was deleting the parent frame from the tree:

```
// xk6-browser first navigates to about:blank.
onFrameNavigated sid:6D13FFCBEEEBDF7A2D25A3D752665F3E tid:9A6048556C8F260031B29E6904CEDD74 fid:9A6048556C8F260031B29E6904CEDD74
FrameManager:frameNavigated fid:9A6048556C8F260031B29E6904CEDD74 pfid: docid:23336728A436D9DE441088A2FF2E8801 fname: furl:about:blank initial:true
// Now it navigates to a test page with an embedded video.
onFrameNavigated sid:6D13FFCBEEEBDF7A2D25A3D752665F3E tid:9A6048556C8F260031B29E6904CEDD74 fid:9A6048556C8F260031B29E6904CEDD74
FrameManager:frameNavigated fid:9A6048556C8F260031B29E6904CEDD74 pfid: docid:2105D98CAFCAFCBF61926EC686DDBBC8 fname: furl:http://localhost:8080/embed-youtube initial:false
// Chrome sends a signal that a child frame is being attached.
onFrameAttached sid:6D13FFCBEEEBDF7A2D25A3D752665F3E tid:9A6048556C8F260031B29E6904CEDD74 fid:4E07510D2F5ED2D15367F9C84839737D pfid:9A6048556C8F260031B29E6904CEDD74
FrameManager:frameAttached no frame exists fmid:1 fid:4E07510D2F5ED2D15367F9C84839737D pfid:9A6048556C8F260031B29E6904CEDD74
FrameManager:frameAttached new frame fmid:1 fid:4E07510D2F5ED2D15367F9C84839737D pfid:9A6048556C8F260031B29E6904CEDD74
// Navigate to about:blank initially in the iframe (newly attache child frame).
onFrameNavigated sid:BE8A4A02AE79ED9590C3656367DEA2B8 tid:4E07510D2F5ED2D15367F9C84839737D fid:4E07510D2F5ED2D15367F9C84839737D
FrameManager:frameNavigated fid:4E07510D2F5ED2D15367F9C84839737D pfid:9A6048556C8F260031B29E6904CEDD74 docid:EAF6A40F4EB139978F4BE3A693A9E6E2 fname: furl:https://www.youtube.com/embed/gwO7k5RTE54?wmode=opaque&enablejsapi=1 initial:false
// Frame is detached to show that a different process will take over the rendering of the child frame since it's a remote frame (not from the current site origin). xk6-browser will delete the frame from the tree.
FrameManager:frameDetached fmid:1 fid:4E07510D2F5ED2D15367F9C84839737D reason:swap
// Remote frame is being attached.
onFrameAttached sid:BE8A4A02AE79ED9590C3656367DEA2B8 tid:4E07510D2F5ED2D15367F9C84839737D fid:36406088C5AB20583D2DA08AF31E4370 pfid:4E07510D2F5ED2D15367F9C84839737D
FrameManager:frameAttached no frame exists fmid:1 fid:36406088C5AB20583D2DA08AF31E4370 pfid:4E07510D2F5ED2D15367F9C84839737D
// This is the problem here -- the parent frame with fid 4E07510D2F5ED2D15367F9C84839737D was deleted above.
FrameManager:frameAttached no parent frame exists fmid:1 fid:36406088C5AB20583D2DA08AF31E4370 pfid:4E07510D2F5ED2D15367F9C84839737D
onFrameNavigated sid:BE8A4A02AE79ED9590C3656367DEA2B8 tid:4E07510D2F5ED2D15367F9C84839737D fid:36406088C5AB20583D2DA08AF31E4370
FrameManager:frameNavigated fid:36406088C5AB20583D2DA08AF31E4370 pfid:4E07510D2F5ED2D15367F9C84839737D docid:A2C16738A5F0D984DC6D41A83BE8BE24 fname: furl:about:blank initial:false
panic: GoError: handling frameNavigated event to "about:blank": we either navigate top level or have old version of the navigated frame
```

So the issue is related to embedded `iframe`s where the `iframe` navigates to a different origin (e.g. youtube.com).

Compare these logs to the one where an iframe navigates to about:blank:

```html
<html>
    <head></head>
    <body>
        <iframe src=""></iframe>
    </body>
</html>
```

```
// xk6-browser first navigates to about:blank.
onFrameNavigated sid:42A41C3A9B41233D25BCEF6D66D133DA tid:997DCB5956FC7B5D63307C8373556D7C fid:997DCB5956FC7B5D63307C8373556D7C
FrameManager:frameNavigated fid:997DCB5956FC7B5D63307C8373556D7C pfid: docid:A195B4E45ABF20B5A978D18C5D6F2E87 fname: furl:about:blank initial:true
// Now it navigates to a test page with an iframe.
onFrameNavigated sid:42A41C3A9B41233D25BCEF6D66D133DA tid:997DCB5956FC7B5D63307C8373556D7C fid:997DCB5956FC7B5D63307C8373556D7C
FrameManager:frameNavigated fid:997DCB5956FC7B5D63307C8373556D7C pfid: docid:1A0CF3B86D0BF83CE707BFFFA532B166 fname: furl:http://localhost:8080/embed-youtube initial:false
// Chrome sends a signal that a child frame is being attached.
onFrameAttached sid:42A41C3A9B41233D25BCEF6D66D133DA tid:997DCB5956FC7B5D63307C8373556D7C fid:94DFCBB3C80861CA9ECA2B2DDD91D473 pfid:997DCB5956FC7B5D63307C8373556D7C
FrameManager:frameAttached fmid:1 fid:94DFCBB3C80861CA9ECA2B2DDD91D473 pfid:997DCB5956FC7B5D63307C8373556D7C
FrameManager:frameAttached no frame exists fmid:1 fid:94DFCBB3C80861CA9ECA2B2DDD91D473 pfid:997DCB5956FC7B5D63307C8373556D7C
FrameManager:frameAttached new frame fmid:1 fid:94DFCBB3C80861CA9ECA2B2DDD91D473 pfid:997DCB5956FC7B5D63307C8373556D7C
// Navigate to about:blank initially in the iframe (newly attache child frame).
onFrameNavigated sid:42A41C3A9B41233D25BCEF6D66D133DA tid:997DCB5956FC7B5D63307C8373556D7C fid:94DFCBB3C80861CA9ECA2B2DDD91D473
FrameManager:frameNavigated fid:94DFCBB3C80861CA9ECA2B2DDD91D473 pfid:997DCB5956FC7B5D63307C8373556D7C docid:3BF362B038AC26AB7A4861D750329436 fname: furl:about:blank initial:false
```

No detach and attach of frames since the `iframe` is navigating to the same origin as the parent frame.

# Fix

This fix is to not delete the frame with the id in the detach event, but to clean it of its child frames. This will allow the incoming remote frame to attach itself to the same frame that was specified in the detach event.

## Why are you skipping the test?

This issue is non existent when running tests in headless mode, which is how we run tests in CLI. Therefore the test that was written is being skipped.