### PR TITLE
Release v0.8.0

### DIFF
--- a/browser/module.go
+++ b/browser/module.go
@@ -10,7 +10,7 @@ import (
 	k6modules "go.k6.io/k6/js/modules"
 )
 
-const version = "0.7.0"
+const version = "0.8.0"
 
 type (
 	// RootModule is the global module instance that will create module

--- a/release notes/v0.8.0.md
+++ b/release notes/v0.8.0.md
@@ -1,0 +1,45 @@
+xk6-browser v0.8.0 is here! :tada:
+
+This release contains preparation for the upcoming `xk6-browser` and `k6` merge, preparations for the upcoming Async API features, bug fixes, and code refactoring.
+
+
+## Experimental Module Merge into k6
+
+We've been busy preparing for this big change that will occur very soon :crossed_fingers:. We have [refactored the code](https://github.com/grafana/xk6-browser/issues/683) in preparation for the merge into `k6` (see [the related issue list](https://github.com/grafana/xk6-browser/issues?q=label%3Ak6-core-compatibility+is%3Aclosed)). This will mean that all future releases of `xk6-browser` will also be part of the `k6` releases (as an experimental module). Merging `xk6-browser` into `k6` will allow you to run both the protocol and browser tests using the same `k6` command line tool. This will also increase the reach and visibility of `xk6-browser` and allow us to collect more feedback and guidance from the community to tailor our product to your needs. _It's worth noting that we're not merging the two code bases into a single one. `xk6-browser` will still be in its own repository._
+
+As an experimental module, some of our APIs are likely to change, causing breaking changes in future releases—for example, now that we have `async`/`await` keyword support, we're going to move most of our APIs to `async`. Changes in APIs also means that your Playwright scripts will also start to work in `xk6-browser` with less and less tweaking of your `xk6-browser` test scripts in the upcoming releases—As per our rough compatibility goal with Playwright APIs.
+
+Currently, browser based tests can only be performed within your own test environments, and it won't be available in the [cloud](https://k6.io/cloud/) (yet). Keep your eyes peeled though on future releases, and the blog to hear more on the public launch of browser testing in the cloud.
+
+With this release we are continuing to build and upload the artifacts (binaries) for you to download and work with. In the near future we intend to stop that, and instead we will redirect you to the k6 repo, where you will be able to download the latest binary with browser test functionality. We may also stop releasing the release notes here and move them to the k6 release notes. We will create a blog post outlining these details soon.
+
+
+## Improvements
+
+- Convert promisified (`.then()`) examples to `async`/`await`. [#703](https://github.com/grafana/xk6-browser/pull/703)
+  
+  Now all our examples use `async`/`await` instead of the promise `.then()` chains. Please look at the [`examples/`](https://github.com/grafana/xk6-browser/tree/main/examples) folder to see how we use the new feature. We're changing the meaning of this folder and will use it for internal JavaScript tests instead of showing how to use the `xk6-browser` extension.
+
+- Log a friendly message if the browser process closes before `xk6-browser` is able to connect to the browser. [#735](https://github.com/grafana/xk6-browser/pull/735)
+
+
+### Documentation
+
+- We're updating all our docs so that they reflect the merge and the `async`/`await` changes. These updates will be released after the merge and the latest version of `k6` has been released.
+
+
+### Internal bug fixes and improvements
+
+- Pre-merge: Map k6-browser Async API to Goja. [#683](https://github.com/grafana/xk6-browser/issues/683)
+
+  This is the groundwork for abstracting our internals to get ready for the merge and make it straightforward to upgrade our API to async in the upcoming releases. With this work, we're now able to unlock the following features:
+
+  - Provide an easy switch to the k6 browser Async API.
+  - Unlock merging of k6 browser to k6 core: Mapping Async APIs.
+  - Increase developer productivity by clearly separating the k6 browser code and Goja.
+- Fix the race condition in frame management. [#696](https://github.com/grafana/xk6-browser/pull/696)
+- Fix dismiss dialog test bug. [#713](https://github.com/grafana/xk6-browser/pull/713)
+- Fix frame manager navigate frame bug. [#714](https://github.com/grafana/xk6-browser/pull/714)
+- Fix lifecycle tests bug. [#712](https://github.com/grafana/xk6-browser/pull/712)
+- Several other refactors and bug fixes to improve maintainability and stability: ([#694](https://github.com/grafana/xk6-browser/pull/694), [#699](https://github.com/grafana/xk6-browser/pull/699), [#700](https://github.com/grafana/xk6-browser/pull/700), [#723](https://github.com/grafana/xk6-browser/pull/723), [#716](https://github.com/grafana/xk6-browser/pull/716), [#734](https://github.com/grafana/xk6-browser/pull/734), [#740](https://github.com/grafana/xk6-browser/pull/740), [#741](https://github.com/grafana/xk6-browser/pull/741)).
+


### PR DESCRIPTION
- [x] Update version to `v0.8.0` in the `browser/module.go` file.
- [x] Add a readme.
- [x] Update the readme with the release details.
- [x] Leave the bump commit and squash the rest into `Add v0.8.0 release notes` commit with co-authors as the team members.