### PR TITLE
Remove existing browser namespaced metrics

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -49,7 +49,6 @@ type Frame struct {
 	url          string
 	detached     bool
 	vu           k6modules.VU
-	initTime     time.Time
 
 	// A life cycle event is only considered triggered for a frame if the entire
 	// frame subtree has also had the life cycle event triggered.

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -803,12 +803,6 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 	case "networkIdle":
 		fs.manager.frameLifecycleEvent(event.FrameID, LifecycleEventNetworkIdle)
 	}
-
-	eventToMetric := map[string]*k6metrics.Metric{}
-
-	if m, ok := eventToMetric[event.Name]; ok {
-		frame.emitMetric(m, event.Timestamp.Time())
-	}
 }
 
 func (fs *FrameSession) onPageNavigatedWithinDocument(event *cdppage.EventNavigatedWithinDocument) {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -804,9 +804,7 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 		fs.manager.frameLifecycleEvent(event.FrameID, LifecycleEventNetworkIdle)
 	}
 
-	eventToMetric := map[string]*k6metrics.Metric{
-		"firstPaint": fs.k6Metrics.BrowserFirstPaint,
-	}
+	eventToMetric := map[string]*k6metrics.Metric{}
 
 	if m, ok := eventToMetric[event.Name]; ok {
 		frame.emitMetric(m, event.Timestamp.Time())

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -805,9 +805,8 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 	}
 
 	eventToMetric := map[string]*k6metrics.Metric{
-		"load":             fs.k6Metrics.BrowserLoaded,
-		"DOMContentLoaded": fs.k6Metrics.BrowserDOMContentLoaded,
-		"firstPaint":       fs.k6Metrics.BrowserFirstPaint,
+		"load":       fs.k6Metrics.BrowserLoaded,
+		"firstPaint": fs.k6Metrics.BrowserFirstPaint,
 	}
 
 	if m, ok := eventToMetric[event.Name]; ok {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -793,9 +793,6 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 	}
 
 	switch event.Name {
-	case "init", "commit":
-		frame.initTime = event.Timestamp.Time()
-		return
 	case "load":
 		fs.manager.frameLifecycleEvent(event.FrameID, LifecycleEventLoad)
 	case "DOMContentLoaded":

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -805,7 +805,6 @@ func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {
 	}
 
 	eventToMetric := map[string]*k6metrics.Metric{
-		"load":       fs.k6Metrics.BrowserLoaded,
 		"firstPaint": fs.k6Metrics.BrowserFirstPaint,
 	}
 

--- a/examples/multiple-scenario.js
+++ b/examples/multiple-scenario.js
@@ -17,7 +17,6 @@ export const options = {
     },
   },
   thresholds: {
-    browser_dom_content_loaded: ['p(90) < 1000'],
     webvital_first_contentful_paint: ['max < 1000'],
     checks: ["rate==1.0"]
   }

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -17,8 +17,6 @@ const (
 
 // CustomMetrics are the custom k6 metrics used by xk6-browser.
 type CustomMetrics struct {
-	BrowserFirstPaint *k6metrics.Metric
-
 	WebVitals map[string]*k6metrics.Metric
 }
 
@@ -54,8 +52,6 @@ func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
 	}
 
 	return &CustomMetrics{
-		BrowserFirstPaint: registry.MustNewMetric(
-			"browser_first_paint", k6metrics.Trend, k6metrics.Time),
 		WebVitals: webVitals,
 	}
 }

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -17,9 +17,8 @@ const (
 
 // CustomMetrics are the custom k6 metrics used by xk6-browser.
 type CustomMetrics struct {
-	BrowserDOMContentLoaded *k6metrics.Metric
-	BrowserFirstPaint       *k6metrics.Metric
-	BrowserLoaded           *k6metrics.Metric
+	BrowserFirstPaint *k6metrics.Metric
+	BrowserLoaded     *k6metrics.Metric
 
 	WebVitals map[string]*k6metrics.Metric
 }
@@ -56,8 +55,6 @@ func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
 	}
 
 	return &CustomMetrics{
-		BrowserDOMContentLoaded: registry.MustNewMetric(
-			"browser_dom_content_loaded", k6metrics.Trend, k6metrics.Time),
 		BrowserFirstPaint: registry.MustNewMetric(
 			"browser_first_paint", k6metrics.Trend, k6metrics.Time),
 		BrowserLoaded: registry.MustNewMetric(

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -18,7 +18,6 @@ const (
 // CustomMetrics are the custom k6 metrics used by xk6-browser.
 type CustomMetrics struct {
 	BrowserFirstPaint *k6metrics.Metric
-	BrowserLoaded     *k6metrics.Metric
 
 	WebVitals map[string]*k6metrics.Metric
 }
@@ -57,8 +56,6 @@ func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
 	return &CustomMetrics{
 		BrowserFirstPaint: registry.MustNewMetric(
 			"browser_first_paint", k6metrics.Trend, k6metrics.Time),
-		BrowserLoaded: registry.MustNewMetric(
-			"browser_loaded", k6metrics.Trend, k6metrics.Time),
 		WebVitals: webVitals,
 	}
 }


### PR DESCRIPTION
Now that we have web vitals, we have evaluated the existing browser metrics:

- [browser_first_paint](https://github.com/grafana/xk6-browser/issues/831#issuecomment-1496313265)
- [browser_dom_content_loaded](https://github.com/grafana/xk6-browser/issues/831#issuecomment-1497094423)
- [browser_loaded](https://github.com/grafana/xk6-browser/issues/831#issuecomment-1497100020)

Our conclusion is that none of these metrics gives us more value or answers questions that we don't already have answers for from the web vitals. The web vitals concentrate on measuring and showing users how useable the website it, rather than these existing metrics which only show us how long it took to download the html file, it's dependencies and when the first element was rendered (usually the background colour).

closes: https://github.com/grafana/xk6-browser/issues/831