### PR TITLE
Release v0.8.1

### DIFF
--- a/browser/module.go
+++ b/browser/module.go
@@ -9,7 +9,7 @@ import (
 	k6modules "go.k6.io/k6/js/modules"
 )
 
-const version = "0.8.0"
+const version = "0.8.1"
 
 type (
 	// RootModule is the global module instance that will create module

--- a/release notes/v0.8.1.md
+++ b/release notes/v0.8.1.md
@@ -1,0 +1,20 @@
+This is a patch release that fixes a few bugs, including one [regression bug](https://github.com/grafana/xk6-browser/issues/749) introduced in v0.8.0, adds one improvement on documentation, and does minor internal modifications.
+
+
+## Bugs fixed
+
+- Fix mapping of `Page`'s `Keyboard`, `Mouse`, and `Touchscreen` properties. ([#751](https://github.com/grafana/xk6-browser/pull/751))
+- Fix `Page.URL()` method. ([#758](https://github.com/grafana/xk6-browser/pull/758))
+- Fix `Frame.Title()` method. ([#761](https://github.com/grafana/xk6-browser/pull/761))
+
+
+## Improvements
+
+- Added contributing guidelines. ([#750](https://github.com/grafana/xk6-browser/pull/750))
+
+
+## Internals
+
+- Reverted version bump for some dependencies in order to match k6 versions. ([#743](https://github.com/grafana/xk6-browser/pull/743))
+- Fix usage of stale virtual user context in mapping layer. ([#754](https://github.com/grafana/xk6-browser/pull/754))
+- Removed the unused browser closing state. ([#759](https://github.com/grafana/xk6-browser/pull/759))


### PR DESCRIPTION
- [x] Update version to `v0.8.1` in the `browser/module.go` file.
- [x] Add release notes for the version.
- [x] Update the release notes with the release details.
- [x] Leave the bump commit and squash the rest into `Add v0.8.1 release notes` commit with co-authors as the team members.