### PR TITLE
Fix for data directory not being cleared during browser.close() panic

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -453,7 +453,7 @@ func (b *Browser) Close() {
 		var closeErr *websocket.CloseError
 		err := cdpbrowser.Close().Do(cdp.WithExecutor(b.ctx, b.conn))
 		if err != nil && !errors.As(err, &closeErr) {
-			k6ext.Panic(b.ctx, "closing the browser: %v", err)
+			b.logger.Errorf("Browser:Close", "closing the browser: %v", err)
 		}
 	}
 

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -69,7 +69,14 @@ func TestBrowserNewContext(t *testing.T) {
 func TestTmpDirCleanup(t *testing.T) {
 	t.Parallel()
 
-	const tmpDirPath = "./"
+	const tmpDirPath = "./1/"
+	err := os.Mkdir(tmpDirPath, os.ModePerm)
+	require.NoError(t, err)
+
+	defer func() {
+		err = os.Remove(tmpDirPath)
+		require.NoError(t, err)
+	}()
 
 	b := newTestBrowser(
 		t,
@@ -77,7 +84,7 @@ func TestTmpDirCleanup(t *testing.T) {
 		withEnvLookup(env.ConstLookup("TMPDIR", tmpDirPath)),
 	)
 	p := b.NewPage(nil)
-	err := p.Close(nil)
+	err = p.Close(nil)
 	require.NoError(t, err)
 
 	matches, err := filepath.Glob(tmpDirPath + "xk6-browser-data-*")

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -70,10 +70,12 @@ func TestTmpDirCleanup(t *testing.T) {
 	t.Parallel()
 
 	tmpDirPath, err := os.MkdirTemp("./", "")
-	defer func() {
-		err := os.RemoveAll(tmpDirPath)
-		require.NoError(t, err)
-	}()
+	t.Cleanup(
+		func() {
+			err := os.RemoveAll(tmpDirPath)
+			require.NoError(t, err)
+		},
+	)
 	require.NoError(t, err)
 
 	b := newTestBrowser(
@@ -100,10 +102,12 @@ func TestTmpDirCleanupOnContextClose(t *testing.T) {
 	t.Parallel()
 
 	tmpDirPath, err := os.MkdirTemp("./", "")
-	defer func() {
-		err := os.RemoveAll(tmpDirPath)
-		require.NoError(t, err)
-	}()
+	t.Cleanup(
+		func() {
+			err := os.RemoveAll(tmpDirPath)
+			require.NoError(t, err)
+		},
+	)
 	require.NoError(t, err)
 
 	b := newTestBrowser(

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -69,14 +69,12 @@ func TestBrowserNewContext(t *testing.T) {
 func TestTmpDirCleanup(t *testing.T) {
 	t.Parallel()
 
-	const tmpDirPath = "./1/"
-	err := os.Mkdir(tmpDirPath, os.ModePerm)
-	require.NoError(t, err)
-
+	tmpDirPath, err := os.MkdirTemp("./", "")
 	defer func() {
-		err = os.Remove(tmpDirPath)
+		err := os.RemoveAll(tmpDirPath)
 		require.NoError(t, err)
 	}()
+	require.NoError(t, err)
 
 	b := newTestBrowser(
 		t,
@@ -87,13 +85,13 @@ func TestTmpDirCleanup(t *testing.T) {
 	err = p.Close(nil)
 	require.NoError(t, err)
 
-	matches, err := filepath.Glob(tmpDirPath + "xk6-browser-data-*")
+	matches, err := filepath.Glob(tmpDirPath + "/xk6-browser-data-*")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, matches, "a dir should exist that matches the pattern `xk6-browser-data-*`")
 
 	b.Close()
 
-	matches, err = filepath.Glob(tmpDirPath + "xk6-browser-data-*")
+	matches, err = filepath.Glob(tmpDirPath + "/xk6-browser-data-*")
 	assert.NoError(t, err)
 	assert.Empty(t, matches, "a dir shouldn't exist which matches the pattern `xk6-browser-data-*`")
 }
@@ -101,14 +99,12 @@ func TestTmpDirCleanup(t *testing.T) {
 func TestTmpDirCleanupOnContextClose(t *testing.T) {
 	t.Parallel()
 
-	const tmpDirPath = "./2/"
-	err := os.Mkdir(tmpDirPath, os.ModePerm)
-	require.NoError(t, err)
-
+	tmpDirPath, err := os.MkdirTemp("./", "")
 	defer func() {
-		err = os.Remove(tmpDirPath)
+		err := os.RemoveAll(tmpDirPath)
 		require.NoError(t, err)
 	}()
+	require.NoError(t, err)
 
 	b := newTestBrowser(
 		t,
@@ -116,7 +112,7 @@ func TestTmpDirCleanupOnContextClose(t *testing.T) {
 		withEnvLookup(env.ConstLookup("TMPDIR", tmpDirPath)),
 	)
 
-	matches, err := filepath.Glob(tmpDirPath + "xk6-browser-data-*")
+	matches, err := filepath.Glob(tmpDirPath + "/xk6-browser-data-*")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, matches, "a dir should exist that matches the pattern `xk6-browser-data-*`")
 
@@ -125,7 +121,7 @@ func TestTmpDirCleanupOnContextClose(t *testing.T) {
 
 	require.NotPanicsf(t, b.Close, "first call to browser.close should not panic")
 
-	matches, err = filepath.Glob(tmpDirPath + "xk6-browser-data-*")
+	matches, err = filepath.Glob(tmpDirPath + "/xk6-browser-data-*")
 	assert.NoError(t, err)
 	assert.Empty(t, matches, "a dir shouldn't exist which matches the pattern `xk6-browser-data-*`")
 }


### PR DESCRIPTION
### Description of changes

While testing for another change, it became apparent that the panic when working with browser.close() would prevent any of the remaining data directories from being cleaned up in the temporary directory. Instead of panicking, we're going to log an error and carry on with rest of the process to try and close the subprocess and eventually delete the data directory. This change does indeed bring about the behaviour we want even when the context has been closed.

### Checklist

- [x] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
