### PR TITLE
Add request failed metric

### DIFF
--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -265,7 +265,7 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 					Time:       wallTime,
 				},
 				{
-					TimeSeries: k6metrics.TimeSeries{Metric: state.BuiltinMetrics.HTTPReqFailed, Tags: tags},
+					TimeSeries: k6metrics.TimeSeries{Metric: m.customMetrics.BrowserHTTPReqFailed, Tags: tags},
 					Value:      failed,
 					Time:       wallTime,
 				},

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -178,6 +178,7 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 		fromCache, fromPreCache, fromSvcWrk bool
 		url                                 = req.url.String()
 		wallTime                            = time.Now()
+		failed                              float64
 	)
 	if resp != nil {
 		status = resp.status
@@ -189,6 +190,11 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 		fromSvcWrk = resp.fromServiceWorker
 		wallTime = resp.wallTime
 		url = resp.url
+		// Assuming that a failure is when status
+		// is between 200 and 399 (inclusive).
+		if status < 200 || status > 399 {
+			failed = 1
+		}
 	} else {
 		m.logger.Debugf("NetworkManager:emitResponseMetrics",
 			"response is nil url:%s method:%s", req.url, req.method)
@@ -256,6 +262,11 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 				{
 					TimeSeries: k6metrics.TimeSeries{Metric: m.customMetrics.BrowserHTTPReqReceiving, Tags: tags},
 					Value:      k6metrics.D(time.Duration(resp.timing.ReceiveHeadersEnd-resp.timing.SendEnd) * time.Millisecond),
+					Time:       wallTime,
+				},
+				{
+					TimeSeries: k6metrics.TimeSeries{Metric: state.BuiltinMetrics.HTTPReqFailed, Tags: tags},
+					Value:      failed,
 					Time:       wallTime,
 				},
 			},

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -191,7 +191,7 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 		wallTime = resp.wallTime
 		url = resp.url
 		// Assuming that a failure is when status
-		// is between 200 and 399 (inclusive).
+		// is not between 200 and 399 (inclusive).
 		if status < 200 || status > 399 {
 			failed = 1
 		}

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -291,7 +291,7 @@ func TestNetworkManagerEmitRequestResponseMetricsTimingSkew(t *testing.T) {
 			n = vu.AssertSamples(func(s k6metrics.Sample) {
 				assert.Equalf(t, tt.wantRes.wt, s.Time, "timing skew in %s", s.Metric.Name)
 			})
-			assert.Equalf(t, 7, n, "should emit 7 response metrics")
+			assert.Equalf(t, 8, n, "should emit 8 response metrics")
 		})
 	}
 }

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -29,6 +29,7 @@ const (
 	browserHTTPReqTLSHandshakingName = "browser_http_req_tls_handshaking"
 	browserHTTPReqSendingName        = "browser_http_req_sending"
 	browserHTTPReqReceivingName      = "browser_http_req_receiving"
+	browserHTTPReqFailedName         = "browser_http_req_failed"
 )
 
 // CustomMetrics are the custom k6 metrics used by xk6-browser.
@@ -43,6 +44,7 @@ type CustomMetrics struct {
 	BrowserHTTPReqTLSHandshaking *k6metrics.Metric
 	BrowserHTTPReqSending        *k6metrics.Metric
 	BrowserHTTPReqReceiving      *k6metrics.Metric
+	BrowserHTTPReqFailed         *k6metrics.Metric
 }
 
 // RegisterCustomMetrics creates and registers our custom metrics with the k6
@@ -87,6 +89,7 @@ func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
 		BrowserHTTPReqTLSHandshaking: registry.MustNewMetric(browserHTTPReqTLSHandshakingName, k6metrics.Trend, k6metrics.Time),
 		BrowserHTTPReqSending:        registry.MustNewMetric(browserHTTPReqSendingName, k6metrics.Trend, k6metrics.Time),
 		BrowserHTTPReqReceiving:      registry.MustNewMetric(browserHTTPReqReceivingName, k6metrics.Trend, k6metrics.Time),
+		BrowserHTTPReqFailed:         registry.MustNewMetric(browserHTTPReqFailedName, k6metrics.Rate),
 	}
 }
 


### PR DESCRIPTION
### Description of changes

When a request completes we want to measure how many of these failed. This is based on the status code of the response. If the code is outside of the 200-399 range, it is deemed to have failed. The default status code range was taken from k6.

The opposite is also possible to determine, we can work out which requests succeeded since the value of the metric will be 0.

We're using a custom metric named `browser_http_req_failed`, instead of the builtin k6 `http_req_failed`. There was a concern that if the browser module worked with the builtin k6 metric, then the results would be skewed for both modules and therefore meaningless. This is due to the fact that the implementation of http could differ. Users are also likely to want to understand their API http failures differently to their browser level http failures.

The shape of the data is free to be moulded the best way that works for the browser module use case. I tested to see whether the [cache](https://github.com/grafana/xk6-browser/blob/015ee2e95fc1e70ba3c7a4ec310c86c43c55fd7a/common/network_manager.go#L220-L222) values varied, which they did, so I've left them in. We can adjust the metrics and labels as we see fit once we have a better idea of what users require. 

### Testing

To test this change, influxdb will need to installed or another suitable backend time series database. Once installed, run a test that you know will navigate to a website which has failing dependencies (e.g. an image that doesn't load). You should see something like this in the `http_req_failed` table:

<img width="1071" alt="Screenshot 2023-05-12 at 14 11 27" src="https://github.com/grafana/xk6-browser/assets/1112428/b5d07eb3-7f07-4c62-9b9b-189a99e8db20">

You should also see metric in the end summary:

```bash
browser_http_req_failed............: 0.00%  ✓ 0         ✗ 218
```