### PR TITLE
Add error handling to wildcard selectors

### DIFF
--- a/api/element_handle.go
+++ b/api/element_handle.go
@@ -27,8 +27,8 @@ type ElementHandle interface {
 	IsVisible() bool
 	OwnerFrame() Frame
 	Press(key string, opts goja.Value)
-	Query(selector string) ElementHandle
-	QueryAll(selector string) []ElementHandle
+	Query(selector string) (ElementHandle, error)
+	QueryAll(selector string) ([]ElementHandle, error)
 	Screenshot(opts goja.Value) goja.ArrayBuffer
 	ScrollIntoViewIfNeeded(opts goja.Value)
 	SelectOption(values goja.Value, opts goja.Value) []string

--- a/api/frame.go
+++ b/api/frame.go
@@ -35,8 +35,8 @@ type Frame interface {
 	// Locator creates and returns a new locator for this frame.
 	Locator(selector string, opts goja.Value) Locator
 	Name() string
-	Query(selector string) ElementHandle
-	QueryAll(selector string) []ElementHandle
+	Query(selector string) (ElementHandle, error)
+	QueryAll(selector string) ([]ElementHandle, error)
 	Page() Page
 	ParentFrame() Frame
 	Press(selector string, key string, opts goja.Value)

--- a/api/page.go
+++ b/api/page.go
@@ -51,8 +51,8 @@ type Page interface {
 	Pause()
 	Pdf(opts goja.Value) []byte
 	Press(selector string, key string, opts goja.Value)
-	Query(selector string) ElementHandle
-	QueryAll(selector string) []ElementHandle
+	Query(selector string) (ElementHandle, error)
+	QueryAll(selector string) ([]ElementHandle, error)
 	Reload(opts goja.Value) Response
 	Route(url goja.Value, handler goja.Callable)
 	Screenshot(opts goja.Value) goja.ArrayBuffer

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -245,21 +245,25 @@ func mapElementHandle(vu moduleVU, eh api.ElementHandle) mapping {
 			return rt.ToValue(ehm).ToObject(rt)
 		},
 	}
-	maps["$"] = func(selector string) *goja.Object {
-		eh := eh.Query(selector)
+	maps["$"] = func(selector string) (mapping, error) {
+		eh, err := eh.Query(selector)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
 		ehm := mapElementHandle(vu, eh)
-		return rt.ToValue(ehm).ToObject(rt)
+		return ehm, nil
 	}
-	maps["$$"] = func(selector string) *goja.Object {
-		var (
-			mehs []mapping
-			ehs  = eh.QueryAll(selector)
-		)
+	maps["$$"] = func(selector string) ([]mapping, error) {
+		ehs, err := eh.QueryAll(selector)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+		var mehs []mapping
 		for _, eh := range ehs {
 			ehm := mapElementHandle(vu, eh)
 			mehs = append(mehs, ehm)
 		}
-		return rt.ToValue(mehs).ToObject(rt)
+		return mehs, nil
 	}
 
 	jsHandleMap := mapJSHandle(vu, eh)
@@ -377,21 +381,25 @@ func mapFrame(vu moduleVU, f api.Frame) mapping {
 		},
 		"waitForTimeout": f.WaitForTimeout,
 	}
-	maps["$"] = func(selector string) *goja.Object {
-		eh := f.Query(selector)
+	maps["$"] = func(selector string) (mapping, error) {
+		eh, err := f.Query(selector)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
 		ehm := mapElementHandle(vu, eh)
-		return rt.ToValue(ehm).ToObject(rt)
+		return ehm, nil
 	}
-	maps["$$"] = func(selector string) *goja.Object {
-		var (
-			mehs []mapping
-			ehs  = f.QueryAll(selector)
-		)
+	maps["$$"] = func(selector string) ([]mapping, error) {
+		ehs, err := f.QueryAll(selector)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+		var mehs []mapping
 		for _, eh := range ehs {
 			ehm := mapElementHandle(vu, eh)
 			mehs = append(mehs, ehm)
 		}
-		return rt.ToValue(mehs).ToObject(rt)
+		return mehs, nil
 	}
 
 	return maps
@@ -540,21 +548,25 @@ func mapPage(vu moduleVU, p api.Page) mapping {
 			return rt.ToValue(mws).ToObject(rt)
 		},
 	}
-	maps["$"] = func(selector string) *goja.Object {
-		eh := p.Query(selector)
+	maps["$"] = func(selector string) (mapping, error) {
+		eh, err := p.Query(selector)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
 		ehm := mapElementHandle(vu, eh)
-		return rt.ToValue(ehm).ToObject(rt)
+		return ehm, nil
 	}
-	maps["$$"] = func(selector string) *goja.Object {
-		var (
-			mehs []mapping
-			ehs  = p.QueryAll(selector)
-		)
+	maps["$$"] = func(selector string) ([]mapping, error) {
+		ehs, err := p.QueryAll(selector)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+		var mehs []mapping
 		for _, eh := range ehs {
 			ehm := mapElementHandle(vu, eh)
 			mehs = append(mehs, ehm)
 		}
-		return rt.ToValue(mehs).ToObject(rt)
+		return mehs, nil
 	}
 
 	return maps

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1023,7 +1023,7 @@ func (h *ElementHandle) Press(key string, opts goja.Value) {
 
 // Query runs "element.querySelector" within the page. If no element matches the selector,
 // the return value resolves to "null".
-func (h *ElementHandle) Query(selector string) api.ElementHandle {
+func (h *ElementHandle) Query(selector string) (api.ElementHandle, error) {
 	parsedSelector, err := NewSelector(selector)
 	if err != nil {
 		k6ext.Panic(h.ctx, "parsing selector %q: %w", selector, err)
@@ -1039,35 +1039,35 @@ func (h *ElementHandle) Query(selector string) api.ElementHandle {
 	}
 	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector)
 	if err != nil {
-		k6ext.Panic(h.ctx, "querying selector %q: %w", selector, err)
+		return nil, fmt.Errorf("querying selector %q: %w", selector, err)
 	}
 	if result == nil {
-		return nil
+		return nil, fmt.Errorf("querying selector %q", selector)
+	}
+	handle, ok := result.(api.JSHandle)
+	if !ok {
+		return nil, fmt.Errorf("querying selector %q, wrong type %T", selector, result)
+	}
+	element := handle.AsElement()
+	if element == nil {
+		handle.Dispose()
+		return nil, fmt.Errorf("querying selector %q", selector)
 	}
 
-	var (
-		handle  = result.(api.JSHandle)
-		element = handle.AsElement()
-	)
-	applySlowMo(h.ctx)
-	if element != nil {
-		return element
-	}
-	handle.Dispose()
-	return nil
+	return element, nil
 }
 
 // QueryAll queries element subtree for matching elements.
 // If no element matches the selector, the return value resolves to "null".
-func (h *ElementHandle) QueryAll(selector string) []api.ElementHandle {
+func (h *ElementHandle) QueryAll(selector string) ([]api.ElementHandle, error) {
 	defer applySlowMo(h.ctx)
 
 	handles, err := h.queryAll(selector, h.evalWithScript)
 	if err != nil {
-		k6ext.Panic(h.ctx, "querying all selector %q: %w", selector, err)
+		return nil, fmt.Errorf("querying all selector %q: %w", selector, err)
 	}
 
-	return handles
+	return handles, err
 }
 
 func (h *ElementHandle) queryAll(selector string, eval evalFunc) ([]api.ElementHandle, error) {

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1067,7 +1067,7 @@ func (h *ElementHandle) QueryAll(selector string) ([]api.ElementHandle, error) {
 		return nil, fmt.Errorf("querying all selector %q: %w", selector, err)
 	}
 
-	return handles, err
+	return handles, nil
 }
 
 func (h *ElementHandle) queryAll(selector string, eval evalFunc) ([]api.ElementHandle, error) {

--- a/common/frame.go
+++ b/common/frame.go
@@ -1304,32 +1304,25 @@ func (f *Frame) Name() string {
 
 // Query runs a selector query against the document tree, returning the first matching element or
 // "null" if no match is found.
-func (f *Frame) Query(selector string) api.ElementHandle {
+func (f *Frame) Query(selector string) (api.ElementHandle, error) {
 	f.log.Debugf("Frame:Query", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
 	document, err := f.document()
 	if err != nil {
 		k6ext.Panic(f.ctx, "getting document: %w", err)
 	}
-	value := document.Query(selector)
-	if value != nil {
-		return value
-	}
-	return nil
+	return document.Query(selector)
 }
 
-func (f *Frame) QueryAll(selector string) []api.ElementHandle {
+// QueryAll runs a selector query against the document tree, returning all matching elements.
+func (f *Frame) QueryAll(selector string) ([]api.ElementHandle, error) {
 	f.log.Debugf("Frame:QueryAll", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
 	document, err := f.document()
 	if err != nil {
 		k6ext.Panic(f.ctx, "getting document: %w", err)
 	}
-	value := document.QueryAll(selector)
-	if value != nil {
-		return value
-	}
-	return nil
+	return document.QueryAll(selector)
 }
 
 // Page returns page that owns frame.

--- a/common/page.go
+++ b/common/page.go
@@ -675,13 +675,15 @@ func (p *Page) Press(selector string, key string, opts goja.Value) {
 	p.MainFrame().Press(selector, key, opts)
 }
 
-func (p *Page) Query(selector string) api.ElementHandle {
+// Query returns the first element matching the specified selector.
+func (p *Page) Query(selector string) (api.ElementHandle, error) {
 	p.logger.Debugf("Page:Query", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.frameManager.MainFrame().Query(selector)
 }
 
-func (p *Page) QueryAll(selector string) []api.ElementHandle {
+// QueryAll returns all elements matching the specified selector.
+func (p *Page) QueryAll(selector string) ([]api.ElementHandle, error) {
 	p.logger.Debugf("Page:QueryAll", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.frameManager.MainFrame().QueryAll(selector)

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -31,7 +31,8 @@ func TestKeyboardPress(t *testing.T) {
 		kb := p.GetKeyboard()
 
 		p.SetContent(`<input>`, nil)
-		el := p.Query("input")
+		el, err := p.Query("input")
+		require.NoError(t, err)
 		p.Focus("input", nil)
 
 		kb.Type("Hello World!", nil)
@@ -46,7 +47,8 @@ func TestKeyboardPress(t *testing.T) {
 		kb := p.GetKeyboard()
 
 		p.SetContent(`<input>`, nil)
-		el := p.Query("input")
+		el, err := p.Query("input")
+		require.NoError(t, err)
 		p.Focus("input", nil)
 
 		kb.Press("Shift++", nil)
@@ -70,7 +72,8 @@ func TestKeyboardPress(t *testing.T) {
 		kb := p.GetKeyboard()
 
 		p.SetContent(`<input>`, nil)
-		el := p.Query("input")
+		el, err := p.Query("input")
+		require.NoError(t, err)
 		p.Focus("input", nil)
 
 		kb.Press("Shift+KeyA", nil)
@@ -93,7 +96,8 @@ func TestKeyboardPress(t *testing.T) {
 		kb := p.GetKeyboard()
 
 		p.SetContent(`<textarea>`, nil)
-		el := p.Query("textarea")
+		el, err := p.Query("textarea")
+		require.NoError(t, err)
 		p.Focus("textarea", nil)
 
 		kb.Type("L+m+KeyN", nil)
@@ -105,7 +109,8 @@ func TestKeyboardPress(t *testing.T) {
 		kb := p.GetKeyboard()
 
 		p.SetContent(`<textarea>`, nil)
-		el := p.Query("textarea")
+		el, err := p.Query("textarea")
+		require.NoError(t, err)
 		p.Focus("textarea", nil)
 
 		kb.Press("C", nil)
@@ -129,7 +134,8 @@ func TestKeyboardPress(t *testing.T) {
 		kb := p.GetKeyboard()
 
 		p.SetContent(`<textarea>`, nil)
-		el := p.Query("textarea")
+		el, err := p.Query("textarea")
+		require.NoError(t, err)
 		p.Focus("textarea", nil)
 
 		kb.Down("Shift")
@@ -144,7 +150,8 @@ func TestKeyboardPress(t *testing.T) {
 		kb := p.GetKeyboard()
 
 		p.SetContent(`<textarea>`, nil)
-		el := p.Query("textarea")
+		el, err := p.Query("textarea")
+		require.NoError(t, err)
 		p.Focus("textarea", nil)
 
 		kb.Type("Hello", nil)
@@ -160,7 +167,8 @@ func TestKeyboardPress(t *testing.T) {
 		kb := p.GetKeyboard()
 
 		p.SetContent(`<input>`, nil)
-		el := p.Query("input")
+		el, err := p.Query("input")
+		require.NoError(t, err)
 		p.Focus("input", nil)
 
 		kb.Type("Hello World!", nil)

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -305,7 +305,8 @@ func TestPageInputSpecialCharacters(t *testing.T) {
 	p := newTestBrowser(t).NewPage(nil)
 
 	p.SetContent(`<input id="special">`, nil)
-	el := p.Query("#special")
+	el, err := p.Query("#special")
+	require.NoError(t, err)
 
 	wants := []string{
 		"test@k6.io",


### PR DESCRIPTION
This allows us to:
- Better handle extension errors.
- Leaves the decision of **properly handling errors** to Goja when an element is not found. This is how it's done in the k6-core and other extensions.

Returning an error from the mapping layer also allows us to prevent multiple unnecesary panics.


<details>
<summary>You can use this script to test the behavior (main and this branch)</summary>

```js
import { check } from 'k6';
import { chromium } from 'k6/x/browser';

export const options = {
  thresholds: {
    checks: ["rate==1.0"]
  }
}

export default async function() {
  const browser = chromium.launch({
    headless: __ENV.XK6_HEADLESS ? true : false,
  });
  const context = browser.newContext();
  const page = context.newPage();

  try {
    await page.goto('https://test.k6.io/');

    check(page, {
      'Title with CSS selector':
        p => {
          console.log('checking page textcontext');
          return p.$('header h1.titlex').textContent() == 'test.k6.io'
        },
    });
  } finally {
    page.close();
    browser.close();
  }
}
```

</details>

<details>
<summary>Error output (current v0.8.0)</summary>

```
ERRO[0001] panic: runtime error: invalid memory address or nil pointer dereference
goroutine 68 [running]:
runtime/debug.Stack()
        runtime/debug/stack.go:24 +0x64
go.k6.io/k6/js/common.RunWithPanicCatching.func1()
        go.k6.io/k6@v0.42.1-0.20230130080633-582ec4d3940c/js/common/util.go:82 +0x190
panic({0x101be1820, 0x102a6d620})
        runtime/panic.go:884 +0x1f4
github.com/dop251/goja.(*Runtime).runWrapped.func1()
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2480 +0x168
panic({0x101be1820, 0x102a6d620})
        runtime/panic.go:884 +0x1f4
github.com/dop251/goja.(*vm).handleThrow(0x140005fc240, {0x101be1820, 0x102a6d620})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:730 +0x334
github.com/dop251/goja.(*vm).try.func1()
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:749 +0x48
panic({0x101be1820, 0x102a6d620})
        runtime/panic.go:884 +0x1f4
github.com/dop251/goja.(*vm).handleThrow(0x140005fc240, {0x101be1820, 0x102a6d620})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:730 +0x334
github.com/dop251/goja.(*vm).runTryInner.func1()
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:772 +0x48
panic({0x101be1820, 0x102a6d620})
        runtime/panic.go:884 +0x1f4
github.com/dop251/goja.(*Runtime).runWrapped.func1()
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2480 +0x168
panic({0x101be1820, 0x102a6d620})
        runtime/panic.go:884 +0x1f4
github.com/dop251/goja.(*vm).handleThrow(0x140005fc240, {0x101be1820, 0x102a6d620})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:730 +0x334
github.com/dop251/goja.(*vm).try.func1()
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:749 +0x48
panic({0x101be1820, 0x102a6d620})
        runtime/panic.go:884 +0x1f4
github.com/dop251/goja.(*vm).handleThrow(0x140005fc240, {0x101be1820, 0x102a6d620})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:730 +0x334
github.com/dop251/goja.(*vm).runTryInner.func1()
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:772 +0x48
panic({0x101be1820, 0x102a6d620})
        runtime/panic.go:884 +0x1f4
github.com/grafana/xk6-browser/browser.mapElementHandle({{0x101debdc0?, 0x14001a0c990?}, 0x140004127e0?}, {0x0?, 0x0})
        github.com/grafana/xk6-browser@v0.0.0-00010101000000-000000000000/browser/mapping.go:198 +0x70
github.com/grafana/xk6-browser/browser.mapPage.func12({0x1400119c400?, 0x1?})
        github.com/grafana/xk6-browser@v0.0.0-00010101000000-000000000000/browser/mapping.go:545 +0x70
reflect.Value.call({0x101b8d9e0?, 0x140006a8900?, 0x10a3c1688?}, {0x1017d290b, 0x4}, {0x140005c6bb8, 0x1, 0x0?})
        reflect/value.go:586 +0x838
reflect.Value.Call({0x101b8d9e0?, 0x140006a8900?, 0x1400119f880?}, {0x140005c6bb8?, 0x140025148e0?, 0x280?})
        reflect/value.go:370 +0x90
github.com/dop251/goja.(*Runtime).wrapReflectFunc.func1({{0x101df6c98, 0x14001f6aba0}, {0x140025602b0, 0x1, 0xd}})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2020 +0x2d8
github.com/dop251/goja.(*nativeFuncObject).vmCall(0x14001c9ad80, 0x140005fc240, 0x1)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/func.go:511 +0x178
github.com/dop251/goja.call.exec(0x5fc240?, 0x140005fc240)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:3308 +0x74
github.com/dop251/goja.(*vm).run(0x140005fc240)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:567 +0x40
github.com/dop251/goja.(*vm).runTryInner(0x140005fc240?)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:776 +0x58
github.com/dop251/goja.(*baseJsFuncObject).__call(0x140025421c0, {0x140025147b0?, 0x1, 0x140010023e0?}, {0x0?, 0x0}, {0x0?, 0x0?})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/func.go:378 +0x638
github.com/dop251/goja.(*baseJsFuncObject)._call(...)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/func.go:394
github.com/dop251/goja.(*arrowFuncObject).Call(0x101baea60?, {{0x101df7580, 0x102ac5f40}, {0x140025147b0, 0x1, 0x1}})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/func.go:338 +0x54
github.com/dop251/goja.AssertFunction.func1.1()
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2440 +0x6c
github.com/dop251/goja.(*vm).try(0x140005fc240, 0x14001ca2508)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:753 +0x1dc
github.com/dop251/goja.(*Runtime).runWrapped(0x140000bc800, 0x102fe0f18?)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2484 +0x64
github.com/dop251/goja.AssertFunction.func1({0x101df7580?, 0x102ac5f40?}, {0x140025147b0?, 0x14002782120?, 0x17?})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2439 +0x78
go.k6.io/k6/js/modules/k6.(*K6).Check(0x14001c94170, {0x101df6c98?, 0x14001f6aba0}, {0x101df6c98, 0x1400252a720}, {0x102ac6318, 0x0, 0x100a46570?})
        go.k6.io/k6@v0.42.1-0.20230130080633-582ec4d3940c/js/modules/k6/k6.go:182 +0x2f4
reflect.Value.call({0x101bdd260?, 0x14001c94180?, 0x10a3c1688?}, {0x1017d290b, 0x4}, {0x1400252a810, 0x2, 0x0?})
        reflect/value.go:586 +0x838
reflect.Value.Call({0x101bdd260?, 0x14001c94180?, 0x1400252a720?}, {0x1400252a810?, 0x140025146d0?, 0x1009b3fa4?})
        reflect/value.go:370 +0x90
github.com/dop251/goja.(*Runtime).wrapReflectFunc.func1({{0x101df7580, 0x102ac5f40}, {0x14002542160, 0x2, 0x6}})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2020 +0x2d8
github.com/dop251/goja.(*nativeFuncObject).vmCall(0x14001c9ac00, 0x140005fc240, 0x2)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/func.go:511 +0x178
github.com/dop251/goja.call.exec(0x5fc240?, 0x140005fc240)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:3308 +0x74
github.com/dop251/goja.(*vm).run(0x140005fc240)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:567 +0x40
github.com/dop251/goja.(*vm).runTryInner(0x140012a3530?)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:776 +0x58
github.com/dop251/goja.(*generator).step(0x14001da01e0)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/func.go:722 +0x30
github.com/dop251/goja.(*generator).next(0x14001da01e0, {0x101df6c98, 0x1400252a5d0})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/func.go:756 +0x16c
github.com/dop251/goja.(*asyncRunner).onFulfilled(0x14001da01e0, {{0x101df7580, 0x102ac5f40}, {0x14002514660, 0x1, 0x1}})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/func.go:636 +0x128
github.com/dop251/goja.(*Runtime).callJobCallback(...)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2898
github.com/dop251/goja.(*Runtime).newPromiseReactionJob.func1.1()
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/builtin_promise.go:204 +0xe0
github.com/dop251/goja.(*vm).try(0x140005fc240, 0x14001ca3500)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:753 +0x1dc
github.com/dop251/goja.(*Runtime).newPromiseReactionJob.func1()
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/builtin_promise.go:203 +0xa0
github.com/dop251/goja.(*Runtime).leave(0x140000bc800)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2771 +0xec
github.com/dop251/goja.(*Runtime).runWrapped(0x140000bc800, 0x102fe0f18?)
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2489 +0xf0
github.com/dop251/goja.AssertFunction.func1({0x0?, 0x0?}, {0x14002514650?, 0x0?, 0x0?})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2439 +0x78
github.com/dop251/goja.(*Runtime).wrapPromiseReaction.func1({0x101bd6a40?, 0x1400252a5a0?})
        github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/builtin_promise.go:576 +0xa8
github.com/grafana/xk6-browser/k6ext.promise.func1.1()
        github.com/grafana/xk6-browser@v0.0.0-00010101000000-000000000000/k6ext/promise.go:46 +0x70
go.k6.io/k6/js/eventloop.(*EventLoop).Start(0x140005f85f0, 0x14001d12a20)
        go.k6.io/k6@v0.42.1-0.20230130080633-582ec4d3940c/js/eventloop/eventloop.go:171 +0x164
go.k6.io/k6/js.(*VU).runFn.func2()
        go.k6.io/k6@v0.42.1-0.20230130080633-582ec4d3940c/js/runner.go:795 +0xe4
go.k6.io/k6/js/common.RunWithPanicCatching({0x101dfa9e8?, 0x1400070aa80?}, 0x14001b45200?, 0x14001b45288?)
        go.k6.io/k6@v0.42.1-0.20230130080633-582ec4d3940c/js/common/util.go:86 +0x74
go.k6.io/k6/js.(*VU).runFn(0x14001c9a780, {0x101de9368, 0x140005f9680}, 0x80?, 0x140000b0ab0, 0x14001c94d60, {0x14001c94d70, 0x1, 0x1})
        go.k6.io/k6@v0.42.1-0.20230130080633-582ec4d3940c/js/runner.go:794 +0x1e8
go.k6.io/k6/js.(*ActiveVU).RunOnce(0x1400067ae40)
        go.k6.io/k6@v0.42.1-0.20230130080633-582ec4d3940c/js/runner.go:739 +0x348
go.k6.io/k6/lib/executor.getIterationRunner.func1({0x101de9410, 0x14001d12810}, {0x101dddcf8?, 0x1400067ae40?})
        go.k6.io/k6@v0.42.1-0.20230130080633-582ec4d3940c/lib/executor/helpers.go:81 +0x4c
go.k6.io/k6/lib/executor.PerVUIterations.Run.func5({0x101de4508, 0x14001c9a780})
        go.k6.io/k6@v0.42.1-0.20230130080633-582ec4d3940c/lib/executor/per_vu_iterations.go:227 +0x378
created by go.k6.io/k6/lib/executor.PerVUIterations.Run
        go.k6.io/k6@v0.42.1-0.20230130080633-582ec4d3940c/lib/executor/per_vu_iterations.go:240 +0x9bc

Goja stack: 
ERRO[0001] communicating with browser: websocket: close 1006 (abnormal closure): unexpected EOF  category=cdp elapsed="0 ms" goroutine=16
ERRO[0001] process with PID 5864 unexpectedly ended: signal: killed  category=browser elapsed="0 ms" goroutine=72
```

</details>

<details>
<summary>Error output (this PR)</summary>

```
ERRO[0001] Uncaught (in promise) GoError: querying selector "header h1.titlex"
        at github.com/grafana/xk6-browser/browser.mapPage.func12 (native)
        at Title with CSS selector (file:///Users/inanc/grafana/k6browser/tests/issue814.js:24:21(9))
        at go.k6.io/k6/js/modules/k6.(*K6).Check-fm (native)
        at file:///Users/inanc/grafana/k6browser/tests/issue814.js:20:10(36)  executor=per-vu-iterations scenario=default
```

</details>

<details>
<summary>The error output if we panicked in the mapping layer, instead.</summary>

```
ERRO[0001] communicating with browser: read tcp 127.0.0.1:56064->127.0.0.1:56063: read: connection reset by peer  category=cdp elapsed="0 ms" goroutine=82
ERRO[0001] process with PID 6834 unexpectedly ended: signal: killed  category=browser elapsed="0 ms" goroutine=47
ERRO[0001] Uncaught (in promise) GoError: disposing browser context: disposing browser context ID 51E2EDDC7717E43861E3C62287000B86: read tcp 127.0.0.1:56064->127.0.0.1:56063: read: connection reset by peer
        at github.com/grafana/xk6-browser/api.Page.Close-fm (native)
        at file:///Users/inanc/grafana/k6browser/tests/issue814.js:28:4(41)  executor=per-vu-iterations scenario=default
```

The error from `$` is swallowed. Even if we silence the `close` panic and log, this happens:

```
ERRO[0001] communicating with browser: read tcp 127.0.0.1:56106->127.0.0.1:56105: read: connection reset by peer  category=cdp elapsed="0 ms" goroutine=78
ERRO[0001] process with PID 8012 unexpectedly ended: signal: killed  category=browser elapsed="0 ms" goroutine=75
WARN[0001] bctxid:FBF0BEA2D27232D0C863AC0FAE541A44 err:disposing browser context ID FBF0BEA2D27232D0C863AC0FAE541A44: read tcp 127.0.0.1:56106->127.0.0.1:56105: read: connection reset by peer  category="BrowserContext:Close" elapsed="1 ms" goroutine=71
ERRO[0001] Uncaught (in promise) GoError: closing the browser: canceled
        at github.com/grafana/xk6-browser/api.Browser.Close-fm (native)
        at file:///Users/inanc/grafana/k6browser/tests/issue814.js:29:4(45)  executor=per-vu-iterations scenario=default
```

If we also log in the `Browser.Close` instead of panicking, this happens:

```
ERRO[0001] communicating with browser: read tcp 127.0.0.1:56137->127.0.0.1:56136: read: connection reset by peer  category=cdp elapsed="0 ms" goroutine=82
ERRO[0001] process with PID 8893 unexpectedly ended: signal: killed  category=browser elapsed="0 ms" goroutine=71
WARN[0001] bctxid:B727D7F1443FCF198513661E5F5BEFED err:disposing browser context ID B727D7F1443FCF198513661E5F5BEFED: read tcp 127.0.0.1:56137->127.0.0.1:56136: read: connection reset by peer  category="BrowserContext:Close" elapsed="1 ms" goroutine=67
WARN[0001] closing the browser: context canceled         category="Browser:Close" elapsed="0 ms" goroutine=67
ERRO[0001] Uncaught (in promise) GoError: could not find element with selector "header h1.titlex"
        at github.com/grafana/xk6-browser/browser.mapPage.func12 (native)
        at Title with CSS selector (file:///Users/inanc/grafana/k6browser/tests/issue814.js:24:21(9))
        at go.k6.io/k6/js/modules/k6.(*K6).Check-fm (native)
        at file:///Users/inanc/grafana/k6browser/tests/issue814.js:20:10(36)  executor=per-vu-iterations scenario=default
```

</details>

Updates: #804
Related: #688