### PR TITLE
Fix multi browser close vu was missing in Context

### DIFF
--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -25,5 +25,5 @@ func (vu moduleVU) Context() context.Context {
 	// We should not cache the context (especially the init
 	// context from the vu that is received from k6 in
 	// NewModuleInstance).
-	return k6ext.WithVU(vu.VU.Context(), vu.VU)
+	return k6ext.WithVU(vu.VU.Context(), vu)
 }


### PR DESCRIPTION
Fixes a tiny but important regression in #779.

We should put the VU with `pidRegistry` into the `Context` so the panicking goroutines can grab it.