### PR TITLE
Rename web vital metrics

### DIFF
--- a/examples/multiple-scenario.js
+++ b/examples/multiple-scenario.js
@@ -17,7 +17,7 @@ export const options = {
     },
   },
   thresholds: {
-    webvital_first_contentful_paint: ['max < 1000'],
+    browser_web_vital_fcp: ['max < 1000'],
     checks: ["rate==1.0"]
   }
 }

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -24,12 +24,12 @@ type CustomMetrics struct {
 // VU Registry and returns our internal struct pointer.
 func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
 	wvs := map[string]string{
-		webVitalFID:  "webvital_first_input_delay",
-		webVitalTTFB: "webvital_time_to_first_byte",
-		webVitalLCP:  "webvital_largest_content_paint",
-		webVitalCLS:  "webvital_cumulative_layout_shift",
-		webVitalINP:  "webvital_interaction_to_next_paint",
-		webVitalFCP:  "webvital_first_contentful_paint",
+		webVitalFID:  "browser_web_vital_fid",  // first input delay
+		webVitalTTFB: "browser_web_vital_ttfb", // time to first byte
+		webVitalLCP:  "browser_web_vital_lcp",  // largest content paint
+		webVitalCLS:  "browser_web_vital_cls",  // cumulative layout shift
+		webVitalINP:  "browser_web_vital_inp",  // interaction to next paint
+		webVitalFCP:  "browser_web_vital_fcp",  // first contentful paint
 	}
 	webVitals := make(map[string]*k6metrics.Metric)
 

--- a/tests/webvital_test.go
+++ b/tests/webvital_test.go
@@ -20,16 +20,16 @@ func TestWebVitalMetric(t *testing.T) {
 		browser  = newTestBrowser(t, withFileServer(), withSamplesListener(samples))
 		page     = browser.NewPage(nil)
 		expected = map[string]bool{
-			"webvital_time_to_first_byte":           false,
-			"webvital_time_to_first_byte_good":      false,
-			"webvital_first_contentful_paint":       false,
-			"webvital_first_contentful_paint_good":  false,
-			"webvital_largest_content_paint":        false,
-			"webvital_largest_content_paint_good":   false,
-			"webvital_first_input_delay":            false,
-			"webvital_first_input_delay_good":       false,
-			"webvital_cumulative_layout_shift":      false,
-			"webvital_cumulative_layout_shift_good": false,
+			"browser_web_vital_ttfb":      false,
+			"browser_web_vital_ttfb_good": false,
+			"browser_web_vital_fcp":       false,
+			"browser_web_vital_fcp_good":  false,
+			"browser_web_vital_lcp":       false,
+			"browser_web_vital_lcp_good":  false,
+			"browser_web_vital_fid":       false,
+			"browser_web_vital_fid_good":  false,
+			"browser_web_vital_cls":       false,
+			"browser_web_vital_cls_good":  false,
 		}
 	)
 


### PR DESCRIPTION
### Description of changes

We're renaming them from `webvital_xxx_xxx_xxx` to `browser_web_vital_xxx`. This change benefits us in three ways:
1. Browser metrics will be namespaced with `browser_`;
2. _Webvital_ is actually two words, so _web vital_;
3. We're assuming that users will have the context of web vital metrics, so we can use the abbreviations which also helps with the display of them at the end of the test run.

Closes: https://github.com/grafana/xk6-browser/issues/884

### Checklist
```[tasklist]
- [X] Written tests for the changes
```

### Optional tasks
```[tasklist]
- [X] Update k6 documentation -- https://github.com/grafana/k6-docs/pull/1178
```