### PR TITLE
Fix to use a fresh VU context on each mapped method call

### DIFF
--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -97,25 +97,25 @@ func TestMappings(t *testing.T) {
 		"browserType": {
 			apiInterface: (*api.BrowserType)(nil),
 			mapp: func() mapping {
-				return mapBrowserType(vu.Context(), vu, &chromium.BrowserType{})
+				return mapBrowserType(vu, &chromium.BrowserType{})
 			},
 		},
 		"browser": {
 			apiInterface: (*api.Browser)(nil),
 			mapp: func() mapping {
-				return mapBrowser(vu.Context(), vu, &chromium.Browser{})
+				return mapBrowser(vu, &chromium.Browser{})
 			},
 		},
 		"browserContext": {
 			apiInterface: (*api.BrowserContext)(nil),
 			mapp: func() mapping {
-				return mapBrowserContext(vu.Context(), vu, &common.BrowserContext{})
+				return mapBrowserContext(vu, &common.BrowserContext{})
 			},
 		},
 		"page": {
 			apiInterface: (*api.Page)(nil),
 			mapp: func() mapping {
-				return mapPage(vu.Context(), vu, &common.Page{
+				return mapPage(vu, &common.Page{
 					Keyboard:    &common.Keyboard{},
 					Mouse:       &common.Mouse{},
 					Touchscreen: &common.Touchscreen{},
@@ -125,37 +125,37 @@ func TestMappings(t *testing.T) {
 		"elementHandle": {
 			apiInterface: (*api.ElementHandle)(nil),
 			mapp: func() mapping {
-				return mapElementHandle(vu.Context(), vu, &common.ElementHandle{})
+				return mapElementHandle(vu, &common.ElementHandle{})
 			},
 		},
 		"jsHandle": {
 			apiInterface: (*api.JSHandle)(nil),
 			mapp: func() mapping {
-				return mapJSHandle(vu.Context(), vu, &common.BaseJSHandle{})
+				return mapJSHandle(vu, &common.BaseJSHandle{})
 			},
 		},
 		"frame": {
 			apiInterface: (*api.Frame)(nil),
 			mapp: func() mapping {
-				return mapFrame(vu.Context(), vu, &common.Frame{})
+				return mapFrame(vu, &common.Frame{})
 			},
 		},
 		"mapRequest": {
 			apiInterface: (*api.Request)(nil),
 			mapp: func() mapping {
-				return mapRequest(vu.Context(), vu, &common.Request{})
+				return mapRequest(vu, &common.Request{})
 			},
 		},
 		"mapResponse": {
 			apiInterface: (*api.Response)(nil),
 			mapp: func() mapping {
-				return mapResponse(vu.Context(), vu, &common.Response{})
+				return mapResponse(vu, &common.Response{})
 			},
 		},
 		"mapWorker": {
 			apiInterface: (*api.Worker)(nil),
 			mapp: func() mapping {
-				return mapWorker(vu.Context(), vu, &common.Worker{})
+				return mapWorker(vu, &common.Worker{})
 			},
 		},
 	} {

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -97,25 +97,25 @@ func TestMappings(t *testing.T) {
 		"browserType": {
 			apiInterface: (*api.BrowserType)(nil),
 			mapp: func() mapping {
-				return mapBrowserType(vu, &chromium.BrowserType{})
+				return mapBrowserType(moduleVU{vu}, &chromium.BrowserType{})
 			},
 		},
 		"browser": {
 			apiInterface: (*api.Browser)(nil),
 			mapp: func() mapping {
-				return mapBrowser(vu, &chromium.Browser{})
+				return mapBrowser(moduleVU{vu}, &chromium.Browser{})
 			},
 		},
 		"browserContext": {
 			apiInterface: (*api.BrowserContext)(nil),
 			mapp: func() mapping {
-				return mapBrowserContext(vu, &common.BrowserContext{})
+				return mapBrowserContext(moduleVU{vu}, &common.BrowserContext{})
 			},
 		},
 		"page": {
 			apiInterface: (*api.Page)(nil),
 			mapp: func() mapping {
-				return mapPage(vu, &common.Page{
+				return mapPage(moduleVU{vu}, &common.Page{
 					Keyboard:    &common.Keyboard{},
 					Mouse:       &common.Mouse{},
 					Touchscreen: &common.Touchscreen{},
@@ -125,37 +125,37 @@ func TestMappings(t *testing.T) {
 		"elementHandle": {
 			apiInterface: (*api.ElementHandle)(nil),
 			mapp: func() mapping {
-				return mapElementHandle(vu, &common.ElementHandle{})
+				return mapElementHandle(moduleVU{vu}, &common.ElementHandle{})
 			},
 		},
 		"jsHandle": {
 			apiInterface: (*api.JSHandle)(nil),
 			mapp: func() mapping {
-				return mapJSHandle(vu, &common.BaseJSHandle{})
+				return mapJSHandle(moduleVU{vu}, &common.BaseJSHandle{})
 			},
 		},
 		"frame": {
 			apiInterface: (*api.Frame)(nil),
 			mapp: func() mapping {
-				return mapFrame(vu, &common.Frame{})
+				return mapFrame(moduleVU{vu}, &common.Frame{})
 			},
 		},
 		"mapRequest": {
 			apiInterface: (*api.Request)(nil),
 			mapp: func() mapping {
-				return mapRequest(vu, &common.Request{})
+				return mapRequest(moduleVU{vu}, &common.Request{})
 			},
 		},
 		"mapResponse": {
 			apiInterface: (*api.Response)(nil),
 			mapp: func() mapping {
-				return mapResponse(vu, &common.Response{})
+				return mapResponse(moduleVU{vu}, &common.Response{})
 			},
 		},
 		"mapWorker": {
 			apiInterface: (*api.Worker)(nil),
 			mapp: func() mapping {
-				return mapWorker(vu, &common.Worker{})
+				return mapWorker(moduleVU{vu}, &common.Worker{})
 			},
 		},
 	} {

--- a/browser/module.go
+++ b/browser/module.go
@@ -44,7 +44,7 @@ func New() *RootModule {
 func (*RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 	return &ModuleInstance{
 		mod: &JSModule{
-			Chromium: mapBrowserToGoja(vu),
+			Chromium: mapBrowserToGoja(moduleVU{vu}),
 			Devices:  common.GetDevices(),
 			Version:  version,
 		},

--- a/browser/module.go
+++ b/browser/module.go
@@ -5,7 +5,6 @@ import (
 	"github.com/dop251/goja"
 
 	"github.com/grafana/xk6-browser/common"
-	"github.com/grafana/xk6-browser/k6ext"
 
 	k6modules "go.k6.io/k6/js/modules"
 )
@@ -43,13 +42,9 @@ func New() *RootModule {
 // NewModuleInstance implements the k6modules.Module interface to return
 // a new instance for each VU.
 func (*RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
-	// promises and inner objects need the VU object to be
-	// able to use k6-core specific functionality.
-	ctx := k6ext.WithVU(vu.Context(), vu)
-
 	return &ModuleInstance{
 		mod: &JSModule{
-			Chromium: mapBrowserToGoja(ctx, vu),
+			Chromium: mapBrowserToGoja(vu),
 			Devices:  common.GetDevices(),
 			Version:  version,
 		},


### PR DESCRIPTION
The initial context that we get from the vu in NewModuleInstance should not be cached since the context is closed per iteration. The best practice is to work with the context directly from vu when it's needed.

This became apparent when the initial context was used in a test API method (`Launch`) and the test was failing with `context canceled`.

Related: #704 #702 #673 #744