### PR TITLE
Refactor the browser context cookie API and error messages

### DIFF
--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -9,7 +9,7 @@ type BrowserContext interface {
 	AddCookies(cookies goja.Value) error
 	AddInitScript(script goja.Value, arg goja.Value) error
 	Browser() Browser
-	ClearCookies()
+	ClearCookies() error
 	ClearPermissions()
 	Close()
 	Cookies() ([]any, error) // TODO: make it []Cookie later on

--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -6,7 +6,7 @@ import (
 
 // BrowserContext is the public interface of a CDP browser context.
 type BrowserContext interface {
-	AddCookies(cookies goja.Value)
+	AddCookies(cookies goja.Value) error
 	AddInitScript(script goja.Value, arg goja.Value) error
 	Browser() Browser
 	ClearCookies()

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -79,17 +79,6 @@ func NewBrowserContext(
 	return &b, nil
 }
 
-// AddCookies adds cookies into this browser context.
-// All pages within this context will have these cookies installed.
-func (b *BrowserContext) AddCookies(cookies goja.Value) {
-	b.logger.Debugf("BrowserContext:AddCookies", "bctxid:%v", b.id)
-
-	err := b.addCookies(cookies)
-	if err != nil {
-		k6ext.Panic(b.ctx, "adding cookies: %w", err)
-	}
-}
-
 // AddInitScript adds a script that will be initialized on all new pages.
 func (b *BrowserContext) AddInitScript(script goja.Value, arg goja.Value) error {
 	b.logger.Debugf("BrowserContext:AddInitScript", "bctxid:%v", b.id)
@@ -145,16 +134,6 @@ func (b *BrowserContext) Browser() api.Browser {
 	return b.browser
 }
 
-// ClearCookies clears cookies.
-func (b *BrowserContext) ClearCookies() {
-	b.logger.Debugf("BrowserContext:ClearCookies", "bctxid:%v", b.id)
-
-	action := storage.ClearCookies().WithBrowserContextID(b.id)
-	if err := action.Do(b.ctx); err != nil {
-		k6ext.Panic(b.ctx, "clearing cookies: %w", err)
-	}
-}
-
 // ClearPermissions clears any permission overrides.
 func (b *BrowserContext) ClearPermissions() {
 	b.logger.Debugf("BrowserContext:ClearPermissions", "bctxid:%v", b.id)
@@ -175,11 +154,6 @@ func (b *BrowserContext) Close() {
 	if err := b.browser.disposeContext(b.id); err != nil {
 		k6ext.Panic(b.ctx, "disposing browser context: %w", err)
 	}
-}
-
-// Cookies is not implemented.
-func (b *BrowserContext) Cookies() ([]any, error) {
-	return nil, fmt.Errorf("BrowserContext.cookies() has not been implemented yet: %w", k6error.ErrFatal)
 }
 
 // ExposeBinding is not implemented.
@@ -463,6 +437,17 @@ func (b *BrowserContext) getSession(id target.SessionID) *Session {
 	return b.browser.conn.getSession(id)
 }
 
+// AddCookies adds cookies into this browser context.
+// All pages within this context will have these cookies installed.
+func (b *BrowserContext) AddCookies(cookies goja.Value) {
+	b.logger.Debugf("BrowserContext:AddCookies", "bctxid:%v", b.id)
+
+	err := b.addCookies(cookies)
+	if err != nil {
+		k6ext.Panic(b.ctx, "adding cookies: %w", err)
+	}
+}
+
 func (b *BrowserContext) addCookies(cookies goja.Value) error {
 	var cookieParams []network.CookieParam
 	if !gojaValueExists(cookies) {
@@ -507,4 +492,19 @@ func (b *BrowserContext) addCookies(cookies goja.Value) error {
 	}
 
 	return nil
+}
+
+// ClearCookies clears cookies.
+func (b *BrowserContext) ClearCookies() {
+	b.logger.Debugf("BrowserContext:ClearCookies", "bctxid:%v", b.id)
+
+	action := storage.ClearCookies().WithBrowserContextID(b.id)
+	if err := action.Do(b.ctx); err != nil {
+		k6ext.Panic(b.ctx, "clearing cookies: %w", err)
+	}
+}
+
+// Cookies is not implemented.
+func (b *BrowserContext) Cookies() ([]any, error) {
+	return nil, fmt.Errorf("BrowserContext.cookies() has not been implemented yet: %w", k6error.ErrFatal)
 }

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -479,15 +479,16 @@ func (b *BrowserContext) AddCookies(cookies goja.Value) error {
 }
 
 // ClearCookies clears cookies.
-func (b *BrowserContext) ClearCookies() {
+func (b *BrowserContext) ClearCookies() error {
 	b.logger.Debugf("BrowserContext:ClearCookies", "bctxid:%v", b.id)
 
 	clearCookies := storage.
 		ClearCookies().
 		WithBrowserContextID(b.id)
 	if err := clearCookies.Do(b.ctx); err != nil {
-		k6ext.Panic(b.ctx, "clearing cookies: %w", err)
+		return fmt.Errorf("clearing cookies: %w", err)
 	}
+	return nil
 }
 
 // Cookies is not implemented.

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -439,16 +439,9 @@ func (b *BrowserContext) getSession(id target.SessionID) *Session {
 
 // AddCookies adds cookies into this browser context.
 // All pages within this context will have these cookies installed.
-func (b *BrowserContext) AddCookies(cookies goja.Value) {
+func (b *BrowserContext) AddCookies(cookies goja.Value) error {
 	b.logger.Debugf("BrowserContext:AddCookies", "bctxid:%v", b.id)
 
-	err := b.addCookies(cookies)
-	if err != nil {
-		k6ext.Panic(b.ctx, "adding cookies: %w", err)
-	}
-}
-
-func (b *BrowserContext) addCookies(cookies goja.Value) error {
 	var cookieParams []network.CookieParam
 	if !gojaValueExists(cookies) {
 		return Error("cookies argument must be set")

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -489,8 +489,10 @@ func (b *BrowserContext) addCookies(cookies goja.Value) error {
 func (b *BrowserContext) ClearCookies() {
 	b.logger.Debugf("BrowserContext:ClearCookies", "bctxid:%v", b.id)
 
-	action := storage.ClearCookies().WithBrowserContextID(b.id)
-	if err := action.Do(b.ctx); err != nil {
+	clearCookies := storage.
+		ClearCookies().
+		WithBrowserContextID(b.id)
+	if err := clearCookies.Do(b.ctx); err != nil {
 		k6ext.Panic(b.ctx, "clearing cookies: %w", err)
 	}
 }

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -55,22 +55,22 @@ func TestBrowserContextAddCookies(t *testing.T) {
 	errorTests := []struct {
 		description string
 		cookiesCmd  string
-		shouldPanic bool
+		shouldFail  bool
 	}{
 		{
 			description: "nil_cookies",
 			cookiesCmd:  "",
-			shouldPanic: true,
+			shouldFail:  true,
 		},
 		{
 			description: "goja_null_cookies",
 			cookiesCmd:  "null;",
-			shouldPanic: true,
+			shouldFail:  true,
 		},
 		{
 			description: "goja_undefined_cookies",
 			cookiesCmd:  "undefined;",
-			shouldPanic: true,
+			shouldFail:  true,
 		},
 		{
 			description: "goja_cookies_object",
@@ -81,12 +81,12 @@ func TestBrowserContextAddCookies(t *testing.T) {
 					url: "http://test.go",
 				});
 			`,
-			shouldPanic: true,
+			shouldFail: true,
 		},
 		{
 			description: "goja_cookies_string",
 			cookiesCmd:  `"test_cookie_name=test_cookie_value"`,
-			shouldPanic: true,
+			shouldFail:  true,
 		},
 		{
 			description: "cookie_missing_name",
@@ -96,7 +96,7 @@ func TestBrowserContextAddCookies(t *testing.T) {
 					url: "http://test.go",
 				}
 			];`,
-			shouldPanic: true,
+			shouldFail: true,
 		},
 		{
 			description: "cookie_missing_value",
@@ -106,7 +106,7 @@ func TestBrowserContextAddCookies(t *testing.T) {
 					url: "http://test.go",
 				}
 			];`,
-			shouldPanic: true,
+			shouldFail: true,
 		},
 		{
 			description: "cookie_missing_url",
@@ -116,7 +116,7 @@ func TestBrowserContextAddCookies(t *testing.T) {
 					value: "test_cookie_value",
 				}
 			];`,
-			shouldPanic: true,
+			shouldFail: true,
 		},
 		{
 			description: "cookies_missing_path",
@@ -127,7 +127,7 @@ func TestBrowserContextAddCookies(t *testing.T) {
 					domain: "http://test.go",
 				}
 			];`,
-			shouldPanic: true,
+			shouldFail: true,
 		},
 		{
 			description: "cookies_missing_domain",
@@ -138,7 +138,7 @@ func TestBrowserContextAddCookies(t *testing.T) {
 					path: "/to/page",
 				}
 			];`,
-			shouldPanic: true,
+			shouldFail: true,
 		},
 		{
 			description: "cookie_with_url",
@@ -149,7 +149,7 @@ func TestBrowserContextAddCookies(t *testing.T) {
 					url: "http://test.go",
 				}
 			];`,
-			shouldPanic: false,
+			shouldFail: false,
 		},
 		{
 			description: "cookie_with_domain_and_path",
@@ -161,10 +161,9 @@ func TestBrowserContextAddCookies(t *testing.T) {
 					path: "/to/page",
 				}
 			];`,
-			shouldPanic: false,
+			shouldFail: false,
 		},
 	}
-
 	for _, tt := range errorTests {
 		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
@@ -182,11 +181,11 @@ func TestBrowserContextAddCookies(t *testing.T) {
 			bc, err := tb.NewContext(nil)
 			require.NoError(t, err)
 
-			if tt.shouldPanic {
-				assert.Panics(t, func() { bc.AddCookies(cookies) })
-			} else {
-				assert.NotPanics(t, func() { bc.AddCookies(cookies) })
+			if tt.shouldFail {
+				require.Error(t, bc.AddCookies(cookies))
+				return
 			}
+			require.NoError(t, bc.AddCookies(cookies))
 		})
 	}
 }


### PR DESCRIPTION
## What?

Refactors the browser context cookie API methods and makes them return errors to the mapping layer instead of panicking.

## Why?

* Better maintainability and provide the base work for #6.
* To increase compliance with the mapping layer, like reducing out-of-band panics and providing controllable testing.
* To improve the error messages for better compatibility with the rest of the module.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Related: #6 and #1005.