### PR TITLE
Return an error from BrowserContext.AddCookies and handle panic in mapping layer

### DIFF
--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -1,11 +1,14 @@
 package api
 
 import (
+	"context"
+
 	"github.com/dop251/goja"
 )
 
 // BrowserContext is the public interface of a CDP browser context.
 type BrowserContext interface {
+	// Externally available methods
 	AddCookies(cookies goja.Value) error
 	AddInitScript(script goja.Value, arg goja.Value)
 	Browser() Browser
@@ -35,4 +38,7 @@ type BrowserContext interface {
 	StorageState(opts goja.Value)
 	Unroute(url goja.Value, handler goja.Callable)
 	WaitForEvent(event string, optsOrPredicate goja.Value) any
+
+	// Internally available methods
+	Ctx() context.Context
 }

--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -6,7 +6,7 @@ import (
 
 // BrowserContext is the public interface of a CDP browser context.
 type BrowserContext interface {
-	AddCookies(cookies goja.Value)
+	AddCookies(cookies goja.Value) error
 	AddInitScript(script goja.Value, arg goja.Value)
 	Browser() Browser
 	ClearCookies()

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -539,7 +539,7 @@ func mapBrowserContext(ctx context.Context, vu k6modules.VU, bc api.BrowserConte
 		"addCookies": func(cookies goja.Value) *goja.Promise {
 			return k6ext.Promise(ctx, func() (result any, reason error) {
 				err := bc.AddCookies(cookies)
-				panicIfInternalError(ctx, err)
+				panicIfInternalError(bc, err)
 				return nil, err //nolint:wrapcheck
 			})
 		},
@@ -628,8 +628,12 @@ func mapBrowserType(ctx context.Context, vu k6modules.VU, bt api.BrowserType) ma
 	}
 }
 
-func panicIfInternalError(ctx context.Context, err error) {
+type withCtx interface {
+	Ctx() context.Context
+}
+
+func panicIfInternalError(w withCtx, err error) {
 	if errors.Is(err, k6error.ErrInternal) {
-		k6ext.Panic(ctx, err.Error())
+		k6ext.Panic(w.Ctx(), err.Error())
 	}
 }

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -37,6 +37,14 @@ func customMappings() map[string]string {
 	}
 }
 
+// ignoreUnmapped is used to ignore the unmapped
+// exported methods.
+func ignoreUnmapped() map[string]interface{} {
+	return map[string]interface{}{
+		"ctx": nil,
+	}
+}
+
 // TestMappings tests that all the methods of the API (api/) are
 // to the module. This is to ensure that we don't forget to map
 // a new method to the module.
@@ -56,6 +64,7 @@ func TestMappings(t *testing.T) {
 			},
 		}
 		customMappings = customMappings()
+		ignoreUnmapped = ignoreUnmapped()
 	)
 
 	// testMapping tests that all the methods of an API are mapped
@@ -87,7 +96,9 @@ func TestMappings(t *testing.T) {
 			if cmok {
 				m = cm
 			}
-			if _, ok := mapped[m]; !ok {
+			_, iOk := ignoreUnmapped[m]
+			_, mOk := mapped[m]
+			if !mOk && !iOk {
 				t.Errorf("method %s not found", m)
 			}
 		}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6error"
 	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/log"
 
@@ -64,8 +65,8 @@ func NewBrowserContext(
 }
 
 // AddCookies is not implemented.
-func (b *BrowserContext) AddCookies(cookies goja.Value) {
-	k6ext.Panic(b.ctx, "BrowserContext.addCookies(cookies) has not been implemented yet")
+func (b *BrowserContext) AddCookies(cookies goja.Value) error {
+	return fmt.Errorf("BrowserContext.addCookies(cookies) has not been implemented yet: %w", k6error.ErrInternal)
 }
 
 // AddInitScript adds a script that will be initialized on all new pages.

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -362,6 +362,14 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 	return b.waitForEvent(event, predicateFn, timeout)
 }
 
+// Ctx returns the go context that is associated
+// with BrowserContext. It's main uses is to help
+// shutdown the browser process if a panic occurs
+// in the mapping layer.
+func (b *BrowserContext) Ctx() context.Context {
+	return b.ctx
+}
+
 func (b *BrowserContext) waitForEvent(event string, predicateFn goja.Callable, timeout time.Duration) any {
 	evCancelCtx, evCancelFn := context.WithCancel(b.ctx)
 	chEvHandler := make(chan Event)

--- a/k6error/internal.go
+++ b/k6error/internal.go
@@ -1,0 +1,11 @@
+// Package k6error contains ErrInternal.
+package k6error
+
+import (
+	"errors"
+)
+
+// ErrInternal should be wrapped into an error
+// to signal to the mapping layer that the error
+// is an internal error and we should abort the test run.
+var ErrInternal = errors.New("internal error")


### PR DESCRIPTION
At the moment the codebase uses panic too liberally and we don't have control over when we actually want to abort all test runs vs when we only want to fail the current test iteration.

This is a POC (which if we're all on agreement with could become the first PR for this way of working with errors and panics) of what was suggested in a [comment](https://github.com/grafana/xk6-browser/issues/688#issuecomment-1408543524) on #688. The idea is that we will bubble up errors all the way to the mapping layer, where it can decide on whether to panic or to return an error to goja.

This would mean that we have more control over when to panic, and to be more aware of what we want to panic on, as well as using good GO error handling practices throughout the codebase.