### PR TITLE
Move the vu context creation during iteration

### DIFF
--- a/browser/registry.go
+++ b/browser/registry.go
@@ -230,10 +230,9 @@ func newBrowserRegistry(vu k6modules.VU, remote *remoteRegistry, pids *pidRegist
 
 func (r *browserRegistry) handleIterEvents(eventsCh <-chan *k6event.Event, unsubscribeFn func()) {
 	var (
-		ok    bool
-		data  k6event.IterData
-		ctx   = context.Background()
-		vuCtx = k6ext.WithVU(r.vu.Context(), r.vu)
+		ok   bool
+		data k6event.IterData
+		ctx  = context.Background()
 	)
 
 	for e := range eventsCh {
@@ -250,6 +249,12 @@ func (r *browserRegistry) handleIterEvents(eventsCh <-chan *k6event.Event, unsub
 			e.Done()
 			return
 		}
+
+		// The context in the VU is not thread safe. It can
+		// be safely accessed during an iteration but not
+		// before one is started. This is why it is being
+		// accessed and used here.
+		vuCtx := k6ext.WithVU(r.vu.Context(), r.vu)
 
 		if data, ok = e.Data.(k6event.IterData); !ok {
 			e.Done()


### PR DESCRIPTION
### Description of changes

The context in the vu is not thread safe outside of the iteration or the start or end of the vu. By retrieving the vu's context inside the iteration we are working with the vu's context in a thread safe way.

### Checklist

- [X] Written tests for the changes
- [ ] Update k6 documentation (if relevant) -- PR link: ?
- [ ] Update [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog (if relevant) -- PR link: ?
- [ ] Generate and update [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser) (if relevant)
