### PR TITLE
Fix lingering/leaking goroutines for k6 upgrade

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -185,20 +185,6 @@ func (b *BrowserType) launch(
 	}
 	flags["user-data-dir"] = dataDir.Dir
 
-	go func(c context.Context) {
-		defer func() {
-			if err := dataDir.Cleanup(); err != nil {
-				logger.Errorf("BrowserType:Launch", "cleaning up the user data directory: %v", err)
-			}
-		}()
-		// There's a small chance that this might be called
-		// if the context is closed by the k6 runtime. To
-		// guarantee the cleanup we would need to orchestrate
-		// it correctly which https://github.com/grafana/k6/issues/2432
-		// will enable once it's complete.
-		<-c.Done()
-	}(ctx)
-
 	browserProc, err := b.allocate(ctx, opts, flags, dataDir, logger)
 	if browserProc == nil {
 		return nil, 0, fmt.Errorf("launching browser: %w", err)


### PR DESCRIPTION
### Description of changes

This change ensures that goroutines that were lingering/leaking are cleared once the test ends. This change focuses on the goroutines that were highlighted when trying to create e2e tests for the change in https://github.com/grafana/k6/pull/3235. There could be more goroutines that are lingering/leaking that we need to deal with in the future.

Closes: https://github.com/grafana/xk6-browser/issues/989

### Checklist

- [ ] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
