### PR TITLE
Map [Page|Frame].WaitForFunction promises and fix tests

### DIFF
--- a/api/frame.go
+++ b/api/frame.go
@@ -49,7 +49,7 @@ type Frame interface {
 	Type(selector string, text string, opts goja.Value)
 	Uncheck(selector string, opts goja.Value)
 	URL() string
-	WaitForFunction(pageFunc, opts goja.Value, args ...goja.Value) *goja.Promise
+	WaitForFunction(pageFunc, opts goja.Value, args ...goja.Value) (any, error)
 	WaitForLoadState(state string, opts goja.Value)
 	WaitForNavigation(opts goja.Value) (Response, error)
 	WaitForSelector(selector string, opts goja.Value) ElementHandle

--- a/api/page.go
+++ b/api/page.go
@@ -70,7 +70,7 @@ type Page interface {
 	Video() *goja.Promise
 	ViewportSize() map[string]float64
 	WaitForEvent(event string, optsOrPredicate goja.Value) *goja.Promise
-	WaitForFunction(fn, opts goja.Value, args ...goja.Value) *goja.Promise
+	WaitForFunction(fn, opts goja.Value, args ...goja.Value) (any, error)
 	WaitForLoadState(state string, opts goja.Value)
 	WaitForNavigation(opts goja.Value) (Response, error)
 	WaitForRequest(urlOrPredicate, opts goja.Value) *goja.Promise

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -287,17 +287,21 @@ func mapFrame(ctx context.Context, vu k6modules.VU, f api.Frame) mapping {
 			mf := mapFrame(ctx, vu, f.ParentFrame())
 			return rt.ToValue(mf).ToObject(rt)
 		},
-		"press":            f.Press,
-		"selectOption":     f.SelectOption,
-		"setContent":       f.SetContent,
-		"setInputFiles":    f.SetInputFiles,
-		"tap":              f.Tap,
-		"textContent":      f.TextContent,
-		"title":            f.Title,
-		"type":             f.Type,
-		"uncheck":          f.Uncheck,
-		"url":              f.URL,
-		"waitForFunction":  f.WaitForFunction,
+		"press":         f.Press,
+		"selectOption":  f.SelectOption,
+		"setContent":    f.SetContent,
+		"setInputFiles": f.SetInputFiles,
+		"tap":           f.Tap,
+		"textContent":   f.TextContent,
+		"title":         f.Title,
+		"type":          f.Type,
+		"uncheck":       f.Uncheck,
+		"url":           f.URL,
+		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) *goja.Promise {
+			return k6ext.Promise(ctx, func() (result any, reason error) {
+				return f.WaitForFunction(pageFunc, opts, args...) //nolint:wrapcheck
+			})
+		},
 		"waitForLoadState": f.WaitForLoadState,
 		"waitForNavigation": func(opts goja.Value) *goja.Promise {
 			return k6ext.Promise(ctx, func() (result any, reason error) {
@@ -433,8 +437,12 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 		"video":                       p.Video,
 		"viewportSize":                p.ViewportSize,
 		"waitForEvent":                p.WaitForEvent,
-		"waitForFunction":             p.WaitForFunction,
-		"waitForLoadState":            p.WaitForLoadState,
+		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) *goja.Promise {
+			return k6ext.Promise(ctx, func() (result any, reason error) {
+				return p.WaitForFunction(pageFunc, opts, args...) //nolint:wrapcheck
+			})
+		},
+		"waitForLoadState": p.WaitForLoadState,
 		"waitForNavigation": func(opts goja.Value) *goja.Promise {
 			return k6ext.Promise(ctx, func() (result any, reason error) {
 				resp, err := p.WaitForNavigation(opts)

--- a/common/page.go
+++ b/common/page.go
@@ -890,7 +890,7 @@ func (p *Page) WaitForEvent(event string, optsOrPredicate goja.Value) *goja.Prom
 }
 
 // WaitForFunction waits for the given predicate to return a truthy value.
-func (p *Page) WaitForFunction(fn, opts goja.Value, args ...goja.Value) *goja.Promise {
+func (p *Page) WaitForFunction(fn, opts goja.Value, args ...goja.Value) (any, error) {
 	p.logger.Debugf("Page:WaitForFunction", "sid:%v", p.sessionID())
 
 	return p.frameManager.MainFrame().WaitForFunction(fn, opts, args...)


### PR DESCRIPTION
The tests still need some refactoring, but it's out of focus for this PR. I tried to make them pass without changing things much.

Ideally, these tests should be written by the JavaScript side (as we'll do in #675). They are entirely concerned about the JS side of things, and these Go tests become futile, complicated, and hard to understand and maintain.

Closes #708. Updates #683.