### PR TITLE
Fix deadlock by removing lock in frameNavigated

### DIFF
--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -238,9 +238,11 @@ func (m *FrameManager) frameNavigated(frameID cdp.FrameID, parentFrameID cdp.Fra
 		m.ID(), frameID, parentFrameID, documentID, name, url, initial)
 
 	if frame != nil {
+		m.framesMu.Unlock()
 		for _, child := range frame.ChildFrames() {
 			m.removeFramesRecursively(child.(*Frame))
 		}
+		m.framesMu.Lock()
 	}
 
 	var mainFrame *Frame

--- a/tests/static/iframe_home.html
+++ b/tests/static/iframe_home.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head></head>
+    <body>
+        <a href="/iframeSignIn">Sign In</a>
+        <iframe src="about:blank"></iframe>
+    </body>
+</html>

--- a/tests/static/iframe_signin.html
+++ b/tests/static/iframe_signin.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head></head>
+    <body>
+        <div id="doneDiv">Sign In Page</div>
+        <iframe src="about:blank"></iframe>
+    </body>
+</html>


### PR DESCRIPTION
### Description of changes

In certain navigations, the current frame may have child frames. In these cases, the child frames need to be removed. frameNavigated holds on to a framesMu lock for the whole duration of the frameNavigated.

removeFramesRecursively, which is what removes the child frames, needs the same lock so that it can amend the synchronised variable.

It's also worth noting that this also prevent frameNavigated holding on to a lock when it calls ChildFrames, which requires another lock. It's generally unsafe to hold onto more than one lock at a time.

Closes: https://github.com/grafana/xk6-browser/issues/941

### Checklist

- [ ] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
