### PR TITLE
POC for webvital summary

### DIFF
--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -238,6 +238,10 @@ func (b *BrowserContext) NewPage() api.Page {
 	}
 	b.logger.Debugf("BrowserContext:NewPage:return", "bctxid:%v ptid:%s", bctxid, ptid)
 
+	for _, s := range b.evaluateOnNewDocumentSources {
+		p.evaluateOnNewDocument(s)
+	}
+
 	return p
 }
 

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/k6ext"
@@ -530,6 +532,15 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 			handleParseRemoteObjectErr(fs.ctx, err, l)
 		}
 		parsedObjects = append(parsedObjects, i)
+
+		dontPrint, err := fs.parseAndRecordWebVitalMetric(robj)
+		if err != nil {
+			fs.logger.Errorf("FrameSession:onConsoleAPICalled", "%v", err)
+			return
+		}
+		if dontPrint {
+			return
+		}
 	}
 
 	l = l.WithField("objects", parsedObjects)
@@ -544,6 +555,90 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 	default:
 		l.Debug()
 	}
+}
+
+type WebVitalMetric struct {
+	ID             string
+	Name           string
+	Value          json.Number
+	Rating         string
+	Delta          json.Number
+	NumEntries     json.Number
+	NavigationType string
+}
+
+func (fs *FrameSession) parseAndRecordWebVitalMetric(robj *cdpruntime.RemoteObject) (bool, error) {
+	if robj.Type != "string" {
+		return false, nil
+	}
+
+	if !bytes.Contains(robj.Value, []byte("xk6-browser.web.vital.metric=")) {
+		return false, nil
+	}
+
+	s := bytes.Index(robj.Value, []byte("{"))
+	e := bytes.Index(robj.Value, []byte("}"))
+	bb := robj.Value[s : e+1]
+	bb = bytes.ReplaceAll(bb, []byte("\\"), []byte(""))
+
+	var w WebVitalMetric
+	err := json.Unmarshal(bb, &w)
+	if err != nil {
+		return false, Error(fmt.Sprintf("failed to parse web vital '%s'", bb))
+	}
+
+	switch w.Name {
+	case "FID":
+		fallthrough
+	case "TTFB":
+		fallthrough
+	case "LCP":
+		fallthrough
+	case "CLS":
+		fallthrough
+	case "INP":
+		fallthrough
+	case "FCP":
+		err = fs.emitMetric(
+			fs.k6Metrics.WebVitals[w.Name],
+			fs.k6Metrics.WebVitals[w.Name+":"+w.Rating],
+			w.Value,
+		)
+	default:
+		err = Error(fmt.Sprintf("web vital type not found '%s'", bb))
+	}
+
+	return err == nil, err
+}
+
+func (fs *FrameSession) emitMetric(m *k6metrics.Metric, mRating *k6metrics.Metric, n json.Number) error {
+	fs.logger.Debugf("FrameSession:emitMetric", "m:%s v:%f", m.Name, n)
+
+	f, err := n.Float64()
+	if err != nil {
+		return Error(fmt.Sprintf("failed to parse web vital value '%v'", n))
+	}
+
+	state := fs.vu.State()
+	tags := state.Tags.GetCurrentValues().Tags
+
+	now := time.Now()
+	k6metrics.PushIfNotDone(fs.ctx, state.Samples, k6metrics.ConnectedSamples{
+		Samples: []k6metrics.Sample{
+			{
+				TimeSeries: k6metrics.TimeSeries{Metric: m, Tags: tags},
+				Value:      f,
+				Time:       now,
+			},
+			{
+				TimeSeries: k6metrics.TimeSeries{Metric: mRating, Tags: tags},
+				Value:      1,
+				Time:       now,
+			},
+		},
+	})
+
+	return nil
 }
 
 func (fs *FrameSession) onExceptionThrown(event *cdpruntime.EventExceptionThrown) {
@@ -732,10 +827,10 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 	}
 
 	eventToMetric := map[string]*k6metrics.Metric{
-		"load":                 fs.k6Metrics.BrowserLoaded,
-		"DOMContentLoaded":     fs.k6Metrics.BrowserDOMContentLoaded,
-		"firstPaint":           fs.k6Metrics.BrowserFirstPaint,
-		"firstContentfulPaint": fs.k6Metrics.BrowserFirstContentfulPaint,
+		"load":             fs.k6Metrics.BrowserLoaded,
+		"DOMContentLoaded": fs.k6Metrics.BrowserDOMContentLoaded,
+		"firstPaint":       fs.k6Metrics.BrowserFirstPaint,
+		// "firstContentfulPaint": fs.k6Metrics.BrowserFirstContentfulPaint,
 		"firstMeaningfulPaint": fs.k6Metrics.BrowserFirstMeaningfulPaint,
 	}
 

