### PR TITLE
Fix Locator.WaitFor for `detached` and `hidden` states

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -490,6 +490,18 @@ func (f *Frame) waitForSelector(selector string, opts *FrameWaitForSelectorOptio
 	return handle, nil
 }
 
+func (f *Frame) waitFor(selector string, opts *FrameWaitForSelectorOptions) error {
+	f.log.Debugf("Frame:waitFor", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
+
+	document, err := f.document()
+	if err != nil {
+		return err
+	}
+
+	_, err = document.waitForSelector(f.ctx, selector, opts)
+	return err
+}
+
 // AddScriptTag is not implemented.
 func (f *Frame) AddScriptTag(opts goja.Value) {
 	k6ext.Panic(f.ctx, "Frame.AddScriptTag() has not been implemented yet")

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -889,7 +889,7 @@ class InjectedScript {
         case "attached":
           return element ? element : continuePolling;
         case "detached":
-          return !element ? undefined : continuePolling;
+          return !element ? true : continuePolling;
         case "visible":
           return visible ? element : continuePolling;
         case "hidden":

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -893,7 +893,7 @@ class InjectedScript {
         case "visible":
           return visible ? element : continuePolling;
         case "hidden":
-          return !visible ? undefined : continuePolling;
+          return !visible ? element : continuePolling;
       }
     };
 

--- a/common/locator.go
+++ b/common/locator.go
@@ -620,6 +620,5 @@ func (l *Locator) WaitFor(opts goja.Value) {
 
 func (l *Locator) waitFor(opts *FrameWaitForSelectorOptions) error {
 	opts.Strict = true
-	_, err := l.frame.waitForSelector(l.selector, opts)
-	return err
+	return l.frame.waitFor(l.selector, opts)
 }

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -17,6 +17,12 @@ import (
 // Note:
 // We skip adding t.Parallel to subtests because goja or our code might race.
 
+type jsFrameWaitForSelectorOpts struct {
+	jsFrameBaseOpts
+
+	State string
+}
+
 func TestLocator(t *testing.T) {
 	t.Parallel()
 
@@ -176,6 +182,33 @@ func TestLocator(t *testing.T) {
 			"WaitFor state:visible", func(tb *testBrowser, p api.Page) {
 				opts := tb.toGojaValue(jsFrameBaseOpts{Timeout: "100"})
 				require.NotPanics(t, func() { p.Locator("#link", nil).WaitFor(opts) })
+			},
+		},
+		{
+			"WaitFor state:attached", func(tb *testBrowser, p api.Page) {
+				opts := tb.toGojaValue(jsFrameWaitForSelectorOpts{
+					jsFrameBaseOpts: jsFrameBaseOpts{Timeout: "100"},
+					State:           "attached",
+				})
+				require.NotPanics(t, func() { p.Locator("#link", nil).WaitFor(opts) })
+			},
+		},
+		{
+			"WaitFor state:hidden", func(tb *testBrowser, p api.Page) {
+				opts := tb.toGojaValue(jsFrameWaitForSelectorOpts{
+					jsFrameBaseOpts: jsFrameBaseOpts{Timeout: "100"},
+					State:           "hidden",
+				})
+				require.NotPanics(t, func() { p.Locator("#inputHiddenText", nil).WaitFor(opts) })
+			},
+		},
+		{
+			"WaitFor state:detached", func(tb *testBrowser, p api.Page) {
+				opts := tb.toGojaValue(jsFrameWaitForSelectorOpts{
+					jsFrameBaseOpts: jsFrameBaseOpts{Timeout: "100"},
+					State:           "detached",
+				})
+				require.NotPanics(t, func() { p.Locator("#nonExistingElement", nil).WaitFor(opts) })
 			},
 		},
 	}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -173,9 +173,9 @@ func TestLocator(t *testing.T) {
 			},
 		},
 		{
-			"WaitFor", func(tb *testBrowser, p api.Page) {
-				timeout := tb.toGojaValue(jsFrameBaseOpts{Timeout: "100"})
-				require.NotPanics(t, func() { p.Locator("#link", nil).WaitFor(timeout) })
+			"WaitFor state:visible", func(tb *testBrowser, p api.Page) {
+				opts := tb.toGojaValue(jsFrameBaseOpts{Timeout: "100"})
+				require.NotPanics(t, func() { p.Locator("#link", nil).WaitFor(opts) })
 			},
 		},
 	}

--- a/tests/static/locators.html
+++ b/tests/static/locators.html
@@ -12,6 +12,7 @@
     <input id="inputCheckbox" type="checkbox" />
     <input type="checkbox" />
     <input id="inputText" type="text" value="something" />
+    <input id="inputHiddenText" type="text" hidden="true">
     <div id="divHello"><span>hello</span></div>
     <div><span>bye</span></div>
     <textarea>text area</textarea>


### PR DESCRIPTION
This PR fixes the `Locator.WaitFor` functionality when the state defined is either `hidden` or `detached`. Previously, waiting for these two states would result in an infinite pooling loop and eventually a TO error.

Besides the integration tests included in the PR, this changes can be tested also using this [test browser](https://github.com/ankur22/testserver) implemented by @ankur22 and executing the following script:
```js
import { chromium } from 'k6/x/browser'

export default async function () {
    const browser = chromium.launch({
        headless: false,
    })
    const context = browser.newContext()
    const page = context.newPage()

    try {
        await page.goto('http://localhost/other', { waitUntil: 'networkidle' })
        
        page.locator("#attach-detach").waitFor({state: "detached"});
        console.log("detached");

        page.locator('#input-text-hidden').waitFor({state: "hidden"});
        console.log("hidden");
    } finally {
        page.close()
        browser.close()
    }
}
```
Take into account that **this test will require user interaction** to click on the `Detach` button on the top left of the page in order to remove the element that we are waiting for from the DOM.

Closes: #736.
Closes: #472.