### PR TITLE
Add browser close friendly err (#687)

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -62,6 +62,9 @@ type Browser struct {
 	sessionIDtoTargetIDMu sync.RWMutex
 	sessionIDtoTargetID   map[target.SessionID]target.ID
 
+	// Used to display a warning when the browser is reclosed.
+	closed bool
+
 	vu k6modules.VU
 
 	logger *log.Logger
@@ -391,6 +394,15 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 
 // Close shuts down the browser.
 func (b *Browser) Close() {
+	if b.closed {
+		b.logger.Warnf(
+			"Browser:Close",
+			"Please call browser.close only once, and do not use the browser after calling close.",
+		)
+		return
+	}
+	b.closed = true
+
 	defer func() {
 		if err := b.browserProc.userDataDir.Cleanup(); err != nil {
 			b.logger.Errorf("Browser:Close", "cleaning up the user data directory: %v", err)

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -209,3 +209,13 @@ func TestMultiBrowserPanic(t *testing.T) {
 	err = p2.Signal(syscall.Signal(0))
 	assert.Error(t, err, "process #2 should be dead, but exists")
 }
+
+func TestBrowserMultiClose(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withSkipClose(), withLogCache())
+
+	require.NotPanicsf(t, tb.Close, "first call to browser.close should not panic")
+	require.NotPanicsf(t, tb.Close, "second call to browser.close should not panic")
+	tb.logCache.assertContains(t, "browser.close only once")
+}


### PR DESCRIPTION
This PR does the following:
* Allows executing `Browser.Close` only once.
* Warns users with "a friendly message" when it's called multiple times.

Notes:
* `Close()` is thread-safe as only the same VU or testBrowser use it.

You can try the result with this script:

```js
import { chromium } from 'k6/x/browser';

export default async function () {
    const browser = chromium.launch();
    const page = browser.newPage();

    await page
        .goto('https://test.k6.io/', { waitUntil: 'networkidle' })
        .finally(() => {
            page.close();
            browser.close();
        });

    await page
        .goto('https://test.k6.io/contacts.php', { waitUntil: 'networkidle' })
        .finally(() => {
            page.close();
            browser.close();
        });
}
```

It should print:

```
WARN[0002] Please call browser.close only once, and do not use the browser after calling close.
  category="Browser:Close" elapsed="0 ms" goroutine=84
```