### PR TITLE
Add browserContext.cookies()

### DIFF
--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -36,3 +36,37 @@ type BrowserContext interface {
 	Unroute(url goja.Value, handler goja.Callable)
 	WaitForEvent(event string, optsOrPredicate goja.Value) any
 }
+
+// Cookie represents a browser cookie.
+//
+// https://datatracker.ietf.org/doc/html/rfc6265.
+type Cookie struct {
+	Name     string         `json:"name"`     // Cookie name.
+	Value    string         `json:"value"`    // Cookie value.
+	Domain   string         `json:"domain"`   // Cookie domain.
+	Path     string         `json:"path"`     // Cookie path.
+	Expires  int64          `json:"expires"`  // Cookie expiration date as the number of seconds since the UNIX epoch.
+	HTTPOnly bool           `json:"httpOnly"` // True if cookie is http-only.
+	Secure   bool           `json:"secure"`   // True if cookie is secure.
+	SameSite CookieSameSite `json:"sameSite"` // Cookie SameSite type.
+}
+
+// CookieSameSite represents the cookie's 'SameSite' status.
+//
+// https://tools.ietf.org/html/draft-west-first-party-cookies.
+type CookieSameSite string
+
+const (
+	// CookieSameSiteStrict sets the cookie to be sent only in a first-party
+	// context and not be sent along with requests initiated by third party
+	// websites.
+	CookieSameSiteStrict CookieSameSite = "Strict"
+
+	// CookieSameSiteLax sets the cookie to be sent along with "same-site"
+	// requests, and with "cross-site" top-level navigations.
+	CookieSameSiteLax CookieSameSite = "Lax"
+
+	// CookieSameSiteNone sets the cookie to be sent in all contexts, i.e
+	// potentially insecure third-party requests.
+	CookieSameSiteNone CookieSameSite = "None"
+)

