### PR TITLE
Web Vitals force page hide

### DIFF
--- a/common/page.go
+++ b/common/page.go
@@ -425,6 +425,10 @@ func (p *Page) Click(selector string, opts goja.Value) error {
 func (p *Page) Close(opts goja.Value) error {
 	p.logger.Debugf("Page:Close", "sid:%v", p.sessionID())
 
+	// forcing the pagehide event to trigger web vitals metrics.
+	v := p.vu.Runtime().ToValue(`() => window.dispatchEvent(new Event('pagehide'))`)
+	_ = p.Evaluate(v)
+
 	add := runtime.RemoveBinding(webVitalBinding)
 	if err := add.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
 		return fmt.Errorf("internal error while removing binding from page: %w", err)


### PR DESCRIPTION
After reverting #949 in #964, which main purpose was to improve Web Vitals metrics consistent reporting, we need to provide an implementation that would achieve this consistency without the drawbacks introduced in #949 and explained in #964.
For that purpose this modification to force `pagehide` event has proven to be the better fix so far as commented in https://github.com/grafana/xk6-browser/issues/960#issuecomment-1628654930 and also similar to recommendations given in the Web Vitals library [readme](https://github.com/GoogleChrome/web-vitals):

> Note that some of these metrics will not report until the user has interacted with the page, switched tabs, or the page starts to unload. If you don't see the values logged to the console immediately, try reloading the page (with [preserve log](https://developer.chrome.com/docs/devtools/console/reference/#persist) enabled) or switching tabs and then switching back.

Related #960.