### PR TITLE
Remove the web vital rate metric time series metrics

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -306,11 +306,6 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 		return fmt.Errorf("metric not registered %q", wv.Name)
 	}
 
-	metricRating, ok := fs.k6Metrics.WebVitals[k6ext.ConcatWebVitalNameRating(wv.Name, wv.Rating)]
-	if !ok {
-		return fmt.Errorf("metric not registered %q", k6ext.ConcatWebVitalNameRating(wv.Name, wv.Rating))
-	}
-
 	value, err := wv.Value.Float64()
 	if err != nil {
 		return fmt.Errorf("value couldn't be parsed %q", wv.Value)
@@ -322,17 +317,14 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 		tags = tags.With("url", wv.URL)
 	}
 
+	tags = tags.With("rate", wv.Rating)
+
 	now := time.Now()
 	k6metrics.PushIfNotDone(fs.ctx, state.Samples, k6metrics.ConnectedSamples{
 		Samples: []k6metrics.Sample{
 			{
 				TimeSeries: k6metrics.TimeSeries{Metric: metric, Tags: tags},
 				Value:      value,
-				Time:       now,
-			},
-			{
-				TimeSeries: k6metrics.TimeSeries{Metric: metricRating, Tags: tags},
-				Value:      1,
 				Time:       now,
 			},
 		},

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -317,7 +317,7 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 		tags = tags.With("url", wv.URL)
 	}
 
-	tags = tags.With("rate", wv.Rating)
+	tags = tags.With("rating", wv.Rating)
 
 	now := time.Now()
 	k6metrics.PushIfNotDone(fs.ctx, state.Samples, k6metrics.ConnectedSamples{

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -1,8 +1,6 @@
 package k6ext
 
 import (
-	"fmt"
-
 	k6metrics "go.k6.io/k6/metrics"
 )
 
@@ -69,13 +67,6 @@ func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
 		}
 
 		webVitals[k] = registry.MustNewMetric(v, k6metrics.Trend, t)
-
-		webVitals[ConcatWebVitalNameRating(k, "good")] = registry.MustNewMetric(
-			v+"_good", k6metrics.Counter)
-		webVitals[ConcatWebVitalNameRating(k, "needs-improvement")] = registry.MustNewMetric(
-			v+"_needs_improvement", k6metrics.Counter)
-		webVitals[ConcatWebVitalNameRating(k, "poor")] = registry.MustNewMetric(
-			v+"_poor", k6metrics.Counter)
 	}
 
 	//nolint:lll
@@ -91,12 +82,4 @@ func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
 		BrowserHTTPReqReceiving:      registry.MustNewMetric(browserHTTPReqReceivingName, k6metrics.Trend, k6metrics.Time),
 		BrowserHTTPReqFailed:         registry.MustNewMetric(browserHTTPReqFailedName, k6metrics.Rate),
 	}
-}
-
-// ConcatWebVitalNameRating can be used
-// to create the correct metric key name
-// to retrieve the corresponding metric
-// from the registry.
-func ConcatWebVitalNameRating(name, rating string) string {
-	return fmt.Sprintf("%s:%s", name, rating)
 }

--- a/tests/webvital_test.go
+++ b/tests/webvital_test.go
@@ -20,16 +20,11 @@ func TestWebVitalMetric(t *testing.T) {
 		browser  = newTestBrowser(t, withFileServer(), withSamplesListener(samples))
 		page     = browser.NewPage(nil)
 		expected = map[string]bool{
-			"browser_web_vital_ttfb":      false,
-			"browser_web_vital_ttfb_good": false,
-			"browser_web_vital_fcp":       false,
-			"browser_web_vital_fcp_good":  false,
-			"browser_web_vital_lcp":       false,
-			"browser_web_vital_lcp_good":  false,
-			"browser_web_vital_fid":       false,
-			"browser_web_vital_fid_good":  false,
-			"browser_web_vital_cls":       false,
-			"browser_web_vital_cls_good":  false,
+			"browser_web_vital_ttfb": false,
+			"browser_web_vital_fcp":  false,
+			"browser_web_vital_lcp":  false,
+			"browser_web_vital_fid":  false,
+			"browser_web_vital_cls":  false,
 		}
 	)
 


### PR DESCRIPTION
### Description of changes

There are multiple reasons for making this change:

1. We're reducing the number of time series.
2. The rating should live as close to the value that it represents.
3. The rating in the summary is noise that doesn't add value unless we break them down by url.
4. This shouldn't increase the cardinality of the metric that we're labelling with the rating. It's a better trade off than having more time series metrics.
5. The summary at the end will be a bit more focused and shorter.

### Test

You should be able to run any example test (e.g. the fillform.js test). The web vital summary output should now look like this (note that we no longer have the rating metrics):

```bash
     browser_web_vital_cls..............: avg=0.000029 min=0        med=0.000029 max=0.000057 p(90)=0.000052 p(95)=0.000055
     browser_web_vital_fcp..............: avg=288.9ms  min=131.79ms med=240ms    max=494.9ms  p(90)=443.92ms p(95)=469.41ms
     browser_web_vital_fid..............: avg=500µs    min=100µs    med=500µs    max=899.99µs p(90)=819.99µs p(95)=859.99µs
     browser_web_vital_inp..............: avg=136ms    min=16ms     med=136ms    max=256ms    p(90)=232ms    p(95)=244ms   
     browser_web_vital_lcp..............: avg=313.35ms min=131.79ms med=313.35ms max=494.9ms  p(90)=458.59ms p(95)=476.74ms
     browser_web_vital_ttfb.............: avg=219.13ms min=105.09ms med=212.29ms max=340ms    p(90)=314.45ms p(95)=327.22ms
```

If you run it against influxdb or another backend you should find the new `rating` label like so:

<img width="961" alt="Screenshot 2023-05-31 at 17 43 56" src="https://github.com/grafana/xk6-browser/assets/1112428/92218508-b655-4c85-83ea-5074539b58d7">

### Checklist
```[tasklist]
- [X] Written tests for the changes
- [ ] Update k6 documentation
```