### PR TITLE
Add restriction on one context per iteration

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -774,13 +774,13 @@ func getOrInitBrowser(
 		vu.registerPid(pid)
 	}
 
-	vu.setBrowser(id, b)
-
 	go func(ctx context.Context) {
 		<-ctx.Done()
 		b.Close()
 		vu.deleteBrowser(id)
 	}(vu.Context())
+
+	vu.setBrowser(id, b)
 
 	return b, nil
 }

--- a/common/browser.go
+++ b/common/browser.go
@@ -47,6 +47,7 @@ type Browser struct {
 	// A *Connection is saved to this field, see: connect().
 	conn connection
 
+	contextCreated bool
 	context        *BrowserContext
 	defaultContext *BrowserContext
 
@@ -496,8 +497,8 @@ func (b *Browser) IsConnected() bool {
 
 // NewContext creates a new incognito-like browser context.
 func (b *Browser) NewContext(opts goja.Value) (api.BrowserContext, error) {
-	if b.context != nil {
-		return nil, errors.New("existing browser context must be closed before creating a new one")
+	if b.contextCreated {
+		return nil, fmt.Errorf("only one browser context can be setup per iteration")
 	}
 
 	action := target.CreateBrowserContext().WithDisposeOnDetach(true)
@@ -517,6 +518,7 @@ func (b *Browser) NewContext(opts goja.Value) (api.BrowserContext, error) {
 		return nil, fmt.Errorf("new context: %w", err)
 	}
 	b.context = browserCtx
+	b.contextCreated = true
 
 	return browserCtx, nil
 }

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -27,7 +27,7 @@ func TestBrowserNewPage(t *testing.T) {
 	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
 
 	_, err := b.Browser.NewPage(nil)
-	assert.EqualError(t, err, "new page: existing browser context must be closed before creating a new one")
+	assert.EqualError(t, err, "new page: only one browser context can be setup per iteration")
 
 	err = p1.Close(nil)
 	require.NoError(t, err)
@@ -35,15 +35,16 @@ func TestBrowserNewPage(t *testing.T) {
 	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
 
 	_, err = b.Browser.NewPage(nil)
-	assert.EqualError(t, err, "new page: existing browser context must be closed before creating a new one")
+	assert.EqualError(t, err, "new page: only one browser context can be setup per iteration")
 
 	b.Contexts()[0].Close()
 	l = len(b.Contexts())
 	assert.Equal(t, 0, l, "expected there to be 0 browser context, but found %d", l)
 
-	_ = b.NewPage(nil)
+	_, err = b.Browser.NewPage(nil)
+	assert.EqualError(t, err, "new page: only one browser context can be setup per iteration")
 	l = len(b.Contexts())
-	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
+	assert.Equal(t, 0, l, "expected there to be 0 browser context, but found %d", l)
 }
 
 func TestBrowserNewContext(t *testing.T) {
@@ -54,16 +55,16 @@ func TestBrowserNewContext(t *testing.T) {
 	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
 
 	_, err = b.NewContext(nil)
-	assert.EqualError(t, err, "existing browser context must be closed before creating a new one")
+	assert.EqualError(t, err, "only one browser context can be setup per iteration")
 
 	bc1.Close()
 	l = len(b.Contexts())
 	assert.Equal(t, 0, l, "expected there to be 0 browser context, but found %d", l)
 
 	_, err = b.NewContext(nil)
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "only one browser context can be setup per iteration")
 	l = len(b.Contexts())
-	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
+	assert.Equal(t, 0, l, "expected there to be 0 browser context, but found %d", l)
 }
 
 func TestTmpDirCleanup(t *testing.T) {


### PR DESCRIPTION
### Description of changes

This change will restrict the creation and use of a single `browserContext` per iteration. Once the `browserContext` has been closed, a new one cannot be created in the same iteration. This essentially ends the browser test for the iteration, but allows the user to run other k6 tests.
    
The reason for this change is:
1. restricting the user to work with a single browser context per iteration will restrict the scenario to one type of `browserContext`. If the user wishes to work with different types of `browserContext`s, they should work with `scenarios` to create a new test that changes the type of `browserContext`. This helps separate the concerns of the different types of `browserContext`s.
2. Creating and closing `browserContext`s while also running async APIs will cause errors and issues for the user. They are likely to be a confusing experience. We want to avoid this.
3. The browser module processes background async operations when APIs are called. If a `browserContext` is closed, this will affect how we process those background operations which will inadvertently affect the test and the results.

```js
export default async function() {
  const context = browser.newContext();
  const page = context.newPage();

  // const context2 = context.newContext(); // If uncommented, it will cause an error.

  await page2.goto("https://test.k6.io");

  ...

  // The browser and context cannot be used after this call.
  // This will essentially end the browser test for the current
  // iteration, but allow the use of other k6 APIs.
  context.close();

  // const context2 = context.newContext(); // If uncommented, it will cause an error.

  const res = http.get('https://test.k6.io/news.php');

  check(res, {
    'status is 200': (r) => r.status === 200,
  });
```

### Checklist

- [X] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
