### PR TITLE
Fix zombie browser by only kill

### DIFF
--- a/osext/register.go
+++ b/osext/register.go
@@ -46,6 +46,5 @@ var Kill = func(pid int) { //nolint:gochecknoglobals
 		return
 	}
 	// no need to check the error since we're already dying.
-	_ = p.Release()
 	_ = p.Kill()
 }


### PR DESCRIPTION
While testing I noticed that zombie browser processes were being left behind. It turns out the we don't need to use process [Release](https://pkg.go.dev/os#Process.Release) since we're using `Wait`. `Release` will prevent `Kill` from working since the `pid` in the process structure is overwritten, signalling that the process has already been released. Using `Kill` alone now kills the browser processes and no more zombie browser processes when a panic forces the browser to shutdown.