### PR TITLE
log serializer: fix loki log output

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -160,6 +160,7 @@ func (l *Logger) ConsoleLogFormatterSerializer() *Logger {
 			Out:       l.Out,
 			Level:     l.Level,
 			Formatter: &consoleLogFormatter{l.Formatter},
+			Hooks:     l.Hooks,
 		},
 	}
 }


### PR DESCRIPTION
logs going through loki use the `hooks` logrus concept.

The serialzer was not copying this which meant logs wouldn't have been send to loki.