### PR TITLE
Add `Page.executionContextForID`

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -1084,3 +1084,16 @@ func (fs *FrameSession) updateViewport() error {
 
 	return nil
 }
+
+func (fs *FrameSession) executionContextForID(
+	executionContextID cdpruntime.ExecutionContextID,
+) (*ExecutionContext, error) {
+	fs.contextIDToContextMu.Lock()
+	defer fs.contextIDToContextMu.Unlock()
+
+	if exc, ok := fs.parent.contextIDToContext[executionContextID]; ok {
+		return exc, nil
+	}
+
+	return nil, fmt.Errorf("no execution context found for id: %v", executionContextID)
+}

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -1085,7 +1085,7 @@ func (fs *FrameSession) updateViewport() error {
 	return nil
 }
 
-func (fs *FrameSession) executionContextForID(
+func (fs *FrameSession) executionContextForID( //nolint:unused
 	executionContextID cdpruntime.ExecutionContextID,
 ) (*ExecutionContext, error) {
 	fs.contextIDToContextMu.Lock()

--- a/common/page.go
+++ b/common/page.go
@@ -20,6 +20,7 @@ import (
 	"github.com/chromedp/cdproto/page"
 	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/runtime"
+	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 	"github.com/dop251/goja"
 )
@@ -1036,6 +1037,22 @@ func (p *Page) Workers() []api.Worker {
 		workers = append(workers, w)
 	}
 	return workers
+}
+
+// executionContextForID returns the page ExecutionContext for the given ID.
+func (p *Page) executionContextForID(
+	executionContextID cdpruntime.ExecutionContextID,
+) (*ExecutionContext, error) {
+	p.frameSessionsMu.RLock()
+	defer p.frameSessionsMu.RUnlock()
+
+	for _, fs := range p.frameSessions {
+		if exc, err := fs.executionContextForID(executionContextID); err == nil {
+			return exc, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no execution context found for id: %v", executionContextID)
 }
 
 // sessionID returns the Page's session ID.

--- a/common/page.go
+++ b/common/page.go
@@ -1040,7 +1040,7 @@ func (p *Page) Workers() []api.Worker {
 }
 
 // executionContextForID returns the page ExecutionContext for the given ID.
-func (p *Page) executionContextForID(
+func (p *Page) executionContextForID( //nolint:unused
 	executionContextID cdpruntime.ExecutionContextID,
 ) (*ExecutionContext, error) {
 	p.frameSessionsMu.RLock()


### PR DESCRIPTION
## What?

Adds support to retrieve the associated execution context from within all page frames for a given ID.

## Why?

This is required to associate CDP runtime events for a given page, which include the associated execution context ID (e.g.: see [onConsoleAPICalled](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#event-consoleAPICalled)), with the execution context itself among the page frames and their sessions.

## Checklist

- [X] I have performed a self-review of my code

## Related PR(s)/Issue(s)

Related #1006 .
