### PR TITLE
Remove the BaseEventEmitter from browser

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -25,8 +25,7 @@ import (
 
 // Ensure Browser implements the EventEmitter and Browser interfaces.
 var (
-	_ EventEmitter = &Browser{}
-	_ api.Browser  = &Browser{}
+	_ api.Browser = &Browser{}
 )
 
 const (
@@ -36,8 +35,6 @@ const (
 
 // Browser stores a Browser context.
 type Browser struct {
-	BaseEventEmitter
-
 	ctx      context.Context
 	cancelFn context.CancelFunc
 
@@ -96,7 +93,6 @@ func newBrowser(
 	logger *log.Logger,
 ) *Browser {
 	return &Browser{
-		BaseEventEmitter:    NewBaseEventEmitter(ctx),
 		ctx:                 ctx,
 		cancelFn:            cancelFn,
 		state:               int64(BrowserStateOpen),


### PR DESCRIPTION
### Description of changes

While exploring the event emitters for another PR I noticed that although we're setting the BaseEventEmitter on browser, we're not actually using it. This is a cleanup and as far as I can tell doesn't affect the behaviour of the app.

### Checklist

- [X] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
