### PR TITLE
Disable timeout on browser process execution

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -120,7 +120,7 @@ func (b *BrowserType) Connect(wsEndpoint string, opts goja.Value) api.Browser {
 func (b *BrowserType) connect(
 	ctx context.Context, wsURL string, opts *common.LaunchOptions, logger *log.Logger,
 ) (*common.Browser, error) {
-	browserProc, err := b.link(ctx, wsURL, opts, logger)
+	browserProc, err := b.link(ctx, wsURL, logger)
 	if browserProc == nil {
 		return nil, fmt.Errorf("connecting to browser: %w", err)
 	}
@@ -140,10 +140,9 @@ func (b *BrowserType) connect(
 }
 
 func (b *BrowserType) link(
-	ctx context.Context, wsURL string,
-	opts *common.LaunchOptions, logger *log.Logger,
+	ctx context.Context, wsURL string, logger *log.Logger,
 ) (*common.BrowserProcess, error) {
-	bProcCtx, bProcCtxCancel := context.WithTimeout(ctx, opts.Timeout)
+	bProcCtx, bProcCtxCancel := context.WithCancel(ctx)
 	p, err := common.NewRemoteBrowserProcess(bProcCtx, wsURL, bProcCtxCancel, logger)
 	if err != nil {
 		bProcCtxCancel()

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -240,7 +240,7 @@ func (b *BrowserType) allocate(
 	flags map[string]any, env []string, dataDir *storage.Dir,
 	logger *log.Logger,
 ) (_ *common.BrowserProcess, rerr error) {
-	bProcCtx, bProcCtxCancel := context.WithTimeout(ctx, opts.Timeout)
+	bProcCtx, bProcCtxCancel := context.WithCancel(ctx)
 	defer func() {
 		if rerr != nil {
 			bProcCtxCancel()


### PR DESCRIPTION
This PR modifies the browser launching/connecting process to not pass a context with timeout to the actual browser process cmd handle and/or implementation closing handle. Currently this was done using as timeout the value set for the browser.timeout option, which should serve a different purpose.

Instead, it makes the browser process handle and its [closing handling method](https://github.com/grafana/xk6-browser/blob/480c0c1f74ef377570be4a6a720ddd7a1cd447e7/common/browser_process.go#L64) depend on the VU context.

Closes #865.
Closes #864.