### PR TITLE
Add `page.on`

### DIFF
--- a/api/console_message.go
+++ b/api/console_message.go
@@ -1,0 +1,19 @@
+package api
+
+// ConsoleMessage represents a page console message.
+type ConsoleMessage struct {
+	// Args represent the list of arguments passed to a console function call.
+	Args []JSHandle
+
+	// Page is the page that produced the console message, if any.
+	Page Page
+
+	// Text represents the text of the console message.
+	Text string
+
+	// Type is the type of the console message.
+	// It can be one of 'log', 'debug', 'info', 'error', 'warning', 'dir', 'dirxml',
+	// 'table', 'trace', 'clear', 'startGroup', 'startGroupCollapsed', 'endGroup',
+	// 'assert', 'profile', 'profileEnd', 'count', 'timeEnd'.
+	Type string
+}

--- a/api/page.go
+++ b/api/page.go
@@ -47,6 +47,7 @@ type Page interface {
 	// Locator creates and returns a new locator for this page (main frame).
 	Locator(selector string, opts goja.Value) Locator
 	MainFrame() Frame
+	On(event string, handler func(*ConsoleMessage) error) error
 	Opener() Page
 	Pause()
 	Pdf(opts goja.Value) []byte

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -506,7 +506,15 @@ func mapPage(vu moduleVU, p api.Page) mapping {
 			mf := mapFrame(vu, p.MainFrame())
 			return rt.ToValue(mf).ToObject(rt)
 		},
-		"mouse":  rt.ToValue(p.GetMouse()).ToObject(rt),
+		"mouse": rt.ToValue(p.GetMouse()).ToObject(rt),
+		"on": func(event string, handler goja.Callable) error {
+			mapMsgAndHandleEvent := func(m *api.ConsoleMessage) error {
+				mapping := mapConsoleMessage(vu, m)
+				_, err := handler(goja.Undefined(), vu.Runtime().ToValue(mapping))
+				return err
+			}
+			return p.On(event, mapMsgAndHandleEvent) //nolint:wrapcheck
+		},
 		"opener": p.Opener,
 		"pause":  p.Pause,
 		"pdf":    p.Pdf,

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -666,6 +666,37 @@ func mapBrowserContext(vu moduleVU, bc api.BrowserContext) mapping {
 	}
 }
 
+// mapConsoleMessage to the JS module.
+func mapConsoleMessage(vu moduleVU, cm *api.ConsoleMessage) mapping {
+	rt := vu.Runtime()
+	return mapping{
+		"args": func() *goja.Object {
+			var (
+				margs []mapping
+				args  = cm.Args
+			)
+			for _, arg := range args {
+				a := mapJSHandle(vu, arg)
+				margs = append(margs, a)
+			}
+
+			return rt.ToValue(margs).ToObject(rt)
+		},
+		// page(), text() and type() are defined as
+		// functions in order to match Playwright's API
+		"page": func() *goja.Object {
+			mp := mapPage(vu, cm.Page)
+			return rt.ToValue(mp).ToObject(rt)
+		},
+		"text": func() *goja.Object {
+			return rt.ToValue(cm.Text).ToObject(rt)
+		},
+		"type": func() *goja.Object {
+			return rt.ToValue(cm.Type).ToObject(rt)
+		},
+	}
+}
+
 // mapBrowser to the JS module.
 func mapBrowser(vu moduleVU) mapping {
 	rt := vu.Runtime()

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -45,7 +45,6 @@ func customMappings() map[string]string {
 		// types other than 'disconnect' are supported.
 		// See: https://github.com/grafana/xk6-browser/issues/913
 		"Browser.on": "",
-		"Page.on":    "",
 	}
 }
 

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -188,6 +188,17 @@ func TestMappings(t *testing.T) {
 				return mapLocator(moduleVU{VU: vu}, &common.Locator{})
 			},
 		},
