### PR TITLE
Fix mapping tests

### DIFF
--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -78,10 +78,9 @@ func TestMappings(t *testing.T) {
 		t.Helper()
 
 		var (
-			typ     = reflect.TypeOf(tt.apiInterface).Elem()
-			typName = typ.Name()
-			mapped  = tt.mapp()
-			tested  = make(map[string]bool)
+			typ    = reflect.TypeOf(tt.apiInterface).Elem()
+			mapped = tt.mapp()
+			tested = make(map[string]bool)
 		)
 		for i := 0; i < typ.NumMethod(); i++ {
 			method := typ.Method(i)
@@ -91,12 +90,12 @@ func TestMappings(t *testing.T) {
 			// so we need to convert the first letter to lowercase.
 			m := toFirstLetterLower(method.Name)
 
-			cm, cmok := isCustomMapping(customMappings, typName, m)
+			cm, cmok := isCustomMapping(customMappings, typ.Name(), m)
 			// if the method is a custom mapping, it should not be
 			// mapped to the module. so we should not find it in
 			// the mapped methods.
 			if _, ok := mapped[m]; cmok && ok {
-				t.Errorf("method %s should not be mapped for %s", m, typName)
+				t.Errorf("method %s should not be mapped", m)
 			}
 			// a custom mapping with an empty string means that
 			// the method should not exist on the API.
@@ -110,7 +109,7 @@ func TestMappings(t *testing.T) {
 				m = cm
 			}
 			if _, ok := mapped[m]; !ok {
-				t.Errorf("method %s for %s not found", m, typName)
+				t.Errorf("method %s not found", m)
 			}
 			// to detect if a method is redundantly mapped.
 			tested[m] = true
@@ -118,7 +117,7 @@ func TestMappings(t *testing.T) {
 		// detect redundant mappings.
 		for m := range mapped {
 			if !tested[m] {
-				t.Errorf("method %s is redundant for %s", m, typName)
+				t.Errorf("method %s is redundant", m)
 			}
 		}
 	}

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -74,7 +74,9 @@ func TestMappings(t *testing.T) {
 	// testMapping tests that all the methods of an API are mapped
 	// to the module. And wildcards are mapped correctly and their
 	// methods are not mapped.
-	testMapping := func(tt test) {
+	testMapping := func(t *testing.T, tt test) {
+		t.Helper()
+
 		var (
 			typ     = reflect.TypeOf(tt.apiInterface).Elem()
 			typName = typ.Name()
@@ -190,7 +192,7 @@ func TestMappings(t *testing.T) {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			testMapping(tt)
+			testMapping(t, tt)
 		})
 	}
 }

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -95,7 +95,7 @@ func TestMappings(t *testing.T) {
 			// mapped to the module. so we should not find it in
 			// the mapped methods.
 			if _, ok := mapped[m]; cmok && ok {
-				t.Errorf("method %s should not be mapped", m)
+				t.Errorf("method %q should not be mapped", m)
 			}
 			// a custom mapping with an empty string means that
 			// the method should not exist on the API.
@@ -109,7 +109,7 @@ func TestMappings(t *testing.T) {
 				m = cm
 			}
 			if _, ok := mapped[m]; !ok {
-				t.Errorf("method %s not found", m)
+				t.Errorf("method %q not found", m)
 			}
 			// to detect if a method is redundantly mapped.
 			tested[m] = true
@@ -117,7 +117,7 @@ func TestMappings(t *testing.T) {
 		// detect redundant mappings.
 		for m := range mapped {
 			if !tested[m] {
-				t.Errorf("method %s is redundant", m)
+				t.Errorf("method %q is redundant", m)
 			}
 		}
 	}


### PR DESCRIPTION
## What?

Fixes the mapping layer tests in order to use the subtest `testing.T` reference so the subtest name is identified on failure and therefore there is no need to reference the specific type through reflection.

Previous error message on a subtest failure:
```
--- FAIL: TestMappings (0.00s) // --> Does not reference the specific subtest
    /home/ka3de/devel/go/src/github.com/grafana/xk6-browser/browser/mapping_test.go:111: method on for Browser not found
FAIL
FAIL	github.com/grafana/xk6-browser/browser	0.008s
FAIL
```

Current error message:
```
--- FAIL: TestMappings (0.00s)
    --- FAIL: TestMappings/browser (0.00s)
        /home/ka3de/devel/go/src/github.com/grafana/xk6-browser/browser/mapping_test.go:194: method "on" not found
FAIL
FAIL	github.com/grafana/xk6-browser/browser	0.007s
FAIL
```
## Why?

Previous behavior was not correct and required the actual type name specification in the error message through reflection in order to understand which was the failing test.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [X] I have commented on my code, particularly in hard-to-understand areas
