### PR TITLE
Revert "Report all web vital metric changes (#949)"

### DIFF
--- a/common/js/web_vital_init.js
+++ b/common/js/web_vital_init.js
@@ -13,15 +13,13 @@ function print(metric) {
 }
 
 function load() {
-  const reportAllChanges = {
-    reportAllChanges: true,
-  }
-  webVitals.onCLS(print, reportAllChanges);
-  webVitals.onFID(print, reportAllChanges);
-  webVitals.onLCP(print, reportAllChanges);
-  webVitals.onFCP(print, reportAllChanges);
-  webVitals.onINP(print, reportAllChanges);
-  webVitals.onTTFB(print, reportAllChanges);
+  webVitals.onCLS(print);
+  webVitals.onFID(print);
+  webVitals.onLCP(print);
+
+  webVitals.onFCP(print);
+  webVitals.onINP(print);
+  webVitals.onTTFB(print);
 }
 
 load();


### PR DESCRIPTION
This reverts commit f25b1d427af756b58a1a424bf66f735b0d710ad5.

### Description of changes

In our effort to achieve more consistent Web Vitals reporting, a change was introduced in https://github.com/grafana/xk6-browser/pull/949 to force the Web Vitals library to report metrics [on every value change](https://github.com/GoogleChrome/web-vitals#report-the-value-on-every-change). But, in recent tests we have observed that this was an incorrect configuration, especially for [LCP](https://web.dev/lcp/#when-is-largest-contentful-paint-reported) metric. LCP measures the time it takes to render the largest [image or text block](https://web.dev/lcp/#what-elements-are-considered) visible within the viewport, relative to when the page [first started loading](https://w3c.github.io/hr-time/#timeorigin-attribute). Because there can only be one "largest" element in a page, LCP should only provide one sample per page load. Instead, if we use the `reportAllChanges` flag, LCP is reported multiple times when rendering intermediate elements that, up until that point, are the largest rendered in the page. This makes k6 browser record incorrect values for LCP on every new page.

Therefore, we should not use `reportAllChanges` flag for Web Vitals library.

Related: #960.
