### PR TITLE
Remove first meaningful paint

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -808,7 +808,7 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 		"load":                 fs.k6Metrics.BrowserLoaded,
 		"DOMContentLoaded":     fs.k6Metrics.BrowserDOMContentLoaded,
 		"firstPaint":           fs.k6Metrics.BrowserFirstPaint,
-		"firstMeaningfulPaint": fs.k6Metrics.BrowserFirstMeaningfulPaint,
+		"firstContentfulPaint": fs.k6Metrics.BrowserFirstContentfulPaint,
 	}
 
 	if m, ok := eventToMetric[event.Name]; ok {

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -19,7 +19,7 @@ const (
 type CustomMetrics struct {
 	BrowserDOMContentLoaded     *k6metrics.Metric
 	BrowserFirstPaint           *k6metrics.Metric
-	BrowserFirstMeaningfulPaint *k6metrics.Metric
+	BrowserFirstContentfulPaint *k6metrics.Metric
 	BrowserLoaded               *k6metrics.Metric
 
 	WebVitals map[string]*k6metrics.Metric
@@ -61,8 +61,8 @@ func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
 			"browser_dom_content_loaded", k6metrics.Trend, k6metrics.Time),
 		BrowserFirstPaint: registry.MustNewMetric(
 			"browser_first_paint", k6metrics.Trend, k6metrics.Time),
-		BrowserFirstMeaningfulPaint: registry.MustNewMetric(
-			"browser_first_meaningful_paint", k6metrics.Trend, k6metrics.Time),
+		BrowserFirstContentfulPaint: registry.MustNewMetric(
+			"browser_first_contentful_paint", k6metrics.Trend, k6metrics.Time),
 		BrowserLoaded: registry.MustNewMetric(
 			"browser_loaded", k6metrics.Trend, k6metrics.Time),
 		WebVitals: webVitals,


### PR DESCRIPTION
We no longer need this metric for three reasons:

1. For an unknown reason Chrome doesn't always return this metric measurement. It seems that if we use slowmo, then it does appear.
2. It's being deprecated by Chrome and lighthouse as it is very inconsistent where small difference in page loads and how the browser implements the measurement all affect the end result.
3. Web vitals is almost ready and it is the industry standard way of measuring frontend performance.

Closes: https://github.com/grafana/xk6-browser/issues/837