--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -12,7 +12,7 @@ type BrowserContext interface {
 	ClearCookies() error
 	ClearPermissions()
 	Close()
-	Cookies() ([]any, error) // TODO: make it []Cookie later on
+	Cookies() ([]*Cookie, error)
 	ExposeBinding(name string, callback goja.Callable, opts goja.Value)
 	ExposeFunction(name string, callback goja.Callable)
 	GrantPermissions(permissions []string, opts goja.Value)

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -613,18 +613,13 @@ func mapWorker(vu moduleVU, w api.Worker) mapping {
 func mapBrowserContext(vu moduleVU, bc api.BrowserContext) mapping {
 	rt := vu.Runtime()
 	return mapping{
-		"addCookies":       bc.AddCookies,
-		"addInitScript":    bc.AddInitScript,
-		"browser":          bc.Browser,
-		"clearCookies":     bc.ClearCookies,
-		"clearPermissions": bc.ClearPermissions,
-		"close":            bc.Close,
-		"cookies": func() ([]*api.Cookie, error) {
-			cc, err := bc.Cookies()
-			ctx := vu.Context()
-			panicIfFatalError(ctx, err)
-			return cc, err //nolint:wrapcheck
-		},
+		"addCookies":                  bc.AddCookies,
+		"addInitScript":               bc.AddInitScript,
+		"browser":                     bc.Browser,
+		"clearCookies":                bc.ClearCookies,
+		"clearPermissions":            bc.ClearPermissions,
+		"close":                       bc.Close,
+		"cookies":                     bc.Cookies,
 		"exposeBinding":               bc.ExposeBinding,
 		"exposeFunction":              bc.ExposeFunction,
 		"grantPermissions":            bc.GrantPermissions,

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -619,7 +619,7 @@ func mapBrowserContext(vu moduleVU, bc api.BrowserContext) mapping {
 		"clearCookies":     bc.ClearCookies,
 		"clearPermissions": bc.ClearPermissions,
 		"close":            bc.Close,
-		"cookies": func() ([]any, error) {
+		"cookies": func() ([]*api.Cookie, error) {
 			cc, err := bc.Cookies()
 			ctx := vu.Context()
 			panicIfFatalError(ctx, err)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -491,7 +491,11 @@ func (b *BrowserContext) ClearCookies() error {
 	return nil
 }
 
-// Cookies is not implemented.
-func (b *BrowserContext) Cookies() ([]any, error) {
+// Cookies returns all cookies.
+// Some of them can be added with the AddCookies method and some of them are
+// automatically taken from the browser context when it is created. And some of
+// them are set by the page, i.e., using the Set-Cookie HTTP header or via
+// JavaScript like document.cookie.
+func (b *BrowserContext) Cookies() ([]*api.Cookie, error) {
 	return nil, fmt.Errorf("BrowserContext.cookies() has not been implemented yet: %w", k6error.ErrFatal)
 }

--- a/examples/cookies.js
+++ b/examples/cookies.js
@@ -1,0 +1,50 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+};
+
+export default async function () {
+  const page = browser.newPage();
+  const context = page.context();
+
+  try {
+    // get cookies from the browser context
+    check(context.cookies().length, {
+        'initial number of cookies should be zero': n => n === 0,
+    });
+
+    // add some cookies to the browser context
+    context.addCookies([{name: 'testcookie', value: '1', sameSite: 'Strict', domain: '127.0.0.1', path: '/'}]);
+    context.addCookies([{name: 'testcookie2', value: '2', sameSite: 'Lax', domain: '127.0.0.1', path: '/'}]);
+
+    check(context.cookies().length, {
+      'number of cookies should be 2': n => n === 2,
+    });
+
+    const cookies = context.cookies();
+    check(cookies[0], {
+      'cookie 1 name should be testcookie': c => c.name === 'testcookie',
+      'cookie 1 value should be 1': c => c.value === '1',
+    });
+    check(cookies[1], {
+      'cookie 2 name should be testcookie2': c => c.name === 'testcookie2',
+      'cookie 2 value should be 2': c => c.value === '2',
+    });
+  } finally {
+    page.close();
+  } 
+}

--- a/examples/cookies.js
+++ b/examples/cookies.js
@@ -46,5 +46,5 @@ export default async function () {
     });
   } finally {
     page.close();
-  } 
+  }
 }

--- a/examples/fillform.js
+++ b/examples/fillform.js
@@ -41,6 +41,14 @@ export default async function() {
     check(page, {
       'header': page.locator('h2').textContent() == 'Welcome, admin!',
     });
+
+    // Check whether we receive cookies from the logged site.
+    check(context.cookies(), {
+      'session cookie is set': cookies => {
+        const sessionID = cookies.find(c => c.name == 'sid')
+        return typeof sessionID !== 'undefined'
+      }
+    })
   } finally {
     page.close();
   }

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -284,6 +284,28 @@ func TestBrowserContextCookies(t *testing.T) {
 				},
 			},
 		},
+		"cookie_with_path": {
+			setupHandler: okHandler,
+			documentCookiesSnippet: `
+				() => {
+					document.cookie = "name=value; path=/empty";
+					return document.cookie;
+				}
+			`,
+			wantDocumentCookies: "name=value",
+			wantContextCookies: []*api.Cookie{
+				{
+					Name:     "name",
+					Value:    "value",
+					Domain:   "127.0.0.1",
+					Expires:  -1,
+					HTTPOnly: false,
+					Path:     "/empty",
+					SameSite: "",
+					Secure:   false,
+				},
+			},
+		},
 	}
 	for name, tt := range tests {
 		tt := tt

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -229,6 +229,28 @@ func TestBrowserContextCookies(t *testing.T) {
 			wantDocumentCookies: "",
 			wantContextCookies:  nil,
 		},
+		"cookie": {
+			setupHandler: okHandler,
+			documentCookiesSnippet: `
+				() => {
+					document.cookie = "name=value";
+					return document.cookie;
+				}
+			`,
+			wantDocumentCookies: "name=value",
+			wantContextCookies: []*api.Cookie{
+				{
+					Name:     "name",
+					Value:    "value",
+					Domain:   "127.0.0.1",
+					Expires:  -1,
+					HTTPOnly: false,
+					Path:     "/",
+					SameSite: "",
+					Secure:   false,
+				},
+			},
+		},
 	}
 	for name, tt := range tests {
 		tt := tt

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -251,6 +251,39 @@ func TestBrowserContextCookies(t *testing.T) {
 				},
 			},
 		},
