### PR TITLE
Add K6_BROWSER_EXECUTABLE_PATH in ci

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         go: [stable, tip]
         platform: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,13 +23,15 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
         uses: actions/checkout@v2
       - name: Install Go
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
         uses: actions/setup-go@v2
         with:
           go-version: 1.x
       - name: Install Go tip
-        if: matrix.go == 'tip'
+        if: matrix.go == 'tip' && matrix.platform != 'windows-latest'
         run: |
           go install golang.org/dl/gotip@latest
           gotip download
@@ -38,8 +40,10 @@ jobs:
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
           echo "$HOME/sdk/gotip/bin" >> "$GITHUB_PATH"
       - name: Install xk6
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
         run: go install go.k6.io/xk6/cmd/xk6@master
       - name: Build extension
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
         run: |
           which go
           go version
@@ -49,6 +53,7 @@ jobs:
             --with github.com/grafana/xk6-browser=.
           ./k6extension version
       - name: Run E2E tests
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
         run: |
           set -x
           if [ "$RUNNER_OS" == "Linux" ]; then
@@ -63,5 +68,6 @@ jobs:
             ./k6extension run "$f"
           done
       - name: Check screenshot
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
         # TODO: Do something more sophisticated?
         run: test -s screenshot.png

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         go: [stable, tip]
-        platform: [ubuntu-latest-8-cores, windows-latest, macos-latest]
-    runs-on: ubuntu-latest-8-cores
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,22 +48,6 @@ jobs:
             --output ./k6extension \
             --with github.com/grafana/xk6-browser=.
           ./k6extension version
