### PR TITLE
Remove browser module Version

### DIFF
--- a/browser/module.go
+++ b/browser/module.go
@@ -30,7 +30,6 @@ type (
 	JSModule struct {
 		Browser *goja.Object
 		Devices map[string]common.Device
-		Version string
 	}
 
 	// ModuleInstance represents an instance of the JS module.


### PR DESCRIPTION
We should have removed the exported field after the following change: 710e616957cd2ff4abaae9218ede0d12cbcae267. This PR removes the `Version` field for good.