### PR TITLE
Add assert log contains and log dump helpers

### DIFF
--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -23,11 +23,11 @@ func TestURLSkipRequest(t *testing.T) {
 
 	_, err := p.Goto("data:text/html,hello", nil)
 	require.NoError(t, err)
-	assert.True(t, tb.logCache.contains("skipping request handling of data URL"))
+	tb.logCache.assertContains(t, "skipping request handling of data URL")
 
 	_, err = p.Goto("blob:something", nil)
 	require.NoError(t, err)
-	assert.True(t, tb.logCache.contains("skipping request handling of blob URL"))
+	tb.logCache.assertContains(t, "skipping request handling of blob URL")
 }
 
 func TestBlockHostnames(t *testing.T) {
@@ -42,7 +42,7 @@ func TestBlockHostnames(t *testing.T) {
 	res, err := p.Goto("http://host.test/", nil)
 	require.NoError(t, err)
 	require.Nil(t, res)
-	require.True(t, tb.logCache.contains("was interrupted: hostname host.test is in a blocked pattern"))
+	tb.logCache.assertContains(t, "was interrupted: hostname host.test is in a blocked pattern")
 
 	res, err = p.Goto(tb.URL("/get"), nil)
 	require.NoError(t, err)
@@ -60,8 +60,7 @@ func TestBlockIPs(t *testing.T) {
 	res, err := p.Goto("http://10.0.0.1:8000/", nil)
 	require.NoError(t, err)
 	require.Nil(t, res)
-	assert.True(t, tb.logCache.contains(
-		`was interrupted: IP 10.0.0.1 is in a blacklisted range "10.0.0.0/8"`))
+	tb.logCache.assertContains(t, `was interrupted: IP 10.0.0.1 is in a blacklisted range "10.0.0.0/8"`)
 
 	// Ensure other requests go through
 	res, err = p.Goto(tb.URL("/get"), nil)


### PR DESCRIPTION
These helpers should help us to better see the log output locally and on CI if the test fails. I constantly needed to dump log requests when testing #687. This helper automatically does that for us.

For example, if the following fails, we have no idea why it fails unless we dump the logs by hand:

https://github.com/grafana/xk6-browser/blob/34827928fce38c3ac395b3542a3bac9f20063366/tests/network_manager_test.go#L26

Example output when we use the `assertContains` helper:

https://github.com/grafana/xk6-browser/blob/7bd82754483c8b5b3680c50c35f5cabdaf53375e/tests/network_manager_test.go#L26

```bash
=== RUN   TestURLSkipRequest
=== PAUSE TestURLSkipRequest
=== CONT  TestURLSkipRequest
    network_manager_test.go:26: expected log cache to contain "skipping request handling of data URL", but it didn't.
    network_manager_test.go:26: --------------------------------------------------------------------------------
    network_manager_test.go:26: wsURL:"ws://127.0.0.1:57218/devtools/browser/6e48a690-4676-4b99-9efe-8223a3d91cda"
    ...
    network_manager_test.go:26: sid:71D7211C20290E9E84D3E61C20BA2C6E tid:F077AC9457875E49FE074C9D8F7F1619 method:"Page.enable"
    network_manager_test.go:26: sid:71D7211C20290E9E84D3E61C20BA2C6E tid:F077AC9457875E49FE074C9D8F7F1619
    network_manager_test.go:26: sid:71D7211C20290E9E84D3E61C20BA2C6E tid:F077AC9457875E49FE074C9D8F7F1619 method:"Page.enable"
    network_manager_test.go:26: SUPPOSED TO BE HERE!
    network_manager_test.go:26: sid:71D7211C20290E9E84D3E61C20BA2C6E tid:F077AC9457875E49FE074C9D8F7F1619 method:"Page.getFrameTree"
    ...
```