### PR TITLE
Remove goroutine ID field from logger

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -98,9 +97,8 @@ func (l *Logger) Logf(level logrus.Level, category string, msg string, args ...a
 		return
 	}
 	fields := logrus.Fields{
-		"category":  category,
-		"elapsed":   fmt.Sprintf("%d ms", elapsed),
-		"goroutine": goRoutineID(),
+		"category": category,
+		"elapsed":  fmt.Sprintf("%d ms", elapsed),
 	}
 	if l.iterID != "" && l.GetLevel() > logrus.InfoLevel {
 		fields["iteration_id"] = l.iterID
@@ -174,17 +172,6 @@ func (l *Logger) SetCategoryFilter(filter string) (err error) {
 		return fmt.Errorf("invalid category filter %q: %w", filter, err)
 	}
 	return nil
-}
-
-func goRoutineID() int {
-	var buf [64]byte
-	n := runtime.Stack(buf[:], false)
-	idField := strings.Fields(strings.TrimPrefix(string(buf[:n]), "goroutine "))[0]
-	id, err := strconv.Atoi(idField)
-	if err != nil {
-		panic(fmt.Sprintf("internal error while getting goroutine ID: %v", err))
-	}
-	return id
 }
 
 type consoleLogFormatter struct {


### PR DESCRIPTION
### Description of changes

Adding the goroutine ID as a log field required copying the calling goroutine stack into a buffer and parsing the ID from it. This was done for each log action which is very inefficient and does not provide much value as we are already using a field for the iteration ID which allows us to correlate logs. Therefore our decision is to remove it completely.