--- a/common/page.go
+++ b/common/page.go
@@ -17,6 +17,7 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
 	"github.com/chromedp/cdproto/emulation"
+	"github.com/chromedp/cdproto/page"
 	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
@@ -168,8 +169,16 @@ func (p *Page) didCrash() {
 	p.emit(EventPageCrash, p)
 }
 
-func (p *Page) evaluateOnNewDocument(source string) {
-	// TODO: implement
+func (p *Page) evaluateOnNewDocument(source string) error {
+	p.logger.Debugf("Page:evaluateOnNewDocument", "sid:%v frame:nil", p.sessionID())
+
+	action := page.AddScriptToEvaluateOnNewDocument(source)
+	_, err := action.Do(cdp.WithExecutor(p.ctx, p.session))
+	if err != nil {
+		return fmt.Errorf("failed to add script to page: %w", err)
+	}
+
+	return nil
 }
 
 func (p *Page) getFrameElement(f *Frame) (handle *ElementHandle, _ error) {

--- a/examples/webvitals-test.js
+++ b/examples/webvitals-test.js
@@ -1,5 +1,427 @@
 import { chromium } from 'k6/x/browser';
 
+var forEach = function (obj, callback) {
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      if (callback(key, obj[key])) {
+        break
+      }
+    }
+  }
+}
+
+var palette = {
+  bold: 1,
+  faint: 2,
+  red: 31,
+  green: 32,
+  cyan: 36,
+  //TODO: add others?
+}
+
+var groupPrefix = '█'
+var detailsPrefix = '↳'
+var succMark = '✓'
+var failMark = '✗'
+var defaultOptions = {
+  indent: ' ',
+  enableColors: true,
+  summaryTimeUnit: null,
+  summaryTrendStats: null,
+}
+
+// strWidth tries to return the actual width the string will take up on the
+// screen, without any terminal formatting, unicode ligatures, etc.
+function strWidth(s) {
+  // TODO: determine if NFC or NFKD are not more appropriate? or just give up? https://hsivonen.fi/string-length/
+  var data = s.normalize('NFKC') // This used to be NFKD in Go, but this should be better
+  var inEscSeq = false
+  var inLongEscSeq = false
+  var width = 0
+  for (var char of data) {
+    if (char.done) {
+      break
+    }
+
+    // Skip over ANSI escape codes.
+    if (char == '\x1b') {
+      inEscSeq = true
+      continue
+    }
+    if (inEscSeq && char == '[') {
+      inLongEscSeq = true
+      continue
+    }
+    if (inEscSeq && inLongEscSeq && char.charCodeAt(0) >= 0x40 && char.charCodeAt(0) <= 0x7e) {
+      inEscSeq = false
+      inLongEscSeq = false
+      continue
+    }
+    if (inEscSeq && !inLongEscSeq && char.charCodeAt(0) >= 0x40 && char.charCodeAt(0) <= 0x5f) {
+      inEscSeq = false
+      continue
+    }
+
+    if (!inEscSeq && !inLongEscSeq) {
+      width++
+    }
+  }
+  return width
+}
+
+function summarizeCheck(indent, check, decorate) {
+  if (check.fails == 0) {
+    return decorate(indent + succMark + ' ' + check.name, palette.green)
+  }
+
+  var succPercent = Math.floor((100 * check.passes) / (check.passes + check.fails))
+  return decorate(
+    indent +
+    failMark +
+    ' ' +
+    check.name +
+    '\n' +
+    indent +
+    ' ' +
+    detailsPrefix +
+    '  ' +
+    succPercent +
+    '% — ' +
+    succMark +
+    ' ' +
+    check.passes +
+    ' / ' +
+    failMark +
+    ' ' +
+    check.fails,
+    palette.red
+  )
+}
+
+function summarizeGroup(indent, group, decorate) {
+  var result = []
+  if (group.name != '') {
+    result.push(indent + groupPrefix + ' ' + group.name + '\n')
+    indent = indent + '  '
+  }
+
+  for (var i = 0; i < group.checks.length; i++) {
+    result.push(summarizeCheck(indent, group.checks[i], decorate))
+  }
+  if (group.checks.length > 0) {
+    result.push('')
+  }
+  for (var i = 0; i < group.groups.length; i++) {
+    Array.prototype.push.apply(result, summarizeGroup(indent, group.groups[i], decorate))
+  }
+
+  return result
+}
+
+function displayNameForMetric(name) {
+  var subMetricPos = name.indexOf('{')
+  if (subMetricPos >= 0) {
+    return '{ ' + name.substring(subMetricPos + 1, name.length - 1) + ' }'
+  }
+  return name
+}
+
+function indentForMetric(name) {
+  if (name.indexOf('{') >= 0) {
+    return '  '
+  }
+  return ''
+}
+
+function humanizeBytes(bytes) {
+  var units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+  var base = 1000
+  if (bytes < 10) {
+    return bytes + ' B'
+  }
+
+  var e = Math.floor(Math.log(bytes) / Math.log(base))
+  var suffix = units[e | 0]
+  var val = Math.floor((bytes / Math.pow(base, e)) * 10 + 0.5) / 10
+  return val.toFixed(val < 10 ? 1 : 0) + ' ' + suffix
+}
+
+var unitMap = {
+  s: { unit: 's', coef: 0.001 },
+  ms: { unit: 'ms', coef: 1 },
+  us: { unit: 'µs', coef: 1000 },
+}
+
+function toFixedNoTrailingZeros(val, prec) {
+  // TODO: figure out something better?
+  return parseFloat(val.toFixed(prec)).toString()
+}
+
+function toFixedNoTrailingZerosTrunc(val, prec) {
+  var mult = Math.pow(10, prec)
+  return toFixedNoTrailingZeros(Math.trunc(mult * val) / mult, prec)
+}
+
+function humanizeGenericDuration(dur) {
+  if (dur === 0) {
+    return '0s'
+  }
+
+  if (dur < 0.001) {
+    // smaller than a microsecond, print nanoseconds
+    return Math.trunc(dur * 1000000) + 'ns'
+  }
+  if (dur < 1) {
+    // smaller than a millisecond, print microseconds
+    return toFixedNoTrailingZerosTrunc(dur * 1000, 2) + 'µs'
+  }
+  if (dur < 1000) {
+    // duration is smaller than a second
+    return toFixedNoTrailingZerosTrunc(dur, 2) + 'ms'
+  }
+
+  var result = toFixedNoTrailingZerosTrunc((dur % 60000) / 1000, dur > 60000 ? 0 : 2) + 's'
+  var rem = Math.trunc(dur / 60000)
+  if (rem < 1) {
+    // less than a minute
+    return result
+  }
+  result = (rem % 60) + 'm' + result
+  rem = Math.trunc(rem / 60)
+  if (rem < 1) {
+    // less than an hour
+    return result
+  }
+  return rem + 'h' + result
+}
+
+function humanizeDuration(dur, timeUnit) {
+  if (timeUnit !== '' && unitMap.hasOwnProperty(timeUnit)) {
+    return (dur * unitMap[timeUnit].coef).toFixed(2) + unitMap[timeUnit].unit
+  }
+
+  return humanizeGenericDuration(dur)
+}
+
+function humanizeValue(val, metric, timeUnit) {
+  if (metric.type == 'rate') {
+    // Truncate instead of round when decreasing precision to 2 decimal places
+    return (Math.trunc(val * 100 * 100) / 100).toFixed(2) + '%'
+  }
+
+  switch (metric.contains) {
+    case 'data':
+      return humanizeBytes(val)
+    case 'time':
+      return humanizeDuration(val, timeUnit)
+    default:
+      return toFixedNoTrailingZeros(val, 6)
+  }
+}
+
+function nonTrendMetricValueForSum(metric, timeUnit) {
+  switch (metric.type) {
+    case 'counter':
+      return [
+        humanizeValue(metric.values.count, metric, timeUnit),
+        humanizeValue(metric.values.rate, metric, timeUnit) + '/s',
+      ]
+    case 'gauge':
+      return [
+        humanizeValue(metric.values.value, metric, timeUnit),
+        'min=' + humanizeValue(metric.values.min, metric, timeUnit),
+        'max=' + humanizeValue(metric.values.max, metric, timeUnit),
+      ]
+    case 'rate':
+      return [
+        humanizeValue(metric.values.rate, metric, timeUnit),
+        succMark + ' ' + metric.values.passes,
+        failMark + ' ' + metric.values.fails,
+      ]
+    default:
+      return ['[no data]']
+  }
+}
+
+function summarizeMetrics(options, data, decorate) {
+  var indent = options.indent + '  '
+  var result = []
+
+  var names = []
+  var nameLenMax = 0
+
+  var nonTrendValues = {}
+  var nonTrendValueMaxLen = 0
+  var nonTrendExtras = {}
+  var nonTrendExtraMaxLens = [0, 0]
+
+  var trendCols = {}
+  var numTrendColumns = options.summaryTrendStats.length
+  var trendColMaxLens = new Array(numTrendColumns).fill(0)
+  forEach(data.metrics, function (name, metric) {
+    names.push(name)
+    // When calculating widths for metrics, account for the indentation on submetrics.
+    var displayName = indentForMetric(name) + displayNameForMetric(name)
+    var displayNameWidth = strWidth(displayName)
+    if (displayNameWidth > nameLenMax) {
+      nameLenMax = displayNameWidth
+    }
+
+    if (metric.type == 'trend') {
+      var cols = []
+      for (var i = 0; i < numTrendColumns; i++) {
+        var tc = options.summaryTrendStats[i]
+        var value = metric.values[tc]
+        if (tc === 'count') {
+          value = value.toString()
+        } else {
+          value = humanizeValue(value, metric, options.summaryTimeUnit)
+        }
+        var valLen = strWidth(value)
+        if (valLen > trendColMaxLens[i]) {
+          trendColMaxLens[i] = valLen
+        }
+        cols[i] = value
+      }
+      trendCols[name] = cols
+      return
+    }
+    var values = nonTrendMetricValueForSum(metric, options.summaryTimeUnit)
+    nonTrendValues[name] = values[0]
+    var valueLen = strWidth(values[0])
+    if (valueLen > nonTrendValueMaxLen) {
+      nonTrendValueMaxLen = valueLen
+    }
+    nonTrendExtras[name] = values.slice(1)
+    for (var i = 1; i < values.length; i++) {
+      var extraLen = strWidth(values[i])
+      if (extraLen > nonTrendExtraMaxLens[i - 1]) {
+        nonTrendExtraMaxLens[i - 1] = extraLen
+      }
+    }
+  })
+
+  // sort all metrics but keep sub metrics grouped with their parent metrics
+  names.sort(function (metric1, metric2) {
+    var parent1 = metric1.split('{', 1)[0]
+    var parent2 = metric2.split('{', 1)[0]
+    var result = parent1.localeCompare(parent2)
+    if (result !== 0) {
+      return result
+    }
+    var sub1 = metric1.substring(parent1.length)
+    var sub2 = metric2.substring(parent2.length)
+    return sub1.localeCompare(sub2)
+  })
+
+  var getData = function (name) {
+    if (trendCols.hasOwnProperty(name)) {
+      var cols = trendCols[name]
+      var tmpCols = new Array(numTrendColumns)
+      for (var i = 0; i < cols.length; i++) {
+        tmpCols[i] =
+          options.summaryTrendStats[i] +
+          '=' +
+          decorate(cols[i], palette.cyan) +
+          ' '.repeat(trendColMaxLens[i] - strWidth(cols[i]))
+      }
+      return tmpCols.join(' ')
+    }
+
+    var value = nonTrendValues[name]
+    var fmtData = decorate(value, palette.cyan) + ' '.repeat(nonTrendValueMaxLen - strWidth(value))
+
+    var extras = nonTrendExtras[name]
+    if (extras.length == 1) {
+      fmtData = fmtData + ' ' + decorate(extras[0], palette.cyan, palette.faint)
+    } else if (extras.length > 1) {
+      var parts = new Array(extras.length)
+      for (var i = 0; i < extras.length; i++) {
+        parts[i] =
+          decorate(extras[i], palette.cyan, palette.faint) +
+          ' '.repeat(nonTrendExtraMaxLens[i] - strWidth(extras[i]))
+      }
+      fmtData = fmtData + ' ' + parts.join(' ')
+    }
+
+    return fmtData
+  }
+
+  for (var name of names) {
+    var metric = data.metrics[name]
+    var mark = ' '
+    var markColor = function (text) {
+      return text
+    } // noop
+
+    if (metric.thresholds) {
+      mark = succMark
+      markColor = function (text) {
+        return decorate(text, palette.green)
+      }
+      forEach(metric.thresholds, function (name, threshold) {
+        if (!threshold.ok) {
+          mark = failMark
+          markColor = function (text) {
+            return decorate(text, palette.red)
+          }
+          return true // break
+        }
+      })
+    }
+    var fmtIndent = indentForMetric(name)
+    var fmtName = displayNameForMetric(name)
+    fmtName =
+      fmtName +
+      decorate(
+        '.'.repeat(nameLenMax - strWidth(fmtName) - strWidth(fmtIndent) + 3) + ':',
+        palette.faint
+      )
+
+    result.push(indent + fmtIndent + markColor(mark) + ' ' + fmtName + ' ' + getData(name))
+  }
+
+  return result
+}
+
+function generateTextSummary(data, options) {
+  var mergedOpts = Object.assign({}, defaultOptions, data.options, options)
+  var lines = []
+
+  // TODO: move all of these functions into an object with methods?
+  var decorate = function (text) {
+    return text
+  }
+  if (mergedOpts.enableColors) {
+    decorate = function (text, color /*, ...rest*/) {
+      var result = '\x1b[' + color
+      for (var i = 2; i < arguments.length; i++) {
+        result += ';' + arguments[i]
+      }
+      return result + 'm' + text + '\x1b[0m'
+    }
+  }
+
+  Array.prototype.push.apply(
+    lines,
+    summarizeGroup(mergedOpts.indent + '    ', data.root_group, decorate)
+  )
+
+  Array.prototype.push.apply(lines, summarizeMetrics(mergedOpts, data, decorate))
+
+  return lines.join('\n')
+}
+
+export const options = {
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(75)', 'p(90)', 'p(95)'],
+};
+
+export function handleSummary(data) {
+  return {
+    'stdout': '\n' + generateTextSummary(data, {summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(75)', 'p(90)', 'p(95)']}) + '\n\n'
+  };
+}
+
 export default async function () {
   const browser = chromium.launch({headless: true});
   const context = browser.newContext();

--- a/examples/webvitals-test.js
+++ b/examples/webvitals-test.js
@@ -1,0 +1,52 @@
+import { chromium } from 'k6/x/browser';
+
+export default async function () {
+  const browser = chromium.launch({headless: true});
+  const context = browser.newContext();
+  context.addInitScript(`{
+    function print(metric) {
+      const m = {
+        id: metric.id,
+        name: metric.name,
+        value: metric.value,
+        rating: metric.rating,
+        delta: metric.delta,
+        numEntries: metric.entries.length,
+        navigationType: metric.navigationType,
+        url: window.location.href,
+      }
+      console.log('xk6-browser.web.vital.metric=' + JSON.stringify(m))
+    }
+
+    async function load() {
+      let {
+        onCLS, onFID, onLCP, onFCP, onINP, onTTFB
+      } = await import('https://unpkg.com/web-vitals@3?module');
+
+      onCLS(print);
+      onFID(print);
+      onLCP(print);
+  
+      onFCP(print);
+      onINP(print);
+      onTTFB(print);
+    }
+
+    load();
+  }`);
+  const page = context.newPage();
+
+  try {
+    await page.goto('https://grafana.com', { waitUntil: 'networkidle' })
+
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'networkidle' }),
+      page.locator('a[href="https://play.grafana.org/"]').click(),
+    ]);
+
+    page.screenshot({ path: 'screenshot.png' });
+  } finally {
+    page.close();
+    browser.close();
+  }
+}

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -16,12 +16,12 @@ type CustomMetrics struct {
 // VU Registry and returns our internal struct pointer.
 func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
 	wvs := map[string]string{
-		"LCP":  "browser_largest_content_paint",
-		"FID":  "browser_first_input_delay",
-		"CLS":  "browser_cumulative_layout_shift",
-		"FCP":  "browser_first_contentful_paint",
-		"TTFB": "browser_time_to_first_byte",
-		"INP":  "browser_interaction_to_next_paint",
+		"LCP":  "webvital_largest_content_paint",
+		"FID":  "webvital_first_input_delay",
+		"CLS":  "webvital_cumulative_layout_shift",
+		"FCP":  "webvital_first_contentful_paint",
+		"TTFB": "webvital_time_to_first_byte",
+		"INP":  "webvital_interaction_to_next_paint",
 	}
 	webVitals := make(map[string]*k6metrics.Metric)
 

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -6,24 +6,52 @@ import k6metrics "go.k6.io/k6/metrics"
 type CustomMetrics struct {
 	BrowserDOMContentLoaded     *k6metrics.Metric
 	BrowserFirstPaint           *k6metrics.Metric
-	BrowserFirstContentfulPaint *k6metrics.Metric
 	BrowserFirstMeaningfulPaint *k6metrics.Metric
 	BrowserLoaded               *k6metrics.Metric
+
+	WebVitals map[string]*k6metrics.Metric
 }
 
 // RegisterCustomMetrics creates and registers our custom metrics with the k6
 // VU Registry and returns our internal struct pointer.
 func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
+	wvs := map[string]string{
+		"LCP":  "browser_largest_content_paint",
+		"FID":  "browser_first_input_delay",
+		"CLS":  "browser_cumulative_layout_shift",
+		"FCP":  "browser_first_contentful_paint",
+		"TTFB": "browser_time_to_first_byte",
+		"INP":  "browser_interaction_to_next_paint",
+	}
+	webVitals := make(map[string]*k6metrics.Metric)
+
+	for k, v := range wvs {
+		t := k6metrics.Time
+		if k == "CLS" {
+			t = k6metrics.Default
+		}
+
+		webVitals[k] = registry.MustNewMetric(
+			v, k6metrics.Trend, t)
+
+		webVitals[k+":good"] = registry.MustNewMetric(
+			v+"_good", k6metrics.Counter)
+		webVitals[k+":needs-improvement"] = registry.MustNewMetric(
+			v+"_needs_improvement", k6metrics.Counter)
+		webVitals[k+":poor"] = registry.MustNewMetric(
+			v+"_poor", k6metrics.Counter)
+	}
+
 	return &CustomMetrics{
 		BrowserDOMContentLoaded: registry.MustNewMetric(
 			"browser_dom_content_loaded", k6metrics.Trend, k6metrics.Time),
 		BrowserFirstPaint: registry.MustNewMetric(
 			"browser_first_paint", k6metrics.Trend, k6metrics.Time),
-		BrowserFirstContentfulPaint: registry.MustNewMetric(
-			"browser_first_contentful_paint", k6metrics.Trend, k6metrics.Time),
 		BrowserFirstMeaningfulPaint: registry.MustNewMetric(
 			"browser_first_meaningful_paint", k6metrics.Trend, k6metrics.Time),
 		BrowserLoaded: registry.MustNewMetric(
 			"browser_loaded", k6metrics.Trend, k6metrics.Time),
+
+		WebVitals: webVitals,
 	}
 }


