### PR TITLE
WIP: Avoid parsing object of subtype null

### DIFF
--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -123,7 +123,7 @@ func parseRemoteObjectValue(t cdpruntime.Type, val string, op *cdpruntime.Object
 	case cdpruntime.TypeSymbol:
 		return val, nil
 	case cdpruntime.TypeObject:
-		if op != nil {
+		if op != nil && op.Subtype != "null" {
 			return parseRemoteObjectPreview(op)
 		}
 		if val == "Object" {


### PR DESCRIPTION
WIP

This pr is solving the bug in the following issue [#793 ](https://github.com/grafana/xk6-browser/issues/793)

