### PR TITLE
Map [Page|Frame].Goto promises and fix tests

### DIFF
--- a/api/frame.go
+++ b/api/frame.go
@@ -18,7 +18,7 @@ type Frame interface {
 	Focus(selector string, opts goja.Value)
 	FrameElement() ElementHandle
 	GetAttribute(selector string, name string, opts goja.Value) goja.Value
-	Goto(url string, opts goja.Value) *goja.Promise
+	Goto(url string, opts goja.Value) (Response, error)
 	Hover(selector string, opts goja.Value)
 	InnerHTML(selector string, opts goja.Value) string
 	InnerText(selector string, opts goja.Value) string

--- a/api/page.go
+++ b/api/page.go
@@ -29,7 +29,7 @@ type Page interface {
 	GetAttribute(selector string, name string, opts goja.Value) goja.Value
 	GoBack(opts goja.Value) *goja.Promise
 	GoForward(opts goja.Value) *goja.Promise
-	Goto(url string, opts goja.Value) *goja.Promise
+	Goto(url string, opts goja.Value) (Response, error)
 	Hover(selector string, opts goja.Value)
 	InnerHTML(selector string, opts goja.Value) string
 	InnerText(selector string, opts goja.Value) string

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/chromium"
+	"github.com/grafana/xk6-browser/k6ext"
 
 	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
@@ -243,22 +244,31 @@ func mapFrame(ctx context.Context, vu k6modules.VU, f api.Frame) mapping {
 			return rt.ToValue(eh).ToObject(rt)
 		},
 		"getAttribute": f.GetAttribute,
-		"goto":         f.Goto,
-		"hover":        f.Hover,
-		"innerHTML":    f.InnerHTML,
-		"innerText":    f.InnerText,
-		"inputValue":   f.InputValue,
-		"isChecked":    f.IsChecked,
-		"isDetached":   f.IsDetached,
-		"isDisabled":   f.IsDisabled,
-		"isEditable":   f.IsEditable,
-		"isEnabled":    f.IsEnabled,
-		"isHidden":     f.IsHidden,
-		"isVisible":    f.IsVisible,
-		"iD":           f.ID,
-		"loaderID":     f.LoaderID,
-		"locator":      f.Locator,
-		"name":         f.Name,
+		"goto": func(url string, opts goja.Value) *goja.Promise {
+			return k6ext.Promise(ctx, func() (any, error) {
+				resp, err := f.Goto(url, opts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+
+				return mapResponse(ctx, vu, resp), nil
+			})
+		},
+		"hover":      f.Hover,
+		"innerHTML":  f.InnerHTML,
+		"innerText":  f.InnerText,
+		"inputValue": f.InputValue,
+		"isChecked":  f.IsChecked,
+		"isDetached": f.IsDetached,
+		"isDisabled": f.IsDisabled,
+		"isEditable": f.IsEditable,
+		"isEnabled":  f.IsEnabled,
+		"isHidden":   f.IsHidden,
+		"isVisible":  f.IsVisible,
+		"iD":         f.ID,
+		"loaderID":   f.LoaderID,
+		"locator":    f.Locator,
+		"name":       f.Name,
 		"page": func() *goja.Object {
 			mp := mapPage(ctx, vu, f.Page())
 			return rt.ToValue(mp).ToObject(rt)
@@ -347,19 +357,28 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 		"getAttribute": p.GetAttribute,
 		"goBack":       p.GoBack,
 		"goForward":    p.GoForward,
-		"goto":         p.Goto,
-		"hover":        p.Hover,
-		"innerHTML":    p.InnerHTML,
-		"innerText":    p.InnerText,
-		"inputValue":   p.InputValue,
-		"isChecked":    p.IsChecked,
-		"isClosed":     p.IsClosed,
-		"isDisabled":   p.IsDisabled,
-		"isEditable":   p.IsEditable,
-		"isEnabled":    p.IsEnabled,
-		"isHidden":     p.IsHidden,
-		"isVisible":    p.IsVisible,
-		"locator":      p.Locator,
+		"goto": func(url string, opts goja.Value) *goja.Promise {
+			return k6ext.Promise(ctx, func() (any, error) {
+				resp, err := p.Goto(url, opts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+
+				return mapResponse(ctx, vu, resp), nil
+			})
+		},
+		"hover":      p.Hover,
+		"innerHTML":  p.InnerHTML,
+		"innerText":  p.InnerText,
+		"inputValue": p.InputValue,
+		"isChecked":  p.IsChecked,
+		"isClosed":   p.IsClosed,
+		"isDisabled": p.IsDisabled,
+		"isEditable": p.IsEditable,
+		"isEnabled":  p.IsEnabled,
+		"isHidden":   p.IsHidden,
+		"isVisible":  p.IsVisible,
+		"locator":    p.Locator,
 		"mainFrame": func() *goja.Object {
 			mf := mapFrame(ctx, vu, p.MainFrame())
 			return rt.ToValue(mf).ToObject(rt)

--- a/common/page.go
+++ b/common/page.go
@@ -553,7 +553,7 @@ func (p *Page) GoForward(opts goja.Value) *goja.Promise {
 }
 
 // Goto will navigate the page to the specified URL and return a HTTP response object.
-func (p *Page) Goto(url string, opts goja.Value) *goja.Promise {
+func (p *Page) Goto(url string, opts goja.Value) (api.Response, error) {
 	p.logger.Debugf("Page:Goto", "sid:%v url:%q", p.sessionID(), url)
 
 	return p.MainFrame().Goto(url, opts)

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/common"
 )
 
@@ -77,14 +76,16 @@ func TestBrowserContextOptionsExtraHTTPHeaders(t *testing.T) {
 	p := bctx.NewPage()
 
 	err := tb.awaitWithTimeout(time.Second*5, func() error {
-		tb.promise(p.Goto(tb.URL("/get"), nil)).then(func(resp api.Response) {
-			require.NotNil(t, resp)
-			var body struct{ Headers map[string][]string }
-			require.NoError(t, json.Unmarshal(resp.Body().Bytes(), &body))
-			h := body.Headers["Some-Header"]
-			require.NotEmpty(t, h)
-			assert.Equal(t, "Some-Value", h[0])
-		})
+		resp, err := p.Goto(tb.URL("/get"), nil)
+		if err != nil {
+			return err
+		}
+		require.NotNil(t, resp)
+		var body struct{ Headers map[string][]string }
+		require.NoError(t, json.Unmarshal(resp.Body().Bytes(), &body))
+		h := body.Headers["Some-Header"]
+		require.NotEmpty(t, h)
+		assert.Equal(t, "Some-Value", h[0])
 		return nil
 	})
 	require.NoError(t, err)

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -188,12 +188,13 @@ func TestElementHandleClickConcealedLink(t *testing.T) {
 		cr := p.Evaluate(tb.toGojaValue(cmd))
 		return tb.asGojaValue(cr).String()
 	}
-	err := tb.await(func() error {
-		tb.promise(p.Goto(tb.staticURL("/concealed_link.html"), nil)).
-			then(func() *goja.Promise {
-				require.Equal(t, wantBefore, clickResult())
-				return p.Click("#concealed", nil)
-			}).
+	resp, err := p.Goto(tb.staticURL("/concealed_link.html"), nil)
+	require.NotNil(t, resp)
+	require.NoError(t, err)
+	require.Equal(t, wantBefore, clickResult())
+
+	err = tb.await(func() error {
+		tb.promise(p.Click("#concealed", nil)).
 			then(func() {
 				require.Equal(t, wantAfter, clickResult())
 			})
@@ -206,12 +207,13 @@ func TestElementHandleNonClickable(t *testing.T) {
 	tb := newTestBrowser(t, withFileServer())
 	p := tb.NewContext(nil).NewPage()
 
+	resp, err := p.Goto(tb.staticURL("/non_clickable.html"), nil)
+	require.NotNil(t, resp)
+	require.NoError(t, err)
+
 	var notClickable bool
-	err := tb.await(func() error {
-		tb.promise(p.Goto(tb.staticURL("/non_clickable.html"), nil)).
-			then(func() *goja.Promise {
-				return p.Click("#non-clickable", nil)
-			}).
+	err = tb.await(func() error {
+		tb.promise(p.Click("#non-clickable", nil)).
 			then(
 				func() { t.Fatal("element should not be clickable") },
 				func() { notClickable = true },

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -3,11 +3,11 @@ package tests
 import (
 	"testing"
 
-	"github.com/grafana/xk6-browser/api"
-
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/api"
 )
 
 // Strict mode:
@@ -185,12 +185,8 @@ func TestLocator(t *testing.T) {
 
 			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
-			err := tb.await(func() error {
-				tb.promise(p.Goto(tb.staticURL("locators.html"), nil)).then(func() {
-					tt.do(tb, p)
-				})
-				return nil
-			})
+			_, err := p.Goto(tb.staticURL("locators.html"), nil)
+			tt.do(tb, p)
 			require.NoError(t, err)
 		})
 	}
@@ -277,13 +273,13 @@ func TestLocator(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
-			err := tb.await(func() error {
-				tb.promise(p.Goto(tb.staticURL("locators.html"), nil)).then(func() {
-					assert.Panics(t, func() { tt.do(p.Locator("a", nil), tb) })
-				})
-				return nil
-			})
+
+			_, err := p.Goto(tb.staticURL("locators.html"), nil)
 			require.NoError(t, err)
+
+			assert.Panics(t, func() {
+				tt.do(p.Locator("a", nil), tb)
+			})
 		})
 	}
 }
@@ -329,16 +325,15 @@ func TestLocatorElementState(t *testing.T) {
 
 			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
-			err := tb.await(func() error {
-				tb.promise(p.Goto(tb.staticURL("locators.html"), nil)).then(func() {
-					l := p.Locator("#inputText", nil)
-					require.True(t, tt.query(l))
 
-					p.Evaluate(tb.toGojaValue(tt.eval))
-					require.False(t, tt.query(l))
-				})
-				return nil
-			})
+			_, err := p.Goto(tb.staticURL("locators.html"), nil)
+			require.NoError(t, err)
+
+			l := p.Locator("#inputText", nil)
+			require.True(t, tt.query(l))
+
+			p.Evaluate(tb.toGojaValue(tt.eval))
+			require.False(t, tt.query(l))
 			require.NoError(t, err)
 		})
 	}
@@ -388,11 +383,10 @@ func TestLocatorElementState(t *testing.T) {
 
 			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
-			err := tb.await(func() error {
-				tb.promise(p.Goto(tb.staticURL("locators.html"), nil)).then(func() {
-					assert.Panics(t, func() { tt.do(p.Locator("a", nil), tb) })
-				})
-				return nil
+
+			_, err := p.Goto(tb.staticURL("locators.html"), nil)
+			assert.Panics(t, func() {
+				tt.do(p.Locator("a", nil), tb)
 			})
 			require.NoError(t, err)
 		})


### PR DESCRIPTION
This PR removes the promise handling from the `Goto` methods and moves the handling to the mapping layer. Sorry, the PR is pretty big. It wasn't possible to split it into more commits without breaking tests. I hope you'll be able to review it. One tip is to review each file from the `Files changed` tab with the file navigation on. Depends on your preference. Feel free to let me know if you have any questions.

PS: I kept the fixup commits for your convenience. I'll squash them all when you finish reviewing. That's why it's not in the "ready for review" yet; still a draft.

Closes #705. Updates #683.