### PR TITLE
Revert env var that disables test runs

### DIFF
--- a/browser/module.go
+++ b/browser/module.go
@@ -2,15 +2,11 @@
 package browser
 
 import (
-	"errors"
-	"os"
-
 	"github.com/dop251/goja"
 
 	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/k6ext"
 
-	k6common "go.k6.io/k6/js/common"
 	k6modules "go.k6.io/k6/js/modules"
 )
 
@@ -47,15 +43,6 @@ func New() *RootModule {
 // NewModuleInstance implements the k6modules.Module interface to return
 // a new instance for each VU.
 func (*RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
-	if _, ok := os.LookupEnv("K6_BROWSER_DISABLE_RUN"); ok {
-		msg := "Disable run flag enabled, browser test run aborted. Please contact support."
-		if m, ok := os.LookupEnv("K6_BROWSER_DISABLE_RUN_MSG"); ok {
-			msg = m
-		}
-
-		k6common.Throw(vu.Runtime(), errors.New(msg))
-	}
-
 	// promises and inner objects need the VU object to be
 	// able to use k6-core specific functionality.
 	ctx := k6ext.WithVU(vu.Context(), vu)

--- a/browser/module_test.go
+++ b/browser/module_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/dop251/goja"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	k6common "go.k6.io/k6/js/common"
@@ -32,16 +31,4 @@ func TestModuleNew(t *testing.T) {
 	require.NotNil(t, m.mod.Chromium, "Chromium should be set")
 	require.NotNil(t, m.mod.Devices, "Devices should be set")
 	require.Equal(t, version, m.mod.Version, "Incorrect version")
-}
-
-func TestModuleNewDisabled(t *testing.T) {
-	t.Setenv("K6_BROWSER_DISABLE_RUN", "")
-
-	vu := &k6modulestest.VU{
-		RuntimeField: goja.New(),
-		InitEnvField: &k6common.InitEnvironment{
-			Registry: k6metrics.NewRegistry(),
-		},
-	}
-	assert.Panics(t, func() { New().NewModuleInstance(vu) })
 }


### PR DESCRIPTION
We have decided that after the merge k6 will take control of restricting test runs, allowing current browser test users to not be affected (for now).