### PR DESCRIPTION
This is a POC to show that we can indeed restructure the summary for webvital so that instead of:

```bash
     webvital_cumulative_layout_shift....................: avg=0.002929 min=0.002727 med=0.002903 max=0.003211 p(90)=0.003211 p(95)=0.003211
     webvital_cumulative_layout_shift_good...............: 10     0.179492/s
     webvital_first_contentful_paint.....................: avg=1.09s    min=174.69ms med=1.05s    max=2.24s    p(90)=2.02s    p(95)=2.11s   
     webvital_first_contentful_paint_good................: 10     0.179492/s
     webvital_first_contentful_paint_needs_improvement...: 10     0.179492/s
     webvital_first_input_delay..........................: avg=48.54ms  min=32.8ms   med=47.75ms  max=58ms     p(90)=57.91ms  p(95)=57.95ms 
     webvital_first_input_delay_good.....................: 10     0.179492/s
     webvital_interaction_to_next_paint..................: avg=69.59ms  min=56ms     med=68ms     max=80ms     p(90)=80ms     p(95)=80ms    
     webvital_interaction_to_next_paint_good.............: 10     0.179492/s
     webvital_largest_content_paint......................: avg=399.53ms min=358.89ms med=406.04ms max=417.79ms p(90)=415.54ms p(95)=416.67ms
     webvital_largest_content_paint_good.................: 10     0.179492/s
     webvital_time_to_first_byte.........................: avg=221.98ms min=70.69ms  med=210.75ms max=484.9ms  p(90)=365.04ms p(95)=445.76ms
     webvital_time_to_first_byte_good....................: 20     0.358984/s
```

