### PR TITLE
Remove support for browser env option

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -176,10 +176,6 @@ func (b *BrowserType) Launch(opts goja.Value) (_ api.Browser, browserProcessID i
 func (b *BrowserType) launch(
 	ctx context.Context, opts *common.LaunchOptions, logger *log.Logger,
 ) (_ *common.Browser, pid int, _ error) {
-	envs := make([]string, 0, len(opts.Env))
-	for k, v := range opts.Env {
-		envs = append(envs, fmt.Sprintf("%s=%s", k, v))
-	}
 	flags, err := prepareFlags(opts, &(b.vu.State()).Options)
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w", err)
@@ -204,7 +200,7 @@ func (b *BrowserType) launch(
 		<-c.Done()
 	}(ctx)
 
-	browserProc, err := b.allocate(ctx, opts, flags, envs, dataDir, logger)
+	browserProc, err := b.allocate(ctx, opts, flags, dataDir, logger)
 	if browserProc == nil {
 		return nil, 0, fmt.Errorf("launching browser: %w", err)
 	}
@@ -237,7 +233,7 @@ func (b *BrowserType) Name() string {
 // allocate starts a new Chromium browser process and returns it.
 func (b *BrowserType) allocate(
 	ctx context.Context, opts *common.LaunchOptions,
-	flags map[string]any, env []string, dataDir *storage.Dir,
+	flags map[string]any, dataDir *storage.Dir,
 	logger *log.Logger,
 ) (_ *common.BrowserProcess, rerr error) {
 	bProcCtx, bProcCtxCancel := context.WithTimeout(ctx, opts.Timeout)
@@ -257,7 +253,7 @@ func (b *BrowserType) allocate(
 		path = b.ExecutablePath()
 	}
 
-	return common.NewLocalBrowserProcess(bProcCtx, path, args, env, dataDir, bProcCtxCancel, logger) //nolint: wrapcheck
+	return common.NewLocalBrowserProcess(bProcCtx, path, args, dataDir, bProcCtxCancel, logger) //nolint: wrapcheck
 }
 
 // ExecutablePath returns the path where the extension expects to find the browser executable.

--- a/common/browser_options.go
+++ b/common/browser_options.go
@@ -14,7 +14,6 @@ const (
 	optArgs              = "args"
 	optDebug             = "debug"
 	optDevTools          = "devtools"
-	optEnv               = "env"
 	optExecutablePath    = "executablePath"
 	optHeadless          = "headless"
 	optIgnoreDefaultArgs = "ignoreDefaultArgs"
@@ -37,7 +36,6 @@ type LaunchOptions struct {
 	Args              []string
 	Debug             bool
 	Devtools          bool
-	Env               map[string]string
 	ExecutablePath    string
 	Headless          bool
 	IgnoreDefaultArgs []string
@@ -58,7 +56,6 @@ type LaunchPersistentContextOptions struct {
 // NewLaunchOptions returns a new LaunchOptions.
 func NewLaunchOptions() *LaunchOptions {
 	return &LaunchOptions{
-		Env:               make(map[string]string),
 		Headless:          true,
 		LogCategoryFilter: ".*",
 		Timeout:           DefaultTimeout,
@@ -69,7 +66,6 @@ func NewLaunchOptions() *LaunchOptions {
 // for a browser running in a remote machine.
 func NewRemoteBrowserLaunchOptions() *LaunchOptions {
 	return &LaunchOptions{
-		Env:               make(map[string]string),
 		Headless:          true,
 		LogCategoryFilter: ".*",
 		Timeout:           DefaultTimeout,
@@ -87,7 +83,6 @@ func (l *LaunchOptions) Parse(ctx context.Context, logger *log.Logger, opts goja
 		rt       = k6ext.Runtime(ctx)
 		o        = opts.ToObject(rt)
 		defaults = map[string]any{
-			optEnv:               l.Env,
 			optHeadless:          l.Headless,
 			optLogCategoryFilter: l.LogCategoryFilter,
 			optTimeout:           l.Timeout,
@@ -113,8 +108,6 @@ func (l *LaunchOptions) Parse(ctx context.Context, logger *log.Logger, opts goja
 			l.Debug, err = parseBoolOpt(k, v)
 		case optDevTools:
 			l.Devtools, err = parseBoolOpt(k, v)
-		case optEnv:
-			err = exportOpt(rt, k, v, &l.Env)
 		case optExecutablePath:
 			l.ExecutablePath, err = parseStrOpt(k, v)
 		case optHeadless:
@@ -146,7 +139,6 @@ func (l *LaunchOptions) shouldIgnoreIfBrowserIsRemote(opt string) bool {
 	shouldIgnoreIfBrowserIsRemote := map[string]struct{}{
 		optArgs:              {},
 		optDevTools:          {},
-		optEnv:               {},
 		optExecutablePath:    {},
 		optHeadless:          {},
 		optIgnoreDefaultArgs: {},

--- a/common/browser_options_test.go
+++ b/common/browser_options_test.go
@@ -15,7 +15,6 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 	t.Parallel()
 
 	defaultOptions := &LaunchOptions{
-		Env:               make(map[string]string),
 		Headless:          true,
 		LogCategoryFilter: ".*",
 		Timeout:           DefaultTimeout,
@@ -47,7 +46,6 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 				// disallow changing the following opts
 				"args":              []string{"any"},
 				"devtools":          true,
-				"env":               map[string]string{"some": "thing"},
 				"executablePath":    "something else",
 				"headless":          false,
 				"ignoreDefaultArgs": []string{"any"},
@@ -62,7 +60,6 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 				tb.Helper()
 				assert.Equal(t, &LaunchOptions{
 					// disallowed:
-					Env:      make(map[string]string),
 					Headless: true,
 					// allowed:
 					Debug:             true,
@@ -76,7 +73,6 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 		},
 		"nulls": { // don't override the defaults on `null`
 			opts: map[string]any{
-				"env":               nil,
 				"headless":          nil,
 				"logCategoryFilter": nil,
 				"timeout":           nil,
@@ -84,7 +80,6 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 			assert: func(tb testing.TB, lo *LaunchOptions) {
 				tb.Helper()
 				assert.Equal(tb, &LaunchOptions{
-					Env:               make(map[string]string),
 					Headless:          true,
 					LogCategoryFilter: ".*",
 					Timeout:           DefaultTimeout,
@@ -132,19 +127,6 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 		"devtools_err": {
 			opts: map[string]any{"devtools": "true"},
 			err:  "devtools should be a boolean",
-		},
-		"env": {
-			opts: map[string]any{
-				"env": map[string]string{"key": "value"},
-			},
-			assert: func(tb testing.TB, lo *LaunchOptions) {
-				tb.Helper()
-				assert.Equal(t, map[string]string{"key": "value"}, lo.Env)
-			},
-		},
-		"env_err": {
-			opts: map[string]any{"env": 1},
-			err:  "env should be a map",
 		},
 		"executablePath": {
 			opts: map[string]any{

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -38,7 +38,7 @@ func NewLocalBrowserProcess(
 	ctx context.Context, path string, args []string, dataDir *storage.Dir,
 	ctxCancel context.CancelFunc, logger *log.Logger,
 ) (*BrowserProcess, error) {
-	cmd, err := execute(ctx, ctxCancel, path, args, dataDir, logger)
+	cmd, err := execute(ctx, path, args, dataDir, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ type command struct {
 }
 
 func execute(
-	ctx context.Context, ctxCancel func(), path string, args []string,
+	ctx context.Context, path string, args []string,
 	dataDir *storage.Dir, logger *log.Logger,
 ) (command, error) {
 	cmd := exec.CommandContext(ctx, path, args...)

--- a/common/browser_process.go
+++ b/common/browser_process.go
@@ -35,10 +35,10 @@ type BrowserProcess struct {
 // NewLocalBrowserProcess starts a local browser process and
 // returns a new BrowserProcess instance to interact with it.
 func NewLocalBrowserProcess(
-	ctx context.Context, path string, args, env []string, dataDir *storage.Dir,
+	ctx context.Context, path string, args []string, dataDir *storage.Dir,
 	ctxCancel context.CancelFunc, logger *log.Logger,
 ) (*BrowserProcess, error) {
-	cmd, err := execute(ctx, ctxCancel, path, args, env, dataDir, logger)
+	cmd, err := execute(ctx, ctxCancel, path, args, dataDir, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ type command struct {
 }
 
 func execute(
-	ctx context.Context, ctxCancel func(), path string, args, env []string,
+	ctx context.Context, ctxCancel func(), path string, args []string,
 	dataDir *storage.Dir, logger *log.Logger,
 ) (command, error) {
 	cmd := exec.CommandContext(ctx, path, args...)
@@ -164,11 +164,6 @@ func execute(
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		return command{}, fmt.Errorf("%w", err)
-	}
-
-	// Set up environment variable for process
-	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
 	}
 
 	// We must start the cmd before calling cmd.Wait, as otherwise the two


### PR DESCRIPTION
A decision was made to no longer support the env browser option as this was not providing much value.

Closes #869.