### PR TITLE
Implement `BrowserType.connect`

### DIFF
--- a/api/browser_type.go
+++ b/api/browser_type.go
@@ -6,7 +6,7 @@ import (
 
 // BrowserType is the public interface of a CDP browser client.
 type BrowserType interface {
-	Connect(opts goja.Value)
+	Connect(wsEndpoint string, opts goja.Value) Browser
 	ExecutablePath() string
 	Launch(opts goja.Value) (_ Browser, browserProcessID int)
 	LaunchPersistentContext(userDataDir string, opts goja.Value) Browser

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -660,7 +660,11 @@ func mapBrowser(vu moduleVU, b api.Browser) mapping {
 func mapBrowserType(vu moduleVU, bt api.BrowserType) mapping {
 	rt := vu.Runtime()
 	return mapping{
-		"connect":                 bt.Connect,
+		"connect": func(wsEndpoint string, opts goja.Value) *goja.Object {
+			b := bt.Connect(wsEndpoint, opts)
+			m := mapBrowser(vu, b)
+			return rt.ToValue(m).ToObject(rt)
+		},
 		"executablePath":          bt.ExecutablePath,
 		"launchPersistentContext": bt.LaunchPersistentContext,
 		"name":                    bt.Name,

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -126,46 +126,6 @@ func (b *BrowserType) link(
 	return p, nil
 }
 
-// ExecutablePath returns the path where the extension expects to find the browser executable.
-func (b *BrowserType) ExecutablePath() (execPath string) {
-	if b.execPath != "" {
-		return b.execPath
-	}
-	defer func() {
-		b.execPath = execPath
-	}()
-
-	for _, path := range [...]string{
-		// Unix-like
-		"headless_shell",
-		"headless-shell",
-		"chromium",
-		"chromium-browser",
-		"google-chrome",
-		"google-chrome-stable",
-		"google-chrome-beta",
-		"google-chrome-unstable",
-		"/usr/bin/google-chrome",
-
-		// Windows
-		"chrome",
-		"chrome.exe", // in case PATHEXT is misconfigured
-		`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`,
-		`C:\Program Files\Google\Chrome\Application\chrome.exe`,
-		filepath.Join(os.Getenv("USERPROFILE"), `AppData\Local\Google\Chrome\Application\chrome.exe`),
-
-		// Mac (from https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Mac/857950/)
-		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-		"/Applications/Chromium.app/Contents/MacOS/Chromium",
-	} {
-		if _, err := exec.LookPath(path); err == nil {
-			return path
-		}
-	}
-
-	return ""
-}
-
 func (b *BrowserType) initContext() context.Context {
 	ctx := k6ext.WithVU(b.vu.Context(), b.vu)
 	ctx = k6ext.WithCustomMetrics(ctx, b.k6Metrics)
@@ -294,6 +254,46 @@ func (b *BrowserType) allocate(
 	}
 
 	return common.NewLocalBrowserProcess(bProcCtx, path, args, env, dataDir, bProcCtxCancel, logger) //nolint: wrapcheck
+}
+
+// ExecutablePath returns the path where the extension expects to find the browser executable.
+func (b *BrowserType) ExecutablePath() (execPath string) {
+	if b.execPath != "" {
+		return b.execPath
+	}
+	defer func() {
+		b.execPath = execPath
+	}()
+
+	for _, path := range [...]string{
+		// Unix-like
+		"headless_shell",
+		"headless-shell",
+		"chromium",
+		"chromium-browser",
+		"google-chrome",
+		"google-chrome-stable",
+		"google-chrome-beta",
+		"google-chrome-unstable",
+		"/usr/bin/google-chrome",
+
+		// Windows
+		"chrome",
+		"chrome.exe", // in case PATHEXT is misconfigured
+		`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`,
+		`C:\Program Files\Google\Chrome\Application\chrome.exe`,
+		filepath.Join(os.Getenv("USERPROFILE"), `AppData\Local\Google\Chrome\Application\chrome.exe`),
+
+		// Mac (from https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Mac/857950/)
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+		"/Applications/Chromium.app/Contents/MacOS/Chromium",
+	} {
+		if _, err := exec.LookPath(path); err == nil {
+			return path
+		}
+	}
+
+	return ""
 }
 
 // parseArgs parses command-line arguments and returns them.

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -68,7 +68,13 @@ func (b *BrowserType) init(
 		return nil, nil, nil, fmt.Errorf("error setting up logger: %w", err)
 	}
 
-	launchOpts := common.NewLaunchOptions(k6ext.OnCloud(), isRemoteBrowser)
+	var launchOpts *common.LaunchOptions
+	if isRemoteBrowser {
+		launchOpts = common.NewRemoteBrowserLaunchOptions()
+	} else {
+		launchOpts = common.NewLaunchOptions()
+	}
+
 	if err = launchOpts.Parse(ctx, logger, opts); err != nil {
 		return nil, nil, nil, fmt.Errorf("error parsing launch options: %w", err)
 	}

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -60,9 +60,10 @@ func NewBrowserType(vu k6modules.VU) api.BrowserType {
 }
 
 // Connect attaches k6 browser to an existing browser instance.
-func (b *BrowserType) Connect(opts goja.Value) {
+func (b *BrowserType) Connect(wsEndpoint string, opts goja.Value) api.Browser {
 	rt := b.vu.Runtime()
 	k6common.Throw(rt, errors.New("BrowserType.connect() has not been implemented yet"))
+	return nil
 }
 
 // ExecutablePath returns the path where the extension expects to find the browser executable.

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -123,7 +123,7 @@ func (b *BrowserType) Launch(opts goja.Value) (_ api.Browser, browserProcessID i
 	if logger, err = makeLogger(ctx); err != nil {
 		k6ext.Panic(ctx, "setting up logger: %w", err)
 	}
-	launchOpts := common.NewLaunchOptions(k6ext.OnCloud())
+	launchOpts := common.NewLaunchOptions(k6ext.OnCloud(), false)
 	if err := launchOpts.Parse(ctx, logger, opts); err != nil {
 		k6ext.Panic(ctx, "parsing launch options: %w", err)
 	}

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -232,7 +232,7 @@ func (b *BrowserType) allocate(
 		path = b.ExecutablePath()
 	}
 
-	return common.NewBrowserProcess(bProcCtx, path, args, env, dataDir, bProcCtxCancel, logger) //nolint: wrapcheck
+	return common.NewLocalBrowserProcess(bProcCtx, path, args, env, dataDir, bProcCtxCancel, logger) //nolint: wrapcheck
 }
 
 // parseArgs parses command-line arguments and returns them.

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -38,8 +38,7 @@ type BrowserType struct {
 	vu        k6modules.VU
 	hooks     *common.Hooks
 	k6Metrics *k6ext.CustomMetrics
-	execPath  string       // path to the Chromium executable
-	storage   *storage.Dir // stores temporary data for the extension and user
+	execPath  string // path to the Chromium executable
 	randSrc   *rand.Rand
 	logger    *log.Logger
 }
@@ -54,7 +53,6 @@ func NewBrowserType(vu k6modules.VU) api.BrowserType {
 		vu:        vu,
 		hooks:     common.NewHooks(),
 		k6Metrics: k6m,
-		storage:   &storage.Dir{},
 		randSrc:   rand.New(rand.NewSource(time.Now().UnixNano())), //nolint: gosec
 	}
 
@@ -160,7 +158,7 @@ func (b *BrowserType) launch(
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w", err)
 	}
-	dataDir := b.storage
+	dataDir := &storage.Dir{}
 	if err := dataDir.Make("", flags["user-data-dir"]); err != nil {
 		return nil, 0, fmt.Errorf("%w", err)
 	}

--- a/common/browser.go
+++ b/common/browser.go
@@ -23,8 +23,10 @@ import (
 )
 
 // Ensure Browser implements the EventEmitter and Browser interfaces.
-var _ EventEmitter = &Browser{}
-var _ api.Browser = &Browser{}
+var (
+	_ EventEmitter = &Browser{}
+	_ api.Browser  = &Browser{}
+)
 
 const (
 	BrowserStateOpen int64 = iota
@@ -392,7 +394,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 // Close shuts down the browser.
 func (b *Browser) Close() {
 	defer func() {
-		if err := b.browserProc.userDataDir.Cleanup(); err != nil {
+		if err := b.browserProc.meta.Cleanup(); err != nil {
 			b.logger.Errorf("Browser:Close", "cleaning up the user data directory: %v", err)
 		}
 	}()

--- a/common/browser.go
+++ b/common/browser.go
@@ -526,3 +526,8 @@ func (b *Browser) Version() string {
 	}
 	return product[i+1:]
 }
+
+// WsURL returns the Websocket URL that the browser is listening on for CDP clients.
+func (b *Browser) WsURL() string {
+	return b.browserProc.WsURL()
+}

--- a/common/browser.go
+++ b/common/browser.go
@@ -394,7 +394,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 // Close shuts down the browser.
 func (b *Browser) Close() {
 	defer func() {
-		if err := b.browserProc.meta.Cleanup(); err != nil {
+		if err := b.browserProc.Cleanup(); err != nil {
 			b.logger.Errorf("Browser:Close", "cleaning up the user data directory: %v", err)
 		}
 	}()

--- a/common/browser_options.go
+++ b/common/browser_options.go
@@ -10,6 +10,20 @@ import (
 	"github.com/grafana/xk6-browser/log"
 )
 
+const (
+	optArgs              = "args"
+	optDebug             = "debug"
+	optDevTools          = "devtools"
+	optEnv               = "env"
+	optExecutablePath    = "executablePath"
+	optHeadless          = "headless"
+	optIgnoreDefaultArgs = "ignoreDefaultArgs"
+	optLogCategoryFilter = "logCategoryFilter"
+	optProxy             = "proxy"
+	optSlowMo            = "slowMo"
+	optTimeout           = "timeout"
+)
+
 // ProxyOptions allows configuring a proxy server.
 type ProxyOptions struct {
 	Server   string
@@ -62,10 +76,10 @@ func (l *LaunchOptions) Parse(ctx context.Context, logger *log.Logger, opts goja
 		rt       = k6ext.Runtime(ctx)
 		o        = opts.ToObject(rt)
 		defaults = map[string]any{
-			"env":               l.Env,
-			"headless":          l.Headless,
-			"logCategoryFilter": l.LogCategoryFilter,
-			"timeout":           l.Timeout,
+			optEnv:               l.Env,
+			optHeadless:          l.Headless,
+			optLogCategoryFilter: l.LogCategoryFilter,
+			optTimeout:           l.Timeout,
 		}
 	)
 	for _, k := range o.Keys() {
@@ -82,27 +96,27 @@ func (l *LaunchOptions) Parse(ctx context.Context, logger *log.Logger, opts goja
 		}
 		var err error
 		switch k {
-		case "args":
+		case optArgs:
 			err = exportOpt(rt, k, v, &l.Args)
-		case "debug":
+		case optDebug:
 			l.Debug, err = parseBoolOpt(k, v)
-		case "devtools":
+		case optDevTools:
 			l.Devtools, err = parseBoolOpt(k, v)
-		case "env":
+		case optEnv:
 			err = exportOpt(rt, k, v, &l.Env)
-		case "executablePath":
+		case optExecutablePath:
 			l.ExecutablePath, err = parseStrOpt(k, v)
-		case "headless":
+		case optHeadless:
 			l.Headless, err = parseBoolOpt(k, v)
-		case "ignoreDefaultArgs":
+		case optIgnoreDefaultArgs:
 			err = exportOpt(rt, k, v, &l.IgnoreDefaultArgs)
-		case "logCategoryFilter":
+		case optLogCategoryFilter:
 			l.LogCategoryFilter, err = parseStrOpt(k, v)
-		case "proxy":
+		case optProxy:
 			err = exportOpt(rt, k, v, &l.Proxy)
-		case "slowMo":
+		case optSlowMo:
 			l.SlowMo, err = parseTimeOpt(k, v)
-		case "timeout":
+		case optTimeout:
 			l.Timeout, err = parseTimeOpt(k, v)
 		}
 		if err != nil {
@@ -117,5 +131,11 @@ func (l *LaunchOptions) shouldIgnoreOnCloud(opt string) bool {
 	if !l.onCloud {
 		return false
 	}
-	return opt == "devtools" || opt == "executablePath" || opt == "headless"
+	shouldIgnoreOnCloud := map[string]struct{}{
+		optDevTools:       {},
+		optExecutablePath: {},
+		optHeadless:       {},
+	}
+	_, ignore := shouldIgnoreOnCloud[opt]
+	return ignore
 }

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -117,6 +117,12 @@ func (p *BrowserProcess) AttachLogger(logger *log.Logger) {
 	p.logger = logger
 }
 
+// Cleanup cleans up the metadata associated with the browser
+// process, mainly the browser data directory.
+func (p *BrowserProcess) Cleanup() error {
+	return p.meta.Cleanup() //nolint:wrapcheck
+}
+
 type command struct {
 	*exec.Cmd
 	done           chan struct{}

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -32,7 +32,9 @@ type BrowserProcess struct {
 	logger *log.Logger
 }
 
-func NewBrowserProcess(
+// NewLocalBrowserProcess starts a local browser process and
+// returns a new BrowserProcess instance to interact with it.
+func NewLocalBrowserProcess(
 	ctx context.Context, path string, args, env []string, dataDir *storage.Dir,
 	ctxCancel context.CancelFunc, logger *log.Logger,
 ) (*BrowserProcess, error) {

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -56,6 +56,7 @@ func NewBrowserProcess(
 		processIsGracefullyClosing: make(chan struct{}),
 		processDone:                cmd.done,
 		wsURL:                      wsURL,
+		logger:                     logger,
 	}
 
 	go func() {
@@ -110,11 +111,6 @@ func (p *BrowserProcess) WsURL() string {
 // Pid returns the browser process ID, or -1 if this is unknown.
 func (p *BrowserProcess) Pid() int {
 	return p.meta.Pid()
-}
-
-// AttachLogger attaches a logger to the browser process.
-func (p *BrowserProcess) AttachLogger(logger *log.Logger) {
-	p.logger = logger
 }
 
 // Cleanup cleans up the metadata associated with the browser

--- a/common/browser_process_meta.go
+++ b/common/browser_process_meta.go
@@ -1,0 +1,70 @@
+package common
+
+import (
+	"os"
+
+	"github.com/grafana/xk6-browser/storage"
+)
+
+const (
+	unknownProcessPid = -1
+)
+
+// browserProcessMeta handles the metadata associated with
+// a browser process, especifically, the OS process handle
+// and the associated browser data directory.
+type browserProcessMeta interface {
+	Pid() int
+	Cleanup() error
+}
+
+// localBrowserProcessMeta holds the metadata for local
+// browser process.
+type localBrowserProcessMeta struct {
+	process     *os.Process
+	userDataDir *storage.Dir
+}
+
+// newLocalBrowserProcessMeta returns a new BrowserProcessMeta
+// for the given OS process and storage directory.
+func newLocalBrowserProcessMeta(
+	process *os.Process, userDataDir *storage.Dir,
+) *localBrowserProcessMeta {
+	return &localBrowserProcessMeta{
+		process,
+		userDataDir,
+	}
+}
+
+// Pid returns the Pid for the local browser process.
+func (l *localBrowserProcessMeta) Pid() int {
+	return l.process.Pid
+}
+
+// Cleanup cleans the local user data directory associated
+// with the local browser process.
+func (l *localBrowserProcessMeta) Cleanup() error {
+	return l.userDataDir.Cleanup() //nolint:wrapcheck
+}
+
+// remoteBrowserProcessMeta is a placeholder for a
+// remote browser process metadata.
+type remoteBrowserProcessMeta struct{}
+
+// newRemoteBrowserProcessMeta returns a new BrowserProcessMeta
+// which acts as a placeholder for a remote browser process data.
+func newRemoteBrowserProcessMeta() *remoteBrowserProcessMeta {
+	return &remoteBrowserProcessMeta{}
+}
+
+// Pid returns -1 as the remote browser process is unknown.
+func (r *remoteBrowserProcessMeta) Pid() int {
+	return unknownProcessPid
+}
+
+// Cleanup does nothing and returns nil, as there is no
+// access to the remote browser's user data directory.
+func (r *remoteBrowserProcessMeta) Cleanup() error {
+	// Nothing to do.
+	return nil
+}

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -24,7 +24,7 @@ func TestBrowserNewPageInContext(t *testing.T) {
 	newTestCase := func(id cdp.BrowserContextID) *testCase {
 		ctx, cancel := context.WithCancel(context.Background())
 		logger := log.NewNullLogger()
-		b := newBrowser(ctx, cancel, nil, NewLaunchOptions(false, false), logger)
+		b := newBrowser(ctx, cancel, nil, NewLaunchOptions(), logger)
 		// set a new browser context in the browser with `id`, so that newPageInContext can find it.
 		b.contexts[id] = NewBrowserContext(ctx, b, id, nil, nil)
 		return &testCase{

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -24,7 +24,7 @@ func TestBrowserNewPageInContext(t *testing.T) {
 	newTestCase := func(id cdp.BrowserContextID) *testCase {
 		ctx, cancel := context.WithCancel(context.Background())
 		logger := log.NewNullLogger()
-		b := newBrowser(ctx, cancel, nil, NewLaunchOptions(false), logger)
+		b := newBrowser(ctx, cancel, nil, NewLaunchOptions(false, false), logger)
 		// set a new browser context in the browser with `id`, so that newPageInContext can find it.
 		b.contexts[id] = NewBrowserContext(ctx, b, id, nil, nil)
 		return &testCase{

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -1,0 +1,20 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/grafana/xk6-browser/chromium"
+	"github.com/grafana/xk6-browser/k6ext/k6test"
+)
+
+func TestBrowserTypeConnect(t *testing.T) {
+	// Start a test browser so we can get its WS URL
+	// and use it to connect through BrowserType.Connect.
+	tb := newTestBrowser(t)
+	vu := k6test.NewVU(t)
+	bt := chromium.NewBrowserType(vu)
+	vu.MoveToVUContext()
+
+	b := bt.Connect(tb.wsURL, nil)
+	b.NewPage(nil)
+}


### PR DESCRIPTION
This PR implements the `BrowserType.Connect` method for chromium browser type in order to, instead of launching a browser from our implementation, establish the WS connection to a remote running browser.

The approach taken has been to minimize changes in the current implementation/flow. For that:
- A new interface `BrowserProcessMetadata` has been introduced in order to abstract the elements of the current `BrowserProcess` implementation that differ for a local/remote browser process **[*]**.
- Refactor has been made in order to minimize the interactions with internal `BrowserProcess` properties from other components (mainly from `Browser` implementation).
- A new constructor has been added to comply with the differences for a new `BrowserProcess` struct that references a remote browser.
- Implementation of `BrowserType.Connect` method following behavior defined by the current `launch` method.
- Refactor in order to extract common behavior for `launch` and `connect` methods.

**[*]** There were alternatives other than creating a new interface to abstract these differences, for example to add a `flag` in `BrowserProcess` that would indicate if the `os.Process` property held by `BrowserProcess` was valid or not (due to being remote). But I believe the new interface definition abstracts this in a better way and prevents possible panics due to `NPE`, especially considering that there is not an abstraction in place for the whole `BrowserProcess` element, and this is reachable from other elements implementations, such as `Browser`.

Closes: grafana/xk6-browser#17.