### PR TITLE
Fix Edge-case: Mapping fails if the extension code returns nil values #804

### DIFF
--- a/api/browser.go
+++ b/api/browser.go
@@ -8,7 +8,7 @@ type Browser interface {
 	Contexts() []BrowserContext
 	IsConnected() bool
 	NewContext(opts goja.Value) BrowserContext
-	NewPage(opts goja.Value) Page
+	NewPage(opts goja.Value) (Page, error)
 	On(string) (bool, error)
 	UserAgent() string
 	Version() string

--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -17,7 +17,7 @@ type BrowserContext interface {
 	ExposeFunction(name string, callback goja.Callable)
 	GrantPermissions(permissions []string, opts goja.Value)
 	NewCDPSession() CDPSession
-	NewPage() Page
+	NewPage() (Page, error)
 	Pages() []Page
 	Route(url goja.Value, handler goja.Callable)
 	SetDefaultNavigationTimeout(timeout int64)

--- a/api/element_handle.go
+++ b/api/element_handle.go
@@ -25,7 +25,7 @@ type ElementHandle interface {
 	IsEnabled() bool
 	IsHidden() bool
 	IsVisible() bool
-	OwnerFrame() Frame
+	OwnerFrame() (Frame, error)
 	Press(key string, opts goja.Value)
 	Query(selector string) (ElementHandle, error)
 	QueryAll(selector string) ([]ElementHandle, error)

--- a/api/element_handle.go
+++ b/api/element_handle.go
@@ -39,5 +39,5 @@ type ElementHandle interface {
 	Type(text string, opts goja.Value)
 	Uncheck(opts goja.Value)
 	WaitForElementState(state string, opts goja.Value)
-	WaitForSelector(selector string, opts goja.Value) ElementHandle
+	WaitForSelector(selector string, opts goja.Value) (ElementHandle, error)
 }

--- a/api/element_handle.go
+++ b/api/element_handle.go
@@ -9,7 +9,7 @@ type ElementHandle interface {
 	BoundingBox() *Rect
 	Check(opts goja.Value)
 	Click(opts goja.Value) error
-	ContentFrame() Frame
+	ContentFrame() (Frame, error)
 	Dblclick(opts goja.Value)
 	DispatchEvent(typ string, props goja.Value)
 	Fill(value string, opts goja.Value)

--- a/api/frame.go
+++ b/api/frame.go
@@ -52,6 +52,6 @@ type Frame interface {
 	WaitForFunction(pageFunc, opts goja.Value, args ...goja.Value) (any, error)
 	WaitForLoadState(state string, opts goja.Value)
 	WaitForNavigation(opts goja.Value) (Response, error)
-	WaitForSelector(selector string, opts goja.Value) ElementHandle
+	WaitForSelector(selector string, opts goja.Value) (ElementHandle, error)
 	WaitForTimeout(timeout int64)
 }

--- a/api/frame.go
+++ b/api/frame.go
@@ -16,7 +16,7 @@ type Frame interface {
 	EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (JSHandle, error)
 	Fill(selector string, value string, opts goja.Value)
 	Focus(selector string, opts goja.Value)
-	FrameElement() ElementHandle
+	FrameElement() (ElementHandle, error)
 	GetAttribute(selector string, name string, opts goja.Value) goja.Value
 	Goto(url string, opts goja.Value) (Response, error)
 	Hover(selector string, opts goja.Value)

--- a/api/frame.go
+++ b/api/frame.go
@@ -13,7 +13,7 @@ type Frame interface {
 	Dblclick(selector string, opts goja.Value)
 	DispatchEvent(selector string, typ string, eventInit goja.Value, opts goja.Value)
 	Evaluate(pageFunc goja.Value, args ...goja.Value) any
-	EvaluateHandle(pageFunc goja.Value, args ...goja.Value) JSHandle
+	EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (JSHandle, error)
 	Fill(selector string, value string, opts goja.Value)
 	Focus(selector string, opts goja.Value)
 	FrameElement() ElementHandle

--- a/api/js_handle.go
+++ b/api/js_handle.go
@@ -11,7 +11,7 @@ type JSHandle interface {
 	Dispose()
 	Evaluate(pageFunc goja.Value, args ...goja.Value) any
 	EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (JSHandle, error)
-	GetProperties() map[string]JSHandle
+	GetProperties() (map[string]JSHandle, error)
 	GetProperty(propertyName string) JSHandle
 	JSONValue() goja.Value
 	ObjectID() cdpruntime.RemoteObjectID

--- a/api/js_handle.go
+++ b/api/js_handle.go
@@ -10,7 +10,7 @@ type JSHandle interface {
 	AsElement() ElementHandle
 	Dispose()
 	Evaluate(pageFunc goja.Value, args ...goja.Value) any
-	EvaluateHandle(pageFunc goja.Value, args ...goja.Value) JSHandle
+	EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (JSHandle, error)
 	GetProperties() map[string]JSHandle
 	GetProperty(propertyName string) JSHandle
 	JSONValue() goja.Value

--- a/api/page.go
+++ b/api/page.go
@@ -78,7 +78,7 @@ type Page interface {
 	WaitForNavigation(opts goja.Value) (Response, error)
 	WaitForRequest(urlOrPredicate, opts goja.Value) Request
 	WaitForResponse(urlOrPredicate, opts goja.Value) Response
-	WaitForSelector(selector string, opts goja.Value) ElementHandle
+	WaitForSelector(selector string, opts goja.Value) (ElementHandle, error)
 	WaitForTimeout(timeout int64)
 	Workers() []Worker
 }

--- a/api/page.go
+++ b/api/page.go
@@ -19,7 +19,7 @@ type Page interface {
 	EmulateMedia(opts goja.Value)
 	EmulateVisionDeficiency(typ string)
 	Evaluate(pageFunc goja.Value, arg ...goja.Value) any
-	EvaluateHandle(pageFunc goja.Value, arg ...goja.Value) JSHandle
+	EvaluateHandle(pageFunc goja.Value, arg ...goja.Value) (JSHandle, error)
 	ExposeBinding(name string, callback goja.Callable, opts goja.Value)
 	ExposeFunction(name string, callback goja.Callable)
 	Fill(selector string, value string, opts goja.Value)

--- a/api/worker.go
+++ b/api/worker.go
@@ -5,6 +5,6 @@ import "github.com/dop251/goja"
 // Worker is the interface of a web worker.
 type Worker interface {
 	Evaluate(pageFunc goja.Value, args ...goja.Value) any
-	EvaluateHandle(pageFunc goja.Value, args ...goja.Value) JSHandle
+	EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (JSHandle, error)
 	URL() string
 }

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -662,10 +662,12 @@ func mapBrowserContext(vu moduleVU, bc api.BrowserContext) mapping {
 
 			return rt.ToValue(mpages).ToObject(rt)
 		},
-		"newPage": func() *goja.Object {
-			page := bc.NewPage()
-			m := mapPage(vu, page)
-			return rt.ToValue(m).ToObject(rt)
+		"newPage": func() (mapping, error) {
+			page, err := bc.NewPage()
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return mapPage(vu, page), nil
 		},
 	}
 }
@@ -689,10 +691,12 @@ func mapBrowser(vu moduleVU, b api.Browser) mapping {
 			m := mapBrowserContext(vu, bctx)
 			return rt.ToValue(m).ToObject(rt)
 		},
-		"newPage": func(opts goja.Value) *goja.Object {
-			page := b.NewPage(opts)
-			m := mapPage(vu, page)
-			return rt.ToValue(m).ToObject(rt)
+		"newPage": func(opts goja.Value) (mapping, error) {
+			page, err := b.NewPage(opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return mapPage(vu, page), nil
 		},
 	}
 }

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -208,10 +208,12 @@ func mapElementHandle(vu moduleVU, eh api.ElementHandle) mapping {
 				return nil, err //nolint:wrapcheck
 			})
 		},
-		"contentFrame": func() *goja.Object {
-			f := eh.ContentFrame()
-			mf := mapFrame(vu, f)
-			return rt.ToValue(mf).ToObject(rt)
+		"contentFrame": func() (mapping, error) {
+			f, err := eh.ContentFrame()
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return mapFrame(vu, f), nil
 		},
 		"dblclick":      eh.Dblclick,
 		"dispatchEvent": eh.DispatchEvent,

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -230,10 +230,12 @@ func mapElementHandle(vu moduleVU, eh api.ElementHandle) mapping {
 		"isEnabled":     eh.IsEnabled,
 		"isHidden":      eh.IsHidden,
 		"isVisible":     eh.IsVisible,
-		"ownerFrame": func() *goja.Object {
-			f := eh.OwnerFrame()
-			mf := mapFrame(vu, f)
-			return rt.ToValue(mf).ToObject(rt)
+		"ownerFrame": func() (mapping, error) {
+			f, err := eh.OwnerFrame()
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return mapFrame(vu, f), nil
 		},
 		"press":                  eh.Press,
 		"screenshot":             eh.Screenshot,

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -171,12 +171,17 @@ func mapJSHandle(vu moduleVU, jsh api.JSHandle) mapping {
 			}
 			return mapJSHandle(vu, h), nil
 		},
-		"getProperties": func() *goja.Object {
+		"getProperties": func() (mapping, error) {
+			props, err := jsh.GetProperties()
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+
 			dst := make(map[string]any)
-			for k, v := range jsh.GetProperties() {
+			for k, v := range props {
 				dst[k] = mapJSHandle(vu, v)
 			}
-			return rt.ToValue(dst).ToObject(rt)
+			return dst, nil
 		},
 		"getProperty": func(propertyName string) *goja.Object {
 			var (

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -322,9 +322,12 @@ func mapFrame(vu moduleVU, f api.Frame) mapping {
 		},
 		"fill":  f.Fill,
 		"focus": f.Focus,
-		"frameElement": func() *goja.Object {
-			eh := mapElementHandle(vu, f.FrameElement())
-			return rt.ToValue(eh).ToObject(rt)
+		"frameElement": func() (mapping, error) {
+			fe, err := f.FrameElement()
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return mapElementHandle(vu, fe), nil
 		},
 		"getAttribute": f.GetAttribute,
 		"goto": func(url string, opts goja.Value) *goja.Promise {

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -164,12 +164,12 @@ func mapJSHandle(vu moduleVU, jsh api.JSHandle) mapping {
 		},
 		"dispose":  jsh.Dispose,
 		"evaluate": jsh.Evaluate,
-		"evaluateHandle": func(pageFunc goja.Value, args ...goja.Value) *goja.Object {
-			var (
-				h = jsh.EvaluateHandle(pageFunc, args...)
-				m = mapJSHandle(vu, h)
-			)
-			return rt.ToValue(m).ToObject(rt)
+		"evaluateHandle": func(pageFunc goja.Value, args ...goja.Value) (mapping, error) {
+			h, err := jsh.EvaluateHandle(pageFunc, args...)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return mapJSHandle(vu, h), nil
 		},
 		"getProperties": func() *goja.Object {
 			dst := make(map[string]any)
@@ -303,10 +303,12 @@ func mapFrame(vu moduleVU, f api.Frame) mapping {
 		"dblclick":      f.Dblclick,
 		"dispatchEvent": f.DispatchEvent,
 		"evaluate":      f.Evaluate,
-		"evaluateHandle": func(pageFunction goja.Value, args ...goja.Value) *goja.Object {
-			jsh := f.EvaluateHandle(pageFunction, args...)
-			ehm := mapJSHandle(vu, jsh)
-			return rt.ToValue(ehm).ToObject(rt)
+		"evaluateHandle": func(pageFunction goja.Value, args ...goja.Value) (mapping, error) {
+			jsh, err := f.EvaluateHandle(pageFunction, args...)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return mapJSHandle(vu, jsh), nil
 		},
 		"fill":  f.Fill,
 		"focus": f.Focus,
@@ -431,12 +433,12 @@ func mapPage(vu moduleVU, p api.Page) mapping {
 		"emulateMedia":            p.EmulateMedia,
 		"emulateVisionDeficiency": p.EmulateVisionDeficiency,
 		"evaluate":                p.Evaluate,
-		"evaluateHandle": func(pageFunc goja.Value, args ...goja.Value) *goja.Object {
-			var (
-				jsh = p.EvaluateHandle(pageFunc, args...)
-				m   = mapJSHandle(vu, jsh)
-			)
-			return rt.ToValue(m).ToObject(rt)
+		"evaluateHandle": func(pageFunc goja.Value, args ...goja.Value) (mapping, error) {
+			jsh, err := p.EvaluateHandle(pageFunc, args...)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return mapJSHandle(vu, jsh), nil
 		},
 		"exposeBinding":  p.ExposeBinding,
 		"exposeFunction": p.ExposeFunction,
@@ -574,13 +576,14 @@ func mapPage(vu moduleVU, p api.Page) mapping {
 
 // mapWorker to the JS module.
 func mapWorker(vu moduleVU, w api.Worker) mapping {
-	rt := vu.Runtime()
 	return mapping{
 		"evaluate": w.Evaluate,
-		"evaluateHandle": func(pageFunc goja.Value, args ...goja.Value) *goja.Object {
-			h := w.EvaluateHandle(pageFunc, args...)
-			m := mapJSHandle(vu, h)
-			return rt.ToValue(m).ToObject(rt)
+		"evaluateHandle": func(pageFunc goja.Value, args ...goja.Value) (mapping, error) {
+			h, err := w.EvaluateHandle(pageFunc, args...)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return mapJSHandle(vu, h), nil
 		},
 		"url": w.URL(),
 	}

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -602,6 +602,7 @@ func mapWorker(vu moduleVU, w api.Worker) mapping {
 		"evaluateHandle": func(pageFunc goja.Value, args ...goja.Value) (mapping, error) {
 			h, err := w.EvaluateHandle(pageFunc, args...)
 			if err != nil {
+				panicIfFatalError(vu.Context(), err)
 				return nil, err //nolint:wrapcheck
 			}
 			return mapJSHandle(vu, h), nil

--- a/common/browser.go
+++ b/common/browser.go
@@ -497,7 +497,7 @@ func (b *Browser) NewContext(opts goja.Value) api.BrowserContext {
 }
 
 // NewPage creates a new tab in the browser window.
-func (b *Browser) NewPage(opts goja.Value) api.Page {
+func (b *Browser) NewPage(opts goja.Value) (api.Page, error) {
 	browserCtx := b.NewContext(opts)
 	return browserCtx.NewPage()
 }

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -218,12 +218,12 @@ func (b *BrowserContext) NewCDPSession() api.CDPSession {
 }
 
 // NewPage creates a new page inside this browser context.
-func (b *BrowserContext) NewPage() api.Page {
+func (b *BrowserContext) NewPage() (api.Page, error) {
 	b.logger.Debugf("BrowserContext:NewPage", "bctxid:%v", b.id)
 
 	p, err := b.browser.newPageInContext(b.id)
 	if err != nil {
-		k6ext.Panic(b.ctx, "newPageInContext: %w", err)
+		return nil, fmt.Errorf("creating new page in browser context: %w", err)
 	}
 
 	var (
@@ -238,7 +238,7 @@ func (b *BrowserContext) NewPage() api.Page {
 	}
 	b.logger.Debugf("BrowserContext:NewPage:return", "bctxid:%v ptid:%s", bctxid, ptid)
 
-	return p
+	return p, nil
 }
 
 // Pages returns a list of pages inside this browser context.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1094,10 +1094,14 @@ func (h *ElementHandle) queryAll(selector string, eval evalFunc) ([]api.ElementH
 		return nil, fmt.Errorf("getting element handle for selector %q: %w", selector, ErrJSHandleInvalid)
 	}
 	defer handles.Dispose()
-	var (
-		props = handles.GetProperties()
-		els   = make([]api.ElementHandle, 0, len(props))
-	)
+
+	props, err := handles.GetProperties()
+	if err != nil {
+		// GetProperties has a rich error already, so we don't need to wrap it.
+		return nil, err //nolint:wrapcheck
+	}
+
+	els := make([]api.ElementHandle, 0, len(props))
 	for _, prop := range props {
 		if el := prop.AsElement(); el != nil {
 			els = append(els, el)

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -755,20 +755,21 @@ func (h *ElementHandle) Click(opts goja.Value) error {
 	return nil
 }
 
-func (h *ElementHandle) ContentFrame() api.Frame {
+// ContentFrame returns the frame that contains this element.
+func (h *ElementHandle) ContentFrame() (api.Frame, error) {
 	var (
 		node *cdp.Node
 		err  error
 	)
 	action := dom.DescribeNode().WithObjectID(h.remoteObject.ObjectID)
 	if node, err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-		k6ext.Panic(h.ctx, "getting remote node %q: %w", h.remoteObject.ObjectID, err)
+		return nil, fmt.Errorf("getting remote node %q: %w", h.remoteObject.ObjectID, err)
 	}
 	if node == nil || node.FrameID == "" {
-		return nil
+		return nil, fmt.Errorf("element is not an iframe")
 	}
 
-	return h.frame.manager.getFrameByID(node.FrameID)
+	return h.frame.manager.getFrameByID(node.FrameID), nil
 }
 
 func (h *ElementHandle) Dblclick(opts goja.Value) {

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -55,7 +55,11 @@ func (h *ElementHandle) boundingBox() (*Rect, error) {
 	y := math.Min(quad[1], math.Min(quad[3], math.Min(quad[5], quad[7])))
 	width := math.Max(quad[0], math.Max(quad[2], math.Max(quad[4], quad[6]))) - x
 	height := math.Max(quad[1], math.Max(quad[3], math.Max(quad[5], quad[7]))) - y
-	position := h.frame.position()
+
+	position, err := h.frame.position()
+	if err != nil {
+		return nil, err
+	}
 
 	return &Rect{X: x + position.X, Y: y + position.Y, Width: width, Height: height}, nil
 }
@@ -63,10 +67,11 @@ func (h *ElementHandle) boundingBox() (*Rect, error) {
 func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, point Position) (bool, error) {
 	frame := h.ownerFrame(apiCtx)
 	if frame != nil && frame.parentFrame != nil {
-		var (
-			el          = h.frame.FrameElement()
-			element, ok = el.(*ElementHandle)
-		)
+		el, err := h.frame.FrameElement()
+		if err != nil {
+			return false, err
+		}
+		element, ok := el.(*ElementHandle)
 		if !ok {
 			return false, fmt.Errorf("unexpected type %T", el)
 		}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1308,18 +1308,19 @@ func (h *ElementHandle) WaitForElementState(state string, opts goja.Value) {
 	}
 }
 
-func (h *ElementHandle) WaitForSelector(selector string, opts goja.Value) api.ElementHandle {
+// WaitForSelector waits for the selector to appear in the DOM.
+func (h *ElementHandle) WaitForSelector(selector string, opts goja.Value) (api.ElementHandle, error) {
 	parsedOpts := NewFrameWaitForSelectorOptions(h.defaultTimeout())
 	if err := parsedOpts.Parse(h.ctx, opts); err != nil {
-		k6ext.Panic(h.ctx, "parsing waitForSelector %q options: %w", selector, err)
+		return nil, fmt.Errorf("parsing waitForSelector %q options: %w", selector, err)
 	}
 
 	handle, err := h.waitForSelector(h.ctx, selector, parsedOpts)
 	if err != nil {
-		k6ext.Panic(h.ctx, "waiting for selector %q: %w", selector, err)
+		return nil, fmt.Errorf("waiting for selector %q: %w", selector, err)
 	}
 
-	return handle
+	return handle, nil
 }
 
 // evalWithScript evaluates the given js code in the scope of this ElementHandle and returns the result.

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -319,10 +319,10 @@ func (e *ExecutionContext) EvalHandle(
 	}
 	res, err := e.eval(apiCtx, opts, js.ToString().String(), evalArgs...)
 	if err != nil {
-		return nil, fmt.Errorf("evaluating handle: %w", err)
+		return nil, err
 	}
 	if res == nil {
-		return nil, fmt.Errorf("evaluating handle: result is nil")
+		return nil, errors.New("nil result")
 	}
 
 	return res.(api.JSHandle), nil

--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -319,8 +319,12 @@ func (e *ExecutionContext) EvalHandle(
 	}
 	res, err := e.eval(apiCtx, opts, js.ToString().String(), evalArgs...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("evaluating handle: %w", err)
 	}
+	if res == nil {
+		return nil, fmt.Errorf("evaluating handle: result is nil")
+	}
+
 	return res.(api.JSHandle), nil
 }
 

--- a/common/frame.go
+++ b/common/frame.go
@@ -757,14 +757,13 @@ func (f *Frame) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (handle 
 	{
 		ec := f.executionContexts[mainWorld]
 		if ec == nil {
-			k6ext.Panic(f.ctx, "evaluating handle: execution context %q not found", mainWorld)
+			k6ext.Panic(f.ctx, "evaluating handle for frame: execution context %q not found", mainWorld)
 		}
 		handle, err = ec.EvalHandle(f.ctx, pageFunc, args...)
 	}
 	f.executionContextMu.RUnlock()
 	if err != nil {
-		// EvalHandle has a rich error, nolinting.
-		return nil, err //nolint:wrapcheck
+		return nil, fmt.Errorf("evaluating handle for frame: %w", err)
 	}
 
 	applySlowMo(f.ctx)

--- a/common/frame.go
+++ b/common/frame.go
@@ -1821,16 +1821,17 @@ func (f *Frame) WaitForNavigation(opts goja.Value) (api.Response, error) {
 }
 
 // WaitForSelector waits for the given selector to match the waiting criteria.
-func (f *Frame) WaitForSelector(selector string, opts goja.Value) api.ElementHandle {
+func (f *Frame) WaitForSelector(selector string, opts goja.Value) (api.ElementHandle, error) {
 	parsedOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
 	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parsing wait for selector %q options: %w", selector, err)
+		return nil, fmt.Errorf("parsing wait for selector %q options: %w", selector, err)
 	}
 	handle, err := f.waitForSelectorRetry(selector, parsedOpts, maxRetry)
 	if err != nil {
-		k6ext.Panic(f.ctx, "waiting for selector %q: %w", selector, err)
+		return nil, fmt.Errorf("waiting for selector %q: %w", selector, err)
 	}
-	return handle
+
+	return handle, nil
 }
 
 // WaitForTimeout waits the specified amount of milliseconds.

--- a/common/frame.go
+++ b/common/frame.go
@@ -742,7 +742,7 @@ func (f *Frame) Evaluate(pageFunc goja.Value, args ...goja.Value) any {
 }
 
 // EvaluateHandle will evaluate provided page function within an execution context.
-func (f *Frame) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (handle api.JSHandle) {
+func (f *Frame) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (handle api.JSHandle, _ error) {
 	f.log.Debugf("Frame:EvaluateHandle", "fid:%s furl:%q", f.ID(), f.URL())
 
 	f.waitForExecutionContext(mainWorld)
@@ -758,11 +758,13 @@ func (f *Frame) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (handle 
 	}
 	f.executionContextMu.RUnlock()
 	if err != nil {
-		k6ext.Panic(f.ctx, "evaluating handle: %w", err)
+		// EvalHandle has a rich error, nolinting.
+		return nil, err //nolint:wrapcheck
 	}
 
 	applySlowMo(f.ctx)
-	return handle
+
+	return handle, nil
 }
 
 // Fill fills out the first element found that matches the selector.

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -108,10 +108,10 @@ func (h *BaseJSHandle) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (
 }
 
 // GetProperties retreives the JS handle's properties.
-func (h *BaseJSHandle) GetProperties() map[string]api.JSHandle {
+func (h *BaseJSHandle) GetProperties() (map[string]api.JSHandle, error) {
 	handles, err := h.getProperties()
 	if err != nil {
-		k6ext.Panic(h.ctx, "getProperties: %w", err)
+		return nil, err
 	}
 
 	jsHandles := make(map[string]api.JSHandle, len(handles))
@@ -119,7 +119,7 @@ func (h *BaseJSHandle) GetProperties() map[string]api.JSHandle {
 		jsHandles[k] = v
 	}
 
-	return jsHandles
+	return jsHandles, nil
 }
 
 // getProperties is like GetProperties, but does not panic.

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -104,7 +104,13 @@ func (h *BaseJSHandle) Evaluate(pageFunc goja.Value, args ...goja.Value) any {
 func (h *BaseJSHandle) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (api.JSHandle, error) {
 	rt := h.execCtx.vu.Runtime()
 	args = append([]goja.Value{rt.ToValue(h)}, args...)
-	return h.execCtx.EvalHandle(h.ctx, pageFunc, args...)
+
+	eh, err := h.execCtx.EvalHandle(h.ctx, pageFunc, args...)
+	if err != nil {
+		return nil, fmt.Errorf("evaluating handle for element: %w", err)
+	}
+
+	return eh, nil
 }
 
 // GetProperties retreives the JS handle's properties.

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -101,14 +101,10 @@ func (h *BaseJSHandle) Evaluate(pageFunc goja.Value, args ...goja.Value) any {
 }
 
 // EvaluateHandle will evaluate provided page function within an execution context.
-func (h *BaseJSHandle) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) api.JSHandle {
+func (h *BaseJSHandle) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (api.JSHandle, error) {
 	rt := h.execCtx.vu.Runtime()
 	args = append([]goja.Value{rt.ToValue(h)}, args...)
-	res, err := h.execCtx.EvalHandle(h.ctx, pageFunc, args...)
-	if err != nil {
-		k6ext.Panic(h.ctx, "%w", err)
-	}
-	return res
+	return h.execCtx.EvalHandle(h.ctx, pageFunc, args...)
 }
 
 // GetProperties retreives the JS handle's properties.

--- a/common/page.go
+++ b/common/page.go
@@ -494,7 +494,11 @@ func (p *Page) Evaluate(pageFunc goja.Value, args ...goja.Value) any {
 func (p *Page) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (api.JSHandle, error) {
 	p.logger.Debugf("Page:EvaluateHandle", "sid:%v", p.sessionID())
 
-	return p.MainFrame().EvaluateHandle(pageFunc, args...)
+	h, err := p.MainFrame().EvaluateHandle(pageFunc, args...)
+	if err != nil {
+		return nil, fmt.Errorf("evaluating handle for page: %w", err)
+	}
+	return h, nil
 }
 
 // ExposeBinding is not implemented.

--- a/common/page.go
+++ b/common/page.go
@@ -935,7 +935,7 @@ func (p *Page) WaitForResponse(urlOrPredicate, opts goja.Value) api.Response {
 }
 
 // WaitForSelector waits for the given selector to match the waiting criteria.
-func (p *Page) WaitForSelector(selector string, opts goja.Value) api.ElementHandle {
+func (p *Page) WaitForSelector(selector string, opts goja.Value) (api.ElementHandle, error) {
 	p.logger.Debugf("Page:WaitForSelector",
 		"sid:%v stid:%v ptid:%v selector:%s",
 		p.sessionID(), p.session.TargetID(), p.targetID, selector)

--- a/common/page.go
+++ b/common/page.go
@@ -490,7 +490,8 @@ func (p *Page) Evaluate(pageFunc goja.Value, args ...goja.Value) any {
 	return p.MainFrame().Evaluate(pageFunc, args...)
 }
 
-func (p *Page) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) api.JSHandle {
+// EvaluateHandle runs JS code within the execution context of the main frame of the page.
+func (p *Page) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (api.JSHandle, error) {
 	p.logger.Debugf("Page:EvaluateHandle", "sid:%v", p.sessionID())
 
 	return p.MainFrame().EvaluateHandle(pageFunc, args...)

--- a/common/worker.go
+++ b/common/worker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/xk6-browser/api"
+	"github.com/grafana/xk6-browser/k6error"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/log"
@@ -71,7 +72,7 @@ func (w *Worker) Evaluate(pageFunc goja.Value, args ...goja.Value) any {
 // EvaluateHandle evaluates a page function in the context of the web worker and returns a JS handle.
 func (w *Worker) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (api.JSHandle, error) {
 	// TODO: implement
-	return nil, nil
+	return nil, fmt.Errorf("Worker.EvaluateHandle has not been implemented yet: %w", k6error.ErrFatal)
 }
 
 // URL returns the URL of the web worker.

--- a/common/worker.go
+++ b/common/worker.go
@@ -69,9 +69,9 @@ func (w *Worker) Evaluate(pageFunc goja.Value, args ...goja.Value) any {
 }
 
 // EvaluateHandle evaluates a page function in the context of the web worker and returns a JS handle.
-func (w *Worker) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) api.JSHandle {
+func (w *Worker) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (api.JSHandle, error) {
 	// TODO: implement
-	return nil
+	return nil, nil
 }
 
 // URL returns the URL of the web worker.

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -56,7 +56,8 @@ func TestBrowserContextOptionsSetViewport(t *testing.T) {
 		},
 	}))
 	t.Cleanup(bctx.Close)
-	p := bctx.NewPage()
+	p, err := bctx.NewPage()
+	require.NoError(t, err)
 
 	viewportSize := p.ViewportSize()
 	assert.Equal(t, float64(800), viewportSize["width"])
@@ -73,9 +74,10 @@ func TestBrowserContextOptionsExtraHTTPHeaders(t *testing.T) {
 		},
 	}))
 	t.Cleanup(bctx.Close)
-	p := bctx.NewPage()
+	p, err := bctx.NewPage()
+	require.NoError(t, err)
 
-	err := tb.awaitWithTimeout(time.Second*5, func() error {
+	err = tb.awaitWithTimeout(time.Second*5, func() error {
 		resp, err := p.Goto(tb.URL("/get"), nil)
 		if err != nil {
 			return err

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -34,7 +34,9 @@ func TestBrowserContextAddCookies(t *testing.T) {
 
 		bc.AddCookies(cookies)
 
-		p := bc.NewPage()
+		p, err := bc.NewPage()
+		require.NoError(t, err)
+
 		_, err = p.Goto(
 			tb.staticURL("add_cookies.html"),
 			tb.toGojaValue(struct {

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -187,7 +187,9 @@ func TestMultiBrowserPanic(t *testing.T) {
 		b1 = newTestBrowser(t)
 		b2 = newTestBrowser(t)
 
-		p1 := b1.NewContext(nil).NewPage()
+		p1, err := b1.NewContext(nil).NewPage()
+		require.NoError(t, err, "failed to create page #1")
+
 		func() {
 			defer func() { _ = recover() }()
 			p1.GoBack(nil)

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -375,10 +375,10 @@ func TestElementHandleWaitForSelector(t *testing.T) {
 			}, 100);
 		}
 	`))
-	element := root.WaitForSelector(".element-to-appear", tb.toGojaValue(struct {
+	element, err := root.WaitForSelector(".element-to-appear", tb.toGojaValue(struct {
 		Timeout int64 `js:"timeout"`
 	}{Timeout: 1000}))
-
+	require.NoError(t, err)
 	require.NotNil(t, element, "expected element to have been found after wait")
 
 	element.Dispose()

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -169,7 +169,7 @@ func TestElementHandleClickConcealedLink(t *testing.T) {
 	)
 
 	tb := newTestBrowser(t, withFileServer())
-	p := tb.NewContext(
+	bc := tb.NewContext(
 		tb.toGojaValue(struct {
 			Viewport common.Viewport `js:"viewport"`
 		}{
@@ -178,7 +178,9 @@ func TestElementHandleClickConcealedLink(t *testing.T) {
 				Height: 240,
 			},
 		}),
-	).NewPage()
+	)
+	p, err := bc.NewPage()
+	require.NoError(t, err)
 
 	clickResult := func() string {
 		const cmd = `
@@ -199,7 +201,9 @@ func TestElementHandleClickConcealedLink(t *testing.T) {
 
 func TestElementHandleNonClickable(t *testing.T) {
 	tb := newTestBrowser(t, withFileServer())
-	p := tb.NewContext(nil).NewPage()
+
+	p, err := tb.NewContext(nil).NewPage()
+	require.NoError(t, err)
 
 	resp, err := p.Goto(tb.staticURL("/non_clickable.html"), nil)
 	require.NotNil(t, resp)

--- a/tests/js_handle_get_properties_test.go
+++ b/tests/js_handle_get_properties_test.go
@@ -23,7 +23,9 @@ func TestJSHandleGetProperties(t *testing.T) {
 	`))
 	require.NoError(t, err, "expected no error when evaluating handle")
 
-	props := handle.GetProperties()
+	props, err := handle.GetProperties()
+	require.NoError(t, err, "expected no error when getting properties")
+
 	value := props["prop1"].JSONValue().String()
 	assert.Equal(t, value, "one", `expected property value of "one", got %q`, value)
 }

--- a/tests/js_handle_get_properties_test.go
+++ b/tests/js_handle_get_properties_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJSHandleGetProperties(t *testing.T) {
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
-	handle := p.EvaluateHandle(tb.toGojaValue(`
+	handle, err := p.EvaluateHandle(tb.toGojaValue(`
 	() => {
 		return {
 			prop1: "one",
@@ -20,6 +21,7 @@ func TestJSHandleGetProperties(t *testing.T) {
 		};
 	}
 	`))
+	require.NoError(t, err, "expected no error when evaluating handle")
 
 	props := handle.GetProperties()
 	value := props["prop1"].JSONValue().String()

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -79,7 +79,7 @@ func TestBasicAuth(t *testing.T) {
 	auth := func(tb testing.TB, user, pass string) api.Response {
 		tb.Helper()
 
-		p := browser.NewContext(
+		bc := browser.NewContext(
 			browser.toGojaValue(struct {
 				HttpCredentials *common.Credentials `js:"httpCredentials"` //nolint:revive
 			}{
@@ -87,8 +87,9 @@ func TestBasicAuth(t *testing.T) {
 					Username: user,
 					Password: pass,
 				},
-			})).
-			NewPage()
+			}))
+		p, err := bc.NewPage()
+		require.NoError(t, err)
 
 		opts := browser.toGojaValue(struct {
 			WaitUntil string `js:"waitUntil"`

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -85,6 +85,16 @@ func TestPageEvaluate(t *testing.T) {
 		assert.Equal(t, "test", gotVal.Export())
 	})
 
+	t.Run("ok/void_func", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t)
+		p := tb.NewPage(nil)
+		h, err := p.EvaluateHandle(tb.toGojaValue(`() => console.log("hello")`))
+		assert.Nil(t, h, "expected nil handle")
+		assert.Error(t, err)
+	})
+
 	t.Run("err", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -210,12 +210,13 @@ func (b *testBrowser) attachFrame(page api.Page, frameID string, url string) api
 	}
 	`
 
-	return page.EvaluateHandle(
+	h, err := page.EvaluateHandle(
 		b.toGojaValue(pageFn),
 		b.toGojaValue(frameID),
-		b.toGojaValue(url)).
-		AsElement().
-		ContentFrame()
+		b.toGojaValue(url))
+	require.NoError(b.t, err)
+
+	return h.AsElement().ContentFrame()
 }
 
 // runtime returns a VU runtime.

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -146,6 +146,17 @@ func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 	return tbr
 }
 
+// NewPage is a wrapper around api.Browser.NewPage that fails the test if an
+// error occurs. Added this helper to avoid boilerplate code in tests.
+func (b *testBrowser) NewPage(opts goja.Value) api.Page {
+	b.t.Helper()
+
+	p, err := b.Browser.NewPage(opts)
+	require.NoError(b.t, err)
+
+	return p
+}
+
 // withHandler adds the given handler to the HTTP test server and makes it
 // accessible with the given pattern.
 func (b *testBrowser) withHandler(pattern string, handler http.HandlerFunc) *testBrowser {

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -216,7 +216,10 @@ func (b *testBrowser) attachFrame(page api.Page, frameID string, url string) api
 		b.toGojaValue(url))
 	require.NoError(b.t, err)
 
-	return h.AsElement().ContentFrame()
+	f, err := h.AsElement().ContentFrame()
+	require.NoError(b.t, err)
+
+	return f
 }
 
 // runtime returns a VU runtime.


### PR DESCRIPTION
The error output is similar to #820.

Please let me know if you see other edge cases, so I can amend them.

Here are some test snippets you can try.

<details>
<summary>evaluateHandle</summary>

Output:

```
ERRO[0001] Uncaught (in promise) GoError: evaluating handle: result is nil
        at github.com/grafana/xk6-browser/browser.mapPage.func2 (native)
        at file:///Users/inanc/grafana/k6browser/tests/evaluate_handle.js:20:54(31)  executor=per-vu-iterations scenario=default
```

Script:

```js
await page.goto('https://test.k6.io/', { waitUntil: 'load' });
const pageTitleHandle = await page.evaluateHandle(() => {
  return document.querySelector('nothing');
});
```

</details>

<details>
<summary>waitForSelector</summary>

Output:

```
ERRO[0001] Uncaught (in promise) GoError: querying selector "x"
        at github.com/grafana/xk6-browser/browser.mapPage.func13 (native)
        at file:///Users/inanc/grafana/k6browser/tests/waitforselector.js:20:23(32)  executor=per-vu-iterations scenario=default
```

Script:

```js
await page.goto('https://test.k6.io/', { waitUntil: 'load' });
const a = await page.waitForSelector('x');
```

</details>

Closes: https://github.com/grafana/xk6-browser/issues/804
Related: https://github.com/grafana/xk6-browser/issues/688 #820