### PR TITLE
Fix warn level log to debug

### DIFF
--- a/common/response.go
+++ b/common/response.go
@@ -179,7 +179,7 @@ func (r *Response) bodySize() int64 {
 	}
 
 	if err := r.fetchBody(); err != nil {
-		r.logger.Warnf("Response:bodySize:fetchBody",
+		r.logger.Debugf("Response:bodySize:fetchBody",
 			"url:%s method:%s err:%s", r.url, r.request.method, err)
 	}
 


### PR DESCRIPTION
### Description of changes

While testing the fill form example script against a remote chrome instance, it became apparent that this warning wasn't useful information for the end user. Downgrading from warn to info should avoid noise in the logs.

All other actions which work with `fetchBody` and receive an error will remain to behave as they currently do, which is to assume an error and let the user know -- this still represents the correct behaviour for these actions.

This change will avoid the following errors which seem to occur when the test iteration ends, but dependent responses are still being handled:

```bash
url:https://test.k6.io/static/css/site.css method:GET err:fetching response body: context canceled category=Response:bodySize:fetchBody elapsed=0 ms goroutine=23923 iteration_id=b3d4aaa99ecb1e93
url:https://test.k6.io/ method:GET err:fetching response body: context canceled category=Response:bodySize:fetchBody elapsed=0 ms goroutine=49974 iteration_id=3ecfa4d4951c0dc1
url:https://test.k6.io/static/css/site.css method:GET err:fetching response body: context canceled category=Response:bodySize:fetchBody elapsed=0 ms goroutine=103247 iteration_id=27a6c3b458836b13
url:https://test.k6.io/my_messages.php method:GET err:fetching response body: context canceled category=Response:bodySize:fetchBody elapsed=0 ms goroutine=136093 iteration_id=3a449dfc27ff1fdc
```

Closes: https://github.com/grafana/xk6-browser/issues/968

### Checklist

- [ ] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
