### PR TITLE
Fix auto browser context close on page close

### DIFF
--- a/common/page.go
+++ b/common/page.go
@@ -443,6 +443,10 @@ func (p *Page) Close(opts goja.Value) error {
 		// we're waiting for the response to come back from the browser
 		// for this current command (it's racey).
 		if errors.Is(err, context.Canceled) {
+			// If the context was canceled, it means the session was
+			// closed, so we can just return nil here. No need to
+			// check the error, as we know it's context.Canceled.
+			_ = p.browserCtx.browser.disposeContext(p.browserCtx.id)
 			return nil
 		}
 

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -30,14 +30,15 @@ func TestBrowserNewPage(t *testing.T) {
 	l = len(b.Contexts())
 	assert.Equal(t, 2, l, "expected there to be 2 browser context, but found %d", l)
 
+	// contexts are auto-closed when the page is closed and context.Context is canceled.
 	err := p.Close(nil)
 	require.NoError(t, err)
 	l = len(b.Contexts())
-	assert.Equal(t, 2, l, "expected there to be 2 browser contexts after first page close, but found %d", l)
+	assert.Equal(t, 1, l, "expected there to be one browser context after first page close, but found %d", l)
 	err = p2.Close(nil)
 	require.NoError(t, err)
 	l = len(b.Contexts())
-	assert.Equal(t, 2, l, "expected there to be 2 browser contexts after second page close, but found %d", l)
+	assert.Equal(t, 0, l, "expected there to be zero browser contexts after second page close, but found %d", l)
 }
 
 func TestTmpDirCleanup(t *testing.T) {
@@ -251,7 +252,6 @@ func TestMultiConnectToSingleBrowser(t *testing.T) {
 
 	err = p1.Close(nil)
 	require.NoError(t, err, "failed to close page #1")
-	bctx1.Close()
 
 	p2, err := bctx2.NewPage()
 	require.NoError(t, err, "failed to create page #2")


### PR DESCRIPTION
An experimental fix to help to come up with an actual fix.

This fixes an issue where we try to create a new page while, in that time frame, the context gets canceled. This happens when we detach from a page but do not close a context.

This requires us not to close browser contexts manually. Or, we can do a better fix, like actually managing the order of CDP events, as noted at the link below.

https://github.com/grafana/k6-cloud/issues/1096#issuecomment-1496016640

Example:

```
---> [2023-06-13 11:13:53.943147 +0300 +03 m=+0.261837668] {"id":24,"sessionId":"A3583375BA7F32AAEAB9C1AC2CBDE91F","method":"Target.closeTarget","params":{"targetId":"A97C871B24EDA407A73456BD66F3BB38"}}
<--- [2023-06-13 11:13:53.943205 +0300 +03 m=+0.261896084] {"id":3,"result":{},"sessionId":"51CC05417CBCD9D6C53FFE1415C69FC7"} 
---> [2023-06-13 11:13:53.943224 +0300 +03 m=+0.261915293] {"id":4,"sessionId":"51CC05417CBCD9D6C53FFE1415C69FC7","method":"Page.getFrameTree"}
<--- [2023-06-13 11:13:53.943652 +0300 +03 m=+0.262342834] {"method":"Target.detachedFromTarget","params":{"sessionId":"51CC05417CBCD9D6C53FFE1415C69FC7","targetId":"A97C871B24EDA407A73456BD66F3BB38"}}
<--- [2023-06-13 11:13:53.943726 +0300 +03 m=+0.262417168] {"method":"Target.detachedFromTarget","params":{"sessionId":"A3583375BA7F32AAEAB9C1AC2CBDE91F","targetId":"A97C871B24EDA407A73456BD66F3BB38"}} 
---> [2023-06-13 11:13:53.943764 +0300 +03 m=+0.262455084] {"id":4,"method":"Target.createTarget","params":{"url":"about:blank","browserContextId":"499FDE1E341CE49A7ABA692E29D37E77"}}
<--- [2023-06-13 11:13:53.943788 +0300 +03 m=+0.262478543] {"method":"Target.detachedFromTarget","params":{"sessionId":"CE16D33D3A4F5D6DCE96ECF82FA2F816","targetId":"A97C871B24EDA407A73456BD66F3BB38"}}
<--- [2023-06-13 11:13:53.945993 +0300 +03 m=+0.264683584] {"method":"Target.attachedToTarget","params":{"sessionId":"A1D8B7A6D5B35C6E70B42AAF51C52651","targetInfo":{"targetId":"65F36539B0283566B7B1E2402F1A04D6","type":"page","title":"","url":"","attached":true,"canAccessOpener":false,"browserContextId":"499FDE1E341CE49A7ABA692E29D37E77"},"waitingForDebugger":true}} 
---> [2023-06-13 11:13:53.946108 +0300 +03 m=+0.264799501] {"id":1,"sessionId":"A1D8B7A6D5B35C6E70B42AAF51C52651","method":"Network.enable","params":{}}
<--- [2023-06-13 11:13:53.946128 +0300 +03 m=+0.264818668] {"method":"Target.attachedToTarget","params":{"sessionId":"686322F7BD5A465B1EFE15FEDD1B6E14","targetInfo":{"targetId":"65F36539B0283566B7B1E2402F1A04D6","type":"page","title":"","url":"","attached":true,"canAccessOpener":false,"browserContextId":"499FDE1E341CE49A7ABA692E29D37E77"},"waitingForDebugger":true}} 
---> [2023-06-13 11:13:53.946257 +0300 +03 m=+0.264948501] {"id":1,"sessionId":"686322F7BD5A465B1EFE15FEDD1B6E14","method":"Network.enable","params":{}}
<--- [2023-06-13 11:13:53.946316 +0300 +03 m=+0.265007376] {"id":4,"error":{"code":-32001,"message":"Session with given id not found."}}
<--- [2023-06-13 11:13:53.946328 +0300 +03 m=+0.265018626] {"method":"Target.attachedToTarget","params":{"sessionId":"CD89C89BC60C581FC739971DAAA61C06","targetInfo":{"targetId":"65F36539B0283566B7B1E2402F1A04D6","type":"page","title":"","url":"","attached":true,"canAccessOpener":false,"browserContextId":"499FDE1E341CE49A7ABA692E29D37E77"},"waitingForDebugger":true}}

    browser_test.go:258:
                Error Trace:    /Users/inanc/grafana/k6browser/main/tests/browser_test.go:258
                Error:          Received unexpected error:
                                creating new page in browser context: creating a new blank page: Session with given id not found. (-32001)
                Test:           TestMultiConnectToSingleBrowser
                Messages:       failed to create page #2
```