### PR TITLE
browser: Make NewPage create a page directly on the Browser

### DIFF
--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -249,7 +249,7 @@ func (b *BrowserContext) NewPage() (api.Page, error) {
 
 	p, err := b.browser.newPageInContext(b.id)
 	if err != nil {
-		return nil, fmt.Errorf("creating new page in browser context: %w", err)
+		return nil, fmt.Errorf("creating new page in browser contextxx: %w", err)
 	}
 
 	var (

--- a/common/event_emitter.go
+++ b/common/event_emitter.go
@@ -12,6 +12,7 @@ const (
 	// Browser
 
 	EventBrowserDisconnected string = "disconnected"
+	EventBrowserPage         string = "page"
 
 	// BrowserContext
 

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -140,7 +140,6 @@ func createWaitForEventHandler(
 			case <-evCancelCtx.Done():
 				return
 			case ev := <-chEvHandler:
-				panic(32)
 				fmt.Println("           ---> EVENT:", ev.typ, stringSliceContains(events, ev.typ))
 				if stringSliceContains(events, ev.typ) {
 					if predicateFn != nil {

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -140,6 +140,8 @@ func createWaitForEventHandler(
 			case <-evCancelCtx.Done():
 				return
 			case ev := <-chEvHandler:
+				panic(32)
+				fmt.Println("           ---> EVENT:", ev.typ, stringSliceContains(events, ev.typ))
 				if stringSliceContains(events, ev.typ) {
 					if predicateFn != nil {
 						if predicateFn(ev.data) {

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -280,14 +280,14 @@ func (m *NetworkManager) handleRequestRedirect(req *Request, redirectResponse *n
 }
 
 func (m *NetworkManager) initDomains() error {
-	actions := []Action{network.Enable()}
+	actions := []Action{}
 
 	// Only enable the Fetch domain if necessary, as it has a performance overhead.
-	if m.userReqInterceptionEnabled {
-		actions = append(actions,
-			network.SetCacheDisabled(true),
-			fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: "*"}}))
-	}
+	// if m.userReqInterceptionEnabled {
+	// 	actions = append(actions,
+	// 		network.SetCacheDisabled(true),
+	// 		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: "*"}}))
+	// }
 	for _, action := range actions {
 		if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
 			return fmt.Errorf("initializing networking %T: %w", action, err)

--- a/register.go
+++ b/register.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec
 	"os"
+	"runtime"
 
 	"github.com/grafana/xk6-browser/browser"
 
@@ -15,6 +16,12 @@ import (
 func init() {
 	if _, ok := os.LookupEnv("K6_BROWSER_PPROF"); ok {
 		go func() {
+
+			// set blocking profile rate:
+			// https://golang.org/pkg/runtime/#SetBlockProfileRate
+
+			runtime.SetBlockProfileRate(1)
+
 			address := "localhost:6060"
 			log.Println("Starting http debug server", address)
 			log.Println(http.ListenAndServe(address, nil)) //nolint:gosec

--- a/register.go
+++ b/register.go
@@ -31,5 +31,5 @@ func init() {
 }
 
 func init() {
-	k6modules.Register("k6/x/browser2", browser.New())
+	k6modules.Register("k6/x/browser", browser.New())
 }

--- a/register.go
+++ b/register.go
@@ -31,5 +31,5 @@ func init() {
 }
 
 func init() {
-	k6modules.Register("k6/x/browser", browser.New())
+	k6modules.Register("k6/x/browser2", browser.New())
 }


### PR DESCRIPTION
### Description of changes

In this change I'm making `*Browser.NewPage()` not use a context. This has the benefit of more easily reusing existing browser state which can aid in a smoother and more approachable test development workflow.

### Checklist
```[tasklist]
- [ ] Written tests for the changes
```

### Optional tasks
```[tasklist]
- [ ] Update k6 documentation (if relevant)
- [ ] Generate TS definitions (if relevant)
```