### PR TITLE
Return an error from BrowserContext.SetExtraHTTPHeaders and handle panic in mapping layer

### DIFF
--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -22,7 +22,7 @@ type BrowserContext interface {
 	Route(url goja.Value, handler goja.Callable)
 	SetDefaultNavigationTimeout(timeout int64)
 	SetDefaultTimeout(timeout int64)
-	SetExtraHTTPHeaders(headers map[string]string)
+	SetExtraHTTPHeaders(headers map[string]string) error
 	SetGeolocation(geolocation goja.Value)
 	// SetHTTPCredentials sets username/password credentials to use for HTTP authentication.
 	//

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6error"
 	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/log"
 
@@ -270,8 +271,8 @@ func (b *BrowserContext) SetDefaultTimeout(timeout int64) {
 }
 
 // SetExtraHTTPHeaders is not implemented.
-func (b *BrowserContext) SetExtraHTTPHeaders(headers map[string]string) {
-	k6ext.Panic(b.ctx, "BrowserContext.setExtraHTTPHeaders(headers) has not been implemented yet")
+func (b *BrowserContext) SetExtraHTTPHeaders(headers map[string]string) error {
+	return fmt.Errorf("BrowserContext.setExtraHTTPHeaders(headers) has not been implemented yet: %w", k6error.ErrInternal)
 }
 
 // SetGeolocation overrides the geo location of the user.

--- a/k6error/internal.go
+++ b/k6error/internal.go
@@ -1,0 +1,11 @@
+// Package k6error contains ErrInternal.
+package k6error
+
+import (
+	"errors"
+)
+
+// ErrInternal should be wrapped into an error
+// to signal to the mapping layer that the error
+// is an internal error and we should abort the test run.
+var ErrInternal = errors.New("internal error")


### PR DESCRIPTION
At the moment the codebase uses panic too liberally and we don't have control over when we actually want to abort all test runs vs when we only want to fail the current test iteration.

The idea is that we will bubble up errors all the way to the mapping layer, where it can decide on whether to panic or to return an error to goja.

This would mean that we have more control over when to panic, and to be more aware of what we want to panic on, as well as using good GO error handling practices throughout the codebase.

This is the first PR that demonstrates how we can catch internal errors. There is another PR where we had most of the discussion and several other issues were found and resolved ([#744](https://github.com/grafana/xk6-browser/pull/744)). #744 was abandoned in favour of a new PR as the previous issue would require a lot of rework.

The script i've used to test this is:

```javascript
import { chromium } from 'k6/x/browser'

export default async function () {
  const browser = chromium.launch({headless: false})
  const context = browser.newContext()
  context.setExtraHTTPHeaders()
  const page = context.newPage()

  try {
    await page.goto('https://test.k6.io/flip_coin.php')
  } finally {
    page.close()
    browser.close()
  }
}
```

The output of this when ran with this should be:

```bash
panic: GoError: BrowserContext.setExtraHTTPHeaders(headers) has not been implemented yet: internal error
```