### PR TITLE
Fix frame manager navigate frame bug

### DIFF
--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -563,7 +563,7 @@ func (m *FrameManager) setMainFrame(f *Frame) {
 // NavigateFrame will navigate specified frame to specified URL.
 //
 //nolint:funlen,cyclop
-func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *FrameGotoOptions) (api.Response, error) {
+func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *FrameGotoOptions) (*Response, error) {
 	var (
 		fmid = m.ID()
 		fid  = frame.ID()


### PR DESCRIPTION
Returning an interface makes the `response` never `nil`. This creates problems when we want to check whether the `response` is `nil` or not.

Here, it never becomes `nil` even if it happens to be `nil`:

https://github.com/grafana/xk6-browser/blob/f2e001837a6b426fba95c873d4f97b3378da5d94/common/frame_manager.go#L644-L666

So we can't check whether it's `nil` or not here:

https://github.com/grafana/xk6-browser/blob/d2785768849aa7cc976eba27cb983cf2dd1475af/browser/mapping.go#L99-L102