### PR TITLE
Fix lifecycle tests parallelism bug

### DIFF
--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -137,6 +137,7 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -265,6 +266,7 @@ func TestLifecycleWaitForLoadState(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -359,6 +361,7 @@ func TestLifecycleReload(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -454,6 +457,7 @@ func TestLifecycleGotoWithSubFrame(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -525,6 +529,7 @@ func TestLifecycleGoto(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
So far, we haven't been testing the lifecycle tests. The test variables were captured because `t.Parallel`. This fixes it.

Related: #647, #644, #643