### PR TITLE
Add WaitForNavigation with Click in Test

### DIFF
--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -1,9 +1,11 @@
 package tests
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,7 +134,14 @@ func TestFrameNoPanicNavigateAndClickOnPageWithIFrames(t *testing.T) {
 	_, err := p.Goto(tb.staticURL("iframe_home.html"), nil)
 	require.NoError(t, err)
 
-	err = p.Click(`a[href="/iframeSignIn"]`, nil)
+	ctx, cancel := context.WithTimeout(tb.context(), 5*time.Second)
+	defer cancel()
+
+	err = tb.run(
+		ctx,
+		func() error { return p.Click(`a[href="/iframeSignIn"]`, nil) },
+		func() error { _, err := p.WaitForNavigation(nil); return err },
+	)
 	require.NoError(t, err)
 
 	result := p.TextContent("#doneDiv", nil)


### PR DESCRIPTION
### Description of changes

This test was flaky due to the state changing during the navigation on `click`. Working with `WaitForNavigation` should resolve this.

### Checklist

- [X] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
