### PR TITLE
Remove support for browser devtools option

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -354,11 +354,10 @@ func prepareFlags(lopts *common.LaunchOptions, k6opts *k6lib.Options) (map[strin
 		"use-mock-keychain":               true,
 		"no-service-autorun":              true,
 
-		"no-startup-window":           true,
-		"no-default-browser-check":    true,
-		"headless":                    lopts.Headless,
-		"auto-open-devtools-for-tabs": lopts.Devtools,
-		"window-size":                 fmt.Sprintf("%d,%d", 800, 600),
+		"no-startup-window":        true,
+		"no-default-browser-check": true,
+		"headless":                 lopts.Headless,
+		"window-size":              fmt.Sprintf("%d,%d", 800, 600),
 	}
 	if lopts.Headless {
 		f["hide-scrollbars"] = true

--- a/chromium/browser_type_test.go
+++ b/chromium/browser_type_test.go
@@ -34,12 +34,6 @@ func TestBrowserTypePrepareFlags(t *testing.T) {
 		post                      func(t *testing.T, flags map[string]any)
 	}{
 		{
-			flag:          "auto-open-devtools-for-tabs",
-			expInitVal:    false,
-			changeOpts:    &common.LaunchOptions{Devtools: true},
-			expChangedVal: true,
-		},
-		{
 			flag:       "hide-scrollbars",
 			changeOpts: &common.LaunchOptions{IgnoreDefaultArgs: []string{"hide-scrollbars"}, Headless: true},
 		},

--- a/common/browser_options.go
+++ b/common/browser_options.go
@@ -13,7 +13,6 @@ import (
 const (
 	optArgs              = "args"
 	optDebug             = "debug"
-	optDevTools          = "devtools"
 	optEnv               = "env"
 	optExecutablePath    = "executablePath"
 	optHeadless          = "headless"
@@ -36,7 +35,6 @@ type ProxyOptions struct {
 type LaunchOptions struct {
 	Args              []string
 	Debug             bool
-	Devtools          bool
 	Env               map[string]string
 	ExecutablePath    string
 	Headless          bool
@@ -111,8 +109,6 @@ func (l *LaunchOptions) Parse(ctx context.Context, logger *log.Logger, opts goja
 			err = exportOpt(rt, k, v, &l.Args)
 		case optDebug:
 			l.Debug, err = parseBoolOpt(k, v)
-		case optDevTools:
-			l.Devtools, err = parseBoolOpt(k, v)
 		case optEnv:
 			err = exportOpt(rt, k, v, &l.Env)
 		case optExecutablePath:
@@ -145,7 +141,6 @@ func (l *LaunchOptions) shouldIgnoreIfBrowserIsRemote(opt string) bool {
 
 	shouldIgnoreIfBrowserIsRemote := map[string]struct{}{
 		optArgs:              {},
-		optDevTools:          {},
 		optEnv:               {},
 		optExecutablePath:    {},
 		optHeadless:          {},

--- a/common/browser_options_test.go
+++ b/common/browser_options_test.go
@@ -46,7 +46,6 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 			opts: map[string]any{
 				// disallow changing the following opts
 				"args":              []string{"any"},
-				"devtools":          true,
 				"env":               map[string]string{"some": "thing"},
 				"executablePath":    "something else",
 				"headless":          false,
@@ -119,19 +118,6 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 		"debug_err": {
 			opts: map[string]any{"debug": "true"},
 			err:  "debug should be a boolean",
-		},
-		"devtools": {
-			opts: map[string]any{
-				"devtools": true,
-			},
-			assert: func(tb testing.TB, lo *LaunchOptions) {
-				tb.Helper()
-				assert.True(t, lo.Devtools)
-			},
-		},
-		"devtools_err": {
-			opts: map[string]any{"devtools": "true"},
-			err:  "devtools should be a boolean",
 		},
 		"env": {
 			opts: map[string]any{


### PR DESCRIPTION
A decision was made to no longer support the devtools browser option, which behaves as a flag in order to automatically enable DevTools in all new pages as this was not providing much value.

Closes #867.