### PR TITLE
Limit browser implementation to hold a single browserContext

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -372,7 +372,7 @@ func (b *Browser) onDetachedFromTarget(ev *target.EventDetachedFromTarget) {
 
 func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 	if b.context == nil || b.context.id != id {
-		return nil, fmt.Errorf("missing browser context: %s", id)
+		return nil, fmt.Errorf("missing browser context %s, current context is %s", id, b.context.id)
 	}
 
 	ctx, cancel := context.WithTimeout(b.ctx, b.browserOpts.Timeout)

--- a/common/browser.go
+++ b/common/browser.go
@@ -501,7 +501,7 @@ func (b *Browser) IsConnected() bool {
 // NewContext creates a new incognito-like browser context.
 func (b *Browser) NewContext(opts goja.Value) (api.BrowserContext, error) {
 	if b.context != nil {
-		return nil, errors.New("close the existing browser context before creating a new one")
+		return nil, errors.New("existing browser context must be closed before creating a new one")
 	}
 
 	action := target.CreateBrowserContext().WithDisposeOnDetach(true)

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -31,11 +31,11 @@ func TestBrowserNewPageInContext(t *testing.T) {
 		var err error
 		vu := k6test.NewVU(t)
 		ctx = k6ext.WithVU(ctx, vu)
-		b.contexts[id], err = NewBrowserContext(ctx, b, id, nil, nil)
+		b.context, err = NewBrowserContext(ctx, b, id, nil, nil)
 		require.NoError(t, err)
 		return &testCase{
 			b:  b,
-			bc: b.contexts[id],
+			bc: b.context,
 		}
 	}
 

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -28,16 +28,16 @@ func TestBrowserNewPage(t *testing.T) {
 
 	p2 := b.NewPage(nil)
 	l = len(b.Contexts())
-	assert.Equal(t, 2, l, "expected there to be 2 browser context, but found %d", l)
+	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
 
 	err := p.Close(nil)
 	require.NoError(t, err)
 	l = len(b.Contexts())
-	assert.Equal(t, 2, l, "expected there to be 2 browser contexts after first page close, but found %d", l)
+	assert.Equal(t, 1, l, "expected there to be 1 browser context after first page close, but found %d", l)
 	err = p2.Close(nil)
 	require.NoError(t, err)
 	l = len(b.Contexts())
-	assert.Equal(t, 2, l, "expected there to be 2 browser contexts after second page close, but found %d", l)
+	assert.Equal(t, 1, l, "expected there to be 1 browser context after second page close, but found %d", l)
 }
 
 func TestTmpDirCleanup(t *testing.T) {

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -27,7 +27,7 @@ func TestBrowserNewPage(t *testing.T) {
 	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
 
 	_, err := b.Browser.NewPage(nil)
-	assert.EqualError(t, err, "new page: close the existing browser context before creating a new one")
+	assert.EqualError(t, err, "new page: existing browser context must be closed before creating a new one")
 
 	err = p1.Close(nil)
 	require.NoError(t, err)
@@ -35,7 +35,7 @@ func TestBrowserNewPage(t *testing.T) {
 	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
 
 	_, err = b.Browser.NewPage(nil)
-	assert.EqualError(t, err, "new page: close the existing browser context before creating a new one")
+	assert.EqualError(t, err, "new page: existing browser context must be closed before creating a new one")
 
 	b.Contexts()[0].Close()
 	l = len(b.Contexts())
@@ -54,7 +54,7 @@ func TestBrowserNewContext(t *testing.T) {
 	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
 
 	_, err = b.NewContext(nil)
-	assert.EqualError(t, err, "close the existing browser context before creating a new one")
+	assert.EqualError(t, err, "existing browser context must be closed before creating a new one")
 
 	bc1.Close()
 	l = len(b.Contexts())

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -12,9 +12,8 @@ import (
 )
 
 func TestKeyboardPress(t *testing.T) {
-	tb := newTestBrowser(t)
-
 	t.Run("all_keys", func(t *testing.T) {
+		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
 		layout := keyboardlayout.GetKeyboardLayout("us")
@@ -27,6 +26,7 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("backspace", func(t *testing.T) {
+		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
 
@@ -43,6 +43,7 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("combo", func(t *testing.T) {
+		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
 
@@ -68,6 +69,7 @@ func TestKeyboardPress(t *testing.T) {
 
 	t.Run("meta", func(t *testing.T) {
 		t.Skip("FIXME") // See https://github.com/grafana/xk6-browser/issues/424
+		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
 
@@ -92,6 +94,7 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("type does not split on +", func(t *testing.T) {
+		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
 
@@ -105,6 +108,7 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("capitalization", func(t *testing.T) {
+		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
 
@@ -130,6 +134,7 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("type not affected by shift", func(t *testing.T) {
+		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
 
@@ -146,6 +151,7 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("newline", func(t *testing.T) {
+		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
 
@@ -163,6 +169,7 @@ func TestKeyboardPress(t *testing.T) {
 
 	// Replicates the test from https://playwright.dev/docs/api/class-keyboard
 	t.Run("selection", func(t *testing.T) {
+		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
 

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -74,11 +74,10 @@ func TestBasicAuth(t *testing.T) {
 		validPassword = "validpass"
 	)
 
-	browser := newTestBrowser(t, withHTTPServer())
-
 	auth := func(tb testing.TB, user, pass string) api.Response {
 		tb.Helper()
 
+		browser := newTestBrowser(t, withHTTPServer())
 		bc, err := browser.NewContext(
 			browser.toGojaValue(struct {
 				HttpCredentials *common.Credentials `js:"httpCredentials"` //nolint:revive


### PR DESCRIPTION
### Description of changes

This PR is one of a few that will be used to help enforce a single `browserContext` per `browser` per iteration. The reason for this change can be found in this directly linked [issue](https://github.com/grafana/xk6-browser/issues/925) and this overarching [issue](https://github.com/grafana/k6-cloud/issues/1077). The summary is that we want to be able to predict the resource requirements of how many browsers a test run may need, and the first step towards this goal is to be able to predict the number of `browserContext`s a test run will need.

At the moment (in this PR) we enforce a single `browserContext` per iteration, which also means we allow the user to `close()` the existing `browserContext` and create a new one with `NewContext`. Any objects still associated to the previous `browserContext` will be closed and the user will not be able to work with those objects. In a later PR we will change this behaviour so once a `browserContext` is setup, no other `browserContext` can be created, even if the existing one is closed.

```js
export default async function() {
  const context = browser.newContext();
  const page = context.newPage();

  // const context2 = context.newContext(); // If uncommented, it would cause an error.

  context.close(); // page cannot be used after this call

  // await page.goto("https://test.k6.io"); // If uncommented, it would cause an error.

  const context2 = context.newContext();

  // await page.goto("https://test.k6.io"); // If uncommented, it would cause an error.

  const page2 = context2.newPage();
  await page2.goto("https://test.k6.io");
  ...
```

### Checklist
```[tasklist]
- [X] Written tests for the changes
- [ ] Update k6 documentation (if relevant)
- [ ] Generate TS definitions (if relevant)
```