+		"mapConsoleMessage": {
+			apiInterface: (*interface {
+				Args() []api.JSHandle
+				Page() api.Page
+				Text() string
+				Type() string
+			})(nil),
+			mapp: func() mapping {
+				return mapConsoleMessage(moduleVU{VU: vu}, &api.ConsoleMessage{})
+			},
+		},
 	} {
 		tt := tt
 		t.Run(name, func(t *testing.T) {

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -45,6 +45,7 @@ func customMappings() map[string]string {
 		// types other than 'disconnect' are supported.
 		// See: https://github.com/grafana/xk6-browser/issues/913
 		"Browser.on": "",
+		"Page.on":    "",
 	}
 }
 

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -1085,7 +1085,7 @@ func (fs *FrameSession) updateViewport() error {
 	return nil
 }
 
-func (fs *FrameSession) executionContextForID( //nolint:unused
+func (fs *FrameSession) executionContextForID(
 	executionContextID cdpruntime.ExecutionContextID,
 ) (*ExecutionContext, error) {
 	fs.contextIDToContextMu.Lock()

--- a/common/page.go
+++ b/common/page.go
@@ -1168,7 +1168,7 @@ func (p *Page) consoleMsgFromConsoleEvent(e *cdpruntime.EventConsoleAPICalled) (
 }
 
 // executionContextForID returns the page ExecutionContext for the given ID.
-func (p *Page) executionContextForID( //nolint:unused
+func (p *Page) executionContextForID(
 	executionContextID cdpruntime.ExecutionContextID,
 ) (*ExecutionContext, error) {
 	p.frameSessionsMu.RLock()

--- a/examples/pageon.js
+++ b/examples/pageon.js
@@ -1,0 +1,39 @@
+import { browser } from 'k6/x/browser';
+import { check } from 'k6';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const page = browser.newPage();
+  
+  try {
+    await page.goto('https://test.k6.io/');
+
+    page.on('console', msg => {
+        check(msg, {
+            'assertConsoleMessageType': msg => msg.type() == 'log',
+            'assertConsoleMessageText': msg => msg.text() == 'this is a console.log message 42',
+            'assertConsoleMessageArgs0': msg => msg.args()[0].jsonValue() == 'this is a console.log message',
+            'assertConsoleMessageArgs1': msg => msg.args()[1].jsonValue() == 42,
+        });
+    });
+
+    page.evaluate(() => console.log('this is a console.log message', 42));
+  } finally {
+    page.close();
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/mailru/easyjson v0.7.7
 	github.com/mccutchen/go-httpbin v1.1.2-0.20190116014521-c5cb2f4802fa
+	github.com/mstoykov/k6-taskqueue-lib v0.1.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	go.k6.io/k6 v0.45.1-0.20230804150043-5b5c5ccbb869

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,7 @@ github.com/mstoykov/atlas v0.0.0-20220811071828-388f114305dd h1:AC3N94irbx2kWGA8
 github.com/mstoykov/atlas v0.0.0-20220811071828-388f114305dd/go.mod h1:9vRHVuLCjoFfE3GT06X0spdOAO+Zzo4AMjdIwUHBvAk=
 github.com/mstoykov/envconfig v1.4.1-0.20220114105314-765c6d8c76f1 h1:94EkGmhXrVUEal+uLwFUf4fMXPhZpM5tYxuIsxrCCbI=
 github.com/mstoykov/k6-taskqueue-lib v0.1.0 h1:M3eww1HSOLEN6rIkbNOJHhOVhlqnqkhYj7GTieiMBz4=
+github.com/mstoykov/k6-taskqueue-lib v0.1.0/go.mod h1:PXdINulapvmzF545Auw++SCD69942FeNvUztaa9dVe4=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=


### PR DESCRIPTION
## What?

Adds support for `page.on` method. Currently `'console'` event is the only one allowed.

This will allow users to define a function to be executed every time a `console` API is called in the web page context. Such as:

- `console.log`
- `console.debug`
- `console.info`
- `console.error`
- `console.warn`
- `console.dir`
- `console.dirxml`
- `console.table`
- `console.trace`
- `console.clear`
- `console.assert`
- `console.profile`
- `console.profileEnd`
- `console.group`
- `console.groupCollapsed`
- `console.groupEnd`
- `console.count`

See full reference and details at [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/console) for `console` API.

The handler function defined by the user will receive a console message object as input for every call, such as:
```js
ConsoleMessage {
    args()    // returns the input arguments for the console API method call
    page()   // returns the page that produced this console message
    text()     // returns the text for the console message
    type()    // returns the type for the console message
}
```

## Why?

- Increases the compatibility with Playwright.
- Allows users to perform assertions on console events from the page context execution.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [X] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates #835.
