### PR TITLE
Clear zombie browser processes on panic

### DIFF
--- a/api/browser_type.go
+++ b/api/browser_type.go
@@ -8,7 +8,7 @@ import (
 type BrowserType interface {
 	Connect(opts goja.Value)
 	ExecutablePath() string
-	Launch(opts goja.Value) Browser
+	Launch(opts goja.Value) (_ Browser, browserProcessID int)
 	LaunchPersistentContext(userDataDir string, opts goja.Value) Browser
 	Name() string
 }

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -616,8 +616,7 @@ func mapBrowserType(vu moduleVU, bt api.BrowserType) mapping {
 		"launch": func(opts goja.Value) *goja.Object {
 			b, pid := bt.Launch(opts)
 			// store the pid so we can kill it later on panic.
-			// idea: a later refactoring can move k6ext.Panic here.
-			vu.root.addPid(pid)
+			vu.registerPid(pid)
 			m := mapBrowser(vu, b)
 			return rt.ToValue(m).ToObject(rt)
 		},

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -614,7 +614,8 @@ func mapBrowserType(vu moduleVU, bt api.BrowserType) mapping {
 		"launchPersistentContext": bt.LaunchPersistentContext,
 		"name":                    bt.Name,
 		"launch": func(opts goja.Value) *goja.Object {
-			m := mapBrowser(vu, bt.Launch(opts))
+			b, _ := bt.Launch(opts)
+			m := mapBrowser(vu, b)
 			return rt.ToValue(m).ToObject(rt)
 		},
 	}

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -425,8 +425,13 @@ func mapPage(vu moduleVU, p api.Page) mapping {
 			return rt.ToValue(mfrs).ToObject(rt)
 		},
 		"getAttribute": p.GetAttribute,
-		"goBack":       p.GoBack,
-		"goForward":    p.GoForward,
+		"goBack": func(opts goja.Value) *goja.Promise {
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				resp := p.GoBack(opts)
+				return mapResponse(vu, resp), nil
+			})
+		},
+		"goForward": p.GoForward,
 		"goto": func(url string, opts goja.Value) *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				resp, err := p.Goto(url, opts)

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -1,7 +1,6 @@
 package browser
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/dop251/goja"
@@ -11,26 +10,7 @@ import (
 	"github.com/grafana/xk6-browser/k6ext"
 
 	k6common "go.k6.io/k6/js/common"
-	k6modules "go.k6.io/k6/js/modules"
 )