+		"cookies": {
+			setupHandler: okHandler,
+			documentCookiesSnippet: `
+				() => {
+					document.cookie = "name=value";
+					document.cookie = "name2=value2";
+					return document.cookie;
+				}
+			`,
+			wantDocumentCookies: "name=value; name2=value2",
+			wantContextCookies: []*api.Cookie{
+				{
+					Name:     "name",
+					Value:    "value",
+					Domain:   "127.0.0.1",
+					Expires:  -1,
+					HTTPOnly: false,
+					Path:     "/",
+					SameSite: "",
+					Secure:   false,
+				},
+				{
+					Name:     "name2",
+					Value:    "value2",
+					Domain:   "127.0.0.1",
+					Expires:  -1,
+					HTTPOnly: false,
+					Path:     "/",
+					SameSite: "",
+					Secure:   false,
+				},
+			},
+		},
 	}
 	for name, tt := range tests {
 		tt := tt

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -306,6 +306,17 @@ func TestBrowserContextCookies(t *testing.T) {
 				},
 			},
 		},
+		"cookie_with_different_domain": {
+			setupHandler: okHandler,
+			documentCookiesSnippet: `
+				() => {
+					document.cookie = "name=value; domain=k6.io";
+					return document.cookie;
+				}
+			`,
+			wantDocumentCookies: "", // some cookies cannot be set (i.e. cookies using different domains)
+			wantContextCookies:  nil,
+		},
 	}
 	for name, tt := range tests {
 		tt := tt

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -363,6 +363,29 @@ func TestBrowserContextCookies(t *testing.T) {
 				},
 			},
 		},
+		"same_site_lax_cookie": {
+			setupHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Set-Cookie", "name=value;SameSite=Lax")
+			},
+			documentCookiesSnippet: `
+				() => {
+					return document.cookie;
+				}
+			`,
+			wantDocumentCookies: "name=value",
+			wantContextCookies: []*api.Cookie{
+				{
+					SameSite: api.CookieSameSiteLax,
+					Name:     "name",
+					Value:    "value",
+					Domain:   "127.0.0.1",
+					Expires:  -1,
+					HTTPOnly: false,
+					Path:     "/",
+					Secure:   false,
+				},
+			},
+		},
 	}
 	for name, tt := range tests {
 		tt := tt

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -340,6 +340,29 @@ func TestBrowserContextCookies(t *testing.T) {
 				},
 			},
 		},
+		"same_site_strict_cookie": {
+			setupHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Set-Cookie", "name=value;SameSite=Strict")
+			},
+			documentCookiesSnippet: `
+				() => {
+					return document.cookie;
+				}
+			`,
+			wantDocumentCookies: "name=value",
+			wantContextCookies: []*api.Cookie{
+				{
+					SameSite: api.CookieSameSiteStrict,
+					Name:     "name",
+					Value:    "value",
+					Domain:   "127.0.0.1",
+					Expires:  -1,
+					HTTPOnly: false,
+					Path:     "/",
+					Secure:   false,
+				},
+			},
+		},
 	}
 	for name, tt := range tests {
 		tt := tt

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -317,6 +317,29 @@ func TestBrowserContextCookies(t *testing.T) {
 			wantDocumentCookies: "", // some cookies cannot be set (i.e. cookies using different domains)
 			wantContextCookies:  nil,
 		},
+		"http_only_cookie": {
+			setupHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Set-Cookie", "name=value;HttpOnly; Path=/")
+			},
+			documentCookiesSnippet: `
+				() => {
+					return document.cookie;
+				}
+			`,
+			wantDocumentCookies: "",
+			wantContextCookies: []*api.Cookie{
+				{
+					HTTPOnly: true,
+					Name:     "name",
+					Value:    "value",
+					Domain:   "127.0.0.1",
+					Expires:  -1,
+					Path:     "/",
+					SameSite: "",
+					Secure:   false,
+				},
+			},
+		},
 	}
 	for name, tt := range tests {
 		tt := tt


### PR DESCRIPTION
## What?

Adds `browserContext.cookies()` support.

There will be another PR to add `browserContext.cookies([urls])` support to filter by cookie URLs.

## Why?

1. To let users access cookies.
2. Providing a better Playwright compatibility.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

The docs will be updated when #6 finishes.

## Related PR(s)/Issue(s)

Updates #6
