### PR TITLE
Temporary fix for deadlock on pagehide event evaluation when page.close is called

### DIFF
--- a/api/frame.go
+++ b/api/frame.go
@@ -1,6 +1,10 @@
 package api
 
-import "github.com/dop251/goja"
+import (
+	"context"
+
+	"github.com/dop251/goja"
+)
 
 // Frame is the interface of a CDP target frame.
 type Frame interface {
@@ -12,6 +16,8 @@ type Frame interface {
 	Content() string
 	Dblclick(selector string, opts goja.Value)
 	DispatchEvent(selector string, typ string, eventInit goja.Value, opts goja.Value)
+	// EvaluateWithContext for internal use only
+	EvaluateWithContext(ctx context.Context, pageFunc goja.Value, args ...goja.Value) (any, error)
 	Evaluate(pageFunc goja.Value, args ...goja.Value) any
 	EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (JSHandle, error)
 	Fill(selector string, value string, opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -35,11 +35,12 @@ func customMappings() map[string]string {
 		"Page.getMouse":       "mouse",
 		"Page.getTouchscreen": "touchscreen",
 		// internal methods
-		"ElementHandle.objectID": "",
-		"Frame.id":               "",
-		"Frame.loaderID":         "",
-		"JSHandle.objectID":      "",
-		"Browser.close":          "",
+		"ElementHandle.objectID":    "",
+		"Frame.id":                  "",
+		"Frame.loaderID":            "",
+		"JSHandle.objectID":         "",
+		"Browser.close":             "",
+		"Frame.evaluateWithContext": "",
 		// TODO: browser.on method is unexposed until more event
 		// types other than 'disconnect' are supported.
 		// See: https://github.com/grafana/xk6-browser/issues/913

--- a/common/frame.go
+++ b/common/frame.go
@@ -709,6 +709,28 @@ func (f *Frame) dispatchEvent(selector, typ string, eventInit goja.Value, opts *
 	return nil
 }
 
+// EvaluateWithContext will evaluate provided page function within an execution context.
+// The passed in context will be used instead of the frame's context. The context must
+// be a derivative of one that contains the goja runtime.
+func (f *Frame) EvaluateWithContext(ctx context.Context, pageFunc goja.Value, args ...goja.Value) (any, error) {
+	f.log.Debugf("Frame:EvaluateWithContext", "fid:%s furl:%q", f.ID(), f.URL())
+
+	f.waitForExecutionContext(mainWorld)
+
+	opts := evalOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
+	result, err := f.evaluate(ctx, mainWorld, opts, pageFunc, args...)
+	if err != nil {
+		return nil, fmt.Errorf("evaluating JS: %w", err)
+	}
+
+	applySlowMo(ctx)
+
+	return result, nil
+}
+
 // Evaluate will evaluate provided page function within an execution context.
 func (f *Frame) Evaluate(pageFunc goja.Value, args ...goja.Value) any {
 	f.log.Debugf("Frame:Evaluate", "fid:%s furl:%q", f.ID(), f.URL())

--- a/common/frame.go
+++ b/common/frame.go
@@ -735,18 +735,10 @@ func (f *Frame) EvaluateWithContext(ctx context.Context, pageFunc goja.Value, ar
 func (f *Frame) Evaluate(pageFunc goja.Value, args ...goja.Value) any {
 	f.log.Debugf("Frame:Evaluate", "fid:%s furl:%q", f.ID(), f.URL())
 
-	f.waitForExecutionContext(mainWorld)
-
-	opts := evalOptions{
-		forceCallable: true,
-		returnByValue: true,
-	}
-	result, err := f.evaluate(f.ctx, mainWorld, opts, pageFunc, args...)
+	result, err := f.EvaluateWithContext(f.ctx, pageFunc, args...)
 	if err != nil {
-		k6ext.Panic(f.ctx, "evaluating JS: %v", err)
+		k6ext.Panic(f.ctx, "%v", err)
 	}
-
-	applySlowMo(f.ctx)
 
 	return result
 }


### PR DESCRIPTION
### Description of changes

When we run the k6 browser module against a remote chrome instance, we've found that 1 or more VUs deadlock when running the test in this [issue](https://github.com/grafana/xk6-browser/issues/971). What we have come to realise during the investigation is that the [evaluate](https://github.com/grafana/xk6-browser/blob/a8ebe8cc24f639e0553b1d969df97368db7b5ec5/common/page.go#L430) on the `pagehide` event when `page.close` is called seems to wait indefinitely for a response from chrome, that never seems to arrive.

This is a temporary fix where we use the page's `defaultTimeout` to timeout this `evaluate` request instead of waiting indefinitely. We still need to investigate the root cause of the issue. The downside of this fix is that when this `evaluate` does timeout then we may not receive all the web vital measurements for that iteration (the reason we added the `pagehide` event evaluate was to force the web vital measurements to be calculated and sent to the browser module: https://github.com/grafana/xk6-browser/pull/953).

Doesn't close issue https://github.com/grafana/xk6-browser/issues/971 but temporarily alleviates the issue.

### Checklist

- [ ] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