-
-// moduleVU carries module specific VU information.
-//
-// Currently, it is used to carry the VU object to the
-// inner objects and promises.
-type moduleVU struct {
-	k6modules.VU
-}
-
-func (vu moduleVU) Context() context.Context {
-	// promises and inner objects need the VU object to be
-	// able to use k6-core specific functionality.
-	//
-	// We should not cache the context (especially the init
-	// context from the vu that is received from k6 in
-	// NewModuleInstance).
-	return k6ext.WithVU(vu.VU.Context(), vu.VU)
-}
 
 // mapping is a type of mapping between our API (api/) and the JS
 // module. It acts like a bridge and allows adding wildcard methods

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -614,7 +614,10 @@ func mapBrowserType(vu moduleVU, bt api.BrowserType) mapping {
 		"launchPersistentContext": bt.LaunchPersistentContext,
 		"name":                    bt.Name,
 		"launch": func(opts goja.Value) *goja.Object {
-			b, _ := bt.Launch(opts)
+			b, pid := bt.Launch(opts)
+			// store the pid so we can kill it later on panic.
+			// idea: a later refactoring can move k6ext.Panic here.
+			vu.root.addPid(pid)
 			m := mapBrowser(vu, b)
 			return rt.ToValue(m).ToObject(rt)
 		},

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -110,25 +110,25 @@ func TestMappings(t *testing.T) {
 		"browserType": {
 			apiInterface: (*api.BrowserType)(nil),
 			mapp: func() mapping {
-				return mapBrowserType(moduleVU{vu}, &chromium.BrowserType{})
+				return mapBrowserType(moduleVU{VU: vu}, &chromium.BrowserType{})
 			},
 		},
 		"browser": {
 			apiInterface: (*api.Browser)(nil),
 			mapp: func() mapping {
-				return mapBrowser(moduleVU{vu}, &chromium.Browser{})
+				return mapBrowser(moduleVU{VU: vu}, &chromium.Browser{})
 			},
 		},
 		"browserContext": {
 			apiInterface: (*api.BrowserContext)(nil),
 			mapp: func() mapping {
-				return mapBrowserContext(moduleVU{vu}, &common.BrowserContext{})
+				return mapBrowserContext(moduleVU{VU: vu}, &common.BrowserContext{})
 			},
 		},
 		"page": {
 			apiInterface: (*api.Page)(nil),
 			mapp: func() mapping {
-				return mapPage(moduleVU{vu}, &common.Page{
+				return mapPage(moduleVU{VU: vu}, &common.Page{
 					Keyboard:    &common.Keyboard{},
 					Mouse:       &common.Mouse{},
 					Touchscreen: &common.Touchscreen{},
@@ -138,37 +138,37 @@ func TestMappings(t *testing.T) {
 		"elementHandle": {
 			apiInterface: (*api.ElementHandle)(nil),
 			mapp: func() mapping {
-				return mapElementHandle(moduleVU{vu}, &common.ElementHandle{})
+				return mapElementHandle(moduleVU{VU: vu}, &common.ElementHandle{})
 			},
 		},
 		"jsHandle": {
 			apiInterface: (*api.JSHandle)(nil),
 			mapp: func() mapping {
-				return mapJSHandle(moduleVU{vu}, &common.BaseJSHandle{})
+				return mapJSHandle(moduleVU{VU: vu}, &common.BaseJSHandle{})
 			},
 		},
 		"frame": {
 			apiInterface: (*api.Frame)(nil),
 			mapp: func() mapping {
-				return mapFrame(moduleVU{vu}, &common.Frame{})
+				return mapFrame(moduleVU{VU: vu}, &common.Frame{})
 			},
 		},
 		"mapRequest": {
 			apiInterface: (*api.Request)(nil),
 			mapp: func() mapping {
-				return mapRequest(moduleVU{vu}, &common.Request{})
+				return mapRequest(moduleVU{VU: vu}, &common.Request{})
 			},
 		},
 		"mapResponse": {
 			apiInterface: (*api.Response)(nil),
 			mapp: func() mapping {
-				return mapResponse(moduleVU{vu}, &common.Response{})
+				return mapResponse(moduleVU{VU: vu}, &common.Response{})
 			},
 		},
 		"mapWorker": {
 			apiInterface: (*api.Worker)(nil),
 			mapp: func() mapping {
-				return mapWorker(moduleVU{vu}, &common.Worker{})
+				return mapWorker(moduleVU{VU: vu}, &common.Worker{})
 			},
 		},
 	} {

--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -15,7 +15,7 @@ import (
 type moduleVU struct {
 	k6modules.VU
 
-	root *RootModule
+	*pidRegistry
 }
 
 func (vu moduleVU) Context() context.Context {
@@ -26,9 +26,4 @@ func (vu moduleVU) Context() context.Context {
 	// context from the vu that is received from k6 in
 	// NewModuleInstance).
 	return k6ext.WithVU(vu.VU.Context(), vu.VU)
-}
-
-// Pids returns the launched browser process IDs across all VUs.
-func (vu moduleVU) Pids() []int {
-	return vu.root.pids()
 }

--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -10,10 +10,12 @@ import (
 
 // moduleVU carries module specific VU information.
 //
-// Currently, it is used to carry the VU object to the
-// inner objects and promises.
+// Currently, it is used to carry the VU object to the inner objects and
+// promises.
 type moduleVU struct {
 	k6modules.VU
+
+	root *RootModule
 }
 
 func (vu moduleVU) Context() context.Context {
@@ -24,4 +26,9 @@ func (vu moduleVU) Context() context.Context {
 	// context from the vu that is received from k6 in
 	// NewModuleInstance).
 	return k6ext.WithVU(vu.VU.Context(), vu.VU)
+}
+
+// Pids returns the launched browser process IDs across all VUs.
+func (vu moduleVU) Pids() []int {
+	return vu.root.pids()
 }

--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -1,0 +1,27 @@
+package browser
+
+import (
+	"context"
+
+	"github.com/grafana/xk6-browser/k6ext"
+
+	k6modules "go.k6.io/k6/js/modules"
+)
+
+// moduleVU carries module specific VU information.
+//
+// Currently, it is used to carry the VU object to the
+// inner objects and promises.
+type moduleVU struct {
+	k6modules.VU
+}
+
+func (vu moduleVU) Context() context.Context {
+	// promises and inner objects need the VU object to be
+	// able to use k6-core specific functionality.
+	//
+	// We should not cache the context (especially the init
+	// context from the vu that is received from k6 in
+	// NewModuleInstance).
+	return k6ext.WithVU(vu.VU.Context(), vu.VU)
+}

--- a/browser/pidregistry.go
+++ b/browser/pidregistry.go
@@ -1,0 +1,28 @@
+package browser
+
+import "sync"
+
+// pidRegistry keeps track of the launched browser process IDs.
+type pidRegistry struct {
+	mu  sync.RWMutex
+	ids []int
+}
+
+// registerPid registers the launched browser process ID.
+func (r *pidRegistry) registerPid(pid int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.ids = append(r.ids, pid)
+}
+
+// Pids returns the launched browser process IDs.
+func (r *pidRegistry) Pids() []int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	pids := make([]int, len(r.ids))
+	copy(pids, r.ids)
+
+	return pids
+}

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -190,10 +190,6 @@ func (b *BrowserType) launch(
 	// If this context is cancelled we'll initiate an extension wide
 	// cancellation and shutdown.
 	browserCtx, browserCtxCancel := context.WithCancel(ctx)
-	// attach the browser process ID to the context
-	// so that we can kill it afterward if it lingers
-	// see: k6ext.Panic function.
-	browserCtx = k6ext.WithProcessID(browserCtx, browserProc.Pid())
 	b.Ctx = browserCtx
 	browser, err := common.NewBrowser(browserCtx, browserCtxCancel,
 		browserProc, opts, b.logger)

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -117,7 +117,7 @@ func (b *BrowserType) initContext() context.Context {
 
 // Launch allocates a new Chrome browser process and returns a new api.Browser value,
 // which can be used for controlling the Chrome browser.
-func (b *BrowserType) Launch(opts goja.Value) api.Browser {
+func (b *BrowserType) Launch(opts goja.Value) (_ api.Browser, browserProcessID int) {
 	ctx := b.initContext()
 
 	var err error
@@ -130,7 +130,7 @@ func (b *BrowserType) Launch(opts goja.Value) api.Browser {
 	}
 	ctx = common.WithLaunchOptions(ctx, launchOpts)
 
-	bp, err := b.launch(ctx, launchOpts)
+	bp, pid, err := b.launch(ctx, launchOpts)
 	if err != nil {
 		err = &k6ext.UserFriendlyError{
 			Err:     err,
@@ -139,12 +139,14 @@ func (b *BrowserType) Launch(opts goja.Value) api.Browser {
 		k6ext.Panic(ctx, "%w", err)
 	}
 
-	return bp
+	return bp, pid
 }
 
-func (b *BrowserType) launch(ctx context.Context, opts *common.LaunchOptions) (*common.Browser, error) {
+func (b *BrowserType) launch(
+	ctx context.Context, opts *common.LaunchOptions,
+) (_ *common.Browser, pid int, _ error) {
 	if err := b.logger.SetCategoryFilter(opts.LogCategoryFilter); err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return nil, 0, fmt.Errorf("%w", err)
 	}
 	if opts.Debug {
 		_ = b.logger.SetLevel("debug")
@@ -156,11 +158,11 @@ func (b *BrowserType) launch(ctx context.Context, opts *common.LaunchOptions) (*
 	}
 	flags, err := prepareFlags(opts, &(b.vu.State()).Options)
 	if err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return nil, 0, fmt.Errorf("%w", err)
 	}
 	dataDir := b.storage
 	if err := dataDir.Make("", flags["user-data-dir"]); err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return nil, 0, fmt.Errorf("%w", err)
 	}
 	flags["user-data-dir"] = dataDir.Dir
 
@@ -180,7 +182,7 @@ func (b *BrowserType) launch(ctx context.Context, opts *common.LaunchOptions) (*
 
 	browserProc, err := b.allocate(ctx, opts, flags, envs, dataDir, b.logger)
 	if browserProc == nil {
-		return nil, fmt.Errorf("launching browser: %w", err)
+		return nil, 0, fmt.Errorf("launching browser: %w", err)
 	}
 
 	browserProc.AttachLogger(b.logger)
@@ -196,10 +198,10 @@ func (b *BrowserType) launch(ctx context.Context, opts *common.LaunchOptions) (*
 	browser, err := common.NewBrowser(browserCtx, browserCtxCancel,
 		browserProc, opts, b.logger)
 	if err != nil {
-		return nil, fmt.Errorf("launching browser: %w", err)
+		return nil, 0, fmt.Errorf("launching browser: %w", err)
 	}
 
-	return browser, nil
+	return browser, browserProc.Pid(), nil
 }
 
 // LaunchPersistentContext launches the browser with persistent storage.

--- a/k6ext/context.go
+++ b/k6ext/context.go
@@ -33,17 +33,6 @@ func GetVU(ctx context.Context) k6modules.VU {
 	return nil
 }
 
-// WithProcessID saves the browser process ID to the context.
-func WithProcessID(ctx context.Context, pid int) context.Context {
-	return context.WithValue(ctx, ctxKeyPid, pid)
-}
-
-// GetProcessID returns the browser process ID from the context.
-func GetProcessID(ctx context.Context) int {
-	v, _ := ctx.Value(ctxKeyPid).(int)
-	return v // it will return zero on error
-}
-
 // WithCustomMetrics attaches the CustomK6Metrics object to the context.
 func WithCustomMetrics(ctx context.Context, k6m *CustomMetrics) context.Context {
 	return context.WithValue(ctx, ctxKeyCustomK6Metrics, k6m)

--- a/k6ext/panic.go
+++ b/k6ext/panic.go
@@ -33,6 +33,7 @@ func Panic(ctx context.Context, format string, a ...any) {
 	}
 	defer k6common.Throw(rt, fmt.Errorf(format, a...))
 
+	// TODO: Remove this after moving k6ext.Panic into the mapping layer.
 	pidder, ok := GetVU(ctx).(interface {
 		Pids() []int
 	})

--- a/k6ext/panic.go
+++ b/k6ext/panic.go
@@ -33,21 +33,23 @@ func Panic(ctx context.Context, format string, a ...any) {
 	}
 	defer k6common.Throw(rt, fmt.Errorf(format, a...))
 
-	pid := GetProcessID(ctx)
-	if pid == 0 {
-		// this should never happen unless a programmer error
-		panic("no browser process ID in context")
-	}
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		// optimistically return and don't kill the process
+	pidder, ok := GetVU(ctx).(interface {
+		Pids() []int
+	})
+	if !ok {
+		// we're running in a test, let's skip killing the process.
 		return
 	}
-	// no need to check the error for waiting the process to release
-	// its resources or whether we could kill it as we're already
-	// dying.
-	_ = p.Release()
-	_ = p.Kill()
+	for _, pid := range pidder.Pids() {
+		p, err := os.FindProcess(pid)
+		if err != nil {
+			// optimistically return and don't kill the process
+			return
+		}
+		// no need to check the error for whether we could kill it as
+		// we're already dying.
+		_ = p.Kill()
+	}
 }
 
 // UserFriendlyError maps an internal error to an error that users

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -108,7 +108,8 @@ func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 		state.TLSConfig = testServer.TLSClientConfig
 		state.Transport = testServer.HTTPTransport
 	}
-	b := bt.Launch(rt.ToValue(launchOpts))
+	// This will become useful soon.
+	b, _ := bt.Launch(rt.ToValue(launchOpts))
 	tb.Cleanup(func() {
 		select {
 		case <-vu.Context().Done():

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -32,6 +32,8 @@ type testBrowser struct {
 	vu       *k6test.VU
 	logCache *logCache
 
+	pid int // the browser process ID
+
 	api.Browser
 }
 
@@ -108,8 +110,8 @@ func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 		state.TLSConfig = testServer.TLSClientConfig
 		state.Transport = testServer.HTTPTransport
 	}
-	// This will become useful soon.
-	b, _ := bt.Launch(rt.ToValue(launchOpts))
+	b, pid := bt.Launch(rt.ToValue(launchOpts))
+
 	tb.Cleanup(func() {
 		select {
 		case <-vu.Context().Done():
@@ -127,6 +129,7 @@ func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 		vu:       vu,
 		logCache: lc,
 		Browser:  b,
+		pid:      pid,
 	}
 	if enableFileServer {
 		tbr = tbr.withFileServer()


### PR DESCRIPTION
I'm strongly against exposing global variables as we did in #762 and #755 😒😭 

Our goal was to _fix_ [the regression](https://github.com/grafana/xk6-browser/pull/744#issuecomment-1418901227), preserve the v0.8.0 behavior, and move on with #744 as we [discussed](https://github.com/grafana/xk6-browser/pull/744#issuecomment-1418986802).

However, we ended up going with #762 and #755 instead and fixed another problem: a multi-browser close issue when one of them panics in the same script (_note that nobody has reported such a problem and usage so far_). While the PRs did fix the multi-browser close issue, they introduced global variables 😒

I'm so grateful for your (@ankur22) contributions to that effort! 🙇 I believe we can do better than relying on global variables. That's not the best solution for us in the short term or the long term.

## Solution

Earlier, I proposed a [solution](https://github.com/grafana/xk6-browser/pull/744#issuecomment-1425427019). This one is similar.

After having many problems introducing global variables on a work I've been working on lately [here](https://github.com/grafana/xk6-browser/pull/778), I took this issue upon myself to work on a different solution that doesn't rely on global variables, so we can move on with #744.

It solves the "multi-browser close on panic" issue in a way that's compatible with our current mapping layer and without using global variables in a cleaner way 🎉 Plus, it's even extensible! If you have a context with a `Pids() int` method, you can use `k6ext.Panic` to kill those processes without even knowing about the mapping layer.

## Testing

I ran the following JavaScript test that uses **multiple VUs and browsers** and no zombies are left 🥳 🧟 

```js
import { chromium } from 'k6/x/browser';

export const options = {
  vus: 2,
  iterations: 2,
}

export default function () {
  const browser = chromium.launch({headless: true});
  const context = browser.newContext();
  const page = context.newPage();

  const browser2 = chromium.launch({headless: true});
  const context2 = browser2.newContext();
  const page2 = context2.newPage();

  page.goto('https://test.k6.io/flip_coin.php').then(() => {
    return page.goBack()
  }).finally(() => {
    page.close();
    page2.close();
    browser.close();
    browser2.close();
  })
}
```

I also ran Go tests on this solution, and I'm happy to say that I was able to eliminate the need to kill any zombie browser processes in tests 🧟‍♀️🛑 . Even if we do run into issues down the line, we can fix the tests after moving all the panicking code to the mapping layer (which is possible now with this PR). **We should not tackle this edge case now: It's a very low priority.**

## PS

* I'm not saying it's the perfect solution; far from it. But it's better than relying on global variables. We can perfect it in time.
* Here, I've also applied the `Release` [fix](https://github.com/grafana/xk6-browser/pull/762). And I'd be happy to get it from the other PR.
* I'm OK with separating the browser process management into a new package, similar to what we did in #755. That would be a nice addition.

@grafana/k6-browser