### PR TITLE
Report Web Vital metrics on every chance

### DIFF
--- a/common/js/web_vital_init.js
+++ b/common/js/web_vital_init.js
@@ -13,13 +13,15 @@ function print(metric) {
 }
 
 function load() {
-  webVitals.onCLS(print);
-  webVitals.onFID(print);
-  webVitals.onLCP(print);
-
-  webVitals.onFCP(print);
-  webVitals.onINP(print);
-  webVitals.onTTFB(print);
+  const reportAllChanges = {
+    reportAllChanges: true,
+  }
+  webVitals.onCLS(print, reportAllChanges);
+  webVitals.onFID(print, reportAllChanges);
+  webVitals.onLCP(print, reportAllChanges);
+  webVitals.onFCP(print, reportAllChanges);
+  webVitals.onINP(print, reportAllChanges);
+  webVitals.onTTFB(print, reportAllChanges);
 }
 
 load();


### PR DESCRIPTION
## First commit explanation

Note: We've decided to remove the first commit as the second commit already fixes the issue. Here's the changes from the first commit in case we need it again.

```go
func (p *Page) Close(opts goja.Value) error {
	p.logger.Debugf("Page:Close", "sid:%v", p.sessionID())

	// forcing the pagehide event to trigger web vitals metrics.
	v := p.vu.Runtime().ToValue(`() => window.dispatchEvent(new Event('pagehide'))`)
	_ = p.Evaluate(v)
	...
}       
```

The [first commit](https://github.com/grafana/xk6-browser/pull/949/commits/5666a13009dfbc90c0e361e3e0a502ea89ffa65b) forces the Web Vital metrics to get triggered on `page.Close`. The page is closing anyway, so there should be no harm in hiding it before it gets closed. Please see [this description](https://github.com/grafana/xk6-browser/pull/943) and [this comment](https://github.com/grafana/xk6-browser/pull/943#discussion_r1239622585) for the details. It turns out that using `pagehide` is the recommended way [here](https://github.com/GoogleChrome/web-vitals#batch-multiple-reports-together). What they really recommend is to batch the events instead of processing them one by one. Anyway, this can shed light on why this fix works.

> Note: see [the Page Lifecycle guide](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid) for an explanation of why visibilitychange and pagehide are recommended over events like beforeunload and unload.

## Second commit explanation

Additionally, `CLS` should/can be called multiple times.

> (CLS) `callback` is always called when the page's visibility state changes to hidden. As a result, the `callback` function might be called multiple times during the same page load.

This [2nd commit](https://github.com/grafana/xk6-browser/pull/949/commits/d0b6d2174620f320c2c5a16f435f4b05fcff5aac) uses this advice and sets the callbacks to report metrics all the time. See [this link](https://github.com/GoogleChrome/web-vitals/blob/main/src/onCLS.ts#L48-L55) for more information.

## Results

Before:

```
browser_web_vital_fcp.......: avg=1.99s    min=1.99s    med=1.99s    max=1.99s    p(90)=1.99s    p(95)=1.99s   
browser_web_vital_ttfb......: avg=1.81s    min=1.81s    med=1.81s    max=1.81s    p(90)=1.81s    p(95)=1.81s 
```

After:

```
browser_web_vital_cls.......: avg=0.000057 min=0.000057 med=0.000057 max=0.000057 p(90)=0.000057 p(95)=0.000057
browser_web_vital_fcp.......: avg=1.99s    min=1.99s    med=1.99s    max=1.99s    p(90)=1.99s    p(95)=1.99s   
browser_web_vital_lcp.......: avg=1.99s    min=1.99s    med=1.99s    max=1.99s    p(90)=1.99s    p(95)=1.99s   
browser_web_vital_ttfb......: avg=1.81s    min=1.81s    med=1.81s    max=1.81s    p(90)=1.81s    p(95)=1.81s 
```

I used the same script from [this comment](https://github.com/grafana/xk6-browser/pull/943#discussion_r1239622585), but without `page.reload()`! So here it is again.

<details>
<summary>Test script</summary>

```js
import { browser } from 'k6/x/browser';

export const options = {
  scenarios: {
    ui: {
      executor: 'shared-iterations',
      options: {
        browser: {
            type: 'chromium',
        },
      },
    },
  },
};

export default async function () {
  const page = browser.newPage();

  try {
    await page.goto('https://test.k6.io/');
  } finally {
    page.close();
  } 
}
```
</details>