### PR TITLE
Remove await method from testBrowser

### DIFF
--- a/tests/launch_options_slowmo_test.go
+++ b/tests/launch_options_slowmo_test.go
@@ -93,10 +93,7 @@ func TestLaunchOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p api.Page) {
-				err := tb.await(func() error {
-					p.Goto("about:blank", nil)
-					return nil
-				})
+				_, err := p.Goto("about:blank", nil)
 				require.NoError(t, err)
 			})
 		})

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -234,13 +234,6 @@ func (b *testBrowser) runJavaScript(s string, args ...any) (goja.Value, error) {
 	return b.runtime().RunString(fmt.Sprintf(s, args...))
 }
 
-// await runs fn in the event loop and awaits its return.
-// Note: Do not confuse the method name with await in JavaScript.
-func (b *testBrowser) await(fn func() error) error {
-	b.t.Helper()
-	return b.vu.Loop.Start(fn)
-}
-
 // Run the given functions in parallel and waits for them to finish.
 func (b *testBrowser) run(ctx context.Context, fs ...func() error) error { //nolint:unused,deadcode
 	b.t.Helper()
@@ -271,7 +264,7 @@ func (b *testBrowser) awaitWithTimeout(timeout time.Duration, fn func() error) e
 	errC := make(chan error)
 	go func() {
 		defer close(errC)
-		errC <- b.await(fn)
+		errC <- fn()
 	}()
 
 	// use timer instead of time.After to not leak time.After for the duration of the timeout


### PR DESCRIPTION
Now that promises have been moved to a level above the business logic, we can remove the need to run things in promises and assume (in most cases) that things will run synchronously. Where there's still a need to run things in parallel we can use the run method on testBrowser.

Updates https://github.com/grafana/xk6-browser/issues/683.