### PR TITLE
Remove --no-sandbox as default browser flag

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -316,12 +316,6 @@ func parseArgs(flags map[string]any) ([]string, error) {
 			return nil, fmt.Errorf(`invalid browser command line flag: "%s=%v"`, name, value)
 		}
 	}
-	if _, ok := flags["no-sandbox"]; !ok && os.Getuid() == 0 {
-		// Running as root, for example in a Linux container. Chromium
-		// needs --no-sandbox when running as root, so make that the
-		// default, unless the user set "no-sandbox": false.
-		args = append(args, "--no-sandbox")
-	}
 	if _, ok := flags["remote-debugging-port"]; !ok {
 		args = append(args, "--remote-debugging-port=0")
 	}
@@ -362,7 +356,6 @@ func prepareFlags(lopts *common.LaunchOptions, k6opts *k6lib.Options) (map[strin
 
 		"no-startup-window":           true,
 		"no-default-browser-check":    true,
-		"no-sandbox":                  true,
 		"headless":                    lopts.Headless,
 		"auto-open-devtools-for-tabs": lopts.Devtools,
 		"window-size":                 fmt.Sprintf("%d,%d", 800, 600),


### PR DESCRIPTION
This increases the security by default when launching chrome browser. This flag was only required when running xk6-browser as root, which mainly happened when being executed in a Docker container.

Now if xk6-browser is run as root, due to the removal of this flag, an error message like: _**"Running as root without --no-sandbox is not supported"**_. Which should be user friendly in order to understand the root cause, and the user can still force the launching with `--no-sandbox` by specifying extra browser flags as explained in `launch` method [documentation](https://k6.io/docs/javascript-api/k6-browser/api/browsertype/launch/).

Example output of running xk6-browser without `--no-sandbox` flag inside a Docker container which runs as root user.
```shell

          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: -
     output: -

  scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
           * default: 1 iterations for each of 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)

time="2023-03-07T14:54:38Z" level=error msg="GoError: launching browser: Running as root without --no-sandbox is not supported. See https://crbug.com/638180.\n\tat github.com/grafana/xk6-browser/browser.mapBrowserType.func2 (native)\n\tat file:///-:4:34(7)\n" executor=per-vu-iterations scenario=default source=stacktrace
time="2023-03-07T14:54:38Z" level=error msg="process with PID 21 unexpectedly ended: exit status 1" category=browser elapsed="0 ms" goroutine=79

running (00m00.0s), 0/1 VUs, 1 complete and 0 interrupted iterations
default ✓ [ 100% ] 1 VUs  00m00.0s/10m0s  1/1 iters, 1 per VU

     data_received........: 0 B 0 B/s
     data_sent............: 0 B 0 B/s
     iteration_duration...: avg=39.62ms min=39.62ms med=39.62ms max=39.62ms p(90)=39.62ms p(95)=39.62ms
     iterations...........: 1   25.129828/s
```

Closes: #813.