### PR TITLE
Fix race condition in navigation (and lifecycle events)

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -326,7 +326,7 @@ func parseArgs(flags map[string]any) ([]string, error) {
 
 	// Force the first page to be blank, instead of the welcome page;
 	// --no-first-run doesn't enforce that.
-	// args = append(args, "about:blank")
+	// args = append(args, common.BlankPage)
 	// args = append(args, "--no-startup-window")
 	return args, nil
 }

--- a/common/browser.go
+++ b/common/browser.go
@@ -395,7 +395,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 	defer removeEventHandler()
 
 	// create a new page.
-	action := target.CreateTarget("about:blank").WithBrowserContextID(id)
+	action := target.CreateTarget(BlankPage).WithBrowserContextID(id)
 	tid, err := action.Do(cdp.WithExecutor(ctx, b.conn))
 	if err != nil {
 		return nil, fmt.Errorf("creating a new blank page: %w", err)

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -61,7 +61,7 @@ func TestBrowserNewPageInContext(t *testing.T) {
 				require.Equal(t, target.CommandCreateTarget, method)
 				require.IsType(t, params, &target.CreateTargetParams{})
 				tp, _ := params.(*target.CreateTargetParams)
-				require.Equal(t, "about:blank", tp.URL)
+				require.Equal(t, BlankPage, tp.URL)
 				require.Equal(t, browserContextID, tp.BrowserContextID)
 
 				// newPageInContext event handler will catch this target ID, and compare it to

--- a/common/frame.go
+++ b/common/frame.go
@@ -305,7 +305,10 @@ func (f *Frame) onLifecycleEvent(event LifecycleEvent) {
 	f.lifecycleEvents[event] = true
 	f.lifecycleEventsMu.Unlock()
 
-	f.emit(EventFrameAddLifecycle, event)
+	f.emit(EventFrameAddLifecycle, FrameLifecycleEvent{
+		URL:   f.URL(),
+		Event: event,
+	})
 }
 
 func (f *Frame) onLoadingStarted() {
@@ -1693,8 +1696,8 @@ func (f *Frame) WaitForLoadState(state string, opts goja.Value) {
 	lifecycleEvtCh, lifecycleEvtCancel := createWaitForEventPredicateHandler(
 		timeoutCtx, f, []string{EventFrameAddLifecycle},
 		func(data any) bool {
-			if le, ok := data.(LifecycleEvent); ok {
-				return le == waitUntil
+			if le, ok := data.(FrameLifecycleEvent); ok {
+				return le.Event == waitUntil
 			}
 			return false
 		})
@@ -1736,8 +1739,8 @@ func (f *Frame) WaitForNavigation(opts goja.Value) (api.Response, error) {
 	lifecycleEvtCh, lifecycleEvtCancel := createWaitForEventPredicateHandler(
 		timeoutCtx, f, []string{EventFrameAddLifecycle},
 		func(data any) bool {
-			if le, ok := data.(LifecycleEvent); ok {
-				return le == parsedOpts.WaitUntil
+			if le, ok := data.(FrameLifecycleEvent); ok {
+				return le.Event == parsedOpts.WaitUntil
 			}
 			return false
 		})

--- a/common/frame.go
+++ b/common/frame.go
@@ -1776,7 +1776,7 @@ func (f *Frame) WaitForNavigation(opts goja.Value) (api.Response, error) {
 				sameDocNav = true
 				break
 			}
-			// request could be nil if navigating to e.g. about:blank
+			// request could be nil if navigating to e.g. BlankPage.
 			req := e.newDocument.request
 			if req != nil {
 				req.responseMu.RLock()

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -592,10 +592,23 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *Frame
 	lifecycleEvtCh, lifecycleEvtCancel := createWaitForEventPredicateHandler(
 		timeoutCtx, frame, []string{EventFrameAddLifecycle},
 		func(data any) bool {
-			if le, ok := data.(LifecycleEvent); ok {
-				return le == parsedOpts.WaitUntil
+			le, ok := data.(FrameLifecycleEvent)
+			if !ok {
+				return false
 			}
-			return false
+			// skip the initial blank page if we are navigating to a non-blank page.
+			// otherwise, we will get a lifecycle event for the initial blank page
+			// and return prematurely before waiting for the navigation to complete.
+			if url != "about:blank" && le.URL == "about:blank" {
+				m.logger.Debugf(
+					"FrameManager:NavigateFrame:createWaitForEventPredicateHandler",
+					"fmid:%d fid:%v furl:%s url:%s waitUntil:%s event.lifecycle:%q event.url:%q skipping about:blank",
+					fmid, fid, furl, url, parsedOpts.WaitUntil, le.Event, le.URL,
+				)
+				return false
+			}
+
+			return le.Event == parsedOpts.WaitUntil
 		})
 	defer lifecycleEvtCancel()
 

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -599,11 +599,11 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *Frame
 			// skip the initial blank page if we are navigating to a non-blank page.
 			// otherwise, we will get a lifecycle event for the initial blank page
 			// and return prematurely before waiting for the navigation to complete.
-			if url != "about:blank" && le.URL == "about:blank" {
+			if url != BlankPage && le.URL == BlankPage {
 				m.logger.Debugf(
 					"FrameManager:NavigateFrame:createWaitForEventPredicateHandler",
-					"fmid:%d fid:%v furl:%s url:%s waitUntil:%s event.lifecycle:%q event.url:%q skipping about:blank",
-					fmid, fid, furl, url, parsedOpts.WaitUntil, le.Event, le.URL,
+					"fmid:%d fid:%v furl:%s url:%s waitUntil:%s event.lifecycle:%q event.url:%q skipping %s",
+					fmid, fid, furl, url, parsedOpts.WaitUntil, le.Event, le.URL, BlankPage,
 				)
 				return false
 			}
@@ -659,7 +659,7 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *Frame
 	case evt := <-navEvtCh:
 		if e, ok := evt.(*NavigationEvent); ok {
 			req := e.newDocument.request
-			// Request could be nil in case of navigation to e.g. about:blank
+			// Request could be nil in case of navigation to e.g. BlankPage.
 			if req != nil {
 				req.responseMu.RLock()
 				resp = req.response

--- a/common/page.go
+++ b/common/page.go
@@ -762,8 +762,8 @@ func (p *Page) Reload(opts goja.Value) api.Response {
 	lifecycleEvtCh, lifecycleEvtCancel := createWaitForEventPredicateHandler(
 		timeoutCtx, p.frameManager.MainFrame(), []string{EventFrameAddLifecycle},
 		func(data any) bool {
-			if le, ok := data.(LifecycleEvent); ok {
-				return le == parsedOpts.WaitUntil
+			if le, ok := data.(FrameLifecycleEvent); ok {
+				return le.Event == parsedOpts.WaitUntil
 			}
 			return false
 		})

--- a/common/types.go
+++ b/common/types.go
@@ -15,6 +15,9 @@ import (
 	"github.com/dop251/goja"
 )
 
+// BlankPage represents a blank page.
+const BlankPage = "about:blank"
+
 // ColorScheme represents a browser color scheme.
 type ColorScheme string
 

--- a/common/types.go
+++ b/common/types.go
@@ -217,6 +217,15 @@ func (f *ImageFormat) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// FrameLifecycleEvent is emitted when a frame lifecycle event occurs.
+type FrameLifecycleEvent struct {
+	// URL is the URL of the frame that emitted the event.
+	URL string
+
+	// Event is the lifecycle event that occurred.
+	Event LifecycleEvent
+}
+
 type LifecycleEvent int
 
 const (

--- a/tests/launch_options_slowmo_test.go
+++ b/tests/launch_options_slowmo_test.go
@@ -93,7 +93,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
-				_, err := p.Goto("about:blank", nil)
+				_, err := p.Goto(common.BlankPage, nil)
 				require.NoError(t, err)
 			})
 		})
@@ -223,7 +223,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f api.Frame) {
-				f.Goto("about:blank", nil)
+				_, _ = f.Goto(common.BlankPage, nil)
 			})
 		})
 		t.Run("hover", func(t *testing.T) {

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/common"
 )
 
 type emulateMediaOpts struct {
@@ -664,7 +666,7 @@ func TestPageURL(t *testing.T) {
 	b := newTestBrowser(t, withHTTPServer())
 
 	p := b.NewPage(nil)
-	assert.Equal(t, "about:blank", p.URL())
+	assert.Equal(t, common.BlankPage, p.URL())
 
 	resp, err := p.Goto(b.url("/get"), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
_TLDR: Skip the initial blank page navigation/lifecycle event if we want to navigate to a non-blank page so that we can wait for the navigation to complete. This way, we can receive custom metrics like Web Vitals. Custom metrics would be randomly skipped without this._

In order to make sure we receive custom metrics like Web Vitals, it is necessary to skip the initial blank page navigation event when navigating to a non-blank page. By doing this, we can wait for the navigation to complete fully. Without skipping this event, custom metrics could be randomly skipped.

<details>
<summary>Before this fix, this test's Web Vital metrics were flaky. Sometimes they show up, and sometimes, they don't.</summary>

```js
import { browser } from 'k6/x/browser';

export const options = {
  scenarios: {
    ui: {
      executor: 'shared-iterations',
      vus: 1,
      iterations: 1,
      options: {
        browser: {
          type: 'chromium',
        },
      },
    },
  },
};

export default async function() {
  const page = browser.newPage();
  try {
    await page.goto('https://test.k6.io', { waitUntil: 'networkidle' });
    // the above was returning prematurely and caused page.close to be
    // called before the navigation finished.
  } finally {
    page.close();
  } 
}
```

</details>

I'll go ahead and explain the problem using the provided script.

The issue of inconsistency arose because we were removing the Web Vital bindings using `page.Close` before the navigation had finished. The navigation process was prematurely interrupted due to the initial blank page lifecycle events. As a result, we were not able to receive all the events from the Web Vitals library since we didn't wait for the navigation to complete.

This pull request resolves the problem of unreliable behavior in emitting Web Vitals (or other custom metrics). However, it doesn't address the issue of displaying all Web Vital reports. According to [Google's Web Vital documentation](https://github.com/GoogleChrome/web-vitals#usage), most metrics are meant to be reported only occasionally.

P.S.: I attempted to create a test for this behavior, but I was unable to replicate it. Please let me know if you have any ideas. The existing tests _locally_ pass!

**Tip:** I noticed that reloading the page just before closing it leads to more emitted metrics. Another pull request could tackle this aspect. Update: See #949.

Updates: #914.