### PR TITLE
Parse the scenarios json from the `K6_INSTANCE_SCENARIOS` env var

### DIFF
--- a/browser/module.go
+++ b/browser/module.go
@@ -2,6 +2,7 @@
 package browser
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/dop251/goja"
@@ -39,9 +40,14 @@ var (
 
 // New returns a pointer to a new RootModule instance.
 func New() *RootModule {
+	rr, err := newRemoteRegistry(os.LookupEnv)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create remote registry: %v", err.Error()))
+	}
+
 	return &RootModule{
 		PidRegistry:    &pidRegistry{},
-		remoteRegistry: newRemoteRegistry(os.LookupEnv),
+		remoteRegistry: rr,
 	}
 }
 

--- a/browser/registry.go
+++ b/browser/registry.go
@@ -49,23 +49,22 @@ type remoteRegistry struct {
 //
 // K6_BROWSER_WS_URL can be defined as a single WS URL or a
 // comma separated list of URLs.
-func newRemoteRegistry(envLookup env.LookupFunc) *remoteRegistry {
+func newRemoteRegistry(envLookup env.LookupFunc) (*remoteRegistry, error) {
 	r := &remoteRegistry{}
 
 	isRemote, wsURLs, err := checkForScenarios(envLookup)
 	if err != nil {
-		// TODO: Return error
-		return nil
+		return nil, err
 	}
 	if isRemote {
 		r.isRemote = isRemote
 		r.wsURLs = wsURLs
-		return r
+		return r, nil
 	}
 
 	r.isRemote, r.wsURLs = checkForBrowserWSURLs(envLookup)
 
-	return r
+	return r, nil
 }
 
 func checkForBrowserWSURLs(envLookup env.LookupFunc) (bool, []string) {

--- a/browser/registry.go
+++ b/browser/registry.go
@@ -112,8 +112,15 @@ func checkForScenarios(envLookup env.LookupFunc) (bool, []string, error) {
 	var wsURLs []string
 	for _, s := range scenarios {
 		for _, b := range s.Browsers {
+			if b.Handle == "" {
+				continue
+			}
 			wsURLs = append(wsURLs, b.Handle)
 		}
+	}
+
+	if len(wsURLs) == 0 {
+		return false, wsURLs, nil
 	}
 
 	return true, wsURLs, nil

--- a/browser/registry.go
+++ b/browser/registry.go
@@ -77,6 +77,27 @@ func newRemoteRegistry(envLookup env.LookupFunc) *remoteRegistry {
 	return r
 }
 
+func checkForBrowserWSURLs(envLookup env.LookupFunc) (bool, []string) {
+	wsURL, isRemote := envLookup("K6_BROWSER_WS_URL")
+	if !isRemote {
+		return false, nil
+	}
+
+	if !strings.ContainsRune(wsURL, ',') {
+		return true, []string{wsURL}
+	}
+
+	// If last parts element is a void string,
+	// because WS URL contained an ending comma,
+	// remove it
+	parts := strings.Split(wsURL, ",")
+	if parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+
+	return true, parts
+}
+
 // newRemoteRegistry will create a new RemoteRegistry. This will
 // parse the K6_BROWSER_WS_URL env var to retrieve the defined
 // list of WS URLs from the scenarios object.

--- a/browser/registry.go
+++ b/browser/registry.go
@@ -85,7 +85,7 @@ func newRemoteRegistry(envLookup env.LookupFunc) *remoteRegistry {
 func newRemoteRegistryFromScenarios(envLookup env.LookupFunc) (*remoteRegistry, error) {
 	r := &remoteRegistry{}
 
-	scenariosJSON, isRemote := envLookup("K6_BROWSER_WS_URL")
+	scenariosJSON, isRemote := envLookup("K6_INSTANCE_SCENARIOS")
 	if !isRemote {
 		return r, nil
 	}
@@ -99,7 +99,7 @@ func newRemoteRegistryFromScenarios(envLookup env.LookupFunc) (*remoteRegistry, 
 
 	err := json.Unmarshal([]byte(scenariosJSON), &scenarios)
 	if err != nil {
-		return nil, fmt.Errorf("parsing K6_BROWSER_WS_URL: %w", err)
+		return nil, fmt.Errorf("parsing K6_INSTANCE_SCENARIOS: %w", err)
 	}
 
 	for _, s := range scenarios {

--- a/browser/registry.go
+++ b/browser/registry.go
@@ -111,7 +111,7 @@ func checkForScenarios(envLookup env.LookupFunc) (bool, []string, error) {
 	var wsURLs []string
 	for _, s := range scenarios {
 		for _, b := range s.Browsers {
-			if b.Handle == "" {
+			if strings.TrimSpace(b.Handle) == "" {
 				continue
 			}
 			wsURLs = append(wsURLs, b.Handle)

--- a/browser/registry.go
+++ b/browser/registry.go
@@ -52,6 +52,17 @@ type remoteRegistry struct {
 func newRemoteRegistry(envLookup env.LookupFunc) *remoteRegistry {
 	r := &remoteRegistry{}
 
+	isRemote, wsURLs, err := checkForScenarios(envLookup)
+	if err != nil {
+		// TODO: Return error
+		return nil
+	}
+	if isRemote {
+		r.isRemote = isRemote
+		r.wsURLs = wsURLs
+		return r
+	}
+
 	r.isRemote, r.wsURLs = checkForBrowserWSURLs(envLookup)
 
 	return r

--- a/browser/registry.go
+++ b/browser/registry.go
@@ -52,27 +52,7 @@ type remoteRegistry struct {
 func newRemoteRegistry(envLookup env.LookupFunc) *remoteRegistry {
 	r := &remoteRegistry{}
 
-	wsURL, isRemote := envLookup("K6_BROWSER_WS_URL")
-	if !isRemote {
-		return r
-	}
-
-	if !strings.ContainsRune(wsURL, ',') {
-		r.isRemote = true
-		r.wsURLs = []string{wsURL}
-		return r
-	}
-
-	// If last parts element is a void string,
-	// because WS URL contained an ending comma,
-	// remove it
-	parts := strings.Split(wsURL, ",")
-	if parts[len(parts)-1] == "" {
-		parts = parts[:len(parts)-1]
-	}
-
-	r.isRemote = true
-	r.wsURLs = parts
+	r.isRemote, r.wsURLs = checkForBrowserWSURLs(envLookup)
 
 	return r
 }

--- a/browser/registry_test.go
+++ b/browser/registry_test.go
@@ -82,6 +82,28 @@ func TestIsRemoteBrowser(t *testing.T) {
 			envVarName:     "K6_BROWSER_WS_URL",
 			envVarValue:    ",",
 		},
+		{
+			name:           "read a single scenario with a single ws url",
+			expIsRemote:    true,
+			expValidWSURLs: []string{"WS_URL_1"},
+			envVarName:     "K6_INSTANCE_SCENARIOS",
+			envVarValue:    `[{"id": "one","browsers": [{ "handle": "WS_URL_1" }]}]`,
+		},
+		{
+			name:           "read a single scenario with a two ws urls",
+			expIsRemote:    true,
+			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2"},
+			envVarName:     "K6_INSTANCE_SCENARIOS",
+			envVarValue:    `[{"id": "one","browsers": [{"handle": "WS_URL_1"}, {"handle": "WS_URL_2"}]}]`,
+		},
+		{
+			name:           "read two scenarios with multiple ws urls",
+			expIsRemote:    true,
+			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2", "WS_URL_3", "WS_URL_4"},
+			envVarName:     "K6_INSTANCE_SCENARIOS",
+			envVarValue: `[{"id": "one","browsers": [{"handle": "WS_URL_1"}, {"handle": "WS_URL_2"}]},
+			{"id": "two","browsers": [{"handle": "WS_URL_3"}, {"handle": "WS_URL_4"}]}]`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/browser/registry_test.go
+++ b/browser/registry_test.go
@@ -102,6 +102,20 @@ func TestIsRemoteBrowser(t *testing.T) {
 			envVarValue: `[{"id": "one","browsers": [{"handle": "WS_URL_1"}, {"handle": "WS_URL_2"}]},
 			{"id": "two","browsers": [{"handle": "WS_URL_3"}, {"handle": "WS_URL_4"}]}]`,
 		},
+		{
+			name:           "read scenarios without any ws urls",
+			expIsRemote:    false,
+			expValidWSURLs: []string{""},
+			envVarName:     "K6_INSTANCE_SCENARIOS",
+			envVarValue:    `[{"id": "one","browsers": [{}]}]`,
+		},
+		{
+			name:           "read scenarios without any browser objects",
+			expIsRemote:    false,
+			expValidWSURLs: []string{""},
+			envVarName:     "K6_INSTANCE_SCENARIOS",
+			envVarValue:    `[{"id": "one"}]`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/browser/registry_test.go
+++ b/browser/registry_test.go
@@ -107,7 +107,7 @@ func TestIsRemoteBrowser(t *testing.T) {
 	}
 }
 
-func TestIsRemoteBrowserWithScenarios(t *testing.T) {
+func TestCheckForScenarios(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -148,13 +148,12 @@ func TestIsRemoteBrowserWithScenarios(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			rr, err := newRemoteRegistryFromScenarios(tc.envLookup)
+			isRemote, wsURLs, err := checkForScenarios(tc.envLookup)
 			assert.NoError(t, err)
-			wsURL, isRemote := rr.isRemoteBrowser()
 
 			require.Equal(t, tc.expIsRemote, isRemote)
 			if isRemote {
-				require.Contains(t, tc.expValidWSURLs, wsURL)
+				require.Equal(t, tc.expValidWSURLs, wsURLs)
 			}
 		})
 	}

--- a/browser/registry_test.go
+++ b/browser/registry_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/xk6-browser/env"
 )
 
 func TestPidRegistry(t *testing.T) {
@@ -115,58 +113,6 @@ func TestIsRemoteBrowser(t *testing.T) {
 			require.Equal(t, tc.expIsRemote, isRemote)
 			if isRemote {
 				require.Contains(t, tc.expValidWSURLs, wsURL)
-			}
-		})
-	}
-}
-
-func TestCheckForScenarios(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name           string
-		envLookup      env.LookupFunc
-		expIsRemote    bool
-		expValidWSURLs []string
-	}{
-		{
-			name: "multiple scenarios",
-			envLookup: func(key string) (string, bool) {
-				json := `[
-					{
-						"id": "one",
-						"browsers": [
-							{ "handle": "ws://1..." },
-							{ "handle": "ws://2..." }
-						]
-					},
-					{
-						"id": "two",
-						"browsers": [
-							{ "handle": "ws://3..." }
-						]
-					}
-				]`
-
-				return json, true
-			},
-			expIsRemote:    true,
-			expValidWSURLs: []string{"ws://1...", "ws://2...", "ws://3..."},
-		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			isRemote, wsURLs, err := checkForScenarios(tc.envLookup)
-			assert.NoError(t, err)
-
-			require.Equal(t, tc.expIsRemote, isRemote)
-			if isRemote {
-				require.Equal(t, tc.expValidWSURLs, wsURLs)
 			}
 		})
 	}

--- a/browser/registry_test.go
+++ b/browser/registry_test.go
@@ -145,4 +145,17 @@ func TestIsRemoteBrowser(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("K6_INSTANCE_SCENARIOS should override K6_BROWSER_WS_URL", func(t *testing.T) {
+		t.Setenv("K6_BROWSER_WS_URL", "WS_URL_1")
+		t.Setenv("K6_INSTANCE_SCENARIOS", `[{"id": "one","browsers": [{ "handle": "WS_URL_2" }]}]`)
+
+		rr, err := newRemoteRegistry(os.LookupEnv)
+		assert.NoError(t, err)
+
+		wsURL, isRemote := rr.isRemoteBrowser()
+
+		require.Equal(t, true, isRemote)
+		require.Equal(t, "WS_URL_2", wsURL)
+	})
 }


### PR DESCRIPTION
### Description of changes

`newRemoteRegistry` now needs to parse two env vars. The first is the one that we have already defined, `K6_BROWSER_WS_URL`, the new one is `K6_INSTANCE_SCENARIOS`. `K6_INSTANCE_SCENARIOS` defines a JSON object of the form:

```json
[
    {
        "id": "one",
        "browsers": [
            { "handle": "ws://1..." }
        ]
    },
]
```

Each scenario will generally point to a unique ws url, which is from a unique instance of chrome. Currently we are only working with chrome, and all chrome instances are setup in the same way. In the future we will want to be able to launch different chrome instances each with their own unique characteristics as well as other web browsers.

`K6_INSTANCE_SCENARIOS` takes precedence over `K6_BROWSER_WS_URL`. `K6_BROWSER_WS_URL` could still be useful for debugging purposes.

Closes: https://github.com/grafana/xk6-browser/issues/888

### Checklist
```[tasklist]
- [X] Written tests for the changes
```