### PR TITLE
Refactor/pid registry

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -731,7 +731,7 @@ func mapBrowserType(vu moduleVU, bt api.BrowserType, wsURL string, isRemoteBrows
 
 			b, pid := bt.Launch()
 			// store the pid so we can kill it later on panic.
-			vu.registerPid(pid)
+			vu.RegisterPid(pid)
 			m := mapBrowser(vu, b)
 			return rt.ToValue(m).ToObject(rt)
 		},

--- a/browser/module.go
+++ b/browser/module.go
@@ -16,7 +16,7 @@ type (
 	// RootModule is the global module instance that will create module
 	// instances for each VU.
 	RootModule struct {
-		PidRegistry    *pidRegistry
+		PidRegistry    *registry.PidRegistry
 		remoteRegistry *registry.RemoteRegistry
 	}
 
@@ -41,7 +41,7 @@ var (
 // New returns a pointer to a new RootModule instance.
 func New() *RootModule {
 	return &RootModule{
-		PidRegistry:    &pidRegistry{},
+		PidRegistry:    &registry.PidRegistry{},
 		remoteRegistry: registry.NewRemoteRegistry(os.LookupEnv),
 	}
 }
@@ -53,7 +53,7 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 		mod: &JSModule{
 			Chromium: mapBrowserToGoja(moduleVU{
 				VU:             vu,
-				pidRegistry:    m.PidRegistry,
+				PidRegistry:    m.PidRegistry,
 				RemoteRegistry: m.remoteRegistry,
 			}),
 			Devices: common.GetDevices(),

--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -16,7 +16,7 @@ import (
 type moduleVU struct {
 	k6modules.VU
 
-	*pidRegistry
+	*registry.PidRegistry
 	*registry.RemoteRegistry
 }
 

--- a/registry/pid.go
+++ b/registry/pid.go
@@ -1,15 +1,15 @@
-package browser
+package registry
 
 import "sync"
 
-// pidRegistry keeps track of the launched browser process IDs.
-type pidRegistry struct {
+// PidRegistry keeps track of the launched browser process IDs.
+type PidRegistry struct {
 	mu  sync.RWMutex
 	ids []int
 }
 
-// registerPid registers the launched browser process ID.
-func (r *pidRegistry) registerPid(pid int) {
+// RegisterPid registers the launched browser process ID.
+func (r *PidRegistry) RegisterPid(pid int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -17,7 +17,7 @@ func (r *pidRegistry) registerPid(pid int) {
 }
 
 // Pids returns the launched browser process IDs.
-func (r *pidRegistry) Pids() []int {
+func (r *PidRegistry) Pids() []int {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/registry/pid_test.go
+++ b/registry/pid_test.go
@@ -1,0 +1,30 @@
+package registry
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPidRegistry(t *testing.T) {
+	p := &PidRegistry{}
+
+	var wg sync.WaitGroup
+	expected := []int{}
+	iteration := 100
+	wg.Add(iteration)
+	for i := 0; i < iteration; i++ {
+		go func(i int) {
+			p.RegisterPid(i)
+			wg.Done()
+		}(i)
+		expected = append(expected, i)
+	}
+
+	wg.Wait()
+
+	got := p.Pids()
+
+	assert.ElementsMatch(t, expected, got)
+}


### PR DESCRIPTION
### Description of changes

This moves the `pidRegistry` from the `browser` package into the `registry` package. This refactor will help isolate the details to within the `registry` package.

Related to: https://github.com/grafana/xk6-browser/pull/889#discussion_r1200622188

### Checklist
```[tasklist]
- [X] Written tests for the changes
```