### PR TITLE
Fix page.URL() method

### DIFF
--- a/common/page.go
+++ b/common/page.go
@@ -869,8 +869,10 @@ func (p *Page) Unroute(url goja.Value, handler goja.Callable) {
 
 // URL returns the location of the page.
 func (p *Page) URL() string {
-	rt := p.vu.Runtime()
-	return p.Evaluate(rt.ToValue("document.location.toString()")).(string)
+	p.logger.Debugf("Page:URL", "sid:%v", p.sessionID())
+
+	v := p.vu.Runtime().ToValue(`() => document.location.toString()`)
+	return gojaValueToString(p.ctx, p.Evaluate(v))
 }
 
 // Video returns information of recorded video.

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -656,6 +656,18 @@ func TestPagePress(t *testing.T) {
 	require.Equal(t, "AbC", p.InputValue("#text1", nil))
 }
 
+func TestPageURL(t *testing.T) {
+	b := newTestBrowser(t, withHTTPServer())
+
+	p := b.NewPage(nil)
+	assert.Equal(t, "about:blank", p.URL())
+
+	resp, err := p.Goto(b.URL("/get"), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Regexp(t, "http://.*/get", p.URL())
+}
+
 func assertExceptionContains(t *testing.T, rt *goja.Runtime, fn func(), expErrMsg string) {
 	t.Helper()
 


### PR DESCRIPTION
The problem was present in the way frame.Evaluate method was called underneath, as it currently only supports executing callable functions. The fix mimics the implementation currently in place for page.Title() method.

Closes #748 .