### PR TITLE
Update the message when browser failed to load

### DIFF
--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -243,11 +243,14 @@ func (p *devToolsURLParser) err() error {
 	if len(p.errs) > 0 {
 		return p.errs[0]
 	}
-	if err := p.sc.Err(); err != nil {
-		if errors.Is(err, fs.ErrClosed) {
-			return fmt.Errorf("browser process shutdown unexpectedly before a connection could be made to it: %w", err)
-		}
-		return fmt.Errorf("%w", err)
+
+	err := p.sc.Err()
+	if errors.Is(err, fs.ErrClosed) {
+		return fmt.Errorf("browser process shutdown unexpectedly before establishing a connection: %w", err)
 	}
+	if err != nil {
+		return err //nolint:wrapcheck
+	}
+
 	return nil
 }

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"strings"
@@ -243,6 +244,9 @@ func (p *devToolsURLParser) err() error {
 		return p.errs[0]
 	}
 	if err := p.sc.Err(); err != nil {
+		if errors.Is(err, fs.ErrClosed) {
+			return fmt.Errorf("browser process shutdown unexpectedly before a connection could be made to it: %w", err)
+		}
 		return fmt.Errorf("%w", err)
 	}
 	return nil


### PR DESCRIPTION
When the browser fails to load prior to xk6-browser connecting to it via CDP, then we need to make it clear what's happened.

Partially Resolves: https://github.com/grafana/xk6-browser/issues/648