### PR TITLE
Rename ErrInternal to ErrFatal and use abort

### DIFF
--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -12,7 +12,7 @@ type BrowserContext interface {
 	ClearCookies()
 	ClearPermissions()
 	Close()
-	Cookies() []any // TODO: make it []Cookie later on
+	Cookies() ([]any, error) // TODO: make it []Cookie later on
 	ExposeBinding(name string, callback goja.Callable, opts goja.Value)
 	ExposeFunction(name string, callback goja.Callable)
 	GrantPermissions(permissions []string, opts goja.Value)

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -596,7 +596,7 @@ func mapBrowserContext(vu moduleVU, bc api.BrowserContext) mapping {
 			ctx := vu.Context()
 			return k6ext.Promise(ctx, func() (result any, reason error) {
 				err := bc.SetExtraHTTPHeaders(headers)
-				panicIfInternalError(ctx, err)
+				panicIfFatalError(ctx, err)
 				return nil, err //nolint:wrapcheck
 			})
 		},
@@ -678,8 +678,8 @@ func mapBrowserType(vu moduleVU, bt api.BrowserType) mapping {
 	}
 }
 
-func panicIfInternalError(ctx context.Context, err error) {
-	if errors.Is(err, k6error.ErrInternal) {
+func panicIfFatalError(ctx context.Context, err error) {
+	if errors.Is(err, k6error.ErrFatal) {
 		k6ext.Panic(ctx, err.Error())
 	}
 }

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -680,6 +680,6 @@ func mapBrowserType(vu moduleVU, bt api.BrowserType) mapping {
 
 func panicIfFatalError(ctx context.Context, err error) {
 	if errors.Is(err, k6error.ErrFatal) {
-		k6ext.Panic(ctx, err.Error())
+		k6ext.Abort(ctx, err.Error())
 	}
 }

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -578,13 +578,18 @@ func mapWorker(vu moduleVU, w api.Worker) mapping {
 func mapBrowserContext(vu moduleVU, bc api.BrowserContext) mapping {
 	rt := vu.Runtime()
 	return mapping{
-		"addCookies":                  bc.AddCookies,
-		"addInitScript":               bc.AddInitScript,
-		"browser":                     bc.Browser,
-		"clearCookies":                bc.ClearCookies,
-		"clearPermissions":            bc.ClearPermissions,
-		"close":                       bc.Close,
-		"cookies":                     bc.Cookies,
+		"addCookies":       bc.AddCookies,
+		"addInitScript":    bc.AddInitScript,
+		"browser":          bc.Browser,
+		"clearCookies":     bc.ClearCookies,
+		"clearPermissions": bc.ClearPermissions,
+		"close":            bc.Close,
+		"cookies": func() ([]any, error) {
+			cc, err := bc.Cookies()
+			ctx := vu.Context()
+			panicIfFatalError(ctx, err)
+			return cc, err //nolint:wrapcheck
+		},
 		"exposeBinding":               bc.ExposeBinding,
 		"exposeFunction":              bc.ExposeFunction,
 		"grantPermissions":            bc.GrantPermissions,

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -272,7 +272,7 @@ func (b *BrowserContext) SetDefaultTimeout(timeout int64) {
 
 // SetExtraHTTPHeaders is not implemented.
 func (b *BrowserContext) SetExtraHTTPHeaders(headers map[string]string) error {
-	return fmt.Errorf("BrowserContext.setExtraHTTPHeaders(headers) has not been implemented yet: %w", k6error.ErrInternal)
+	return fmt.Errorf("BrowserContext.setExtraHTTPHeaders(headers) has not been implemented yet: %w", k6error.ErrFatal)
 }
 
 // SetGeolocation overrides the geo location of the user.

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -152,9 +152,8 @@ func (b *BrowserContext) Close() {
 }
 
 // Cookies is not implemented.
-func (b *BrowserContext) Cookies() []any {
-	k6ext.Panic(b.ctx, "BrowserContext.cookies() has not been implemented yet")
-	return nil
+func (b *BrowserContext) Cookies() ([]any, error) {
+	return nil, fmt.Errorf("BrowserContext.cookies() has not been implemented yet: %w", k6error.ErrFatal)
 }
 
 // ExposeBinding is not implemented.

--- a/k6error/internal.go
+++ b/k6error/internal.go
@@ -1,11 +1,15 @@
-// Package k6error contains ErrInternal.
+// Package k6error contains ErrFatal.
 package k6error
 
 import (
 	"errors"
 )
 
-// ErrInternal should be wrapped into an error
+// ErrFatal should be wrapped into an error
 // to signal to the mapping layer that the error
-// is an internal error and we should abort the test run.
-var ErrInternal = errors.New("internal error")
+// is a fatal error and we should abort the whole
+// test run, not just the current iteration. It
+// should be used in cases where if the iteration
+// ran again then there's a 100% chance that it
+// will end up running into the same error.
+var ErrFatal = errors.New("fatal error")

--- a/k6ext/panic.go
+++ b/k6ext/panic.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
+
 	"go.k6.io/k6/errext"
 	k6common "go.k6.io/k6/js/common"
 )

--- a/k6ext/panic.go
+++ b/k6ext/panic.go
@@ -9,8 +9,20 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
+	"go.k6.io/k6/errext"
 	k6common "go.k6.io/k6/js/common"
 )
+
+// Abort will shutdown the whole test run. This should
+// only be used from the goja mapping layer. It is only
+// to be used when an error will occur in all iterations,
+// so it's permanent.
+func Abort(ctx context.Context, format string, a ...any) {
+	sharedPanic(ctx, func(rt *goja.Runtime, a ...any) {
+		reason := fmt.Errorf(format, a...).Error()
+		rt.Interrupt(&errext.InterruptError{Reason: reason})
+	}, a...)
+}
 
 // Panic will cause a panic with the given error which will stop
 // the current iteration. Before panicking, it will find the

--- a/k6ext/panic.go
+++ b/k6ext/panic.go
@@ -11,11 +11,15 @@ import (
 	k6common "go.k6.io/k6/js/common"
 )
 
-// Panic will cause a panic with the given error which will shut
-// the application down. Before panicking, it will find the
+// Panic will cause a panic with the given error which will stop
+// the current iteration. Before panicking, it will find the
 // browser process from the context and kill it if it still exists.
 // TODO: test.
 func Panic(ctx context.Context, format string, a ...any) {
+	sharedPanic(ctx, format, a...)
+}
+
+func sharedPanic(ctx context.Context, format string, a ...any) {
 	rt := Runtime(ctx)
 	if rt == nil {
 		// this should never happen unless a programmer error


### PR DESCRIPTION
`Fatal` better describes the error, and it will help distinguish from other internal errors (which are generally temporary). `Fatal` is a permanent error, which should end the whole test run not just the current iteration. If we ran the same iteration again then there's a 100% chance that we will run into the same error, e.g. trying to work with an unimplemented API is a `Fatal` error.

Here are two test scripts I used to test this change:

When ran with `xk6 run -i 10 examples/test.js` before the change, this test will iterate 10 times, failing each iteration. After the change it will stop on the first iteration.
```js
import { chromium } from 'k6/x/browser'

export default async function () {
  const browser = chromium.launch({headless: false})
  const context = browser.newContext()
  context.cookies()
}
```

This test will stop the whole test run before the change and after the change.
```js
import { chromium } from 'k6/x/browser'

export default async function () {
  const browser = chromium.launch({headless: false})
  const context = browser.newContext()
  context.setExtraHTTPHeaders()
}
```