### PR TITLE
Redirect error msg responses without sessionId to all sessions and the connection

### DIFF
--- a/common/connection.go
+++ b/common/connection.go
@@ -381,28 +381,40 @@ func (c *Connection) recvLoop() {
 		// a test iteration) we need to send it to all sessions and the
 		// connection's event loop.
 		case msg.ID != 0 && msg.Error != nil && msg.SessionID == "":
+			c.logger.Infof(
+				"Connection:recvLoop:msg.ID:msg.Error: lost error message",
+				"msg:%v", msg,
+			)
 			c.sessionsMu.RLock()
 			for _, s := range c.sessions {
 				select {
 				case s.readCh <- &msg:
+					c.logger.Infof(
+						"Connection:recvLoop:msg.ID:msg.Error: sent to session",
+						"sid:%v tid:%v msg:%v", s.id, s.targetID, msg,
+					)
 				case code := <-c.closeCh:
 					c.logger.Debugf(
 						"Connection:recvLoop:msg.ID:msg.Error:<-c.closeCh",
-						"sid:%v tid:%v wsURL:%v crashed:%t",
-						s.id, s.targetID, c.wsURL, s.crashed,
+						"sid:%v tid:%v crashed:%t",
+						s.id, s.targetID, s.crashed,
 					)
 					_ = c.close(code)
 				case <-c.done:
 					c.logger.Debugf(
 						"Connection:recvLoop:msg.ID:msg.Error:<-c.done",
-						"sid:%v tid:%v wsURL:%v crashed:%t",
-						s.id, s.targetID, c.wsURL, s.crashed,
+						"sid:%v tid:%v crashed:%t",
+						s.id, s.targetID, s.crashed,
 					)
 					return
 				}
 			}
 			c.sessionsMu.RUnlock()
 			c.emit("", &msg)
+			c.logger.Infof(
+				"Connection:recvLoop:msg.ID:msg.Error: sent to connection",
+				"msg:%v", msg,
+			)
 
 		case msg.Method != "":
 			c.logger.Debugf("Connection:recvLoop:msg.Method:emit", "sid:%v method:%q", msg.SessionID, msg.Method)


### PR DESCRIPTION
### Description of changes

If we receive an error response with an `id`, but no `sessionId`, there's a slim chance that this response should be redirected to a `session` but it will instead be redirected to the `connection`'s event loop. This means that there is a chance that we could end up with a handler that is waiting for a response indefinitely (or until a timeout occurs).

Since we have no knowledge of the `sessionId` from the response msg, we're now sending it to all live `session`s as well as the `connection`'s event loop.

Most handlers should ignore the extra error message, whilst the handler waiting for the msg (with the unique `msgId`) will action on it. If no handlers are alive or the associated `session` has already been closed, then no handlers will action on it still since we're now working with unique `msgId`s at the connection scope level.

### Checklist

- [ ] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
