### PR TITLE
Improve browser not found in registry error message

### DIFF
--- a/browser/registry.go
+++ b/browser/registry.go
@@ -21,6 +21,13 @@ import (
 	k6modules "go.k6.io/k6/js/modules"
 )
 
+// errBrowserNotFoundInRegistry indicates that the browser instance
+// for the iteration, which should have been initialized as a result
+// of the IterStart event, has not been found in the registry. This
+// might happen if browser type option is not set in scenario definition.
+var errBrowserNotFoundInRegistry = errors.New("browser not found in registry. " +
+	"make sure to set browser type option in scenario definition in order to use the browser module")
+
 // pidRegistry keeps track of the launched browser process IDs.
 type pidRegistry struct {
 	mu  sync.RWMutex
@@ -299,7 +306,7 @@ func (r *browserRegistry) getBrowser(id int64) (api.Browser, error) {
 		return b, nil
 	}
 
-	return nil, errors.New("browser not found in registry")
+	return nil, errBrowserNotFoundInRegistry
 }
 
 func (r *browserRegistry) deleteBrowser(id int64) {


### PR DESCRIPTION
### Description of changes

This PR improves the error message shown when a browser instance for an iteration, which should be automatically initialized as a consequence of the `IterStart` event generated from k6-core, is not found in the browser registry. Because this error might be produced due to the browser type option not being set in scenario definition (the only other possibility is a fault in k6-core/k6 browser implementation), it is better to provide more context information to the user.
