### PR TITLE
Map [Page|Frame].WaitForNavigation and fix tests

### DIFF
--- a/api/frame.go
+++ b/api/frame.go
@@ -51,7 +51,7 @@ type Frame interface {
 	URL() string
 	WaitForFunction(pageFunc, opts goja.Value, args ...goja.Value) *goja.Promise
 	WaitForLoadState(state string, opts goja.Value)
-	WaitForNavigation(opts goja.Value) *goja.Promise
+	WaitForNavigation(opts goja.Value) (Response, error)
 	WaitForSelector(selector string, opts goja.Value) ElementHandle
 	WaitForTimeout(timeout int64)
 }

--- a/api/page.go
+++ b/api/page.go
@@ -72,7 +72,7 @@ type Page interface {
 	WaitForEvent(event string, optsOrPredicate goja.Value) *goja.Promise
 	WaitForFunction(fn, opts goja.Value, args ...goja.Value) *goja.Promise
 	WaitForLoadState(state string, opts goja.Value)
-	WaitForNavigation(opts goja.Value) *goja.Promise
+	WaitForNavigation(opts goja.Value) (Response, error)
 	WaitForRequest(urlOrPredicate, opts goja.Value) *goja.Promise
 	WaitForResponse(urlOrPredicate, opts goja.Value) *goja.Promise
 	WaitForSelector(selector string, opts goja.Value) ElementHandle

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -287,19 +287,27 @@ func mapFrame(ctx context.Context, vu k6modules.VU, f api.Frame) mapping {
 			mf := mapFrame(ctx, vu, f.ParentFrame())
 			return rt.ToValue(mf).ToObject(rt)
 		},
-		"press":             f.Press,
-		"selectOption":      f.SelectOption,
-		"setContent":        f.SetContent,
-		"setInputFiles":     f.SetInputFiles,
-		"tap":               f.Tap,
-		"textContent":       f.TextContent,
-		"title":             f.Title,
-		"type":              f.Type,
-		"uncheck":           f.Uncheck,
-		"url":               f.URL,
-		"waitForFunction":   f.WaitForFunction,
-		"waitForLoadState":  f.WaitForLoadState,
-		"waitForNavigation": f.WaitForNavigation,
+		"press":            f.Press,
+		"selectOption":     f.SelectOption,
+		"setContent":       f.SetContent,
+		"setInputFiles":    f.SetInputFiles,
+		"tap":              f.Tap,
+		"textContent":      f.TextContent,
+		"title":            f.Title,
+		"type":             f.Type,
+		"uncheck":          f.Uncheck,
+		"url":              f.URL,
+		"waitForFunction":  f.WaitForFunction,
+		"waitForLoadState": f.WaitForLoadState,
+		"waitForNavigation": func(opts goja.Value) *goja.Promise {
+			return k6ext.Promise(ctx, func() (result any, reason error) {
+				resp, err := f.WaitForNavigation(opts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				return mapResponse(ctx, vu, resp), nil
+			})
+		},
 		"waitForSelector": func(selector string, opts goja.Value) *goja.Object {
 			eh := f.WaitForSelector(selector, opts)
 			ehm := mapElementHandle(ctx, vu, eh)
@@ -427,12 +435,20 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 		"waitForEvent":                p.WaitForEvent,
 		"waitForFunction":             p.WaitForFunction,
 		"waitForLoadState":            p.WaitForLoadState,
-		"waitForNavigation":           p.WaitForNavigation,
-		"waitForRequest":              p.WaitForRequest,
-		"waitForResponse":             p.WaitForResponse,
-		"waitForSelector":             p.WaitForSelector,
-		"waitForTimeout":              p.WaitForTimeout,
-		"workers":                     p.Workers,
+		"waitForNavigation": func(opts goja.Value) *goja.Promise {
+			return k6ext.Promise(ctx, func() (result any, reason error) {
+				resp, err := p.WaitForNavigation(opts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				return mapResponse(ctx, vu, resp), nil
+			})
+		},
+		"waitForRequest":  p.WaitForRequest,
+		"waitForResponse": p.WaitForResponse,
+		"waitForSelector": p.WaitForSelector,
+		"waitForTimeout":  p.WaitForTimeout,
+		"workers":         p.Workers,
 	}
 	maps["$"] = func(selector string) *goja.Object {
 		eh := p.Query(selector)

--- a/common/page.go
+++ b/common/page.go
@@ -904,7 +904,7 @@ func (p *Page) WaitForLoadState(state string, opts goja.Value) {
 }
 
 // WaitForNavigation waits for the given navigation lifecycle event to happen.
-func (p *Page) WaitForNavigation(opts goja.Value) *goja.Promise {
+func (p *Page) WaitForNavigation(opts goja.Value) (api.Response, error) {
 	p.logger.Debugf("Page:WaitForNavigation", "sid:%v", p.sessionID())
 
 	return p.frameManager.MainFrame().WaitForNavigation(opts)

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -654,12 +654,13 @@ func TestPageWaitForLoadState(t *testing.T) {
 }
 
 // See: The issue #187 for details.
-func TestPageWaitForNavigationShouldNotPanic(t *testing.T) {
+func TestPageWaitForNavigationErrOnCtxDone(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	p := newTestBrowser(t, withContext(ctx)).NewPage(nil)
+	p := newTestBrowser(t, ctx).NewPage(nil)
 	go cancel()
 	<-ctx.Done()
-	require.NotPanics(t, func() { p.WaitForNavigation(nil) })
+	_, err := p.WaitForNavigation(nil)
+	require.ErrorContains(t, err, "canceled")
 }
 
 func TestPagePress(t *testing.T) {


### PR DESCRIPTION
This moves the promise handling for [Page|Frame].WaitForNavigation to the mapping layer. The lifecycle tests are still using promises since its logic is complex to figure out for now. We should refactor them when we finish—I've added a task on #683.

Related: #683 
Closes: #706