### PR TITLE
Refactor to k6 lookupEnv and abstract env. var. lookup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run E2E tests
         run: |
           set -x
-          export XK6_HEADLESS=true
+          export K6_BROWSER_HEADLESS=true
           for f in examples/*.js; do
             ./k6extension run "$f"
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
             args[1]="1"
             export GOMAXPROCS=1
           fi
-          export XK6_HEADLESS=true
+          export K6_BROWSER_HEADLESS=true
           go test "${args[@]}" -timeout 5m ./...
 
   test-tip:
@@ -75,7 +75,7 @@ jobs:
           go version
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
-          export XK6_HEADLESS=true
+          export K6_BROWSER_HEADLESS=true
           go test "${args[@]}" -timeout 5m ./...
 
   test-current-cov:
@@ -104,7 +104,7 @@ jobs:
             args[1]="1"
             export GOMAXPROCS=1
           fi
-          export XK6_HEADLESS=true
+          export K6_BROWSER_HEADLESS=true
           echo "mode: set" > coverage.txt
           for pkg in $(go list ./... | grep -v vendor); do
               list=$(go list -test -f  '{{ join .Deps  "\n"}}' $pkg | grep github.com/grafana/xk6-browser | grep -v vendor || true)
@@ -156,5 +156,5 @@ jobs:
           go get go.k6.io/k6@master
           go mod tidy
           cat go.mod | grep go.k6.io/k6
-          export XK6_HEADLESS=true
+          export K6_BROWSER_HEADLESS=true
           go test "${args[@]}" -timeout 5m ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN apt-get update && \
 
 COPY --from=builder /tmp/k6 /usr/bin/k6
 
-ENV XK6_HEADLESS=true
+ENV K6_BROWSER_HEADLESS=true
 
 ENTRYPOINT ["k6"]

--- a/browser/module.go
+++ b/browser/module.go
@@ -2,6 +2,9 @@
 package browser
 
 import (
+	"log"
+	"net/http"
+	_ "net/http/pprof" //nolint:gosec
 	"os"
 	"sync"
 
@@ -89,4 +92,14 @@ func (m *RootModule) initialize(vu k6modules.VU) {
 		ctx := k6ext.WithVU(vu.Context(), vu)
 		k6ext.Panic(ctx, "failed to create remote registry: %v", err)
 	}
+	if _, ok := os.LookupEnv("K6_BROWSER_PPROF"); ok {
+		go startDebugServer()
+	}
+}
+
+func startDebugServer() {
+	address := "localhost:6060"
+	log.Println("Starting http debug server", address)
+	log.Println(http.ListenAndServe(address, nil)) //nolint:gosec
+	// no linted because we don't need to set timeouts for the debug server.
 }

--- a/browser/module.go
+++ b/browser/module.go
@@ -89,8 +89,7 @@ func (m *RootModule) initialize(vu k6modules.VU) {
 	var err error
 	m.remoteRegistry, err = newRemoteRegistry(os.LookupEnv)
 	if err != nil {
-		ctx := k6ext.WithVU(vu.Context(), vu)
-		k6ext.Panic(ctx, "failed to create remote registry: %v", err)
+		k6ext.Abort(vu.Context(), "failed to create remote registry: %v", err)
 	}
 	if _, ok := os.LookupEnv("K6_BROWSER_PPROF"); ok {
 		go startDebugServer()

--- a/browser/module.go
+++ b/browser/module.go
@@ -86,8 +86,11 @@ func (mi *ModuleInstance) Exports() k6modules.Exports {
 // initialize initializes the module instance with a new remote registry
 // and debug server, etc.
 func (m *RootModule) initialize(vu k6modules.VU) {
-	var err error
-	m.remoteRegistry, err = newRemoteRegistry(os.LookupEnv)
+	var (
+		err error
+		env = vu.InitEnv()
+	)
+	m.remoteRegistry, err = newRemoteRegistry(env.LookupEnv)
 	if err != nil {
 		k6ext.Abort(vu.Context(), "failed to create remote registry: %v", err)
 	}

--- a/browser/module.go
+++ b/browser/module.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec
-	"os"
 	"sync"
 
 	"github.com/dop251/goja"
@@ -94,7 +93,7 @@ func (m *RootModule) initialize(vu k6modules.VU) {
 	if err != nil {
 		k6ext.Abort(vu.Context(), "failed to create remote registry: %v", err)
 	}
-	if _, ok := os.LookupEnv("K6_BROWSER_PPROF"); ok {
+	if _, ok := env.LookupEnv("K6_BROWSER_PPROF"); ok {
 		go startDebugServer()
 	}
 }

--- a/browser/module.go
+++ b/browser/module.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dop251/goja"
 
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/env"
 	"github.com/grafana/xk6-browser/k6ext"
 
 	k6modules "go.k6.io/k6/js/modules"
@@ -86,21 +87,20 @@ func (mi *ModuleInstance) Exports() k6modules.Exports {
 // and debug server, etc.
 func (m *RootModule) initialize(vu k6modules.VU) {
 	var (
-		err error
-		env = vu.InitEnv()
+		err     error
+		initEnv = vu.InitEnv()
 	)
-	m.remoteRegistry, err = newRemoteRegistry(env.LookupEnv)
+	m.remoteRegistry, err = newRemoteRegistry(initEnv.LookupEnv)
 	if err != nil {
 		k6ext.Abort(vu.Context(), "failed to create remote registry: %v", err)
 	}
-	if _, ok := env.LookupEnv("K6_BROWSER_PPROF"); ok {
+	if _, ok := initEnv.LookupEnv(env.EnableProfiling); ok {
 		go startDebugServer()
 	}
 }
 
 func startDebugServer() {
-	address := "localhost:6060"
-	log.Println("Starting http debug server", address)
-	log.Println(http.ListenAndServe(address, nil)) //nolint:gosec
+	log.Println("Starting http debug server", env.ProfilingServerAddr)
+	log.Println(http.ListenAndServe(env.ProfilingServerAddr, nil)) //nolint:gosec
 	// no linted because we don't need to set timeouts for the debug server.
 }

--- a/browser/module.go
+++ b/browser/module.go
@@ -20,7 +20,7 @@ type (
 		PidRegistry     *pidRegistry
 		browserRegistry *browserRegistry
 		remoteRegistry  *remoteRegistry
-		once            *sync.Once
+		initOnce        *sync.Once
 	}
 
 	// JSModule exposes the properties available to the JS script.
@@ -46,14 +46,14 @@ func New() *RootModule {
 	return &RootModule{
 		PidRegistry:     &pidRegistry{},
 		browserRegistry: &browserRegistry{},
-		once:            &sync.Once{},
+		initOnce:        &sync.Once{},
 	}
 }
 
 // NewModuleInstance implements the k6modules.Module interface to return
 // a new instance for each VU.
 func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
-	m.once.Do(func() {
+	m.initOnce.Do(func() {
 		// remoteRegistry should only be initialized once as it is
 		// used globally across the whole test run and not just the
 		// current vu. Since newRemoteRegistry can fail with an error,

--- a/browser/module_test.go
+++ b/browser/module_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/xk6-browser/env"
+
 	k6common "go.k6.io/k6/js/common"
 	k6modulestest "go.k6.io/k6/js/modulestest"
 	k6lib "go.k6.io/k6/lib"
@@ -23,10 +25,8 @@ func TestModuleNew(t *testing.T) {
 		RuntimeField: goja.New(),
 		InitEnvField: &k6common.InitEnvironment{
 			TestPreInitState: &k6lib.TestPreInitState{
-				Registry: k6metrics.NewRegistry(),
-				LookupEnv: func(key string) (string, bool) {
-					return "", false
-				},
+				Registry:  k6metrics.NewRegistry(),
+				LookupEnv: env.EmptyLookup,
 			},
 		},
 		CtxField: context.Background(),

--- a/browser/module_test.go
+++ b/browser/module_test.go
@@ -24,6 +24,9 @@ func TestModuleNew(t *testing.T) {
 		InitEnvField: &k6common.InitEnvironment{
 			TestPreInitState: &k6lib.TestPreInitState{
 				Registry: k6metrics.NewRegistry(),
+				LookupEnv: func(key string) (string, bool) {
+					return "", false
+				},
 			},
 		},
 		CtxField: context.Background(),

--- a/browser/registry.go
+++ b/browser/registry.go
@@ -70,7 +70,7 @@ func newRemoteRegistry(envLookup env.LookupFunc) (*remoteRegistry, error) {
 }
 
 func checkForBrowserWSURLs(envLookup env.LookupFunc) (bool, []string) {
-	wsURL, isRemote := envLookup("K6_BROWSER_WS_URL")
+	wsURL, isRemote := envLookup(env.WebSocketURLs)
 	if !isRemote {
 		return false, nil
 	}
@@ -93,7 +93,7 @@ func checkForBrowserWSURLs(envLookup env.LookupFunc) (bool, []string) {
 // checkForScenarios will parse the K6_INSTANCE_SCENARIOS env var if
 // it has been defined.
 func checkForScenarios(envLookup env.LookupFunc) (bool, []string, error) {
-	scenariosJSON, isRemote := envLookup("K6_INSTANCE_SCENARIOS")
+	scenariosJSON, isRemote := envLookup(env.InstanceScenarios)
 	if !isRemote {
 		return false, nil, nil
 	}

--- a/browser/registry_test.go
+++ b/browser/registry_test.go
@@ -35,98 +35,98 @@ func TestPidRegistry(t *testing.T) {
 
 func TestIsRemoteBrowser(t *testing.T) {
 	testCases := []struct {
-		name           string
-		expIsRemote    bool
-		expValidWSURLs []string
-		envVarName     string
-		envVarValue    string
-		expErr         error
+		name                    string
+		envVarName, envVarValue string
+		expIsRemote             bool
+		expValidWSURLs          []string
+		expErr                  error
 	}{
 		{
 			name:        "browser is not remote",
-			expIsRemote: false,
 			envVarName:  "FOO",
 			envVarValue: "BAR",
+			expIsRemote: false,
 		},
 		{
 			name:           "single WS URL",
-			expIsRemote:    true,
-			expValidWSURLs: []string{"WS_URL"},
 			envVarName:     "K6_BROWSER_WS_URL",
 			envVarValue:    "WS_URL",
+			expIsRemote:    true,
+			expValidWSURLs: []string{"WS_URL"},
 		},
 		{
 			name:           "multiple WS URL",
-			expIsRemote:    true,
-			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2", "WS_URL_3"},
 			envVarName:     "K6_BROWSER_WS_URL",
 			envVarValue:    "WS_URL_1,WS_URL_2,WS_URL_3",
+			expIsRemote:    true,
+			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2", "WS_URL_3"},
 		},
 		{
 			name:           "ending comma is handled",
-			expIsRemote:    true,
-			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2"},
 			envVarName:     "K6_BROWSER_WS_URL",
 			envVarValue:    "WS_URL_1,WS_URL_2,",
+			expIsRemote:    true,
+			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2"},
 		},
 		{
 			name:           "void string does not panic",
-			expIsRemote:    true,
-			expValidWSURLs: []string{""},
 			envVarName:     "K6_BROWSER_WS_URL",
 			envVarValue:    "",
+			expIsRemote:    true,
+			expValidWSURLs: []string{""},
 		},
 		{
 			name:           "comma does not panic",
-			expIsRemote:    true,
-			expValidWSURLs: []string{""},
 			envVarName:     "K6_BROWSER_WS_URL",
 			envVarValue:    ",",
+			expIsRemote:    true,
+			expValidWSURLs: []string{""},
 		},
 		{
 			name:           "read a single scenario with a single ws url",
-			expIsRemote:    true,
-			expValidWSURLs: []string{"WS_URL_1"},
 			envVarName:     "K6_INSTANCE_SCENARIOS",
 			envVarValue:    `[{"id": "one","browsers": [{ "handle": "WS_URL_1" }]}]`,
+			expIsRemote:    true,
+			expValidWSURLs: []string{"WS_URL_1"},
 		},
 		{
 			name:           "read a single scenario with a two ws urls",
-			expIsRemote:    true,
-			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2"},
 			envVarName:     "K6_INSTANCE_SCENARIOS",
 			envVarValue:    `[{"id": "one","browsers": [{"handle": "WS_URL_1"}, {"handle": "WS_URL_2"}]}]`,
+			expIsRemote:    true,
+			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2"},
 		},
 		{
-			name:           "read two scenarios with multiple ws urls",
+			name:       "read two scenarios with multiple ws urls",
+			envVarName: "K6_INSTANCE_SCENARIOS",
+			envVarValue: `[
+				{"id": "one","browsers": [{"handle": "WS_URL_1"}, {"handle": "WS_URL_2"}]},
+				{"id": "two","browsers": [{"handle": "WS_URL_3"}, {"handle": "WS_URL_4"}]}
+			]`,
 			expIsRemote:    true,
 			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2", "WS_URL_3", "WS_URL_4"},
-			envVarName:     "K6_INSTANCE_SCENARIOS",
-			envVarValue: `[{"id": "one","browsers": [{"handle": "WS_URL_1"}, {"handle": "WS_URL_2"}]},
-			{"id": "two","browsers": [{"handle": "WS_URL_3"}, {"handle": "WS_URL_4"}]}]`,
 		},
 		{
 			name:           "read scenarios without any ws urls",
-			expIsRemote:    false,
-			expValidWSURLs: []string{""},
 			envVarName:     "K6_INSTANCE_SCENARIOS",
 			envVarValue:    `[{"id": "one","browsers": [{}]}]`,
+			expIsRemote:    false,
+			expValidWSURLs: []string{""},
 		},
 		{
 			name:           "read scenarios without any browser objects",
-			expIsRemote:    false,
-			expValidWSURLs: []string{""},
 			envVarName:     "K6_INSTANCE_SCENARIOS",
 			envVarValue:    `[{"id": "one"}]`,
+			expIsRemote:    false,
+			expValidWSURLs: []string{""},
 		},
 		{
 			name:        "read empty scenarios",
-			expErr:      errors.New("parsing K6_INSTANCE_SCENARIOS: unexpected end of JSON input"),
 			envVarName:  "K6_INSTANCE_SCENARIOS",
 			envVarValue: ``,
+			expErr:      errors.New("parsing K6_INSTANCE_SCENARIOS: unexpected end of JSON input"),
 		},
 	}
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// the real environment  variable we receive needs quoting.

--- a/browser/registry_test.go
+++ b/browser/registry_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/env"
 )
 
 func TestPidRegistry(t *testing.T) {
@@ -50,56 +52,56 @@ func TestIsRemoteBrowser(t *testing.T) {
 		},
 		{
 			name:           "single WS URL",
-			envVarName:     "K6_BROWSER_WS_URL",
+			envVarName:     env.WebSocketURLs,
 			envVarValue:    "WS_URL",
 			expIsRemote:    true,
 			expValidWSURLs: []string{"WS_URL"},
 		},
 		{
 			name:           "multiple WS URL",
-			envVarName:     "K6_BROWSER_WS_URL",
+			envVarName:     env.WebSocketURLs,
 			envVarValue:    "WS_URL_1,WS_URL_2,WS_URL_3",
 			expIsRemote:    true,
 			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2", "WS_URL_3"},
 		},
 		{
 			name:           "ending comma is handled",
-			envVarName:     "K6_BROWSER_WS_URL",
+			envVarName:     env.WebSocketURLs,
 			envVarValue:    "WS_URL_1,WS_URL_2,",
 			expIsRemote:    true,
 			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2"},
 		},
 		{
 			name:           "void string does not panic",
-			envVarName:     "K6_BROWSER_WS_URL",
+			envVarName:     env.WebSocketURLs,
 			envVarValue:    "",
 			expIsRemote:    true,
 			expValidWSURLs: []string{""},
 		},
 		{
 			name:           "comma does not panic",
-			envVarName:     "K6_BROWSER_WS_URL",
+			envVarName:     env.WebSocketURLs,
 			envVarValue:    ",",
 			expIsRemote:    true,
 			expValidWSURLs: []string{""},
 		},
 		{
 			name:           "read a single scenario with a single ws url",
-			envVarName:     "K6_INSTANCE_SCENARIOS",
+			envVarName:     env.InstanceScenarios,
 			envVarValue:    `[{"id": "one","browsers": [{ "handle": "WS_URL_1" }]}]`,
 			expIsRemote:    true,
 			expValidWSURLs: []string{"WS_URL_1"},
 		},
 		{
 			name:           "read a single scenario with a two ws urls",
-			envVarName:     "K6_INSTANCE_SCENARIOS",
+			envVarName:     env.InstanceScenarios,
 			envVarValue:    `[{"id": "one","browsers": [{"handle": "WS_URL_1"}, {"handle": "WS_URL_2"}]}]`,
 			expIsRemote:    true,
 			expValidWSURLs: []string{"WS_URL_1", "WS_URL_2"},
 		},
 		{
 			name:       "read two scenarios with multiple ws urls",
-			envVarName: "K6_INSTANCE_SCENARIOS",
+			envVarName: env.InstanceScenarios,
 			envVarValue: `[
 				{"id": "one","browsers": [{"handle": "WS_URL_1"}, {"handle": "WS_URL_2"}]},
 				{"id": "two","browsers": [{"handle": "WS_URL_3"}, {"handle": "WS_URL_4"}]}
@@ -109,21 +111,21 @@ func TestIsRemoteBrowser(t *testing.T) {
 		},
 		{
 			name:           "read scenarios without any ws urls",
-			envVarName:     "K6_INSTANCE_SCENARIOS",
+			envVarName:     env.InstanceScenarios,
 			envVarValue:    `[{"id": "one","browsers": [{}]}]`,
 			expIsRemote:    false,
 			expValidWSURLs: []string{""},
 		},
 		{
 			name:           "read scenarios without any browser objects",
-			envVarName:     "K6_INSTANCE_SCENARIOS",
+			envVarName:     env.InstanceScenarios,
 			envVarValue:    `[{"id": "one"}]`,
 			expIsRemote:    false,
 			expValidWSURLs: []string{""},
 		},
 		{
 			name:        "read empty scenarios",
-			envVarName:  "K6_INSTANCE_SCENARIOS",
+			envVarName:  env.InstanceScenarios,
 			envVarValue: ``,
 			expErr:      errors.New("parsing K6_INSTANCE_SCENARIOS: unexpected end of JSON input"),
 		},
@@ -162,9 +164,9 @@ func TestIsRemoteBrowser(t *testing.T) {
 	t.Run("K6_INSTANCE_SCENARIOS should override K6_BROWSER_WS_URL", func(t *testing.T) {
 		lookup := func(key string) (string, bool) {
 			switch key {
-			case "K6_BROWSER_WS_URL":
+			case env.WebSocketURLs:
 				return "WS_URL_1", true
-			case "K6_INSTANCE_SCENARIOS":
+			case env.InstanceScenarios:
 				return strconv.Quote(`[{"id": "one","browsers": [{ "handle": "WS_URL_2" }]}]`), true
 			default:
 				return "", false

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -448,7 +448,7 @@ func makeLogger(ctx context.Context, envLookup env.LookupFunc) (*log.Logger, err
 		k6Logger = k6ext.GetVU(ctx).State().Logger
 		logger   = log.New(k6Logger, common.GetIterationID(ctx))
 	)
-	if el, ok := envLookup("XK6_BROWSER_LOG"); ok {
+	if el, ok := envLookup(env.LogLevel); ok {
 		if logger.SetLevel(el) != nil {
 			return nil, fmt.Errorf(
 				"invalid log level %q, should be one of: panic, fatal, error, warn, warning, info, debug, trace",
@@ -456,7 +456,7 @@ func makeLogger(ctx context.Context, envLookup env.LookupFunc) (*log.Logger, err
 			)
 		}
 	}
-	if _, ok := envLookup("XK6_BROWSER_CALLER"); ok {
+	if _, ok := envLookup(env.LogCaller); ok {
 		logger.ReportCaller()
 	}
 

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -46,12 +46,14 @@ type BrowserType struct {
 func NewBrowserType(vu k6modules.VU) *BrowserType {
 	// NOTE: vu.InitEnv() *must* be called from the script init scope,
 	// otherwise it will return nil.
+	env := vu.InitEnv()
+
 	return &BrowserType{
 		vu:           vu,
 		hooks:        common.NewHooks(),
-		k6Metrics:    k6ext.RegisterCustomMetrics(vu.InitEnv().Registry),
+		k6Metrics:    k6ext.RegisterCustomMetrics(env.Registry),
 		randSrc:      rand.New(rand.NewSource(time.Now().UnixNano())), //nolint: gosec
-		envLookupper: os.LookupEnv,
+		envLookupper: env.LookupEnv,
 	}
 }
 

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -46,16 +46,13 @@ type BrowserType struct {
 func NewBrowserType(vu k6modules.VU) *BrowserType {
 	// NOTE: vu.InitEnv() *must* be called from the script init scope,
 	// otherwise it will return nil.
-	k6m := k6ext.RegisterCustomMetrics(vu.InitEnv().Registry)
-	b := BrowserType{
+	return &BrowserType{
 		vu:           vu,
 		hooks:        common.NewHooks(),
-		k6Metrics:    k6m,
+		k6Metrics:    k6ext.RegisterCustomMetrics(vu.InitEnv().Registry),
 		randSrc:      rand.New(rand.NewSource(time.Now().UnixNano())), //nolint: gosec
 		envLookupper: os.LookupEnv,
 	}
-
-	return &b
 }
 
 func (b *BrowserType) init(

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -295,11 +295,6 @@ func (b *BrowserType) ExecutablePath() (execPath string) {
 	return ""
 }
 
-// SetEnvLookupper sets the environment variable lookupper function.
-func (b *BrowserType) SetEnvLookupper(envLookupper env.LookupFunc) {
-	b.envLookupper = envLookupper
-}
-
 // parseArgs parses command-line arguments and returns them.
 func parseArgs(flags map[string]any) ([]string, error) {
 	// Build command line args list

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -273,7 +273,7 @@ func (b *BrowserType) ExecutablePath() (execPath string) {
 		b.execPath = execPath
 	}()
 
-	for _, path := range [...]string{
+	paths := []string{
 		// Unix-like
 		"headless_shell",
 		"headless-shell",
@@ -284,18 +284,19 @@ func (b *BrowserType) ExecutablePath() (execPath string) {
 		"google-chrome-beta",
 		"google-chrome-unstable",
 		"/usr/bin/google-chrome",
-
 		// Windows
 		"chrome",
 		"chrome.exe", // in case PATHEXT is misconfigured
 		`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`,
 		`C:\Program Files\Google\Chrome\Application\chrome.exe`,
-		filepath.Join(os.Getenv("USERPROFILE"), `AppData\Local\Google\Chrome\Application\chrome.exe`),
-
 		// Mac (from https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Mac/857950/)
 		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
 		"/Applications/Chromium.app/Contents/MacOS/Chromium",
-	} {
+	}
+	if userProfile, ok := b.envLookupper("USERPROFILE"); ok {
+		paths = append(paths, filepath.Join(userProfile, `AppData\Local\Google\Chrome\Application\chrome.exe`))
+	}
+	for _, path := range paths {
 		if _, err := exec.LookPath(path); err == nil {
 			return path
 		}

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -179,8 +179,9 @@ func (b *BrowserType) launch(
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w", err)
 	}
+
 	dataDir := &storage.Dir{}
-	if err := dataDir.Make("", flags["user-data-dir"]); err != nil {
+	if err := dataDir.Make(b.tmpdir(), flags["user-data-dir"]); err != nil {
 		return nil, 0, fmt.Errorf("%w", err)
 	}
 	flags["user-data-dir"] = dataDir.Dir
@@ -215,6 +216,14 @@ func (b *BrowserType) launch(
 	}
 
 	return browser, browserProc.Pid(), nil
+}
+
+// tmpdir returns the temporary directory to use for the browser.
+// It returns the value of the TMPDIR environment variable if set,
+// otherwise it returns an empty string.
+func (b *BrowserType) tmpdir() string {
+	dir, _ := b.envLookupper("TMPDIR")
+	return dir
 }
 
 // LaunchPersistentContext launches the browser with persistent storage.

--- a/common/browser_options.go
+++ b/common/browser_options.go
@@ -14,21 +14,8 @@ import (
 	"go.k6.io/k6/lib/types"
 )
 
-const (
-	// Script variables.
-
-	optType = "type"
-
-	// ENV variables.
-
-	optArgs              = "K6_BROWSER_ARGS"
-	optDebug             = "K6_BROWSER_DEBUG"
-	optExecutablePath    = "K6_BROWSER_EXECUTABLE_PATH"
-	optHeadless          = "K6_BROWSER_HEADLESS"
-	optIgnoreDefaultArgs = "K6_BROWSER_IGNORE_DEFAULT_ARGS"
-	optLogCategoryFilter = "K6_BROWSER_LOG_CATEGORY_FILTER"
-	optTimeout           = "K6_BROWSER_TIMEOUT"
-)
+// Script variables.
+const optType = "type"
 
 // BrowserOptions stores browser options.
 type BrowserOptions struct {
@@ -85,13 +72,13 @@ func (bo *BrowserOptions) Parse( //nolint:cyclop
 
 	// Parse env
 	envOpts := [...]string{
-		optArgs,
-		optDebug,
-		optExecutablePath,
-		optHeadless,
-		optIgnoreDefaultArgs,
-		optLogCategoryFilter,
-		optTimeout,
+		env.BrowserArguments,
+		env.BrowserEnableDebugging,
+		env.BrowserExecutablePath,
+		env.BrowserHeadless,
+		env.BrowserIgnoreDefaultArgs,
+		env.LogCategoryFilter,
+		env.BrowserGlobalTimeout,
 	}
 
 	for _, e := range envOpts {
@@ -105,19 +92,19 @@ func (bo *BrowserOptions) Parse( //nolint:cyclop
 		}
 		var err error
 		switch e {
-		case optArgs:
+		case env.BrowserArguments:
 			bo.Args = parseListOpt(ev)
-		case optDebug:
+		case env.BrowserEnableDebugging:
 			bo.Debug, err = parseBoolOpt(e, ev)
-		case optExecutablePath:
+		case env.BrowserExecutablePath:
 			bo.ExecutablePath = ev
-		case optHeadless:
+		case env.BrowserHeadless:
 			bo.Headless, err = parseBoolOpt(e, ev)
-		case optIgnoreDefaultArgs:
+		case env.BrowserIgnoreDefaultArgs:
 			bo.IgnoreDefaultArgs = parseListOpt(ev)
-		case optLogCategoryFilter:
+		case env.LogCategoryFilter:
 			bo.LogCategoryFilter = ev
-		case optTimeout:
+		case env.BrowserGlobalTimeout:
 			bo.Timeout, err = parseTimeOpt(e, ev)
 		}
 		if err != nil {
@@ -134,10 +121,10 @@ func (bo *BrowserOptions) shouldIgnoreIfBrowserIsRemote(opt string) bool {
 	}
 
 	shouldIgnoreIfBrowserIsRemote := map[string]struct{}{
-		optArgs:              {},
-		optExecutablePath:    {},
-		optHeadless:          {},
-		optIgnoreDefaultArgs: {},
+		env.BrowserArguments:         {},
+		env.BrowserExecutablePath:    {},
+		env.BrowserHeadless:          {},
+		env.BrowserIgnoreDefaultArgs: {},
 	}
 	_, ignore := shouldIgnoreIfBrowserIsRemote[opt]
 

--- a/common/browser_options_test.go
+++ b/common/browser_options_test.go
@@ -60,20 +60,20 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			envLookupper: func(k string) (string, bool) {
 				switch k {
 				// disallow changing the following opts
-				case optArgs:
+				case env.BrowserArguments:
 					return "any", true
-				case optExecutablePath:
+				case env.BrowserExecutablePath:
 					return "something else", true
-				case optHeadless:
+				case env.BrowserHeadless:
 					return "false", true
-				case optIgnoreDefaultArgs:
+				case env.BrowserIgnoreDefaultArgs:
 					return "any", true
 				// allow changing the following opts
-				case optDebug:
+				case env.BrowserEnableDebugging:
 					return "true", true
-				case optLogCategoryFilter:
+				case env.LogCategoryFilter:
 					return "...", true
-				case optTimeout:
+				case env.BrowserGlobalTimeout:
 					return "1s", true
 				default:
 					return "", false
@@ -114,7 +114,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 				"type": "chromium",
 			},
 			envLookupper: func(k string) (string, bool) {
-				if k == optArgs {
+				if k == env.BrowserArguments {
 					return "browser-arg1='value1,browser-arg2=value2,browser-flag", true
 				}
 				return "", false
@@ -132,7 +132,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 				"type": "chromium",
 			},
 			envLookupper: func(k string) (string, bool) {
-				if k == optDebug {
+				if k == env.BrowserEnableDebugging {
 					return "true", true
 				}
 				return "", false
@@ -147,7 +147,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 				"type": "chromium",
 			},
 			envLookupper: func(k string) (string, bool) {
-				if k == optDebug {
+				if k == env.BrowserEnableDebugging {
 					return "non-boolean", true
 				}
 				return "", false
@@ -159,7 +159,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 				"type": "chromium",
 			},
 			envLookupper: func(k string) (string, bool) {
-				if k == optExecutablePath {
+				if k == env.BrowserExecutablePath {
 					return "cmd/somewhere", true
 				}
 				return "", false
@@ -174,7 +174,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 				"type": "chromium",
 			},
 			envLookupper: func(k string) (string, bool) {
-				if k == optHeadless {
+				if k == env.BrowserHeadless {
 					return "false", true
 				}
 				return "", false
@@ -189,7 +189,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 				"type": "chromium",
 			},
 			envLookupper: func(k string) (string, bool) {
-				if k == optHeadless {
+				if k == env.BrowserHeadless {
 					return "non-boolean", true
 				}
 				return "", false
@@ -201,7 +201,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 				"type": "chromium",
 			},
 			envLookupper: func(k string) (string, bool) {
-				if k == optIgnoreDefaultArgs {
+				if k == env.BrowserIgnoreDefaultArgs {
 					return "--hide-scrollbars,--hide-something", true
 				}
 				return "", false
@@ -218,7 +218,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 				"type": "chromium",
 			},
 			envLookupper: func(k string) (string, bool) {
-				if k == optLogCategoryFilter {
+				if k == env.LogCategoryFilter {
 					return "**", true
 				}
 				return "", false
@@ -233,7 +233,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 				"type": "chromium",
 			},
 			envLookupper: func(k string) (string, bool) {
-				if k == optTimeout {
+				if k == env.BrowserGlobalTimeout {
 					return "10s", true
 				}
 				return "", false
@@ -248,7 +248,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 				"type": "chromium",
 			},
 			envLookupper: func(k string) (string, bool) {
-				if k == optTimeout {
+				if k == env.BrowserGlobalTimeout {
 					return "ABC", true
 				}
 				return "", false

--- a/common/browser_options_test.go
+++ b/common/browser_options_test.go
@@ -21,10 +21,6 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 		Timeout:           DefaultTimeout,
 	}
 
-	noopEnvLookuper := func(string) (string, bool) {
-		return "", false
-	}
-
 	for name, tt := range map[string]struct {
 		opts            map[string]any
 		envLookupper    env.LookupFunc
@@ -36,7 +32,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: noopEnvLookuper,
+			envLookupper: env.EmptyLookup,
 			assert: func(tb testing.TB, lo *BrowserOptions) {
 				tb.Helper()
 				assert.Equal(t, defaultOptions, lo)
@@ -46,7 +42,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: noopEnvLookuper,
+			envLookupper: env.EmptyLookup,
 			assert: func(tb testing.TB, lo *BrowserOptions) {
 				tb.Helper()
 				assert.Equal(t, defaultOptions, lo)
@@ -113,12 +109,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: func(k string) (string, bool) {
-				if k == env.BrowserArguments {
-					return "browser-arg1='value1,browser-arg2=value2,browser-flag", true
-				}
-				return "", false
-			},
+			envLookupper: env.ConstLookup(env.BrowserArguments, "browser-arg1='value1,browser-arg2=value2,browser-flag"),
 			assert: func(tb testing.TB, lo *BrowserOptions) {
 				tb.Helper()
 				require.Len(tb, lo.Args, 3)
@@ -131,12 +122,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: func(k string) (string, bool) {
-				if k == env.BrowserEnableDebugging {
-					return "true", true
-				}
-				return "", false
-			},
+			envLookupper: env.ConstLookup(env.BrowserEnableDebugging, "true"),
 			assert: func(tb testing.TB, lo *BrowserOptions) {
 				tb.Helper()
 				assert.True(t, lo.Debug)
@@ -146,24 +132,14 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: func(k string) (string, bool) {
-				if k == env.BrowserEnableDebugging {
-					return "non-boolean", true
-				}
-				return "", false
-			},
-			err: "K6_BROWSER_DEBUG should be a boolean",
+			envLookupper: env.ConstLookup(env.BrowserEnableDebugging, "non-boolean"),
+			err:          "K6_BROWSER_DEBUG should be a boolean",
 		},
 		"executablePath": {
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: func(k string) (string, bool) {
-				if k == env.BrowserExecutablePath {
-					return "cmd/somewhere", true
-				}
-				return "", false
-			},
+			envLookupper: env.ConstLookup(env.BrowserExecutablePath, "cmd/somewhere"),
 			assert: func(tb testing.TB, lo *BrowserOptions) {
 				tb.Helper()
 				assert.Equal(t, "cmd/somewhere", lo.ExecutablePath)
@@ -173,12 +149,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: func(k string) (string, bool) {
-				if k == env.BrowserHeadless {
-					return "false", true
-				}
-				return "", false
-			},
+			envLookupper: env.ConstLookup(env.BrowserHeadless, "false"),
 			assert: func(tb testing.TB, lo *BrowserOptions) {
 				tb.Helper()
 				assert.False(t, lo.Headless)
@@ -188,24 +159,14 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: func(k string) (string, bool) {
-				if k == env.BrowserHeadless {
-					return "non-boolean", true
-				}
-				return "", false
-			},
-			err: "K6_BROWSER_HEADLESS should be a boolean",
+			envLookupper: env.ConstLookup(env.BrowserHeadless, "non-boolean"),
+			err:          "K6_BROWSER_HEADLESS should be a boolean",
 		},
 		"ignoreDefaultArgs": {
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: func(k string) (string, bool) {
-				if k == env.BrowserIgnoreDefaultArgs {
-					return "--hide-scrollbars,--hide-something", true
-				}
-				return "", false
-			},
+			envLookupper: env.ConstLookup(env.BrowserIgnoreDefaultArgs, "--hide-scrollbars,--hide-something"),
 			assert: func(tb testing.TB, lo *BrowserOptions) {
 				tb.Helper()
 				assert.Len(t, lo.IgnoreDefaultArgs, 2)
@@ -217,12 +178,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: func(k string) (string, bool) {
-				if k == env.LogCategoryFilter {
-					return "**", true
-				}
-				return "", false
-			},
+			envLookupper: env.ConstLookup(env.LogCategoryFilter, "**"),
 			assert: func(tb testing.TB, lo *BrowserOptions) {
 				tb.Helper()
 				assert.Equal(t, "**", lo.LogCategoryFilter)
@@ -232,12 +188,7 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: func(k string) (string, bool) {
-				if k == env.BrowserGlobalTimeout {
-					return "10s", true
-				}
-				return "", false
-			},
+			envLookupper: env.ConstLookup(env.BrowserGlobalTimeout, "10s"),
 			assert: func(tb testing.TB, lo *BrowserOptions) {
 				tb.Helper()
 				assert.Equal(t, 10*time.Second, lo.Timeout)
@@ -247,19 +198,14 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: func(k string) (string, bool) {
-				if k == env.BrowserGlobalTimeout {
-					return "ABC", true
-				}
-				return "", false
-			},
-			err: "K6_BROWSER_TIMEOUT should be a time duration value",
+			envLookupper: env.ConstLookup(env.BrowserGlobalTimeout, "ABC"),
+			err:          "K6_BROWSER_TIMEOUT should be a time duration value",
 		},
 		"browser_type": {
 			opts: map[string]any{
 				"type": "chromium",
 			},
-			envLookupper: noopEnvLookuper,
+			envLookupper: env.EmptyLookup,
 			assert: func(tb testing.TB, lo *BrowserOptions) {
 				tb.Helper()
 				// Noop, just expect no error
@@ -269,11 +215,11 @@ func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
 			opts: map[string]any{
 				"type": "mybrowsertype",
 			},
-			envLookupper: noopEnvLookuper,
+			envLookupper: env.EmptyLookup,
 			err:          "unsupported browser type: mybrowsertype",
 		},
 		"browser_type_unset_err": {
-			envLookupper: noopEnvLookuper,
+			envLookupper: env.EmptyLookup,
 			err:          "browser type option must be set",
 		},
 	} {

--- a/env/env.go
+++ b/env/env.go
@@ -1,6 +1,8 @@
 // Package env provides types to interact with environment setup.
 package env
 
+import "os"
+
 // Execution specific.
 const (
 	// InstanceScenarios is an environment variable that can be used to
@@ -62,3 +64,21 @@ const (
 
 // LookupFunc defines a function to look up a key from the environment.
 type LookupFunc func(key string) (string, bool)
+
+// EmptyLookup is a LookupFunc that always returns "" and false.
+func EmptyLookup(key string) (string, bool) { return "", false }
+
+// Lookup is a LookupFunc that uses os.LookupEnv.
+func Lookup(key string) (string, bool) { return os.LookupEnv(key) }
+
+// ConstLookup is a LookupFunc that always returns the given value and true
+// if the key matches the given key. Otherwise it returns EmptyLookup
+// behaviour. Useful for testing.
+func ConstLookup(k, v string) LookupFunc {
+	return func(key string) (string, bool) {
+		if key == k {
+			return v, true
+		}
+		return EmptyLookup(key)
+	}
+}

--- a/env/env.go
+++ b/env/env.go
@@ -1,5 +1,64 @@
 // Package env provides types to interact with environment setup.
 package env
 
+// Execution specific.
+const (
+	// InstanceScenarios is an environment variable that can be used to
+	// define the extra scenarios details to use when running remotely.
+	InstanceScenarios = "K6_INSTANCE_SCENARIOS"
+
+	// WebSocketURLs is an environment variable that can be used to
+	// define the WS URLs to connect to when running remotely.
+	WebSocketURLs = "K6_BROWSER_WS_URL"
+
+	// BrowserArguments is an environment variable that can be used to
+	// pass extra arguments to the browser process.
+	BrowserArguments = "K6_BROWSER_ARGS"
+
+	// BrowserExecutablePath is an environment variable that can be used
+	// to define the path to the browser to execute.
+	BrowserExecutablePath = "K6_BROWSER_EXECUTABLE_PATH"
+
+	// BrowserEnableDebugging is an environment variable that can be used to
+	// define if the browser should be launched with debugging enabled.
+	BrowserEnableDebugging = "K6_BROWSER_DEBUG"
+
+	// BrowserHeadless is an environment variable that can be used to
+	// define if the browser should be launched in headless mode.
+	BrowserHeadless = "K6_BROWSER_HEADLESS"
+
+	// BrowserIgnoreDefaultArgs is an environment variable that can be
+	// used to define if the browser should ignore default arguments.
+	BrowserIgnoreDefaultArgs = "K6_BROWSER_IGNORE_DEFAULT_ARGS"
+
+	// BrowserGlobalTimeout is an environment variable that can be used
+	// to set the global timeout for the browser.
+	BrowserGlobalTimeout = "K6_BROWSER_TIMEOUT"
+)
+
+// Logging and debugging.
+const (
+	// EnableProfiling is an environment variable that can be used to
+	// enable profiling for the browser. It will start up a debugging
+	// server on ProfilingServerAddr.
+	EnableProfiling = "K6_BROWSER_ENABLE_PPROF"
+
+	// ProfilingServerAddr is the address of the profiling server.
+	ProfilingServerAddr = "localhost:6060"
+
+	// LogCaller is an environment variable that can be used to enable
+	// the caller function information in the browser logs.
+	LogCaller = "K6_BROWSER_LOG_CALLER"
+
+	// LogLevel is an environment variable that can be used to set the
+	// log level for the browser logs.
+	LogLevel = "K6_BROWSER_LOG"
+
+	// LogCategoryFilter is an environment variable that can be used to
+	// filter the browser logs based on their category. It supports
+	// regular expressions.
+	LogCategoryFilter = "K6_BROWSER_LOG_CATEGORY_FILTER"
+)
+
 // LookupFunc defines a function to look up a key from the environment.
 type LookupFunc func(key string) (string, bool)

--- a/examples/device_emulation.js
+++ b/examples/device_emulation.js
@@ -42,7 +42,7 @@ export default async function() {
       'scale': d => d.deviceScaleFactor === device.deviceScaleFactor,
     });
 
-    if (!__ENV.XK6_HEADLESS) {
+    if (!__ENV.K6_BROWSER_HEADLESS) {
       sleep(10);
     }
   } finally {

--- a/k6ext/k6test/vu.go
+++ b/k6ext/k6test/vu.go
@@ -66,9 +66,7 @@ func NewVU(tb testing.TB, opts ...any) *VU {
 
 	var (
 		samples    = make(chan k6metrics.SampleContainer, 1000)
-		lookupFunc = func(_ string) (string, bool) {
-			return "", false
-		}
+		lookupFunc = env.EmptyLookup
 	)
 	for _, opt := range opts {
 		switch opt := opt.(type) {

--- a/k6ext/k6test/vu.go
+++ b/k6ext/k6test/vu.go
@@ -57,10 +57,11 @@ func (v *VU) AssertSamples(assertSample func(s k6metrics.Sample)) int {
 // so that the test can read the metrics being emitted to the channel.
 type WithSamplesListener chan k6metrics.SampleContainer
 
-// WithLookupFunc a custom lookup function that returns test values.
-type WithLookupFunc env.LookupFunc
-
 // NewVU returns a mock k6 VU.
+//
+// opts can be one of the following:
+//   - WithSamplesListener: a bidirectional channel that will be used to emit metrics.
+//   - env.LookupFunc: a lookup function that will be used to lookup environment variables.
 func NewVU(tb testing.TB, opts ...any) *VU {
 	tb.Helper()
 
@@ -72,8 +73,8 @@ func NewVU(tb testing.TB, opts ...any) *VU {
 		switch opt := opt.(type) {
 		case WithSamplesListener:
 			samples = opt
-		case WithLookupFunc:
-			lookupFunc = env.LookupFunc(opt)
+		case env.LookupFunc:
+			lookupFunc = opt
 		}
 	}
 

--- a/register.go
+++ b/register.go
@@ -2,26 +2,10 @@
 package browser
 
 import (
-	"log"
-	"net/http"
-	_ "net/http/pprof" //nolint:gosec
-	"os"
-
 	"github.com/grafana/xk6-browser/browser"
 
 	k6modules "go.k6.io/k6/js/modules"
 )
-
-func init() {
-	if _, ok := os.LookupEnv("K6_BROWSER_PPROF"); ok {
-		go func() {
-			address := "localhost:6060"
-			log.Println("Starting http debug server", address)
-			log.Println(http.ListenAndServe(address, nil)) //nolint:gosec
-			// no linted because we don't need to set timeouts for the debug server.
-		}()
-	}
-}
 
 func init() {
 	k6modules.Register("k6/x/browser", browser.New())

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -40,18 +40,19 @@ func TestBrowserNewPage(t *testing.T) {
 }
 
 func TestTmpDirCleanup(t *testing.T) {
+	t.Parallel()
+
 	tmpDirPath := "./"
 
-	err := os.Setenv("TMPDIR", tmpDirPath)
-	assert.NoError(t, err)
-	defer func() {
-		err = os.Unsetenv("TMPDIR")
-		assert.NoError(t, err)
-	}()
+	b := newTestBrowser(t, withSkipClose(), withLookupFunc(func(k string) (string, bool) {
+		if k == "TMPDIR" {
+			return tmpDirPath, true
+		}
+		return "", false
+	}))
 
-	b := newTestBrowser(t, withSkipClose())
 	p := b.NewPage(nil)
-	err = p.Close(nil)
+	err := p.Close(nil)
 	require.NoError(t, err)
 
 	matches, err := filepath.Glob(tmpDirPath + "xk6-browser-data-*")

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -43,15 +43,9 @@ func TestBrowserNewPage(t *testing.T) {
 func TestTmpDirCleanup(t *testing.T) {
 	t.Parallel()
 
-	tmpDirPath := "./"
+	const tmpDirPath = "./"
 
-	b := newTestBrowser(t, withSkipClose(), withLookupFunc(func(k string) (string, bool) {
-		if k == "TMPDIR" {
-			return tmpDirPath, true
-		}
-		return "", false
-	}))
-
+	b := newTestBrowser(t, withSkipClose(), withLookupFunc(env.ConstLookup("TMPDIR", tmpDirPath)))
 	p := b.NewPage(nil)
 	err := p.Close(nil)
 	require.NoError(t, err)
@@ -146,12 +140,9 @@ func TestBrowserUserAgent(t *testing.T) {
 
 func TestBrowserCrashErr(t *testing.T) {
 	// create a new VU in an environment that requires a bad remote-debugging-port.
-	vu := k6test.NewVU(t, k6test.WithLookupFunc(func(key string) (string, bool) {
-		if key == env.BrowserArguments {
-			return "remote-debugging-port=99999", true
-		}
-		return "", false
-	}))
+	vu := k6test.NewVU(t, k6test.WithLookupFunc(
+		env.ConstLookup(env.BrowserArguments, "remote-debugging-port=99999"),
+	))
 
 	mod := browser.New().NewModuleInstance(vu)
 	jsMod, ok := mod.Exports().Default.(*browser.JSModule)

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -45,7 +45,7 @@ func TestTmpDirCleanup(t *testing.T) {
 
 	const tmpDirPath = "./"
 
-	b := newTestBrowser(t, withSkipClose(), withLookupFunc(env.ConstLookup("TMPDIR", tmpDirPath)))
+	b := newTestBrowser(t, withSkipClose(), env.ConstLookup("TMPDIR", tmpDirPath))
 	p := b.NewPage(nil)
 	err := p.Close(nil)
 	require.NoError(t, err)
@@ -140,9 +140,7 @@ func TestBrowserUserAgent(t *testing.T) {
 
 func TestBrowserCrashErr(t *testing.T) {
 	// create a new VU in an environment that requires a bad remote-debugging-port.
-	vu := k6test.NewVU(t, k6test.WithLookupFunc(
-		env.ConstLookup(env.BrowserArguments, "remote-debugging-port=99999"),
-	))
+	vu := k6test.NewVU(t, env.ConstLookup(env.BrowserArguments, "remote-debugging-port=99999"))
 
 	mod := browser.New().NewModuleInstance(vu)
 	jsMod, ok := mod.Exports().Default.(*browser.JSModule)

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/grafana/xk6-browser/browser"
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/env"
 	"github.com/grafana/xk6-browser/k6ext/k6test"
 )
 
@@ -146,7 +147,7 @@ func TestBrowserUserAgent(t *testing.T) {
 func TestBrowserCrashErr(t *testing.T) {
 	// create a new VU in an environment that requires a bad remote-debugging-port.
 	vu := k6test.NewVU(t, k6test.WithLookupFunc(func(key string) (string, bool) {
-		if key == "K6_BROWSER_ARGS" {
+		if key == env.BrowserArguments {
 			return "remote-debugging-port=99999", true
 		}
 		return "", false

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/xk6-browser/browser"
 	"github.com/grafana/xk6-browser/chromium"
+	"github.com/grafana/xk6-browser/env"
 	"github.com/grafana/xk6-browser/k6ext/k6test"
 )
 
@@ -32,7 +33,7 @@ func TestBrowserTypeLaunchToConnect(t *testing.T) {
 	// Export WS URL env var
 	// pointing to test browser proxy
 	vu := k6test.NewVU(t, k6test.WithLookupFunc(func(key string) (string, bool) {
-		if key == "K6_BROWSER_WS_URL" {
+		if key == env.WebSocketURLs {
 			return bp.wsURL(), true
 		}
 		return "", false

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -32,12 +32,9 @@ func TestBrowserTypeLaunchToConnect(t *testing.T) {
 
 	// Export WS URL env var
 	// pointing to test browser proxy
-	vu := k6test.NewVU(t, k6test.WithLookupFunc(func(key string) (string, bool) {
-		if key == env.WebSocketURLs {
-			return bp.wsURL(), true
-		}
-		return "", false
-	}))
+	vu := k6test.NewVU(t, k6test.WithLookupFunc(
+		env.ConstLookup(env.WebSocketURLs, bp.wsURL())),
+	)
 
 	// We have to call launch method through JS API in Goja
 	// to take mapping layer into account, instead of calling

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -32,9 +32,7 @@ func TestBrowserTypeLaunchToConnect(t *testing.T) {
 
 	// Export WS URL env var
 	// pointing to test browser proxy
-	vu := k6test.NewVU(t, k6test.WithLookupFunc(
-		env.ConstLookup(env.WebSocketURLs, bp.wsURL())),
-	)
+	vu := k6test.NewVU(t, env.ConstLookup(env.WebSocketURLs, bp.wsURL()))
 
 	// We have to call launch method through JS API in Goja
 	// to take mapping layer into account, instead of calling

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -26,13 +26,17 @@ func TestBrowserTypeConnect(t *testing.T) {
 }
 
 func TestBrowserTypeLaunchToConnect(t *testing.T) {
-	vu := k6test.NewVU(t)
 	tb := newTestBrowser(t)
 	bp := newTestBrowserProxy(t, tb)
 
 	// Export WS URL env var
 	// pointing to test browser proxy
-	t.Setenv("K6_BROWSER_WS_URL", bp.wsURL())
+	vu := k6test.NewVU(t, k6test.WithLookupFunc(func(key string) (string, bool) {
+		if key == "K6_BROWSER_WS_URL" {
+			return bp.wsURL(), true
+		}
+		return "", false
+	}))
 
 	// We have to call launch method through JS API in Goja
 	// to take mapping layer into account, instead of calling

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -16,10 +15,6 @@ import (
 
 func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 	t.Parallel()
-
-	if os.Getenv("SKIP_FLAKY") == "true" {
-		t.SkipNow()
-	}
 
 	const timeout = 5 * time.Second
 

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"os"
 	"strconv"
 	"testing"
 
@@ -70,7 +69,7 @@ func TestFrameDismissDialogBox(t *testing.T) {
 func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 	t.Parallel()
 
-	if s, ok := os.LookupEnv(env.BrowserHeadless); ok {
+	if s, ok := env.Lookup(env.BrowserHeadless); ok {
 		if v, err := strconv.ParseBool(s); err == nil && v {
 			// We're skipping this when running in headless
 			// environments since the bug that the test fixes
@@ -82,12 +81,9 @@ func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 	}
 
 	// run the browser in headfull mode.
-	tb := newTestBrowser(t, withFileServer(), withLookupFunc(func(key string) (string, bool) {
-		if key == env.BrowserHeadless {
-			return "0", true
-		}
-		return "", false
-	}))
+	tb := newTestBrowser(t, withFileServer(), withLookupFunc(
+		env.ConstLookup(env.BrowserHeadless, "0"),
+	))
 
 	p := tb.NewPage(nil)
 	_, err := p.Goto(

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/env"
 )
 
 func TestFramePress(t *testing.T) {
@@ -68,7 +70,7 @@ func TestFrameDismissDialogBox(t *testing.T) {
 func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 	t.Parallel()
 
-	if s, ok := os.LookupEnv("K6_BROWSER_HEADLESS"); ok {
+	if s, ok := os.LookupEnv(env.BrowserHeadless); ok {
 		if v, err := strconv.ParseBool(s); err == nil && v {
 			// We're skipping this when running in headless
 			// environments since the bug that the test fixes
@@ -81,7 +83,7 @@ func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 
 	// run the browser in headfull mode.
 	tb := newTestBrowser(t, withFileServer(), withLookupFunc(func(key string) (string, bool) {
-		if key == "K6_BROWSER_HEADLESS" {
+		if key == env.BrowserHeadless {
 			return "0", true
 		}
 		return "", false

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -81,9 +81,7 @@ func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 	}
 
 	// run the browser in headfull mode.
-	tb := newTestBrowser(t, withFileServer(), withLookupFunc(
-		env.ConstLookup(env.BrowserHeadless, "0"),
-	))
+	tb := newTestBrowser(t, withFileServer(), env.ConstLookup(env.BrowserHeadless, "0"))
 
 	p := tb.NewPage(nil)
 	_, err := p.Goto(

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -65,13 +65,10 @@ func TestFrameDismissDialogBox(t *testing.T) {
 	}
 }
 
-// FIX
-// This test does not work on my machine. It fails with:
-// "" != "Done!".
-//
-// OSX: 13.1 (22C65).
 func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
-	if s, ok := os.LookupEnv("XK6_HEADLESS"); ok {
+	t.Parallel()
+
+	if s, ok := os.LookupEnv("K6_BROWSER_HEADLESS"); ok {
 		if v, err := strconv.ParseBool(s); err == nil && v {
 			// We're skipping this when running in headless
 			// environments since the bug that the test fixes
@@ -82,13 +79,15 @@ func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 		}
 	}
 
-	t.Parallel()
+	// run the browser in headfull mode.
+	tb := newTestBrowser(t, withFileServer(), withLookupFunc(func(key string) (string, bool) {
+		if key == "K6_BROWSER_HEADLESS" {
+			return "0", true
+		}
+		return "", false
+	}))
 
-	opts := defaultBrowserOpts()
-	opts.Headless = false
-	tb := newTestBrowser(t, withFileServer(), opts)
 	p := tb.NewPage(nil)
-
 	_, err := p.Goto(
 		tb.staticURL("embedded_iframe.html"),
 		tb.toGojaValue(struct {

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -44,10 +44,16 @@ type testBrowser struct {
 }
 
 // newTestBrowser configures and launches a new chrome browser.
-// It automatically closes it when `t` returns.
 //
-// opts provides a way to customize the newTestBrowser.
-// see: withFileServer for an example.
+// It automatically closes it when `t` returns unless `withSkipClose` option is provided.
+//
+// The following opts are available to customize the testBrowser:
+//   - withHTTPServer: enables the HTTPMultiBin server.
+//   - withFileServer: enables the HTTPMultiBin server and serves the given files.
+//   - withLogCache: enables the log cache.
+//   - withSamplesListener: provides a channel to receive the browser metrics.
+//   - env.LookupFunc: provides a custom lookup function for environment variables.
+//   - withSkipClose: skips closing the browser when the test finishes.
 func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 	tb.Helper()
 
@@ -75,7 +81,7 @@ func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 			skipClose = true
 		case withSamplesListener:
 			samples = opt
-		case withLookupFunc:
+		case env.LookupFunc:
 			lookupFunc = func(key string) (string, bool) {
 				v, ok := opt(key)
 				if ok {
@@ -471,6 +477,3 @@ func setupHTTPTestModuleInstance(tb testing.TB, samples chan k6metrics.SampleCon
 
 	return vu
 }
-
-// WithLookupFunc is a custom lookup function that returns test values.
-type withLookupFunc func(string) (string, bool)

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -82,15 +82,7 @@ func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 		case withSamplesListener:
 			samples = opt
 		case env.LookupFunc:
-			lookupFunc = func(key string) (string, bool) {
-				v, ok := opt(key)
-				if ok {
-					return v, ok
-				}
-				// return from the real environment lookup function
-				// so that we can debug (or other things) when we want it.
-				return env.Lookup(key)
-			}
+			lookupFunc = opt
 		}
 	}
 

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -55,7 +55,6 @@ func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 
 	// set default options and then customize them
 	var (
-		browserOpts        = defaultBrowserOpts()
 		enableHTTPMultiBin = false
 		enableFileServer   = false
 		enableLogCache     = false
@@ -67,8 +66,6 @@ func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 	)
 	for _, opt := range opts {
 		switch opt := opt.(type) {
-		case withBrowserOptions:
-			browserOpts = opt
 		case httpServerOption:
 			enableHTTPMultiBin = true
 		case fileServerOption:
@@ -124,8 +121,6 @@ func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 		state.TLSConfig = testServer.TLSClientConfig
 		state.Transport = testServer.HTTPTransport
 	}
-
-	bt.SetEnvLookupper(setupEnvLookupper(tb, browserOpts))
 
 	b, pid, err := bt.Launch(dummyCtx)
 	if err != nil {

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -6,14 +6,12 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/chromium"
 	"github.com/grafana/xk6-browser/common"
-	"github.com/grafana/xk6-browser/env"
 	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/k6ext/k6test"
 
@@ -499,26 +497,3 @@ func setupHTTPTestModuleInstance(tb testing.TB, samples chan k6metrics.SampleCon
 
 // WithLookupFunc is a custom lookup function that returns test values.
 type withLookupFunc func(string) (string, bool)
-
-func setupEnvLookupper(tb testing.TB, opts browserOptions) env.LookupFunc {
-	tb.Helper()
-
-	return func(key string) (string, bool) {
-		switch key {
-		case "K6_BROWSER_ARGS":
-			if len(opts.Args) != 0 {
-				return strings.Join(opts.Args, ","), true
-			}
-		case "K6_BROWSER_DEBUG":
-			return strconv.FormatBool(opts.Debug), true
-		case "K6_BROWSER_HEADLESS":
-			return strconv.FormatBool(opts.Headless), true
-		case "K6_BROWSER_TIMEOUT":
-			if opts.Timeout != "" {
-				return opts.Timeout, true
-			}
-		}
-
-		return "", false
-	}
-}

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -409,17 +409,6 @@ type browserOptions struct {
 	Timeout  string   `js:"timeout"`
 }
 
-// withBrowserOptions is a helper for increasing readability
-// in tests while customizing the browser options.
-//
-// example:
-//
-//	b := TestBrowser(t, withBrowserOptions{
-//	    SlowMo:  "100s",
-//	    Timeout: "30s",
-//	})
-type withBrowserOptions = browserOptions
-
 // defaultBrowserOpts returns defaults for browser options.
 // TestBrowser uses this for launching a browser type by default.
 func defaultBrowserOpts() browserOptions {

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/xk6-browser/api"
 	"github.com/grafana/xk6-browser/chromium"
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/env"
 	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/k6ext/k6test"
 
@@ -57,9 +58,9 @@ func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 		enableLogCache     = false
 		skipClose          = false
 		samples            = make(chan k6metrics.SampleContainer, 1000)
-		// default lookup function is os.LookupEnv so that we can
+		// default lookup function is env.Lookup so that we can
 		// pass the environment variables while testing, i.e.: K6_BROWSER_LOG.
-		lookupFunc = os.LookupEnv
+		lookupFunc = env.Lookup
 	)
 	for _, opt := range opts {
 		switch opt := opt.(type) {
@@ -82,7 +83,7 @@ func newTestBrowser(tb testing.TB, opts ...any) *testBrowser {
 				}
 				// return from the real environment lookup function
 				// so that we can debug (or other things) when we want it.
-				return os.LookupEnv(key)
+				return env.Lookup(key)
 			}
 		}
 	}

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -396,29 +395,6 @@ func (t testPromise) then(resolve any, reject ...any) testPromise {
 	require.True(t.tb.t, ok)
 
 	return t.tb.promise(p)
-}
-
-// browserOptions provides a way to customize browser
-// options in tests.
-type browserOptions struct {
-	Args     []string `js:"args"`
-	Debug    bool     `js:"debug"`
-	Headless bool     `js:"headless"`
-	Timeout  string   `js:"timeout"`
-}
-
-// defaultBrowserOpts returns defaults for browser options.
-// TestBrowser uses this for launching a browser type by default.
-func defaultBrowserOpts() browserOptions {
-	headless := true
-	if v, found := os.LookupEnv("XK6_BROWSER_TEST_HEADLESS"); found {
-		headless, _ = strconv.ParseBool(v)
-	}
-
-	return browserOptions{
-		Headless: headless,
-		Timeout:  "30s",
-	}
 }
 
 // httpServerOption is used to detect whether to enable the HTTP test

--- a/tests/test_browser_test.go
+++ b/tests/test_browser_test.go
@@ -32,3 +32,18 @@ func (t *testingT) Fatalf(format string, args ...any) {
 	t.fatalfCalled = true
 	t.SkipNow()
 }
+
+func TestTestBrowserWithLookupFunc(t *testing.T) {
+	tt := &testingT{TB: t}
+
+	// this lookup is expected to fail because the remote debugging port is
+	// invalid, practically testing that the InitEnv.LookupEnv is used.
+	lookup := func(key string) (string, bool) {
+		if key == "K6_BROWSER_ARGS" {
+			return "remote-debugging-port=99999", true
+		}
+		return "", false
+	}
+	_ = newTestBrowser(tt, withLookupFunc(lookup))
+	require.True(t, tt.fatalfCalled)
+}

--- a/tests/test_browser_test.go
+++ b/tests/test_browser_test.go
@@ -18,3 +18,17 @@ func TestTestBrowserAwaitWithTimeoutShortCircuit(t *testing.T) {
 	}))
 	require.Less(t, time.Since(start), time.Second)
 }
+
+// testingT is a wrapper around testing.TB.
+type testingT struct {
+	testing.TB
+	fatalfCalled bool
+}
+
+// Fatalf skips the test immediately after a test is calling it.
+// This is useful when a test is expected to fail, but we don't
+// want to mark it as a failure since it's expected.
+func (t *testingT) Fatalf(format string, args ...any) {
+	t.fatalfCalled = true
+	t.SkipNow()
+}

--- a/tests/test_browser_test.go
+++ b/tests/test_browser_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/env"
 )
 
 func TestTestBrowserAwaitWithTimeoutShortCircuit(t *testing.T) {
@@ -39,7 +41,7 @@ func TestTestBrowserWithLookupFunc(t *testing.T) {
 	// this lookup is expected to fail because the remote debugging port is
 	// invalid, practically testing that the InitEnv.LookupEnv is used.
 	lookup := func(key string) (string, bool) {
-		if key == "K6_BROWSER_ARGS" {
+		if key == env.BrowserArguments {
 			return "remote-debugging-port=99999", true
 		}
 		return "", false

--- a/tests/test_browser_test.go
+++ b/tests/test_browser_test.go
@@ -37,15 +37,9 @@ func (t *testingT) Fatalf(format string, args ...any) {
 
 func TestTestBrowserWithLookupFunc(t *testing.T) {
 	tt := &testingT{TB: t}
-
 	// this lookup is expected to fail because the remote debugging port is
 	// invalid, practically testing that the InitEnv.LookupEnv is used.
-	lookup := func(key string) (string, bool) {
-		if key == env.BrowserArguments {
-			return "remote-debugging-port=99999", true
-		}
-		return "", false
-	}
+	lookup := env.ConstLookup(env.BrowserArguments, "remote-debugging-port=99999")
 	_ = newTestBrowser(tt, withLookupFunc(lookup))
 	require.True(t, tt.fatalfCalled)
 }

--- a/tests/test_browser_test.go
+++ b/tests/test_browser_test.go
@@ -37,9 +37,8 @@ func (t *testingT) Fatalf(format string, args ...any) {
 
 func TestTestBrowserWithLookupFunc(t *testing.T) {
 	tt := &testingT{TB: t}
-	// this lookup is expected to fail because the remote debugging port is
+	// this operation is expected to fail because the remote debugging port is
 	// invalid, practically testing that the InitEnv.LookupEnv is used.
-	lookup := env.ConstLookup(env.BrowserArguments, "remote-debugging-port=99999")
-	_ = newTestBrowser(tt, withLookupFunc(lookup))
+	_ = newTestBrowser(tt, env.ConstLookup(env.BrowserArguments, "remote-debugging-port=99999"))
 	require.True(t, tt.fatalfCalled)
 }


### PR DESCRIPTION
This PR refactors the direct usage of `os.LookupEnv` to k6 `LookupEnv`. Please have a look at the commit descriptions for the changes needed.

These new changes provide enhanced testability and consistency throughout the module.

The following are all the environment variables and options that the k6-browser module supports. The outdated `XK6_*` are removed and aligned with the new browser options we have.

```go
// Execution specific.
const (
	// InstanceScenarios is an environment variable that can be used to
	// define the extra scenarios details to use when running remotely.
	InstanceScenarios = "K6_INSTANCE_SCENARIOS"

	// WebSocketURLs is an environment variable that can be used to
	// define the WS URLs to connect to when running remotely.
	WebSocketURLs = "K6_BROWSER_WS_URL"

	// BrowserArguments is an environment variable that can be used to
	// pass extra arguments to the browser process.
	BrowserArguments = "K6_BROWSER_ARGS"

	// BrowserExecutablePath is an environment variable that can be used
	// to define the path to the browser to execute.
	BrowserExecutablePath = "K6_BROWSER_EXECUTABLE_PATH"

	// BrowserEnableDebugging is an environment variable that can be used to
	// define if the browser should be launched with debugging enabled.
	BrowserEnableDebugging = "K6_BROWSER_DEBUG"

	// BrowserHeadless is an environment variable that can be used to
	// define if the browser should be launched in headless mode.
	BrowserHeadless = "K6_BROWSER_HEADLESS"

	// BrowserIgnoreDefaultArgs is an environment variable that can be
	// used to define if the browser should ignore default arguments.
	BrowserIgnoreDefaultArgs = "K6_BROWSER_IGNORE_DEFAULT_ARGS"

	// BrowserGlobalTimeout is an environment variable that can be used
	// to set the global timeout for the browser.
	BrowserGlobalTimeout = "K6_BROWSER_TIMEOUT"
)

// Logging and debugging.
const (
	// EnableProfiling is an environment variable that can be used to
	// enable profiling for the browser. It will start up a debugging
	// server on ProfilingServerAddr.
	EnableProfiling = "K6_BROWSER_ENABLE_PPROF"

	// ProfilingServerAddr is the address of the profiling server.
	ProfilingServerAddr = "localhost:6060"

	// LogCaller is an environment variable that can be used to enable
	// the caller function information in the browser logs.
	LogCaller = "K6_BROWSER_LOG_CALLER"

	// LogLevel is an environment variable that can be used to set the
	// log level for the browser logs.
	LogLevel = "K6_BROWSER_LOG"

	// LogCategoryFilter is an environment variable that can be used to
	// filter the browser logs based on their category. It supports
	// regular expressions.
	LogCategoryFilter = "K6_BROWSER_LOG_CATEGORY_FILTER"
)
```

