### PR TITLE
Transition from Browser.Launch to Browser.Connect

### DIFF
--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -117,7 +117,7 @@ func TestMappings(t *testing.T) {
 		"browserType": {
 			apiInterface: (*api.BrowserType)(nil),
 			mapp: func() mapping {
-				return mapBrowserType(moduleVU{VU: vu}, &chromium.BrowserType{})
+				return mapBrowserType(moduleVU{VU: vu}, &chromium.BrowserType{}, "", false)
 			},
 		},
 		"browser": {

--- a/browser/module.go
+++ b/browser/module.go
@@ -15,7 +15,7 @@ type (
 	// RootModule is the global module instance that will create module
 	// instances for each VU.
 	RootModule struct {
-		pidRegistry *pidRegistry
+		PidRegistry *pidRegistry
 	}
 
 	// JSModule exposes the properties available to the JS script.
@@ -39,7 +39,7 @@ var (
 // New returns a pointer to a new RootModule instance.
 func New() *RootModule {
 	return &RootModule{
-		pidRegistry: &pidRegistry{},
+		PidRegistry: &pidRegistry{},
 	}
 }
 
@@ -50,7 +50,7 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 		mod: &JSModule{
 			Chromium: mapBrowserToGoja(moduleVU{
 				VU:          vu,
-				pidRegistry: m.pidRegistry,
+				pidRegistry: m.PidRegistry,
 			}),
 			Devices: common.GetDevices(),
 			Version: version,

--- a/k6ext/cloud.go
+++ b/k6ext/cloud.go
@@ -1,9 +1,0 @@
-package k6ext
-
-import "os"
-
-// OnCloud returns true if xk6-browser runs in the cloud.
-func OnCloud() bool {
-	_, ok := os.LookupEnv("K6_CLOUDRUN_INSTANCE_ID")
-	return ok
-}

--- a/k6ext/env.go
+++ b/k6ext/env.go
@@ -1,0 +1,40 @@
+package k6ext
+
+import (
+	"crypto/rand"
+	"math/big"
+	"strings"
+)
+
+type envLookupper func(key string) (string, bool)
+
+// IsRemoteBrowser returns true and the corresponding CDP
+// WS URL if this one is set through the K6_BROWSER_WS_URL
+// environment variable. Otherwise returns false.
+// If K6_BROWSER_WS_URL is set as a comma separated list of
+// URLs, this method returns a randomly chosen URL from the list
+// so connections are done in a round-robin fashion for all the
+// entries in the list.
+func IsRemoteBrowser(envLookup envLookupper) (wsURL string, isRemote bool) {
+	wsURL, isRemote = envLookup("K6_BROWSER_WS_URL")
+	if !isRemote {
+		return "", false
+	}
+	if !strings.ContainsRune(wsURL, ',') {
+		return wsURL, isRemote
+	}
+
+	// If last parts element is a void string,
+	// because WS URL contained an ending comma,
+	// remove it
+	parts := strings.Split(wsURL, ",")
+	if parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+
+	// Choose a random WS URL from the provided list
+	i, _ := rand.Int(rand.Reader, big.NewInt(int64(len(parts))))
+	wsURL = parts[i.Int64()]
+
+	return wsURL, isRemote
+}

--- a/k6ext/env_test.go
+++ b/k6ext/env_test.go
@@ -1,0 +1,81 @@
+package k6ext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRemoteBrowser(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		envLookup      envLookupper
+		expIsRemote    bool
+		expValidWSURLs []string
+	}{
+		{
+			name: "browser is not remote",
+			envLookup: func(key string) (string, bool) {
+				return "", false
+			},
+			expIsRemote: false,
+		},
+		{
+			name: "single WS URL",
+			envLookup: func(key string) (string, bool) {
+				return "WS_URL", true
+			},
+			expIsRemote:    true,
+			expValidWSURLs: []string{"WS_URL"},
+		},
+		{
+			name: "multiple WS URL",
+			envLookup: func(key string) (string, bool) {
+				return "WS_URL_1,WS_URL_2,WS_URL_3", true
+			},
+			expIsRemote:    true,
+			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2", "WS_URL_3"},
+		},
+		{
+			name: "ending comma is handled",
+			envLookup: func(key string) (string, bool) {
+				return "WS_URL_1,WS_URL_2,", true
+			},
+			expIsRemote:    true,
+			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2"},
+		},
+		{
+			name: "void string does not panic",
+			envLookup: func(key string) (string, bool) {
+				return "", true
+			},
+			expIsRemote:    true,
+			expValidWSURLs: []string{""},
+		},
+		{
+			name: "comma does not panic",
+			envLookup: func(key string) (string, bool) {
+				return ",", true
+			},
+			expIsRemote:    true,
+			expValidWSURLs: []string{""},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			wsURL, isRemote := IsRemoteBrowser(tc.envLookup)
+
+			require.Equal(t, tc.expIsRemote, isRemote)
+			if isRemote {
+				require.Contains(t, tc.expValidWSURLs, wsURL)
+			}
+		})
+	}
+}

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -3,6 +3,9 @@ package tests
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/browser"
 	"github.com/grafana/xk6-browser/chromium"
 	"github.com/grafana/xk6-browser/k6ext/k6test"
 )
@@ -17,4 +20,39 @@ func TestBrowserTypeConnect(t *testing.T) {
 
 	b := bt.Connect(tb.wsURL, nil)
 	b.NewPage(nil)
+}
+
+func TestBrowserTypeLaunchToConnect(t *testing.T) {
+	vu := k6test.NewVU(t)
+	tb := newTestBrowser(t)
+	bp := newTestBrowserProxy(t, tb)
+
+	// Export WS URL env var
+	// pointing to test browser proxy
+	t.Setenv("K6_BROWSER_WS_URL", bp.wsURL())
+
+	// We have to call launch method through JS API in Goja
+	// to take mapping layer into account, instead of calling
+	// BrowserType.Launch method directly
+	rt := vu.Runtime()
+	root := browser.New()
+	mod := root.NewModuleInstance(vu)
+	jsMod, ok := mod.Exports().Default.(*browser.JSModule)
+	require.Truef(t, ok, "unexpected default mod export type %T", mod.Exports().Default)
+
+	vu.MoveToVUContext()
+
+	require.NoError(t, rt.Set("chromium", jsMod.Chromium))
+	_, err := rt.RunString(`
+		const b = chromium.launch();
+		b.close();
+	`)
+	require.NoError(t, err)
+
+	// Verify the proxy, which's WS URL was set as
+	// K6_BROWSER_WS_URL, has received a connection req
+	require.True(t, bp.connected)
+	// Verify that no new process pids have been added
+	// to pid registry
+	require.Len(t, root.PidRegistry.Pids(), 0)
 }

--- a/tests/test_browser_proxy.go
+++ b/tests/test_browser_proxy.go
@@ -1,0 +1,124 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+// testBrowserProxy wraps a testBrowser and
+// proxies WS messages to/from it.
+type testBrowserProxy struct {
+	t testing.TB
+
+	mu sync.Mutex // avoid concurrent connect requests
+
+	tb *testBrowser
+	ts *httptest.Server
+
+	connected bool
+}
+
+func newTestBrowserProxy(tb testing.TB, b *testBrowser) *testBrowserProxy {
+	tb.Helper()
+
+	p := &testBrowserProxy{
+		t:  tb,
+		tb: b,
+	}
+	p.ts = httptest.NewServer(p.connHandler())
+
+	return p
+}
+
+func (p *testBrowserProxy) wsURL() string {
+	p.t.Helper()
+
+	tsURL, err := url.Parse(p.ts.URL)
+	if err != nil {
+		p.t.Fatalf("error parsing test server URL: %v", err)
+	}
+	return fmt.Sprintf("ws://%s", tsURL.Host)
+}
+
+func (p *testBrowserProxy) connHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+
+		upgrader := websocket.Upgrader{} // default options
+
+		// Upgrade in connection from client
+		in, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			p.t.Fatalf("error upgrading proxy connection: %v", err)
+		}
+		defer in.Close() //nolint:errcheck
+
+		// Connect to testBrowser CDP WS
+		out, _, err := websocket.DefaultDialer.Dial(p.tb.wsURL, nil)
+		if err != nil {
+			p.t.Fatalf("error connecting to test browser: %v", err)
+		}
+		defer out.Close() //nolint:errcheck
+
+		p.connected = true
+
+		// Stop proxy when test exits
+		ctx, cancel := context.WithCancel(context.Background())
+		p.t.Cleanup(func() {
+			cancel()     // stop forwarding mssgs
+			p.ts.Close() // close test server
+		})
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go p.fwdMssgs(ctx, in, out, &wg)
+		go p.fwdMssgs(ctx, out, in, &wg)
+
+		wg.Wait()
+	})
+}
+
+func (p *testBrowserProxy) fwdMssgs(ctx context.Context,
+	in, out *websocket.Conn, wg *sync.WaitGroup,
+) {
+	p.t.Helper()
+	defer wg.Done()
+
+LOOP:
+	for {
+		select {
+		case <-ctx.Done():
+			break LOOP
+		default:
+			mt, message, err := in.ReadMessage()
+			if err != nil {
+				var cerr *websocket.CloseError
+				if errors.As(err, &cerr) {
+					// If WS conn is closed, just return
+					return
+				}
+				p.t.Fatalf("error reading message: %v", err)
+			}
+
+			err = out.WriteMessage(mt, message)
+			if err != nil {
+				var cerr *websocket.CloseError
+				if errors.As(err, &cerr) {
+					// If WS conn is closed, just return
+					return
+				}
+				p.t.Fatalf("error writing message: %v", err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR modifies the `BrowserType.Launch` mapping function in order to transition to `BrowserType.Connect` if the browser is detected to be remote and the CDP WS URL is given by the environment. This is done to increase compatibility for using `launch` method in the JS API and transparently transition to `connect` if the browser is remotely handled and this set up is indicated by the environment.

Closes #808.