### PR TITLE
Use external Chrome process whenever its DevTools URL is provided via an env var

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -392,6 +392,11 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 
 // Close shuts down the browser.
 func (b *Browser) Close() {
+	if b.browserProc.Pid() < 0 { // we don't own browser process
+		b.logger.Debugf("Ignoring Browser:Close as it has not been started by xk6-browser", "")
+		return
+	}
+
 	defer func() {
 		if err := b.browserProc.userDataDir.Cleanup(); err != nil {
 			b.logger.Errorf("Browser:Close", "cleaning up the user data directory: %v", err)


### PR DESCRIPTION
This is a proof-of-concept to make `xk6-browser` use an external Chrome process to run tests.

Whenever the DevTools URL is provided via the `CHROME_DEVTOOLS_URL=` env var, `chromium.launch()` skips launching the browser process altogether and uses provided URL instead. `browser.close()` is a noop in this case, since we don't own the process and it can be reused by other test runs. It is possible though to terminate the browser process via CDP.

This code by no means should be considered production-ready and provided only to prove the idea.