### PR TITLE
Add a LookupBool utility function

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -1,7 +1,10 @@
 // Package env provides types to interact with environment setup.
 package env
 
-import "os"
+import (
+	"os"
+	"strconv"
+)
 
 // Execution specific.
 const (
@@ -66,7 +69,7 @@ const (
 type LookupFunc func(key string) (string, bool)
 
 // EmptyLookup is a LookupFunc that always returns "" and false.
-func EmptyLookup(key string) (string, bool) { return "", false }
+func EmptyLookup(_ string) (string, bool) { return "", false }
 
 // Lookup is a LookupFunc that uses os.LookupEnv.
 func Lookup(key string) (string, bool) { return os.LookupEnv(key) }
@@ -81,4 +84,19 @@ func ConstLookup(k, v string) LookupFunc {
 		}
 		return EmptyLookup(key)
 	}
+}
+
+// LookupBool returns the result of Lookup as a bool.
+// Returns false if the key does not exist or the value
+// is not a bool.
+func LookupBool(key string) bool {
+	v, ok := Lookup(key)
+	if !ok {
+		return false
+	}
+	bv, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+	return bv
 }

--- a/env/env.go
+++ b/env/env.go
@@ -100,3 +100,11 @@ func LookupBool(key string) (value bool, ok bool) {
 	}
 	return bv, true
 }
+
+// IsBrowserHeadless returns true if the BrowserHeadless environment
+// variable is not set or set to true.
+// The default behaviour is to run the browser in headless mode.
+func IsBrowserHeadless() bool {
+	v, ok := LookupBool(BrowserHeadless)
+	return !ok || v
+}

--- a/env/env.go
+++ b/env/env.go
@@ -87,16 +87,16 @@ func ConstLookup(k, v string) LookupFunc {
 }
 
 // LookupBool returns the result of Lookup as a bool.
-// Returns false if the key does not exist or the value
-// is not a bool.
-func LookupBool(key string) bool {
+// If the key does not exist or the value is not a valid bool, it returns false.
+// Otherwise it returns the bool value and true.
+func LookupBool(key string) (value bool, ok bool) {
 	v, ok := Lookup(key)
 	if !ok {
-		return false
+		return false, false
 	}
 	bv, err := strconv.ParseBool(v)
 	if err != nil {
-		return false
+		return false, true
 	}
-	return bv
+	return bv, true
 }

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 
@@ -72,15 +71,13 @@ func TestFrameDismissDialogBox(t *testing.T) {
 func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 	t.Parallel()
 
-	if s, ok := env.Lookup(env.BrowserHeadless); ok {
-		if v, err := strconv.ParseBool(s); err == nil && v {
-			// We're skipping this when running in headless
-			// environments since the bug that the test fixes
-			// only surfaces when in headfull mode.
-			// Remove this skip once we have headfull mode in
-			// CI: https://github.com/grafana/xk6-browser/issues/678
-			t.Skip("skipped when in headless mode")
-		}
+	// We're skipping this when running in headless
+	// environments since the bug that the test fixes
+	// only surfaces when in headfull mode.
+	// Remove this skip once we have headfull mode in
+	// CI: https://github.com/grafana/xk6-browser/issues/678
+	if env.LookupBool(env.BrowserHeadless) {
+		t.Skip("skipped when in headless mode")
 	}
 
 	// run the browser in headfull mode.
@@ -110,15 +107,13 @@ func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 func TestFrameNoPanicNavigateAndClickOnPageWithIFrames(t *testing.T) {
 	t.Parallel()
 
-	if s, ok := env.Lookup(env.BrowserHeadless); ok {
-		if v, err := strconv.ParseBool(s); err == nil && v {
-			// We're skipping this when running in headless
-			// environments since the bug that the test fixes
-			// only surfaces when in headfull mode.
-			// Remove this skip once we have headfull mode in
-			// CI: https://github.com/grafana/xk6-browser/issues/678
-			t.Skip("skipped when in headless mode")
-		}
+	// We're skipping this when running in headless
+	// environments since the bug that the test fixes
+	// only surfaces when in headfull mode.
+	// Remove this skip once we have headfull mode in
+	// CI: https://github.com/grafana/xk6-browser/issues/678
+	if env.LookupBool(env.BrowserHeadless) {
+		t.Skip("skipped when in headless mode")
 	}
 
 	tb := newTestBrowser(

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -76,7 +76,7 @@ func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 	// only surfaces when in headfull mode.
 	// Remove this skip once we have headfull mode in
 	// CI: https://github.com/grafana/xk6-browser/issues/678
-	if env.LookupBool(env.BrowserHeadless) {
+	if v, ok := env.LookupBool(env.BrowserHeadless); !ok || v {
 		t.Skip("skipped when in headless mode")
 	}
 
@@ -112,7 +112,7 @@ func TestFrameNoPanicNavigateAndClickOnPageWithIFrames(t *testing.T) {
 	// only surfaces when in headfull mode.
 	// Remove this skip once we have headfull mode in
 	// CI: https://github.com/grafana/xk6-browser/issues/678
-	if env.LookupBool(env.BrowserHeadless) {
+	if v, ok := env.LookupBool(env.BrowserHeadless); !ok || v {
 		t.Skip("skipped when in headless mode")
 	}
 

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -76,7 +76,7 @@ func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 	// only surfaces when in headfull mode.
 	// Remove this skip once we have headfull mode in
 	// CI: https://github.com/grafana/xk6-browser/issues/678
-	if v, ok := env.LookupBool(env.BrowserHeadless); !ok || v {
+	if env.IsBrowserHeadless() {
 		t.Skip("skipped when in headless mode")
 	}
 
@@ -112,7 +112,7 @@ func TestFrameNoPanicNavigateAndClickOnPageWithIFrames(t *testing.T) {
 	// only surfaces when in headfull mode.
 	// Remove this skip once we have headfull mode in
 	// CI: https://github.com/grafana/xk6-browser/issues/678
-	if v, ok := env.LookupBool(env.BrowserHeadless); !ok || v {
+	if env.IsBrowserHeadless() {
 		t.Skip("skipped when in headless mode")
 	}
 


### PR DESCRIPTION
## What?

Defines a `LookupBool` helper.

## Why?

To make bool lookup queries less verbose in tests.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes (indirectly)
- [x] I have commented on my code, particularly in hard-to-understand areas