### PR TITLE
Expose VU to the mapping layer

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -39,13 +39,12 @@ func wildcards() map[string]string {
 // methods.
 // See issue #661 for more details.
 func mapBrowserToGoja(vu k6modules.VU) *goja.Object {
-	rt := vu.Runtime()
-
 	var (
+		rt          = vu.Runtime()
 		obj         = rt.NewObject()
 		browserType = chromium.NewBrowserType(vu)
 	)
-	for k, v := range mapBrowserType(rt, browserType) {
+	for k, v := range mapBrowserType(vu, browserType) {
 		err := obj.Set(k, rt.ToValue(v))
 		if err != nil {
 			k6common.Throw(rt, fmt.Errorf("mapping: %w", err))
@@ -56,12 +55,13 @@ func mapBrowserToGoja(vu k6modules.VU) *goja.Object {
 }
 
 // mapRequest to the JS module.
-func mapRequest(rt *goja.Runtime, r api.Request) mapping {
+func mapRequest(vu k6modules.VU, r api.Request) mapping {
+	rt := vu.Runtime()
 	maps := mapping{
 		"allHeaders": r.AllHeaders,
 		"failure":    r.Failure,
 		"frame": func() *goja.Object {
-			mf := mapFrame(rt, r.Frame())
+			mf := mapFrame(vu, r.Frame())
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"headerValue":         r.HeaderValue,
@@ -73,16 +73,16 @@ func mapRequest(rt *goja.Runtime, r api.Request) mapping {
 		"postDataBuffer":      r.PostDataBuffer,
 		"postDataJSON":        r.PostDataJSON,
 		"redirectedFrom": func() *goja.Object {
-			mr := mapRequest(rt, r.RedirectedFrom())
+			mr := mapRequest(vu, r.RedirectedFrom())
 			return rt.ToValue(mr).ToObject(rt)
 		},
 		"redirectedTo": func() *goja.Object {
-			mr := mapRequest(rt, r.RedirectedTo())
+			mr := mapRequest(vu, r.RedirectedTo())
 			return rt.ToValue(mr).ToObject(rt)
 		},
 		"resourceType": r.ResourceType,
 		"response": func() *goja.Object {
-			mr := mapResponse(rt, r.Response())
+			mr := mapResponse(vu, r.Response())
 			return rt.ToValue(mr).ToObject(rt)
 		},
 		"size":   r.Size,
@@ -94,13 +94,14 @@ func mapRequest(rt *goja.Runtime, r api.Request) mapping {
 }
 
 // mapResponse to the JS module.
-func mapResponse(rt *goja.Runtime, r api.Response) mapping {
+func mapResponse(vu k6modules.VU, r api.Response) mapping {
+	rt := vu.Runtime()
 	maps := mapping{
 		"allHeaders": r.AllHeaders,
 		"body":       r.Body,
 		"finished":   r.Finished,
 		"frame": func() *goja.Object {
-			mf := mapFrame(rt, r.Frame())
+			mf := mapFrame(vu, r.Frame())
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"headerValue":  r.HeaderValue,
@@ -110,7 +111,7 @@ func mapResponse(rt *goja.Runtime, r api.Response) mapping {
 		"jSON":         r.JSON,
 		"ok":           r.Ok,
 		"request": func() *goja.Object {
-			mr := mapRequest(rt, r.Request())
+			mr := mapRequest(vu, r.Request())
 			return rt.ToValue(mr).ToObject(rt)
 		},
 		"securityDetails": r.SecurityDetails,
@@ -127,10 +128,11 @@ func mapResponse(rt *goja.Runtime, r api.Response) mapping {
 // mapElementHandle to the JS module.
 //
 //nolint:funlen
-func mapElementHandle(rt *goja.Runtime, eh api.ElementHandle) mapping {
+func mapElementHandle(vu k6modules.VU, eh api.ElementHandle) mapping {
+	rt := vu.Runtime()
 	maps := mapping{
 		"asElement": func() *goja.Object {
-			m := mapElementHandle(rt, eh.AsElement())
+			m := mapElementHandle(vu, eh.AsElement())
 			return rt.ToValue(m).ToObject(rt)
 		},
 		"dispose":        eh.Dispose,
@@ -145,7 +147,7 @@ func mapElementHandle(rt *goja.Runtime, eh api.ElementHandle) mapping {
 		"click":          eh.Click,
 		"contentFrame": func() *goja.Object {
 			f := eh.ContentFrame()
-			mf := mapFrame(rt, f)
+			mf := mapFrame(vu, f)
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"dblclick":      eh.Dblclick,
@@ -165,7 +167,7 @@ func mapElementHandle(rt *goja.Runtime, eh api.ElementHandle) mapping {
 		"isVisible":     eh.IsVisible,
 		"ownerFrame": func() *goja.Object {
 			f := eh.OwnerFrame()
-			mf := mapFrame(rt, f)
+			mf := mapFrame(vu, f)
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"press":                  eh.Press,
@@ -181,13 +183,13 @@ func mapElementHandle(rt *goja.Runtime, eh api.ElementHandle) mapping {
 		"waitForElementState":    eh.WaitForElementState,
 		"waitForSelector": func(selector string, opts goja.Value) *goja.Object {
 			eh := eh.WaitForSelector(selector, opts)
-			ehm := mapElementHandle(rt, eh)
+			ehm := mapElementHandle(vu, eh)
 			return rt.ToValue(ehm).ToObject(rt)
 		},
 	}
 	maps["$"] = func(selector string) *goja.Object {
 		eh := eh.Query(selector)
-		ehm := mapElementHandle(rt, eh)
+		ehm := mapElementHandle(vu, eh)
 		return rt.ToValue(ehm).ToObject(rt)
 	}
 	maps["$$"] = func(selector string) *goja.Object {
@@ -196,7 +198,7 @@ func mapElementHandle(rt *goja.Runtime, eh api.ElementHandle) mapping {
 			ehs  = eh.QueryAll(selector)
 		)
 		for _, eh := range ehs {
-			ehm := mapElementHandle(rt, eh)
+			ehm := mapElementHandle(vu, eh)
 			mehs = append(mehs, ehm)
 		}
 		return rt.ToValue(mehs).ToObject(rt)
@@ -208,7 +210,8 @@ func mapElementHandle(rt *goja.Runtime, eh api.ElementHandle) mapping {
 // mapFrame to the JS module.
 //
 //nolint:funlen
-func mapFrame(rt *goja.Runtime, f api.Frame) mapping {
+func mapFrame(vu k6modules.VU, f api.Frame) mapping {
+	rt := vu.Runtime()
 	maps := mapping{
 		"addScriptTag": f.AddScriptTag,
 		"addStyleTag":  f.AddStyleTag,
@@ -219,7 +222,7 @@ func mapFrame(rt *goja.Runtime, f api.Frame) mapping {
 				cfs  = f.ChildFrames()
 			)
 			for _, fr := range cfs {
-				mcfs = append(mcfs, mapFrame(rt, fr))
+				mcfs = append(mcfs, mapFrame(vu, fr))
 			}
 			return rt.ToValue(mcfs).ToObject(rt)
 		},
@@ -232,7 +235,7 @@ func mapFrame(rt *goja.Runtime, f api.Frame) mapping {
 		"fill":           f.Fill,
 		"focus":          f.Focus,
 		"frameElement": func() *goja.Object {
-			eh := mapElementHandle(rt, f.FrameElement())
+			eh := mapElementHandle(vu, f.FrameElement())
 			return rt.ToValue(eh).ToObject(rt)
 		},
 		"getAttribute": f.GetAttribute,
@@ -253,11 +256,11 @@ func mapFrame(rt *goja.Runtime, f api.Frame) mapping {
 		"locator":      f.Locator,
 		"name":         f.Name,
 		"page": func() *goja.Object {
-			mp := mapPage(rt, f.Page())
+			mp := mapPage(vu, f.Page())
 			return rt.ToValue(mp).ToObject(rt)
 		},
 		"parentFrame": func() *goja.Object {
-			mf := mapFrame(rt, f.ParentFrame())
+			mf := mapFrame(vu, f.ParentFrame())
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"press":             f.Press,
@@ -275,14 +278,14 @@ func mapFrame(rt *goja.Runtime, f api.Frame) mapping {
 		"waitForNavigation": f.WaitForNavigation,
 		"waitForSelector": func(selector string, opts goja.Value) *goja.Object {
 			eh := f.WaitForSelector(selector, opts)
-			ehm := mapElementHandle(rt, eh)
+			ehm := mapElementHandle(vu, eh)
 			return rt.ToValue(ehm).ToObject(rt)
 		},
 		"waitForTimeout": f.WaitForTimeout,
 	}
 	maps["$"] = func(selector string) *goja.Object {
 		eh := f.Query(selector)
-		ehm := mapElementHandle(rt, eh)
+		ehm := mapElementHandle(vu, eh)
 		return rt.ToValue(ehm).ToObject(rt)
 	}
 	maps["$$"] = func(selector string) *goja.Object {
@@ -291,7 +294,7 @@ func mapFrame(rt *goja.Runtime, f api.Frame) mapping {
 			ehs  = f.QueryAll(selector)
 		)
 		for _, eh := range ehs {
-			ehm := mapElementHandle(rt, eh)
+			ehm := mapElementHandle(vu, eh)
 			mehs = append(mehs, ehm)
 		}
 		return rt.ToValue(mehs).ToObject(rt)
@@ -303,7 +306,8 @@ func mapFrame(rt *goja.Runtime, f api.Frame) mapping {
 // mapPage to the JS module.
 //
 //nolint:funlen
-func mapPage(rt *goja.Runtime, p api.Page) mapping {
+func mapPage(vu k6modules.VU, p api.Page) mapping {
+	rt := vu.Runtime()
 	maps := mapping{
 		"addInitScript":           p.AddInitScript,
 		"addScriptTag":            p.AddScriptTag,
@@ -332,7 +336,7 @@ func mapPage(rt *goja.Runtime, p api.Page) mapping {
 				frs  = p.Frames()
 			)
 			for _, fr := range frs {
-				mfrs = append(mfrs, mapFrame(rt, fr))
+				mfrs = append(mfrs, mapFrame(vu, fr))
 			}
 			return rt.ToValue(mfrs).ToObject(rt)
 		},
@@ -353,7 +357,7 @@ func mapPage(rt *goja.Runtime, p api.Page) mapping {
 		"isVisible":    p.IsVisible,
 		"locator":      p.Locator,
 		"mainFrame": func() *goja.Object {
-			mf := mapFrame(rt, p.MainFrame())
+			mf := mapFrame(vu, p.MainFrame())
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"opener": p.Opener,
@@ -361,7 +365,7 @@ func mapPage(rt *goja.Runtime, p api.Page) mapping {
 		"pdf":    p.Pdf,
 		"press":  p.Press,
 		"reload": func(opts goja.Value) *goja.Object {
-			r := mapResponse(rt, p.Reload(opts))
+			r := mapResponse(vu, p.Reload(opts))
 			return rt.ToValue(r).ToObject(rt)
 		},
 		"route":                       p.Route,
@@ -394,7 +398,7 @@ func mapPage(rt *goja.Runtime, p api.Page) mapping {
 	}
 	maps["$"] = func(selector string) *goja.Object {
 		eh := p.Query(selector)
-		ehm := mapElementHandle(rt, eh)
+		ehm := mapElementHandle(vu, eh)
 		return rt.ToValue(ehm).ToObject(rt)
 	}
 	maps["$$"] = func(selector string) *goja.Object {
@@ -403,7 +407,7 @@ func mapPage(rt *goja.Runtime, p api.Page) mapping {
 			ehs  = p.QueryAll(selector)
 		)
 		for _, eh := range ehs {
-			ehm := mapElementHandle(rt, eh)
+			ehm := mapElementHandle(vu, eh)
 			mehs = append(mehs, ehm)
 		}
 		return rt.ToValue(mehs).ToObject(rt)
@@ -413,7 +417,8 @@ func mapPage(rt *goja.Runtime, p api.Page) mapping {
 }
 
 // mapBrowserContext to the JS module.
-func mapBrowserContext(rt *goja.Runtime, bc api.BrowserContext) mapping {
+func mapBrowserContext(vu k6modules.VU, bc api.BrowserContext) mapping {
+	rt := vu.Runtime()
 	return mapping{
 		"addCookies":                  bc.AddCookies,
 		"addInitScript":               bc.AddInitScript,
@@ -445,7 +450,7 @@ func mapBrowserContext(rt *goja.Runtime, bc api.BrowserContext) mapping {
 				if page == nil {
 					continue
 				}
-				m := mapPage(rt, page)
+				m := mapPage(vu, page)
 				mpages = append(mpages, m)
 			}
 
@@ -453,14 +458,15 @@ func mapBrowserContext(rt *goja.Runtime, bc api.BrowserContext) mapping {
 		},
 		"newPage": func() *goja.Object {
 			page := bc.NewPage()
-			m := mapPage(rt, page)
+			m := mapPage(vu, page)
 			return rt.ToValue(m).ToObject(rt)
 		},
 	}
 }
 
 // mapBrowser to the JS module.
-func mapBrowser(rt *goja.Runtime, b api.Browser) mapping {
+func mapBrowser(vu k6modules.VU, b api.Browser) mapping {
+	rt := vu.Runtime()
 	return mapping{
 		"close":       b.Close,
 		"contexts":    b.Contexts,
@@ -470,26 +476,27 @@ func mapBrowser(rt *goja.Runtime, b api.Browser) mapping {
 		"version":     b.Version,
 		"newContext": func(opts goja.Value) *goja.Object {
 			bctx := b.NewContext(opts)
-			m := mapBrowserContext(rt, bctx)
+			m := mapBrowserContext(vu, bctx)
 			return rt.ToValue(m).ToObject(rt)
 		},
 		"newPage": func(opts goja.Value) *goja.Object {
 			page := b.NewPage(opts)
-			m := mapPage(rt, page)
+			m := mapPage(vu, page)
 			return rt.ToValue(m).ToObject(rt)
 		},
 	}
 }
 
 // mapBrowserType to the JS module.
-func mapBrowserType(rt *goja.Runtime, bt api.BrowserType) mapping {
+func mapBrowserType(vu k6modules.VU, bt api.BrowserType) mapping {
+	rt := vu.Runtime()
 	return mapping{
 		"connect":                 bt.Connect,
 		"executablePath":          bt.ExecutablePath,
 		"launchPersistentContext": bt.LaunchPersistentContext,
 		"name":                    bt.Name,
 		"launch": func(opts goja.Value) *goja.Object {
-			m := mapBrowser(rt, bt.Launch(opts))
+			m := mapBrowser(vu, bt.Launch(opts))
 			return rt.ToValue(m).ToObject(rt)
 		},
 	}

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -77,49 +77,49 @@ func TestMappings(t *testing.T) {
 		"browserType": {
 			apiInterface: (*api.BrowserType)(nil),
 			mapp: func() mapping {
-				return mapBrowserType(vu, &chromium.BrowserType{})
+				return mapBrowserType(vu.Context(), vu, &chromium.BrowserType{})
 			},
 		},
 		"browser": {
 			apiInterface: (*api.Browser)(nil),
 			mapp: func() mapping {
-				return mapBrowser(vu, &chromium.Browser{})
+				return mapBrowser(vu.Context(), vu, &chromium.Browser{})
 			},
 		},
 		"browserContext": {
 			apiInterface: (*api.BrowserContext)(nil),
 			mapp: func() mapping {
-				return mapBrowserContext(vu, &common.BrowserContext{})
+				return mapBrowserContext(vu.Context(), vu, &common.BrowserContext{})
 			},
 		},
 		"page": {
 			apiInterface: (*api.Page)(nil),
 			mapp: func() mapping {
-				return mapPage(vu, &common.Page{})
+				return mapPage(vu.Context(), vu, &common.Page{})
 			},
 		},
 		"elementHandle": {
 			apiInterface: (*api.ElementHandle)(nil),
 			mapp: func() mapping {
-				return mapElementHandle(vu, &common.ElementHandle{})
+				return mapElementHandle(vu.Context(), vu, &common.ElementHandle{})
 			},
 		},
 		"frame": {
 			apiInterface: (*api.Frame)(nil),
 			mapp: func() mapping {
-				return mapFrame(vu, &common.Frame{})
+				return mapFrame(vu.Context(), vu, &common.Frame{})
 			},
 		},
 		"mapRequest": {
 			apiInterface: (*api.Request)(nil),
 			mapp: func() mapping {
-				return mapRequest(vu, &common.Request{})
+				return mapRequest(vu.Context(), vu, &common.Request{})
 			},
 		},
 		"mapResponse": {
 			apiInterface: (*api.Response)(nil),
 			mapp: func() mapping {
-				return mapResponse(vu, &common.Response{})
+				return mapResponse(vu.Context(), vu, &common.Response{})
 			},
 		},
 	} {

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -35,7 +35,6 @@ func TestMappings(t *testing.T) {
 				Registry: k6metrics.NewRegistry(),
 			},
 		}
-		rt        = vu.Runtime()
 		wildcards = wildcards()
 	)
 
@@ -78,49 +77,49 @@ func TestMappings(t *testing.T) {
 		"browserType": {
 			apiInterface: (*api.BrowserType)(nil),
 			mapp: func() mapping {
-				return mapBrowserType(rt, &chromium.BrowserType{})
+				return mapBrowserType(vu, &chromium.BrowserType{})
 			},
 		},
 		"browser": {
 			apiInterface: (*api.Browser)(nil),
 			mapp: func() mapping {
-				return mapBrowser(rt, &chromium.Browser{})
+				return mapBrowser(vu, &chromium.Browser{})
 			},
 		},
 		"browserContext": {
 			apiInterface: (*api.BrowserContext)(nil),
 			mapp: func() mapping {
-				return mapBrowserContext(rt, &common.BrowserContext{})
+				return mapBrowserContext(vu, &common.BrowserContext{})
 			},
 		},
 		"page": {
 			apiInterface: (*api.Page)(nil),
 			mapp: func() mapping {
-				return mapPage(rt, &common.Page{})
+				return mapPage(vu, &common.Page{})
 			},
 		},
 		"elementHandle": {
 			apiInterface: (*api.ElementHandle)(nil),
 			mapp: func() mapping {
-				return mapElementHandle(rt, &common.ElementHandle{})
+				return mapElementHandle(vu, &common.ElementHandle{})
 			},
 		},
 		"frame": {
 			apiInterface: (*api.Frame)(nil),
 			mapp: func() mapping {
-				return mapFrame(rt, &common.Frame{})
+				return mapFrame(vu, &common.Frame{})
 			},
 		},
 		"mapRequest": {
 			apiInterface: (*api.Request)(nil),
 			mapp: func() mapping {
-				return mapRequest(rt, &common.Request{})
+				return mapRequest(vu, &common.Request{})
 			},
 		},
 		"mapResponse": {
 			apiInterface: (*api.Response)(nil),
 			mapp: func() mapping {
-				return mapResponse(rt, &common.Response{})
+				return mapResponse(vu, &common.Response{})
 			},
 		},
 	} {

--- a/browser/module.go
+++ b/browser/module.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dop251/goja"
 
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/k6ext"
 
 	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
@@ -55,9 +56,13 @@ func (*RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 		k6common.Throw(vu.Runtime(), errors.New(msg))
 	}
 
+	// promises and inner objects need the VU object to be
+	// able to use k6-core specific functionality.
+	ctx := k6ext.WithVU(vu.Context(), vu)
+
 	return &ModuleInstance{
 		mod: &JSModule{
-			Chromium: mapBrowserToGoja(vu),
+			Chromium: mapBrowserToGoja(ctx, vu),
 			Devices:  common.GetDevices(),
 			Version:  version,
 		},

--- a/browser/module_test.go
+++ b/browser/module_test.go
@@ -1,6 +1,7 @@
 package browser
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dop251/goja"
@@ -23,6 +24,7 @@ func TestModuleNew(t *testing.T) {
 		InitEnvField: &k6common.InitEnvironment{
 			Registry: k6metrics.NewRegistry(),
 		},
+		CtxField: context.Background(),
 	}
 	m, ok := New().NewModuleInstance(vu).(*ModuleInstance)
 	require.True(t, ok, "NewModuleInstance should return a ModuleInstance")


### PR DESCRIPTION
Exposing VU is preliminary for using promises in the mapping layer.

### Context

Normally [this code](https://github.com/grafana/xk6-browser/blob/update/697-js-examples-to-async/chromium/browser_type.go#L112) loads the VU so that the code in the `common` package can call [k6ext/promise](https://github.com/grafana/xk6-browser/blob/a11233766d5580b5ba8cf1ed5b7b9bb4dcfd8f66/k6ext/promise.go#L34-L39).

### Problem

Since we're moving the promise handling to the mapping layer (#683), the mapping layer needs a VU from the context to pass it to the `k6ext.Promise()`.

`k6ext.Promise()` gets the current VU from the context:

https://github.com/grafana/xk6-browser/blob/a11233766d5580b5ba8cf1ed5b7b9bb4dcfd8f66/k6ext/promise.go#L34-L39

### Solution

So, in the mapping layer, we need to inject VU into the context:

```go
func (*RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
    	...
    	ctx := k6ext.WithVU(vu.Context(), vu)
    	...
    	return &ModuleInstance{
		mod: &JSModule{
			Chromium: mapBrowserToGoja(ctx, vu),
			...
		},
	}
}
```

So that we can use `k6ext.Promise` in the mapping layer as follows:

```go
func mapPage(vu k6modules.VU, p api.Page) mapping {
    ...
    "goto": func(url string, opts goja.Value) *goja.Promise {
      // get the VU from the context
      return k6ext.Promise(ctx, func() (any, error) {
        resp, err := p.Goto(url, opts)
        if err != nil {
          return nil, err
        }
 
        return mapResponse(vu, resp), nil
      })
    },
    ...
```

PS: We can directly pass the VU to the `k6ext.Promise` after we finish our work in #683 (_after moving every promise code to the mapping layer_). But that would be another task than the mapping task as I don't know the implications of it yet—and we don't have enough time for it right now. Plus, I'm trying to make a gradual switch and keep the PRs small and focused.

Updates: #683