### PR TITLE
Remove browser first contentful paint

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -805,10 +805,9 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 	}
 
 	eventToMetric := map[string]*k6metrics.Metric{
-		"load":                 fs.k6Metrics.BrowserLoaded,
-		"DOMContentLoaded":     fs.k6Metrics.BrowserDOMContentLoaded,
-		"firstPaint":           fs.k6Metrics.BrowserFirstPaint,
-		"firstContentfulPaint": fs.k6Metrics.BrowserFirstContentfulPaint,
+		"load":             fs.k6Metrics.BrowserLoaded,
+		"DOMContentLoaded": fs.k6Metrics.BrowserDOMContentLoaded,
+		"firstPaint":       fs.k6Metrics.BrowserFirstPaint,
 	}
 
 	if m, ok := eventToMetric[event.Name]; ok {

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -17,10 +17,9 @@ const (
 
 // CustomMetrics are the custom k6 metrics used by xk6-browser.
 type CustomMetrics struct {
-	BrowserDOMContentLoaded     *k6metrics.Metric
-	BrowserFirstPaint           *k6metrics.Metric
-	BrowserFirstContentfulPaint *k6metrics.Metric
-	BrowserLoaded               *k6metrics.Metric
+	BrowserDOMContentLoaded *k6metrics.Metric
+	BrowserFirstPaint       *k6metrics.Metric
+	BrowserLoaded           *k6metrics.Metric
 
 	WebVitals map[string]*k6metrics.Metric
 }
@@ -61,8 +60,6 @@ func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
 			"browser_dom_content_loaded", k6metrics.Trend, k6metrics.Time),
 		BrowserFirstPaint: registry.MustNewMetric(
 			"browser_first_paint", k6metrics.Trend, k6metrics.Time),
-		BrowserFirstContentfulPaint: registry.MustNewMetric(
-			"browser_first_contentful_paint", k6metrics.Trend, k6metrics.Time),
 		BrowserLoaded: registry.MustNewMetric(
 			"browser_loaded", k6metrics.Trend, k6metrics.Time),
 		WebVitals: webVitals,


### PR DESCRIPTION
This is a regression. We had removed this in https://github.com/grafana/xk6-browser/pull/836, but it was accidentally added back in https://github.com/grafana/xk6-browser/pull/838.

As mentioned in https://github.com/grafana/xk6-browser/issues/831#issuecomment-1496285905, we should work with the `webvital_first_contentful_paint` instead of `browser_first_contentful_paint`.

Linked to https://github.com/grafana/xk6-browser/issues/831