### PR TITLE
Remove some of the http metrics

### DIFF
--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -224,11 +224,6 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 	k6metrics.PushIfNotDone(m.ctx, state.Samples, k6metrics.ConnectedSamples{
 		Samples: []k6metrics.Sample{
 			{
-				TimeSeries: k6metrics.TimeSeries{Metric: m.customMetrics.BrowserHTTPReqs, Tags: tags},
-				Value:      1,
-				Time:       wallTime,
-			},
-			{
 				TimeSeries: k6metrics.TimeSeries{Metric: m.customMetrics.BrowserHTTPReqDuration, Tags: tags},
 				Value:      k6metrics.D(wallTime.Sub(req.wallTime)),
 				Time:       wallTime,
@@ -244,26 +239,6 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 	if resp != nil && resp.timing != nil {
 		k6metrics.PushIfNotDone(m.ctx, state.Samples, k6metrics.ConnectedSamples{
 			Samples: []k6metrics.Sample{
-				{
-					TimeSeries: k6metrics.TimeSeries{Metric: m.customMetrics.BrowserHTTPReqConnecting, Tags: tags},
-					Value:      k6metrics.D(time.Duration(resp.timing.ConnectEnd-resp.timing.ConnectStart) * time.Millisecond),
-					Time:       wallTime,
-				},
-				{
-					TimeSeries: k6metrics.TimeSeries{Metric: m.customMetrics.BrowserHTTPReqTLSHandshaking, Tags: tags},
-					Value:      k6metrics.D(time.Duration(resp.timing.SslEnd-resp.timing.SslStart) * time.Millisecond),
-					Time:       wallTime,
-				},
-				{
-					TimeSeries: k6metrics.TimeSeries{Metric: m.customMetrics.BrowserHTTPReqSending, Tags: tags},
-					Value:      k6metrics.D(time.Duration(resp.timing.SendEnd-resp.timing.SendStart) * time.Millisecond),
-					Time:       wallTime,
-				},
-				{
-					TimeSeries: k6metrics.TimeSeries{Metric: m.customMetrics.BrowserHTTPReqReceiving, Tags: tags},
-					Value:      k6metrics.D(time.Duration(resp.timing.ReceiveHeadersEnd-resp.timing.SendEnd) * time.Millisecond),
-					Time:       wallTime,
-				},
 				{
 					TimeSeries: k6metrics.TimeSeries{Metric: m.customMetrics.BrowserHTTPReqFailed, Tags: tags},
 					Value:      failed,

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -291,7 +291,7 @@ func TestNetworkManagerEmitRequestResponseMetricsTimingSkew(t *testing.T) {
 			n = vu.AssertSamples(func(s k6metrics.Sample) {
 				assert.Equalf(t, tt.wantRes.wt, s.Time, "timing skew in %s", s.Metric.Name)
 			})
-			assert.Equalf(t, 8, n, "should emit 8 response metrics")
+			assert.Equalf(t, 3, n, "should emit 8 response metrics")
 		})
 	}
 }

--- a/k6ext/metrics.go
+++ b/k6ext/metrics.go
@@ -21,30 +21,20 @@ const (
 	inpName  = "browser_web_vital_inp"
 	fcpName  = "browser_web_vital_fcp"
 
-	browserDataSentName              = "browser_data_sent"
-	browserDataReceivedName          = "browser_data_received"
-	browserHTTPReqsName              = "browser_http_reqs"
-	browserHTTPReqDurationName       = "browser_http_req_duration"
-	browserHTTPReqConnectingName     = "browser_http_req_connecting"
-	browserHTTPReqTLSHandshakingName = "browser_http_req_tls_handshaking"
-	browserHTTPReqSendingName        = "browser_http_req_sending"
-	browserHTTPReqReceivingName      = "browser_http_req_receiving"
-	browserHTTPReqFailedName         = "browser_http_req_failed"
+	browserDataSentName        = "browser_data_sent"
+	browserDataReceivedName    = "browser_data_received"
+	browserHTTPReqDurationName = "browser_http_req_duration"
+	browserHTTPReqFailedName   = "browser_http_req_failed"
 )
 
 // CustomMetrics are the custom k6 metrics used by xk6-browser.
 type CustomMetrics struct {
 	WebVitals map[string]*k6metrics.Metric
 
-	BrowserDataSent              *k6metrics.Metric
-	BrowserDataReceived          *k6metrics.Metric
-	BrowserHTTPReqs              *k6metrics.Metric
-	BrowserHTTPReqDuration       *k6metrics.Metric
-	BrowserHTTPReqConnecting     *k6metrics.Metric
-	BrowserHTTPReqTLSHandshaking *k6metrics.Metric
-	BrowserHTTPReqSending        *k6metrics.Metric
-	BrowserHTTPReqReceiving      *k6metrics.Metric
-	BrowserHTTPReqFailed         *k6metrics.Metric
+	BrowserDataSent        *k6metrics.Metric
+	BrowserDataReceived    *k6metrics.Metric
+	BrowserHTTPReqDuration *k6metrics.Metric
+	BrowserHTTPReqFailed   *k6metrics.Metric
 }
 
 // RegisterCustomMetrics creates and registers our custom metrics with the k6
@@ -80,16 +70,11 @@ func RegisterCustomMetrics(registry *k6metrics.Registry) *CustomMetrics {
 
 	//nolint:lll
 	return &CustomMetrics{
-		WebVitals:                    webVitals,
-		BrowserDataSent:              registry.MustNewMetric(browserDataSentName, k6metrics.Counter, k6metrics.Data),
-		BrowserDataReceived:          registry.MustNewMetric(browserDataReceivedName, k6metrics.Counter, k6metrics.Data),
-		BrowserHTTPReqs:              registry.MustNewMetric(browserHTTPReqsName, k6metrics.Counter),
-		BrowserHTTPReqDuration:       registry.MustNewMetric(browserHTTPReqDurationName, k6metrics.Trend, k6metrics.Time),
-		BrowserHTTPReqConnecting:     registry.MustNewMetric(browserHTTPReqConnectingName, k6metrics.Trend, k6metrics.Time),
-		BrowserHTTPReqTLSHandshaking: registry.MustNewMetric(browserHTTPReqTLSHandshakingName, k6metrics.Trend, k6metrics.Time),
-		BrowserHTTPReqSending:        registry.MustNewMetric(browserHTTPReqSendingName, k6metrics.Trend, k6metrics.Time),
-		BrowserHTTPReqReceiving:      registry.MustNewMetric(browserHTTPReqReceivingName, k6metrics.Trend, k6metrics.Time),
-		BrowserHTTPReqFailed:         registry.MustNewMetric(browserHTTPReqFailedName, k6metrics.Rate),
+		WebVitals:              webVitals,
+		BrowserDataSent:        registry.MustNewMetric(browserDataSentName, k6metrics.Counter, k6metrics.Data),
+		BrowserDataReceived:    registry.MustNewMetric(browserDataReceivedName, k6metrics.Counter, k6metrics.Data),
+		BrowserHTTPReqDuration: registry.MustNewMetric(browserHTTPReqDurationName, k6metrics.Trend, k6metrics.Time),
+		BrowserHTTPReqFailed:   registry.MustNewMetric(browserHTTPReqFailedName, k6metrics.Rate),
 	}
 }
 


### PR DESCRIPTION
### Description of changes

The motivation for this came from analysing and working on [removing the web vital rating metrics](https://github.com/grafana/xk6-browser/pull/915). It became apparent that we didn't need to expose all these http metrics just yet and instead should focus on the ones that are most used. We used k6 for guidance on this and they have suggested that `browser_http_req_duration` and `browser_http_req_failed` are the most useful. We can add metrics back in when users show interest in them. This will also reduce the overall number of time series metrics.

### Testing

When you run any of the example test scripts, you should find that we now only display `browser_http_req_duration` and `browser_http_req_failed` `http` based metrics:

```bash
     browser_http_req_duration.....: avg=216.97ms min=102.97ms med=208.59ms max=339.36ms p(90)=313.21ms p(95)=326.28ms
     browser_http_req_failed.......: 0.00%  ✓ 0        ✗ 3 
```

Please describe your pull request

### Checklist
```[tasklist]
- [X] Written tests for the changes
- [ ] Generate TS definitions
```