we get:

```bash
     web_vitals.......................:       
       cumulative_layout_shift........: avg=0.003211 min=0.003211 med=0.003211 max=0.003211 p(75)=0.003211 p(90)=0.003211 p(95)=0.003211
         ratings......................: good=1 needs_improvement=0 poor=0
       first_contentful_paint.........: avg=1.1s     min=223.3ms  med=1.1s     max=1.99s    p(75)=1.54s    p(90)=1.81s    p(95)=1.9s    
         ratings......................: good=1 needs_improvement=1 poor=0
       first_input_delay..............: avg=46.5ms   min=46.5ms   med=46.5ms   max=46.5ms   p(75)=46.5ms   p(90)=46.5ms   p(95)=46.5ms  
         ratings......................: good=1 needs_improvement=0 poor=0
       interaction_to_next_paint......: avg=64ms     min=64ms     med=64ms     max=64ms     p(75)=64ms     p(90)=64ms     p(95)=64ms    
         ratings......................: good=1 needs_improvement=0 poor=0
       largest_content_paint..........: avg=383.3ms  min=383.3ms  med=383.3ms  max=383.3ms  p(75)=383.3ms  p(90)=383.3ms  p(95)=383.3ms 
         ratings......................: good=1 needs_improvement=0 poor=0
       time_to_first_byte.............: avg=215.35ms min=89.4ms   med=215.35ms max=341.3ms  p(75)=278.32ms p(90)=316.11ms p(95)=328.7ms 
         ratings......................: good=2 needs_improvement=0 poor=0
```

For the POC i've:
1. copied the summary code from https://github.com/grafana/k6-jslib-summary;
1. amended the metric data structure so that it is hierarchical (metrics can contain metrics);
1. added wv_rating and title metric types;
1. amended the copied summary code to work with the hierarchical metric structure.

The next steps are:
1. find a suitable home for the changes, and work out how they can be loaded with the test script. At the moment the summary code is in the test script itself.
2. Cleanup code and get them reviewed.