### PR TITLE
Fix Frame.Title() method

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -1534,11 +1534,12 @@ func (f *Frame) textContent(selector string, opts *FrameTextContentOptions) (str
 	return gv.String(), nil
 }
 
+// Title returns the title of the frame.
 func (f *Frame) Title() string {
 	f.log.Debugf("Frame:Title", "fid:%s furl:%q", f.ID(), f.URL())
 
-	rt := f.vu.Runtime()
-	return f.Evaluate(rt.ToValue("document.title")).(string)
+	v := f.vu.Runtime().ToValue(`() => document.title`)
+	return gojaValueToString(f.ctx, f.Evaluate(v))
 }
 
 // Type text on the first element found matches the selector.

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -102,3 +102,9 @@ func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 	result := p.TextContent("#doneDiv", nil)
 	assert.EqualValues(t, "Done!", result)
 }
+
+func TestFrameTitle(t *testing.T) {
+	p := newTestBrowser(t).NewPage(nil)
+	p.SetContent(`<html><head><title>Some title</title></head></html>`, nil)
+	assert.Equal(t, "Some title", p.MainFrame().Title())
+}


### PR DESCRIPTION
The problem was present in the way frame.Evaluate method was called underneath, as it currently only supports executing callable functions.

Closes #756.