### PR TITLE
Fix FrameSession.executionContextForID

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -1091,7 +1091,7 @@ func (fs *FrameSession) executionContextForID( //nolint:unused
 	fs.contextIDToContextMu.Lock()
 	defer fs.contextIDToContextMu.Unlock()
 
-	if exc, ok := fs.parent.contextIDToContext[executionContextID]; ok {
+	if exc, ok := fs.contextIDToContext[executionContextID]; ok {
 		return exc, nil
 	}
 


### PR DESCRIPTION
## What?

Fixes a typo in the `FrameSession.executionContextForID` method for which the frame session's parent was being accessed instead of the calling frame itself.

## Related PR(s)/Issue(s)

#1009 
