### PR TITLE
Remove multierror and refactor to Go errors.Join

### DIFF
--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -39,51 +40,6 @@ func (pe *objectPropertyParseError) Unwrap() error {
 	return pe.error
 }
 
-type multiError struct {
-	Errors []error
-}
-
-func (me *multiError) append(err error) {
-	me.Errors = append(me.Errors, err)
-}
-
-func (me multiError) Error() string {
-	if len(me.Errors) == 0 {
-		return ""
-	}
-	if len(me.Errors) == 1 {
-		return me.Errors[0].Error()
-	}
-
-	var buf strings.Builder
-	fmt.Fprintf(&buf, "%d errors occurred:\n", len(me.Errors))
-	for _, e := range me.Errors {
-		fmt.Fprintf(&buf, "\t* %s\n", e)
-	}
-
-	return buf.String()
-}
-
-func multierror(err error, errs ...error) error {
-	me := &multiError{}
-	// We can't use errors.As(), as we want to know if err is of type
-	// multiError, not any error in the chain. If err contains a wrapped
-	// multierror, start a new multiError that will contain err.
-	e, ok := err.(*multiError) //nolint:errorlint
-
-	if ok {
-		me = e
-	} else if err != nil {
-		me.append(err)
-	}
-
-	for _, e := range errs {
-		me.append(e)
-	}
-
-	return me
-}
-
 type remoteObjectParseError struct {
 	error
 	typ     string
@@ -104,21 +60,21 @@ func (e *remoteObjectParseError) Unwrap() error {
 
 func parseRemoteObjectPreview(op *cdpruntime.ObjectPreview) (map[string]any, error) {
 	obj := make(map[string]any)
-	var result error
+	var result []error
 	if op.Overflow {
-		result = multierror(result, &objectOverflowError{})
+		result = append(result, &objectOverflowError{})
 	}
 
 	for _, p := range op.Properties {
 		val, err := parseRemoteObjectValue(p.Type, p.Subtype, p.Value, p.ValuePreview)
 		if err != nil {
-			result = multierror(result, &objectPropertyParseError{err, p.Name})
+			result = append(result, &objectPropertyParseError{err, p.Name})
 			continue
 		}
 		obj[p.Name] = val
 	}
 
-	return obj, result
+	return obj, errors.Join(result...)
 }
 
 //nolint:cyclop

--- a/common/remote_object_test.go
+++ b/common/remote_object_test.go
@@ -2,8 +2,6 @@ package common
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"math"
 	"testing"
 
@@ -260,77 +258,6 @@ func TestParseRemoteObject(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-		})
-	}
-}
-
-func TestMultierror(t *testing.T) {
-	t.Parallel()
-
-	var (
-		mockErr1 = errors.New("mockErr1")
-		mockErr2 = errors.New("mockErr2")
-		mockErr3 = errors.New("mockErr3")
-
-		mockMultiErr = &multiError{
-			Errors: []error{mockErr1},
-		}
-		mockWrappedMultiErr = fmt.Errorf("%w", mockMultiErr)
-	)
-
-	tests := []struct {
-		name    string
-		initial error
-		errs    []error
-		exp     []error
-		expStr  string
-	}{
-		{
-			name:    "initial error is nil",
-			initial: nil,
-			errs:    []error{mockErr1},
-			exp:     []error{mockErr1},
-			expStr:  mockErr1.Error(),
-		},
-		{
-			name:    "initial error is std error",
-			initial: mockErr1,
-			errs:    []error{mockErr2, mockErr3},
-			exp:     []error{mockErr1, mockErr2, mockErr3},
-			expStr: fmt.Sprintf(
-				"3 errors occurred:\n\t* %s\n\t* %s\n\t* %s\n",
-				mockErr1, mockErr2, mockErr3),
-		},
-		{
-			name:    "initial error is multiError",
-			initial: mockMultiErr,
-			errs:    []error{mockErr3},
-			exp:     []error{mockErr1, mockErr3},
-			expStr: fmt.Sprintf(
-				"2 errors occurred:\n\t* %s\n\t* %s\n",
-				mockErr1, mockErr3),
-		},
-		{
-			name:    "initial error is wrapped multiError",
-			initial: mockWrappedMultiErr,
-			errs:    []error{mockErr3, mockErr2},
-			exp:     []error{mockWrappedMultiErr, mockErr3, mockErr2},
-			expStr: fmt.Sprintf(
-				"3 errors occurred:\n\t* %s\n\t* %s\n\t* %s\n",
-				mockWrappedMultiErr, mockErr3, mockErr2),
-		},
-	}
-
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := multierror(tc.initial, tc.errs...)
-			var me *multiError
-			assert.True(t, errors.As(err, &me))
-			assert.Equal(t, tc.exp, me.Errors)
-			assert.Equal(t, tc.expStr, me.Error())
 		})
 	}
 }


### PR DESCRIPTION
This should be merged after upgrading Go's previous version on CI (currently 1.19) to 1.20. Currently, the tests fail because of that.

Updates #738.