### PR TITLE
Fix unmap internal methods

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -168,7 +168,6 @@ func mapJSHandle(vu moduleVU, jsh api.JSHandle) mapping {
 			return rt.ToValue(m).ToObject(rt)
 		},
 		"jsonValue": jsh.JSONValue,
-		"objectID":  jsh.ObjectID,
 	}
 }
 
@@ -315,8 +314,6 @@ func mapFrame(vu moduleVU, f api.Frame) mapping {
 		"isEnabled":  f.IsEnabled,
 		"isHidden":   f.IsHidden,
 		"isVisible":  f.IsVisible,
-		"iD":         f.ID,
-		"loaderID":   f.LoaderID,
 		"locator":    f.Locator,
 		"name":       f.Name,
 		"page": func() *goja.Object {


### PR DESCRIPTION
We shouldn't expose some of the methods as they are internal to the extension, have no meaning for the users, and Playwright doesn't support them.
    
Refactoring to the tests should be done with the fix together so as not to break the tests. Some parts could be in another commit, but the commit itself is short enough anyway.

Updates: #784