### PR TITLE
Refactor contexts to context

### DIFF
--- a/api/browser.go
+++ b/api/browser.go
@@ -5,7 +5,7 @@ import "github.com/dop251/goja"
 // Browser is the public interface of a CDP browser.
 type Browser interface {
 	Close()
-	Contexts() []BrowserContext
+	Context() BrowserContext
 	IsConnected() bool
 	NewContext(opts goja.Value) (BrowserContext, error)
 	NewPage(opts goja.Value) (Page, error)

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -683,12 +683,12 @@ func mapBrowser(vu moduleVU, wsURL string, isRemoteBrowser bool) mapping { //nol
 		bt  = chromium.NewBrowserType(vu)
 	)
 	return mapping{
-		"contexts": func() ([]api.BrowserContext, error) {
+		"context": func() (api.BrowserContext, error) {
 			b, err := getOrInitBrowser(ctx, bt, vu, wsURL, isRemoteBrowser)
 			if err != nil {
 				return nil, err
 			}
-			return b.Contexts(), nil
+			return b.Context(), nil
 		},
 		"isConnected": func() (bool, error) {
 			b, err := getOrInitBrowser(ctx, bt, vu, wsURL, isRemoteBrowser)

--- a/common/browser.go
+++ b/common/browser.go
@@ -479,13 +479,9 @@ func (b *Browser) Close() {
 	b.conn.Close()
 }
 
-// Contexts returns list of browser contexts.
-func (b *Browser) Contexts() []api.BrowserContext {
-	if b.context == nil {
-		return []api.BrowserContext{}
-	}
-
-	return []api.BrowserContext{b.context}
+// Context returns the current browser context or nil.
+func (b *Browser) Context() api.BrowserContext {
+	return b.context
 }
 
 // IsConnected returns whether the WebSocket connection to the browser process

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -23,47 +23,47 @@ import (
 func TestBrowserNewPage(t *testing.T) {
 	b := newTestBrowser(t)
 	p1 := b.NewPage(nil)
-	l := len(b.Contexts())
-	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
+	c := b.Context()
+	assert.NotNil(t, c)
 
 	_, err := b.Browser.NewPage(nil)
 	assert.EqualError(t, err, "new page: existing browser context must be closed before creating a new one")
 
 	err = p1.Close(nil)
 	require.NoError(t, err)
-	l = len(b.Contexts())
-	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
+	c = b.Context()
+	assert.NotNil(t, c)
 
 	_, err = b.Browser.NewPage(nil)
 	assert.EqualError(t, err, "new page: existing browser context must be closed before creating a new one")
 
-	b.Contexts()[0].Close()
-	l = len(b.Contexts())
-	assert.Equal(t, 0, l, "expected there to be 0 browser context, but found %d", l)
+	b.Context().Close()
+	c = b.Context()
+	assert.Nil(t, c)
 
 	_ = b.NewPage(nil)
-	l = len(b.Contexts())
-	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
+	c = b.Context()
+	assert.NotNil(t, c)
 }
 
 func TestBrowserNewContext(t *testing.T) {
 	b := newTestBrowser(t)
 	bc1, err := b.NewContext(nil)
 	assert.NoError(t, err)
-	l := len(b.Contexts())
-	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
+	c := b.Context()
+	assert.NotNil(t, c)
 
 	_, err = b.NewContext(nil)
 	assert.EqualError(t, err, "existing browser context must be closed before creating a new one")
 
 	bc1.Close()
-	l = len(b.Contexts())
-	assert.Equal(t, 0, l, "expected there to be 0 browser context, but found %d", l)
+	c = b.Context()
+	assert.Nil(t, c)
 
 	_, err = b.NewContext(nil)
 	assert.NoError(t, err)
-	l = len(b.Contexts())
-	assert.Equal(t, 1, l, "expected there to be 1 browser context, but found %d", l)
+	c = b.Context()
+	assert.NotNil(t, c)
 }
 
 func TestTmpDirCleanup(t *testing.T) {


### PR DESCRIPTION
### Description of changes

Now that we can only store a single browserContext per browser, the contexts API doesn't make sense to return more than one browserContext so instead we've refactored it to return the only browserContext or nil.

### Checklist

- [X] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
