### PR TITLE
Map Browser.On and fix test

### DIFF
--- a/api/browser.go
+++ b/api/browser.go
@@ -9,7 +9,7 @@ type Browser interface {
 	IsConnected() bool
 	NewContext(opts goja.Value) BrowserContext
 	NewPage(opts goja.Value) Page
-	On(string) *goja.Promise
+	On(string) (bool, error)
 	UserAgent() string
 	Version() string
 }

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -533,9 +533,17 @@ func mapBrowser(ctx context.Context, vu k6modules.VU, b api.Browser) mapping {
 		"close":       b.Close,
 		"contexts":    b.Contexts,
 		"isConnected": b.IsConnected,
-		"on":          b.On,
-		"userAgent":   b.UserAgent,
-		"version":     b.Version,
+		"on": func(event string) *goja.Promise {
+			return k6ext.Promise(ctx, func() (result any, reason error) {
+				res, err := b.On(event)
+				if err != nil {
+					return nil, err
+				}
+				return res, nil
+			})
+		},
+		"userAgent": b.UserAgent,
+		"version":   b.Version,
 		"newContext": func(opts goja.Value) *goja.Object {
 			bctx := b.NewContext(opts)
 			m := mapBrowserContext(ctx, vu, bctx)

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -537,7 +537,7 @@ func mapBrowser(ctx context.Context, vu k6modules.VU, b api.Browser) mapping {
 			return k6ext.Promise(ctx, func() (result any, reason error) {
 				res, err := b.On(event)
 				if err != nil {
-					return nil, err
+					return nil, err //nolint:wrapcheck
 				}
 				return res, nil
 			})

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -535,11 +535,7 @@ func mapBrowser(ctx context.Context, vu k6modules.VU, b api.Browser) mapping {
 		"isConnected": b.IsConnected,
 		"on": func(event string) *goja.Promise {
 			return k6ext.Promise(ctx, func() (result any, reason error) {
-				res, err := b.On(event)
-				if err != nil {
-					return nil, err //nolint:wrapcheck
-				}
-				return res, nil
+				return b.On(event) //nolint:wrapcheck
 			})
 		},
 		"userAgent": b.UserAgent,

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -62,7 +62,9 @@ func TestTmpDirCleanup(t *testing.T) {
 func TestBrowserOn(t *testing.T) {
 	t.Parallel()
 
-	script := `b.on('%s').then(log).catch(log);`
+	script := `
+	const result = b.on('%s')
+	log(result);`
 
 	t.Run("err_wrong_event", func(t *testing.T) {
 		t.Parallel()
@@ -117,8 +119,7 @@ func TestBrowserOn(t *testing.T) {
 			_, err := b.runJavaScript(script, "disconnected")
 			return err
 		})
-		require.NoError(t, err)
-		assert.Contains(t, log, "browser.on promise rejected: context canceled")
+		assert.ErrorContains(t, err, "browser.on promise rejected: context canceled")
 	})
 }
 

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -72,10 +72,7 @@ func TestBrowserOn(t *testing.T) {
 		b := newTestBrowser(t)
 		require.NoError(t, b.vu.Runtime().Set("b", b.Browser))
 
-		err := b.await(func() error {
-			_, err := b.runJavaScript(script, "wrongevent")
-			return err
-		})
+		_, err := b.runJavaScript(script, "wrongevent")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `unknown browser event: "wrongevent", must be "disconnected"`)
 	})
@@ -92,11 +89,8 @@ func TestBrowserOn(t *testing.T) {
 		require.NoError(t, rt.Set("b", b.Browser))
 		require.NoError(t, rt.Set("log", func(s string) { log = append(log, s) }))
 
-		err := b.await(func() error {
-			time.AfterFunc(100*time.Millisecond, b.Browser.Close)
-			_, err := b.runJavaScript(script, "disconnected")
-			return err
-		})
+		time.AfterFunc(100*time.Millisecond, b.Browser.Close)
+		_, err := b.runJavaScript(script, "disconnected")
 		require.NoError(t, err)
 		assert.Contains(t, log, "true")
 	})
@@ -114,11 +108,8 @@ func TestBrowserOn(t *testing.T) {
 		require.NoError(t, rt.Set("b", b.Browser))
 		require.NoError(t, rt.Set("log", func(s string) { log = append(log, s) }))
 
-		err := b.await(func() error {
-			time.AfterFunc(100*time.Millisecond, cancel)
-			_, err := b.runJavaScript(script, "disconnected")
-			return err
-		})
+		time.AfterFunc(100*time.Millisecond, cancel)
+		_, err := b.runJavaScript(script, "disconnected")
 		assert.ErrorContains(t, err, "browser.on promise rejected: context canceled")
 	})
 }

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/grafana/xk6-browser/api"
-	"github.com/grafana/xk6-browser/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/common"
 
 	k6lib "go.k6.io/k6/lib"
 	k6types "go.k6.io/k6/lib/types"


### PR DESCRIPTION
This moves the promise handling of `Browser.on` to the mapping layer.

Ideally, a test should be written by the JavaScript side. See issue #675 for details. The reason is, they are completely concerned about the JS-side of things and the Go tests become futile, complicated and hard to understand.

Closes https://github.com/grafana/xk6-browser/issues/709. Updates https://github.com/grafana/xk6-browser/issues/683.