### PR TITLE
Add browser extension log field

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -582,7 +582,8 @@ func (fs *FrameSession) navigateFrame(frame *Frame, url, referrer string) (strin
 func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICalled) {
 	l := fs.serializer.
 		WithTime(event.Timestamp.Time()).
-		WithField("source", "browser-console-api")
+		WithField("source", "browser").
+		WithField("browser_source", "console-api")
 
 		/* accessing the state Group while not on the eventloop is racy
 		if s := fs.vu.State(); s.Group.Path != "" {

--- a/log/logger.go
+++ b/log/logger.go
@@ -97,6 +97,7 @@ func (l *Logger) Logf(level logrus.Level, category string, msg string, args ...a
 		return
 	}
 	fields := logrus.Fields{
+		"source":   "browser",
 		"category": category,
 		"elapsed":  fmt.Sprintf("%d ms", elapsed),
 	}


### PR DESCRIPTION
### Description of changes

Adds a new `source:browser` log field which allows to distinguish log messages generated by xk6-browser extension from messages generated by k6 core. As mentioned in https://github.com/grafana/xk6-browser/issues/934#issuecomment-1647344562, the `source` label is currently used across k6 codebase.

An example of different log messages after the change applied in this PR including:
- One debug message from k6 browser implementation
- One log [message](https://chromedevtools.github.io/devtools-protocol/tot/Log#event-entryAdded) from browser context execution
- One `console.log` [message](https://chromedevtools.github.io/devtools-protocol/tot/Runtime#event-consoleAPICalled) from browser context execution
- One `console.log` message from k6 test script execution.
```shell
DEBU[0000] wsURL:"ws://127.0.0.1:34591/devtools/browser/dc9e1e8b-058e-47c4-97df-3b4dfa2d81a7"  category="Browser:connect" elapsed="0 ms" iteration_id=dda9fe94f08fa83b source=browser
...
ERRO[0001] Failed to load resource: the server responded with a status of 403 ()  browser_source=network line_number=0 source=browser stacktrace="<nil>" url="https://grafana.com/canspam"
INFO[0001] "This is a console.log message from browser context execution"  browser_source=console-api source=browser
INFO[0001] This is a console.log message from k6 test script context execution  source=console
```

Closes #934