### PR TITLE
Remove support for browser proxy option

### DIFF
--- a/common/browser_options.go
+++ b/common/browser_options.go
@@ -19,18 +19,9 @@ const (
 	optHeadless          = "headless"
 	optIgnoreDefaultArgs = "ignoreDefaultArgs"
 	optLogCategoryFilter = "logCategoryFilter"
-	optProxy             = "proxy"
 	optSlowMo            = "slowMo"
 	optTimeout           = "timeout"
 )
-
-// ProxyOptions allows configuring a proxy server.
-type ProxyOptions struct {
-	Server   string
-	Bypass   string
-	Username string
-	Password string
-}
 
 // LaunchOptions stores browser launch options.
 type LaunchOptions struct {
@@ -42,7 +33,6 @@ type LaunchOptions struct {
 	Headless          bool
 	IgnoreDefaultArgs []string
 	LogCategoryFilter string
-	Proxy             ProxyOptions
 	SlowMo            time.Duration
 	Timeout           time.Duration
 
@@ -123,8 +113,6 @@ func (l *LaunchOptions) Parse(ctx context.Context, logger *log.Logger, opts goja
 			err = exportOpt(rt, k, v, &l.IgnoreDefaultArgs)
 		case optLogCategoryFilter:
 			l.LogCategoryFilter, err = parseStrOpt(k, v)
-		case optProxy:
-			err = exportOpt(rt, k, v, &l.Proxy)
 		case optSlowMo:
 			l.SlowMo, err = parseTimeOpt(k, v)
 		case optTimeout:
@@ -150,7 +138,6 @@ func (l *LaunchOptions) shouldIgnoreIfBrowserIsRemote(opt string) bool {
 		optExecutablePath:    {},
 		optHeadless:          {},
 		optIgnoreDefaultArgs: {},
-		optProxy:             {},
 	}
 	_, ignore := shouldIgnoreIfBrowserIsRemote[opt]
 

--- a/common/browser_options_test.go
+++ b/common/browser_options_test.go
@@ -51,7 +51,6 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 				"executablePath":    "something else",
 				"headless":          false,
 				"ignoreDefaultArgs": []string{"any"},
-				"proxy":             ProxyOptions{Server: "srv"},
 				// allow changing the following opts
 				"debug":             true,
 				"logCategoryFilter": "...",
@@ -199,29 +198,6 @@ func TestBrowserLaunchOptionsParse(t *testing.T) {
 		"logCategoryFilter_err": {
 			opts: map[string]any{"logCategoryFilter": 1},
 			err:  "logCategoryFilter should be a string",
-		},
-		"proxy": {
-			opts: map[string]any{
-				"proxy": ProxyOptions{
-					Server:   "serverVal",
-					Bypass:   "bypassVal",
-					Username: "usernameVal",
-					Password: "passwordVal",
-				},
-			},
-			assert: func(tb testing.TB, lo *LaunchOptions) {
-				tb.Helper()
-				assert.Equal(t, ProxyOptions{
-					Server:   "serverVal",
-					Bypass:   "bypassVal",
-					Username: "usernameVal",
-					Password: "passwordVal",
-				}, lo.Proxy)
-			},
-		},
-		"proxy_err": {
-			opts: map[string]any{"proxy": 1},
-			err:  "proxy should be an object",
 		},
 		"slowMo": {
 			opts: map[string]any{


### PR DESCRIPTION
A decision was made to remove proxy from browser option as, even though the option is parsed and accepted, it has no implication on the rest of the code as we are missing the actual implementation. Therefore the option will not be parsed from now on until we complete the implementation so it can have an effect on k6 browser execution.