### PR TITLE
Remove Async handling from the core methods

### DIFF
--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -6,23 +6,23 @@ import (
 
 // BrowserContext is the public interface of a CDP browser context.
 type BrowserContext interface {
-	AddCookies(cookies goja.Value) *goja.Promise
+	AddCookies(cookies goja.Value)
 	AddInitScript(script goja.Value, arg goja.Value)
 	Browser() Browser
 	ClearCookies()
 	ClearPermissions()
 	Close()
-	Cookies() *goja.Promise
-	ExposeBinding(name string, callback goja.Callable, opts goja.Value) *goja.Promise
-	ExposeFunction(name string, callback goja.Callable) *goja.Promise
+	Cookies() []any // TODO: make it []Cookie later on
+	ExposeBinding(name string, callback goja.Callable, opts goja.Value)
+	ExposeFunction(name string, callback goja.Callable)
 	GrantPermissions(permissions []string, opts goja.Value)
-	NewCDPSession() *goja.Promise
+	NewCDPSession() CDPSession
 	NewPage() Page
 	Pages() []Page
-	Route(url goja.Value, handler goja.Callable) *goja.Promise
+	Route(url goja.Value, handler goja.Callable)
 	SetDefaultNavigationTimeout(timeout int64)
 	SetDefaultTimeout(timeout int64)
-	SetExtraHTTPHeaders(headers map[string]string) *goja.Promise
+	SetExtraHTTPHeaders(headers map[string]string)
 	SetGeolocation(geolocation goja.Value)
 	// SetHTTPCredentials sets username/password credentials to use for HTTP authentication.
 	//
@@ -32,7 +32,7 @@ type BrowserContext interface {
 	// - https://github.com/microsoft/playwright/pull/2763
 	SetHTTPCredentials(httpCredentials goja.Value)
 	SetOffline(offline bool)
-	StorageState(opts goja.Value) *goja.Promise
-	Unroute(url goja.Value, handler goja.Callable) *goja.Promise
+	StorageState(opts goja.Value)
+	Unroute(url goja.Value, handler goja.Callable)
 	WaitForEvent(event string, optsOrPredicate goja.Value) any
 }

--- a/api/browser_type.go
+++ b/api/browser_type.go
@@ -6,9 +6,9 @@ import (
 
 // BrowserType is the public interface of a CDP browser client.
 type BrowserType interface {
-	Connect(opts goja.Value) *goja.Promise
+	Connect(opts goja.Value)
 	ExecutablePath() string
 	Launch(opts goja.Value) Browser
-	LaunchPersistentContext(userDataDir string, opts goja.Value) *goja.Promise
+	LaunchPersistentContext(userDataDir string, opts goja.Value) Browser
 	Name() string
 }

--- a/api/element_handle.go
+++ b/api/element_handle.go
@@ -33,7 +33,7 @@ type ElementHandle interface {
 	ScrollIntoViewIfNeeded(opts goja.Value)
 	SelectOption(values goja.Value, opts goja.Value) []string
 	SelectText(opts goja.Value)
-	SetInputFiles(files goja.Value, opts goja.Value) *goja.Promise
+	SetInputFiles(files goja.Value, opts goja.Value)
 	Tap(opts goja.Value)
 	TextContent() string
 	Type(text string, opts goja.Value)

--- a/api/frame.go
+++ b/api/frame.go
@@ -4,8 +4,8 @@ import "github.com/dop251/goja"
 
 // Frame is the interface of a CDP target frame.
 type Frame interface {
-	AddScriptTag(opts goja.Value) *goja.Promise
-	AddStyleTag(opts goja.Value) *goja.Promise
+	AddScriptTag(opts goja.Value)
+	AddStyleTag(opts goja.Value)
 	Check(selector string, opts goja.Value)
 	ChildFrames() []Frame
 	Click(selector string, opts goja.Value) error
@@ -42,7 +42,7 @@ type Frame interface {
 	Press(selector string, key string, opts goja.Value)
 	SelectOption(selector string, values goja.Value, opts goja.Value) []string
 	SetContent(html string, opts goja.Value)
-	SetInputFiles(selector string, files goja.Value, opts goja.Value) *goja.Promise
+	SetInputFiles(selector string, files goja.Value, opts goja.Value)
 	Tap(selector string, opts goja.Value)
 	TextContent(selector string, opts goja.Value) string
 	Title() string

--- a/api/page.go
+++ b/api/page.go
@@ -4,9 +4,9 @@ import "github.com/dop251/goja"
 
 // Page is the interface of a single browser tab.
 type Page interface {
-	AddInitScript(script goja.Value, arg goja.Value) *goja.Promise
-	AddScriptTag(opts goja.Value) *goja.Promise
-	AddStyleTag(opts goja.Value) *goja.Promise
+	AddInitScript(script goja.Value, arg goja.Value)
+	AddScriptTag(opts goja.Value)
+	AddStyleTag(opts goja.Value)
 	BringToFront()
 	Check(selector string, opts goja.Value)
 	Click(selector string, opts goja.Value) error
@@ -15,20 +15,20 @@ type Page interface {
 	Context() BrowserContext
 	Dblclick(selector string, opts goja.Value)
 	DispatchEvent(selector string, typ string, eventInit goja.Value, opts goja.Value)
-	DragAndDrop(source string, target string, opts goja.Value) *goja.Promise
+	DragAndDrop(source string, target string, opts goja.Value)
 	EmulateMedia(opts goja.Value)
 	EmulateVisionDeficiency(typ string)
 	Evaluate(pageFunc goja.Value, arg ...goja.Value) any
 	EvaluateHandle(pageFunc goja.Value, arg ...goja.Value) JSHandle
-	ExposeBinding(name string, callback goja.Callable, opts goja.Value) *goja.Promise
-	ExposeFunction(name string, callback goja.Callable) *goja.Promise
+	ExposeBinding(name string, callback goja.Callable, opts goja.Value)
+	ExposeFunction(name string, callback goja.Callable)
 	Fill(selector string, value string, opts goja.Value)
 	Focus(selector string, opts goja.Value)
-	Frame(frameSelector goja.Value) *goja.Promise
+	Frame(frameSelector goja.Value) Frame
 	Frames() []Frame
 	GetAttribute(selector string, name string, opts goja.Value) goja.Value
-	GoBack(opts goja.Value) *goja.Promise
-	GoForward(opts goja.Value) *goja.Promise
+	GoBack(opts goja.Value) Response
+	GoForward(opts goja.Value) Response
 	Goto(url string, opts goja.Value) (Response, error)
 	Hover(selector string, opts goja.Value)
 	InnerHTML(selector string, opts goja.Value) string
@@ -45,36 +45,36 @@ type Page interface {
 	Locator(selector string, opts goja.Value) Locator
 	MainFrame() Frame
 	Opener() Page
-	Pause() *goja.Promise
-	Pdf(opts goja.Value) *goja.Promise
+	Pause()
+	Pdf(opts goja.Value) []byte
 	Press(selector string, key string, opts goja.Value)
 	Query(selector string) ElementHandle
 	QueryAll(selector string) []ElementHandle
 	Reload(opts goja.Value) Response
-	Route(url goja.Value, handler goja.Callable) *goja.Promise
+	Route(url goja.Value, handler goja.Callable)
 	Screenshot(opts goja.Value) goja.ArrayBuffer
 	SelectOption(selector string, values goja.Value, opts goja.Value) []string
 	SetContent(html string, opts goja.Value)
 	SetDefaultNavigationTimeout(timeout int64)
 	SetDefaultTimeout(timeout int64)
 	SetExtraHTTPHeaders(headers map[string]string)
-	SetInputFiles(selector string, files goja.Value, opts goja.Value) *goja.Promise
+	SetInputFiles(selector string, files goja.Value, opts goja.Value)
 	SetViewportSize(viewportSize goja.Value)
 	Tap(selector string, opts goja.Value)
 	TextContent(selector string, opts goja.Value) string
 	Title() string
 	Type(selector string, text string, opts goja.Value)
 	Uncheck(selector string, opts goja.Value)
-	Unroute(url goja.Value, handler goja.Callable) *goja.Promise
+	Unroute(url goja.Value, handler goja.Callable)
 	URL() string
-	Video() *goja.Promise
+	Video() Video
 	ViewportSize() map[string]float64
-	WaitForEvent(event string, optsOrPredicate goja.Value) *goja.Promise
+	WaitForEvent(event string, optsOrPredicate goja.Value) any
 	WaitForFunction(fn, opts goja.Value, args ...goja.Value) (any, error)
 	WaitForLoadState(state string, opts goja.Value)
 	WaitForNavigation(opts goja.Value) (Response, error)
-	WaitForRequest(urlOrPredicate, opts goja.Value) *goja.Promise
-	WaitForResponse(urlOrPredicate, opts goja.Value) *goja.Promise
+	WaitForRequest(urlOrPredicate, opts goja.Value) Request
+	WaitForResponse(urlOrPredicate, opts goja.Value) Response
 	WaitForSelector(selector string, opts goja.Value) ElementHandle
 	WaitForTimeout(timeout int64)
 	Workers() []Worker

--- a/api/response.go
+++ b/api/response.go
@@ -6,7 +6,7 @@ import "github.com/dop251/goja"
 type Response interface {
 	AllHeaders() map[string]string
 	Body() goja.ArrayBuffer
-	Finished() *goja.Promise
+	Finished() bool
 	Frame() Frame
 	HeaderValue(string) goja.Value
 	HeaderValues(string) []string

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -63,10 +63,9 @@ func NewBrowserType(vu k6modules.VU) api.BrowserType {
 }
 
 // Connect attaches k6 browser to an existing browser instance.
-func (b *BrowserType) Connect(opts goja.Value) *goja.Promise {
+func (b *BrowserType) Connect(opts goja.Value) {
 	rt := b.vu.Runtime()
 	k6common.Throw(rt, errors.New("BrowserType.connect() has not been implemented yet"))
-	return nil
 }
 
 // ExecutablePath returns the path where the extension expects to find the browser executable.
@@ -205,7 +204,7 @@ func (b *BrowserType) launch(ctx context.Context, opts *common.LaunchOptions) (*
 }
 
 // LaunchPersistentContext launches the browser with persistent storage.
-func (b *BrowserType) LaunchPersistentContext(userDataDir string, opts goja.Value) *goja.Promise {
+func (b *BrowserType) LaunchPersistentContext(userDataDir string, opts goja.Value) api.Browser {
 	rt := b.vu.Runtime()
 	k6common.Throw(rt, errors.New("BrowserType.LaunchPersistentContext(userDataDir, opts) has not been implemented yet"))
 	return nil

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -64,9 +64,8 @@ func NewBrowserContext(
 }
 
 // AddCookies is not implemented.
-func (b *BrowserContext) AddCookies(cookies goja.Value) *goja.Promise {
+func (b *BrowserContext) AddCookies(cookies goja.Value) {
 	k6ext.Panic(b.ctx, "BrowserContext.addCookies(cookies) has not been implemented yet")
-	return nil
 }
 
 // AddInitScript adds a script that will be initialized on all new pages.
@@ -143,21 +142,19 @@ func (b *BrowserContext) Close() {
 }
 
 // Cookies is not implemented.
-func (b *BrowserContext) Cookies() *goja.Promise {
+func (b *BrowserContext) Cookies() []any {
 	k6ext.Panic(b.ctx, "BrowserContext.cookies() has not been implemented yet")
 	return nil
 }
 
 // ExposeBinding is not implemented.
-func (b *BrowserContext) ExposeBinding(name string, callback goja.Callable, opts goja.Value) *goja.Promise {
+func (b *BrowserContext) ExposeBinding(name string, callback goja.Callable, opts goja.Value) {
 	k6ext.Panic(b.ctx, "BrowserContext.exposeBinding(name, callback, opts) has not been implemented yet")
-	return nil
 }
 
 // ExposeFunction is not implemented.
-func (b *BrowserContext) ExposeFunction(name string, callback goja.Callable) *goja.Promise {
+func (b *BrowserContext) ExposeFunction(name string, callback goja.Callable) {
 	k6ext.Panic(b.ctx, "BrowserContext.exposeFunction(name, callback) has not been implemented yet")
-	return nil
 }
 
 // GrantPermissions enables the specified permissions, all others will be disabled.
@@ -206,7 +203,7 @@ func (b *BrowserContext) GrantPermissions(permissions []string, opts goja.Value)
 }
 
 // NewCDPSession returns a new CDP session attached to this target.
-func (b *BrowserContext) NewCDPSession() *goja.Promise {
+func (b *BrowserContext) NewCDPSession() api.CDPSession {
 	k6ext.Panic(b.ctx, "BrowserContext.newCDPSession() has not been implemented yet")
 	return nil
 }
@@ -245,9 +242,8 @@ func (b *BrowserContext) Pages() []api.Page {
 }
 
 // Route is not implemented.
-func (b *BrowserContext) Route(url goja.Value, handler goja.Callable) *goja.Promise {
+func (b *BrowserContext) Route(url goja.Value, handler goja.Callable) {
 	k6ext.Panic(b.ctx, "BrowserContext.route(url, handler) has not been implemented yet")
-	return nil
 }
 
 // SetDefaultNavigationTimeout sets the default navigation timeout in milliseconds.
@@ -265,9 +261,8 @@ func (b *BrowserContext) SetDefaultTimeout(timeout int64) {
 }
 
 // SetExtraHTTPHeaders is not implemented.
-func (b *BrowserContext) SetExtraHTTPHeaders(headers map[string]string) *goja.Promise {
+func (b *BrowserContext) SetExtraHTTPHeaders(headers map[string]string) {
 	k6ext.Panic(b.ctx, "BrowserContext.setExtraHTTPHeaders(headers) has not been implemented yet")
-	return nil
 }
 
 // SetGeolocation overrides the geo location of the user.
@@ -320,15 +315,13 @@ func (b *BrowserContext) SetOffline(offline bool) {
 }
 
 // StorageState is not implemented.
-func (b *BrowserContext) StorageState(opts goja.Value) *goja.Promise {
+func (b *BrowserContext) StorageState(opts goja.Value) {
 	k6ext.Panic(b.ctx, "BrowserContext.storageState(opts) has not been implemented yet")
-	return nil
 }
 
 // Unroute is not implemented.
-func (b *BrowserContext) Unroute(url goja.Value, handler goja.Callable) *goja.Promise {
+func (b *BrowserContext) Unroute(url goja.Value, handler goja.Callable) {
 	k6ext.Panic(b.ctx, "BrowserContext.unroute(url, handler) has not been implemented yet")
-	return nil
 }
 
 // WaitForEvent waits for event.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1233,10 +1233,9 @@ func (h *ElementHandle) SelectText(opts goja.Value) {
 }
 
 // SetInputFiles is not implemented.
-func (h *ElementHandle) SetInputFiles(files goja.Value, opts goja.Value) *goja.Promise {
+func (h *ElementHandle) SetInputFiles(files goja.Value, opts goja.Value) {
 	// TODO: implement
 	k6ext.Panic(h.ctx, "ElementHandle.setInputFiles() has not been implemented yet")
-	return nil
 }
 
 func (h *ElementHandle) Tap(opts goja.Value) {

--- a/common/frame.go
+++ b/common/frame.go
@@ -486,17 +486,15 @@ func (f *Frame) waitForSelector(selector string, opts *FrameWaitForSelectorOptio
 }
 
 // AddScriptTag is not implemented.
-func (f *Frame) AddScriptTag(opts goja.Value) *goja.Promise {
+func (f *Frame) AddScriptTag(opts goja.Value) {
 	k6ext.Panic(f.ctx, "Frame.AddScriptTag() has not been implemented yet")
 	applySlowMo(f.ctx)
-	return nil
 }
 
 // AddStyleTag is not implemented.
-func (f *Frame) AddStyleTag(opts goja.Value) *goja.Promise {
+func (f *Frame) AddStyleTag(opts goja.Value) {
 	k6ext.Panic(f.ctx, "Frame.AddStyleTag() has not been implemented yet")
 	applySlowMo(f.ctx)
-	return nil
 }
 
 // ChildFrames returns a list of child frames.
@@ -1460,9 +1458,8 @@ func (f *Frame) SetContent(html string, opts goja.Value) {
 }
 
 // SetInputFiles is not implemented.
-func (f *Frame) SetInputFiles(selector string, files goja.Value, opts goja.Value) *goja.Promise {
+func (f *Frame) SetInputFiles(selector string, files goja.Value, opts goja.Value) {
 	k6ext.Panic(f.ctx, "Frame.setInputFiles(selector, files, opts) has not been implemented yet")
-	return nil
 	// TODO: needs slowMo
 }
 

--- a/common/page.go
+++ b/common/page.go
@@ -345,21 +345,18 @@ func (p *Page) viewportSize() Size {
 }
 
 // AddInitScript adds script to run in all new frames.
-func (p *Page) AddInitScript(script goja.Value, arg goja.Value) *goja.Promise {
+func (p *Page) AddInitScript(script goja.Value, arg goja.Value) {
 	k6ext.Panic(p.ctx, "Page.addInitScript(script, arg) has not been implemented yet")
-	return nil
 }
 
 // AddScriptTag is not implemented.
-func (p *Page) AddScriptTag(opts goja.Value) *goja.Promise {
+func (p *Page) AddScriptTag(opts goja.Value) {
 	k6ext.Panic(p.ctx, "Page.addScriptTag(opts) has not been implemented yet")
-	return nil
 }
 
 // AddStyleTag is not implemented.
-func (p *Page) AddStyleTag(opts goja.Value) *goja.Promise {
+func (p *Page) AddStyleTag(opts goja.Value) {
 	k6ext.Panic(p.ctx, "Page.addStyleTag(opts) has not been implemented yet")
-	return nil
 }
 
 // BringToFront activates the browser tab for this page.
@@ -434,9 +431,8 @@ func (p *Page) DispatchEvent(selector string, typ string, eventInit goja.Value, 
 }
 
 // DragAndDrop is not implemented.
-func (p *Page) DragAndDrop(source string, target string, opts goja.Value) *goja.Promise {
+func (p *Page) DragAndDrop(source string, target string, opts goja.Value) {
 	k6ext.Panic(p.ctx, "Page.DragAndDrop(source, target, opts) has not been implemented yet")
-	return nil
 }
 
 func (p *Page) EmulateMedia(opts goja.Value) {
@@ -499,15 +495,13 @@ func (p *Page) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) api.JSHan
 }
 
 // ExposeBinding is not implemented.
-func (p *Page) ExposeBinding(name string, callback goja.Callable, opts goja.Value) *goja.Promise {
+func (p *Page) ExposeBinding(name string, callback goja.Callable, opts goja.Value) {
 	k6ext.Panic(p.ctx, "Page.exposeBinding(name, callback) has not been implemented yet")
-	return nil
 }
 
 // ExposeFunction is not implemented.
-func (p *Page) ExposeFunction(name string, callback goja.Callable) *goja.Promise {
+func (p *Page) ExposeFunction(name string, callback goja.Callable) {
 	k6ext.Panic(p.ctx, "Page.exposeFunction(name, callback) has not been implemented yet")
-	return nil
 }
 
 func (p *Page) Fill(selector string, value string, opts goja.Value) {
@@ -523,7 +517,7 @@ func (p *Page) Focus(selector string, opts goja.Value) {
 }
 
 // Frame is not implemented.
-func (p *Page) Frame(frameSelector goja.Value) *goja.Promise {
+func (p *Page) Frame(frameSelector goja.Value) api.Frame {
 	k6ext.Panic(p.ctx, "Page.frame(frameSelector) has not been implemented yet")
 	return nil
 }
@@ -541,13 +535,13 @@ func (p *Page) GetAttribute(selector string, name string, opts goja.Value) goja.
 }
 
 // GoBack is not implemented.
-func (p *Page) GoBack(opts goja.Value) *goja.Promise {
+func (p *Page) GoBack(opts goja.Value) api.Response {
 	k6ext.Panic(p.ctx, "Page.goBack(opts) has not been implemented yet")
 	return nil
 }
 
 // GoForward is not implemented.
-func (p *Page) GoForward(opts goja.Value) *goja.Promise {
+func (p *Page) GoForward(opts goja.Value) api.Response {
 	k6ext.Panic(p.ctx, "Page.goForward(opts) has not been implemented yet")
 	return nil
 }
@@ -648,13 +642,12 @@ func (p *Page) Opener() api.Page {
 }
 
 // Pause is not implemented.
-func (p *Page) Pause() *goja.Promise {
+func (p *Page) Pause() {
 	k6ext.Panic(p.ctx, "Page.pause() has not been implemented yet")
-	return nil
 }
 
 // Pdf is not implemented.
-func (p *Page) Pdf(opts goja.Value) *goja.Promise {
+func (p *Page) Pdf(opts goja.Value) []byte {
 	k6ext.Panic(p.ctx, "Page.pdf(opts) has not been implemented yet")
 	return nil
 }
@@ -754,9 +747,8 @@ func (p *Page) Reload(opts goja.Value) api.Response {
 }
 
 // Route is not implemented.
-func (p *Page) Route(url goja.Value, handler goja.Callable) *goja.Promise {
+func (p *Page) Route(url goja.Value, handler goja.Callable) {
 	k6ext.Panic(p.ctx, "Page.route(url, handler) has not been implemented yet")
-	return nil
 }
 
 // Screenshot will instruct Chrome to save a screenshot of the current page and save it to specified file.
@@ -809,9 +801,8 @@ func (p *Page) SetExtraHTTPHeaders(headers map[string]string) {
 }
 
 // SetInputFiles is not implemented.
-func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value) *goja.Promise {
+func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value) {
 	k6ext.Panic(p.ctx, "Page.textContent(selector, opts) has not been implemented yet")
-	return nil
 	// TODO: needs slowMo
 }
 
@@ -855,9 +846,8 @@ func (p *Page) Type(selector string, text string, opts goja.Value) {
 }
 
 // Unroute is not implemented.
-func (p *Page) Unroute(url goja.Value, handler goja.Callable) *goja.Promise {
+func (p *Page) Unroute(url goja.Value, handler goja.Callable) {
 	k6ext.Panic(p.ctx, "Page.unroute(url, handler) has not been implemented yet")
-	return nil
 }
 
 // URL returns the location of the page.
@@ -867,7 +857,7 @@ func (p *Page) URL() string {
 }
 
 // Video returns information of recorded video.
-func (p *Page) Video() *goja.Promise {
+func (p *Page) Video() api.Video {
 	k6ext.Panic(p.ctx, "Page.video() has not been implemented yet")
 	return nil
 }
@@ -884,7 +874,7 @@ func (p *Page) ViewportSize() map[string]float64 {
 }
 
 // WaitForEvent waits for the specified event to trigger.
-func (p *Page) WaitForEvent(event string, optsOrPredicate goja.Value) *goja.Promise {
+func (p *Page) WaitForEvent(event string, optsOrPredicate goja.Value) any {
 	k6ext.Panic(p.ctx, "Page.waitForEvent(event, optsOrPredicate) has not been implemented yet")
 	return nil
 }
@@ -911,13 +901,13 @@ func (p *Page) WaitForNavigation(opts goja.Value) (api.Response, error) {
 }
 
 // WaitForRequest is not implemented.
-func (p *Page) WaitForRequest(urlOrPredicate, opts goja.Value) *goja.Promise {
+func (p *Page) WaitForRequest(urlOrPredicate, opts goja.Value) api.Request {
 	k6ext.Panic(p.ctx, "Page.waitForRequest(urlOrPredicate, opts) has not been implemented yet")
 	return nil
 }
 
 // WaitForResponse is not implemented.
-func (p *Page) WaitForResponse(urlOrPredicate, opts goja.Value) *goja.Promise {
+func (p *Page) WaitForResponse(urlOrPredicate, opts goja.Value) api.Response {
 	k6ext.Panic(p.ctx, "Page.waitForResponse(urlOrPredicate, opts) has not been implemented yet")
 	return nil
 }

--- a/common/response.go
+++ b/common/response.go
@@ -189,10 +189,10 @@ func (r *Response) bodySize() int64 {
 }
 
 // Finished waits for response to finish, return error if request failed.
-func (r *Response) Finished() *goja.Promise {
+func (r *Response) Finished() bool {
 	// TODO: should return nil|Error
 	k6ext.Panic(r.ctx, "Response.finished() has not been implemented yet")
-	return nil
+	return false
 }
 
 // Frame returns the frame within which the response was received.


### PR DESCRIPTION
This is a continuation of the efforts set in #683. Handling the Async APIs in the mapping layer. Please take a look at issue #742 for more details. This can also help the work in #688—where we need to remove the promises and return errors 🤔?

Closes #742