### PR TITLE
Fix remote object parsing when subtype is `null`

### DIFF
--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -92,7 +92,7 @@ func parseRemoteObjectPreview(op *cdpruntime.ObjectPreview) (map[string]any, err
 	}
 
 	for _, p := range op.Properties {
-		val, err := parseRemoteObjectValue(p.Type, p.Value, p.ValuePreview)
+		val, err := parseRemoteObjectValue(p.Type, p.Subtype, p.Value, p.ValuePreview)
 		if err != nil {
 			result = multierror(result, &objectPropertyParseError{err, p.Name})
 			continue
@@ -104,7 +104,9 @@ func parseRemoteObjectPreview(op *cdpruntime.ObjectPreview) (map[string]any, err
 }
 
 //nolint:cyclop
-func parseRemoteObjectValue(t cdpruntime.Type, val string, op *cdpruntime.ObjectPreview) (any, error) {
+func parseRemoteObjectValue(
+	t cdpruntime.Type, st cdpruntime.Subtype, val string, op *cdpruntime.ObjectPreview,
+) (any, error) {
 	switch t {
 	case cdpruntime.TypeAccessor:
 		return "accessor", nil
@@ -128,6 +130,9 @@ func parseRemoteObjectValue(t cdpruntime.Type, val string, op *cdpruntime.Object
 		}
 		if val == "Object" {
 			return val, nil
+		}
+		if st == "null" {
+			return "null", nil
 		}
 	case cdpruntime.TypeUndefined:
 		return "undefined", nil
@@ -159,7 +164,7 @@ func parseExceptionDetails(exc *cdpruntime.ExceptionDetails) string {
 
 func parseRemoteObject(obj *cdpruntime.RemoteObject) (any, error) {
 	if obj.UnserializableValue == "" {
-		return parseRemoteObjectValue(obj.Type, string(obj.Value), obj.Preview)
+		return parseRemoteObjectValue(obj.Type, obj.Subtype, string(obj.Value), obj.Preview)
 	}
 
 	switch obj.UnserializableValue.String() {

--- a/common/remote_object_test.go
+++ b/common/remote_object_test.go
@@ -155,8 +155,8 @@ func TestParseRemoteObject(t *testing.T) {
 	testCases := []struct {
 		name     string
 		preview  *runtime.ObjectPreview
-		value    string
-		expected map[string]any
+		value    easyjson.RawMessage
+		expected any
 		expErr   string
 	}{
 		{

--- a/common/remote_object_test.go
+++ b/common/remote_object_test.go
@@ -154,6 +154,7 @@ func TestParseRemoteObject(t *testing.T) {
 
 	testCases := []struct {
 		name     string
+		subtype  string
 		preview  *runtime.ObjectPreview
 		value    easyjson.RawMessage
 		expected any
@@ -214,6 +215,12 @@ func TestParseRemoteObject(t *testing.T) {
 			expected: map[string]any{},
 			expErr:   "parsing object property",
 		},
+		{
+			name:     "null",
+			subtype:  "null",
+			value:    nil,
+			expected: "null",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -222,6 +229,7 @@ func TestParseRemoteObject(t *testing.T) {
 			t.Parallel()
 			remoteObject := &runtime.RemoteObject{
 				Type:     "object",
+				Subtype:  runtime.Subtype(tc.subtype),
 				ObjectID: runtime.RemoteObjectID("object_id_0123456789"),
 				Preview:  tc.preview,
 				Value:    easyjson.RawMessage(tc.value),


### PR DESCRIPTION
Closes #793.
Closes #777.