### PR TITLE
Update nil session log warn to debug in page attach

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -235,7 +235,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 	}
 	session := b.conn.getSession(ev.SessionID)
 	if session == nil {
-		b.logger.Warnf("Browser:onAttachedToTarget",
+		b.logger.Debugf("Browser:onAttachedToTarget",
 			"session closed before attachToTarget is handled. sid:%v tid:%v",
 			ev.SessionID, targetPage.TargetID)
 		return // ignore


### PR DESCRIPTION
I suggested this earlier on to detect nil sessions. But now, this warning is outdated because when users running multiple instance/VU tests, they will see dozens/hundreds lines of warnings.

The core reason we receive a lot of these warnings is:

We need to correctly handle the CDP messages while sending and receiving them (the order of them).
https://github.com/grafana/xk6-browser/pull/848