### PR TITLE
Ensure msgId in CDP requests are unique at the connection scope

### DIFF
--- a/common/connection.go
+++ b/common/connection.go
@@ -28,6 +28,19 @@ const wsWriteBufferSize = 1 << 20
 var _ EventEmitter = &Connection{}
 var _ cdp.Executor = &Connection{}
 
+// Each connection needs its own msgID. A msgID will be used by the
+// connection and associated sessions. When a CDP request is made to
+// chrome, it's best to work with unique ids to avoid the Execute
+// handlers working with the wrong response, or handlers deadlocking
+// when their response is rerouted to the wrong handler.
+type msgID struct {
+	id int64
+}
+
+func (m *msgID) new() int64 {
+	return atomic.AddInt64(&m.id, 1)
+}
+
 type executorEmitter interface {
 	cdp.Executor
 	EventEmitter

--- a/common/connection.go
+++ b/common/connection.go
@@ -329,7 +329,7 @@ func (c *Connection) recvLoop() {
 			sid, tid := eva.SessionID, eva.TargetInfo.TargetID
 
 			c.sessionsMu.Lock()
-			session := NewSession(c.ctx, c, sid, tid, c.logger)
+			session := NewSession(c.ctx, c, sid, tid, c.logger, c.msgID)
 			c.logger.Debugf("Connection:recvLoop:EventAttachedToTarget", "sid:%v tid:%v wsURL:%q", sid, tid, c.wsURL)
 			c.sessions[sid] = session
 			c.sessionsMu.Unlock()

--- a/common/connection.go
+++ b/common/connection.go
@@ -125,7 +125,7 @@ type Connection struct {
 	done         chan struct{}
 	closing      chan struct{}
 	shutdownOnce sync.Once
-	msgID        int64
+	msgID        *msgID
 
 	sessionsMu sync.RWMutex
 	sessions   map[target.SessionID]*Session
@@ -163,7 +163,7 @@ func NewConnection(ctx context.Context, wsURL string, logger *log.Logger) (*Conn
 		errorCh:          make(chan error),
 		done:             make(chan struct{}),
 		closing:          make(chan struct{}),
-		msgID:            0,
+		msgID:            &msgID{},
 		sessions:         make(map[target.SessionID]*Session),
 	}
 
@@ -509,7 +509,7 @@ func (c *Connection) Close(args ...goja.Value) {
 // Execute implements cdproto.Executor and performs a synchronous send and receive.
 func (c *Connection) Execute(ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler) error {
 	c.logger.Debugf("connection:Execute", "wsURL:%q method:%q", c.wsURL, method)
-	id := atomic.AddInt64(&c.msgID, 1)
+	id := c.msgID.new()
 
 	// Setup event handler used to block for response to message being sent.
 	ch := make(chan *cdproto.Message, 1)


### PR DESCRIPTION
### Description of changes

A detailed description as to why we're doing this can be found [here](https://github.com/grafana/xk6-browser/issues/861#issuecomment-1653312043).

Currently the `msgId`s clash from one session to another as well as with`msgId`s that are sent without a session on the connection event loop.

Generally this isn't an issue, but recently we have found that chrome sometimes returns an error without the `sessionId` that was in the original request msg. When this occurs, we route those error responses to handlers that are waiting on the connection event loop. If there's a clash in `msgId` then the wrong handler will work with the wrong response, which could result in incorrect behaviour. The other issue with routing the response to the wrong handler is that the correct handler could end up waiting indefinitely (or timeout) which could pause the whole test iteration/vu.

This change will enforce a unique msgId at the connection level, which should avoid such scenarios.

Linked issue: https://github.com/grafana/xk6-browser/issues/861

### Checklist

- [ ] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
