### PR TITLE
Run test and e2e CI actions daily

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    # Daily at 06:00 AM UTC
+    - cron:  '0 6 * * *'
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    # Daily at 06:00 AM UTC
+    - cron:  '0 6 * * *'
 
 defaults:
   run:


### PR DESCRIPTION
This PR modifies the `e2e` and `test` GH actions in order to trigger their execution on a daily basis. The motivation for this is to increase the feedback loop for possible braking changes due to modifications done in k6 core.

Closes #701.