-      - name: Install Chrome dependencies
-        if: runner.os == 'Linux'
-        run: "${GITHUB_WORKSPACE}/.github/bin/install_chrome_deps_linux.sh"
-      - name: Setup Chrome
-        uses: browser-actions/setup-chrome@latest
-        with:
-          chrome-version: stable
-      - name: Chrome version
-        if: runner.os != 'Windows'
-        run: chrome --version
-      - name: Chrome version
-        if: runner.os == 'Windows'
-        shell: pwsh
-        # chrome --version doesn't work on Windows :-/
-        # See https://bugs.chromium.org/p/chromium/issues/detail?id=158372
-        run: (get-command chrome.exe).Version
       - name: Run E2E tests
         run: |
           set -x

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,10 @@ jobs:
           fi
           export K6_BROWSER_HEADLESS=true
           for f in examples/*.js; do
+            if [ "$f" == "examples/hosts.js" ] && [ "$RUNNER_OS" == "Windows" ]; then
+              echo "skipping $f on Windows"
+              continue
+            fi
             ./k6extension run "$f"
           done
       - name: Check screenshot

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Run E2E tests
         run: |
           set -x
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
+          fi
           export K6_BROWSER_HEADLESS=true
           for f in examples/*.js; do
             ./k6extension run "$f"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,9 +46,7 @@ jobs:
             args[1]="1"
             export GOMAXPROCS=1
           fi
-          export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
-          export K6_BROWSER_HEADLESS=true
-          go test "${args[@]}" -timeout 5m ./...
+          K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome K6_BROWSER_HEADLESS=true go test "${args[@]}" -timeout 5m ./...
 
   test-tip:
     runs-on: ubuntu-latest
@@ -76,9 +74,7 @@ jobs:
           go version
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
-          export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
-          export K6_BROWSER_HEADLESS=true
-          go test "${args[@]}" -timeout 5m ./...
+          K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome K6_BROWSER_HEADLESS=true go test "${args[@]}" -timeout 5m ./...
 
   test-current-cov:
     strategy:
@@ -106,8 +102,6 @@ jobs:
             args[1]="1"
             export GOMAXPROCS=1
           fi
-          export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
-          export K6_BROWSER_HEADLESS=true
           echo "mode: set" > coverage.txt
           for pkg in $(go list ./... | grep -v vendor); do
               list=$(go list -test -f  '{{ join .Deps  "\n"}}' $pkg | grep github.com/grafana/xk6-browser | grep -v vendor || true)
@@ -115,7 +109,7 @@ jobs:
                   list=$(echo "$list" | cut -f1 -d ' ' | sort -u | paste -sd, -)
               fi
 
-              go test "${args[@]}" -timeout 5m --coverpkg="$list" -coverprofile=$(echo $pkg | tr / -).coverage $pkg
+              K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome K6_BROWSER_HEADLESS=true go test "${args[@]}" -timeout 5m --coverpkg="$list" -coverprofile=$(echo $pkg | tr / -).coverage $pkg
           done
           grep -h -v "^mode:" *.coverage >> coverage.txt
           rm -f *.coverage
@@ -159,6 +153,4 @@ jobs:
           go get go.k6.io/k6@master
           go mod tidy
           cat go.mod | grep go.k6.io/k6
-          export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
-          export K6_BROWSER_HEADLESS=true
-          go test "${args[@]}" -timeout 5m ./...
+          K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome K6_BROWSER_HEADLESS=true go test "${args[@]}" -timeout 5m ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
             args[1]="1"
             export GOMAXPROCS=1
           fi
+          export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
           export K6_BROWSER_HEADLESS=true
           go test "${args[@]}" -timeout 5m ./...
 
@@ -75,6 +76,7 @@ jobs:
           go version
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
+          export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
           export K6_BROWSER_HEADLESS=true
           go test "${args[@]}" -timeout 5m ./...
 
@@ -104,6 +106,7 @@ jobs:
             args[1]="1"
             export GOMAXPROCS=1
           fi
+          export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
           export K6_BROWSER_HEADLESS=true
           echo "mode: set" > coverage.txt
           for pkg in $(go list ./... | grep -v vendor); do
@@ -156,5 +159,6 @@ jobs:
           go get go.k6.io/k6@master
           go mod tidy
           cat go.mod | grep go.k6.io/k6
+          export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
           export K6_BROWSER_HEADLESS=true
           go test "${args[@]}" -timeout 5m ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.19.x]
-        platform: [ubuntu-latest-8-cores]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -51,7 +51,7 @@ jobs:
           go test "${args[@]}" -timeout 5m ./...
 
   test-tip:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - name: Checkout code
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.19.x]
-        platform: [ubuntu-latest-8-cores]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -132,7 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.19.x]
-        platform: [ubuntu-latest-8-cores]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
### Description of changes

The main change (initially) was to work with the `K6_BROWSER_EXECUTABLE_PATH` env var on linux github actions to ensure it picks chrome and not chromium. The github runners have both chromium and google chrome installed. Google chrome is kept up to date whereas chromium isn't. We want to work with the latest version of google chrome (for now, in the future we may want to install the exact version we want to work with).

I also found that the e2e workflow wasn't correctly using the defined matrix, and was only working with `ubuntu-latest`. There are several commits which attempt to resolve this.

Two issues which were discovered but not resolved in the e2e workflow were:

1. the `examples/hosts.js` test script doesn't pass in the Windows stable e2e test. When tested in a Windows 11 computer, the test passed. I've opened a new issue (https://github.com/grafana/xk6-browser/issues/963) to track this.
2. the Windows tip e2e test fails when building a k6 binary with xk6 and the tip version of go. The tip version of go is installed successfully and we seem to be setting it up correctly (ensuring `GOROOT` is pointing to the tip version and not the stable version that is already on the system), but even still xk6 works with the stable version of go which ends up with an [error](https://github.com/grafana/xk6-browser/actions/runs/5881417653/job/15949854594). This hasn't been tested on a standalone windows computer. I've opened a new issue (https://github.com/grafana/xk6-browser/issues/1002) to track this.

Closes: https://github.com/grafana/xk6-browser/issues/963

### Checklist

- [ ] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
