### PR TITLE
Optimize tests to run in parallel

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,7 +65,7 @@ jobs:
               echo "skipping $f on Windows"
               continue
             fi
-            ./k6extension run "$f"
+            ./k6extension run -q "$f"
           done
       - name: Check screenshot
         if: matrix.go != 'tip' || matrix.platform != 'windows-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,7 @@ jobs:
         run: |
           set -x
           go version
-          export GOMAXPROCS=2
-          args=("-p" "2" "-race")
+          args=("-race")
           # Run with less concurrency on Windows to minimize flakiness.
           if [[ "${{ matrix.platform }}" == windows* ]]; then
             unset args[2]
@@ -72,8 +71,7 @@ jobs:
           set -x
           which go
           go version
-          export GOMAXPROCS=2
-          args=("-p" "2" "-race")
+          args=("-race")
           K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome K6_BROWSER_HEADLESS=true go test "${args[@]}" -timeout 5m ./...
 
   test-current-cov:
@@ -94,8 +92,7 @@ jobs:
       - name: Run tests with code coverage
         run: |
           go version
-          export GOMAXPROCS=2
-          args=("-p" "2" "-race")
+          args=("-race")
           # Run with less concurrency on Windows to minimize flakiness.
           if [[ "${{ matrix.platform }}" == windows* ]]; then
             unset args[2]
@@ -140,8 +137,7 @@ jobs:
         run: |
           set -x
           go version
-          export GOMAXPROCS=2
-          args=("-p" "2" "-race")
+          args=("-race")
           # Run with less concurrency on Windows to minimize flakiness.
           if [[ "${{ matrix.platform }}" == windows* ]]; then
             unset args[2]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,6 @@ jobs:
           set -x
           go version
           args=("-race")
-          # Run with less concurrency on Windows to minimize flakiness.
-          if [[ "${{ matrix.platform }}" == windows* ]]; then
-            unset args[2]
-            args[1]="1"
-            export GOMAXPROCS=1
-          fi
           K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome K6_BROWSER_HEADLESS=true go test "${args[@]}" -timeout 5m ./...
 
   test-tip:
@@ -93,12 +87,6 @@ jobs:
         run: |
           go version
           args=("-race")
-          # Run with less concurrency on Windows to minimize flakiness.
-          if [[ "${{ matrix.platform }}" == windows* ]]; then
-            unset args[2]
-            args[1]="1"
-            export GOMAXPROCS=1
-          fi
           echo "mode: set" > coverage.txt
           for pkg in $(go list ./... | grep -v vendor); do
               list=$(go list -test -f  '{{ join .Deps  "\n"}}' $pkg | grep github.com/grafana/xk6-browser | grep -v vendor || true)
@@ -138,12 +126,6 @@ jobs:
           set -x
           go version
           args=("-race")
-          # Run with less concurrency on Windows to minimize flakiness.
-          if [[ "${{ matrix.platform }}" == windows* ]]; then
-            unset args[2]
-            args[1]="1"
-            export GOMAXPROCS=1
-          fi
           cat go.mod | grep go.k6.io/k6
           # Get the latest master version of k6
           go get go.k6.io/k6@master

--- a/browser/registry_test.go
+++ b/browser/registry_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestPidRegistry(t *testing.T) {
+	t.Parallel()
+
 	p := &pidRegistry{}
 
 	var wg sync.WaitGroup
@@ -166,6 +168,8 @@ func TestIsRemoteBrowser(t *testing.T) {
 	}
 
 	t.Run("K6_INSTANCE_SCENARIOS should override K6_BROWSER_WS_URL", func(t *testing.T) {
+		t.Parallel()
+
 		lookup := func(key string) (string, bool) {
 			switch key {
 			case env.WebSocketURLs:

--- a/common/barrier_test.go
+++ b/common/barrier_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestBarrier(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	log := log.NewNullLogger()

--- a/common/browser_context_test.go
+++ b/common/browser_context_test.go
@@ -14,7 +14,11 @@ import (
 )
 
 func TestNewBrowserContext(t *testing.T) {
+	t.Parallel()
+
 	t.Run("add_web_vital_js_scripts_to_context", func(t *testing.T) {
+		t.Parallel()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		logger := log.NewNullLogger()
 		b := newBrowser(ctx, cancel, nil, NewLocalBrowserOptions(), logger)

--- a/common/browser_options_test.go
+++ b/common/browser_options_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/xk6-browser/log"
 )
 
-func TestBrowserOptionsParse(t *testing.T) { //nolint:gocognit
+func TestBrowserOptionsParse(t *testing.T) {
 	t.Parallel()
 
 	defaultOptions := &BrowserOptions{

--- a/common/connection_test.go
+++ b/common/connection_test.go
@@ -19,9 +19,13 @@ import (
 )
 
 func TestConnection(t *testing.T) {
+	t.Parallel()
+
 	server := ws.NewServer(t, ws.WithEchoHandler("/echo"))
 
 	t.Run("connect", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/echo", url.Host)
@@ -33,9 +37,13 @@ func TestConnection(t *testing.T) {
 }
 
 func TestConnectionClosureAbnormal(t *testing.T) {
+	t.Parallel()
+
 	server := ws.NewServer(t, ws.WithClosureAbnormalHandler("/closure-abnormal"))
 
 	t.Run("closure abnormal", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/closure-abnormal", url.Host)
@@ -50,9 +58,13 @@ func TestConnectionClosureAbnormal(t *testing.T) {
 }
 
 func TestConnectionSendRecv(t *testing.T) {
+	t.Parallel()
+
 	server := ws.NewServer(t, ws.WithCDPHandler("/cdp", ws.CDPDefaultHandler, nil))
 
 	t.Run("send command with empty reply", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
@@ -67,6 +79,8 @@ func TestConnectionSendRecv(t *testing.T) {
 }
 
 func TestConnectionCreateSession(t *testing.T) {
+	t.Parallel()
+
 	cmdsReceived := make([]cdproto.MethodType, 0)
 	handler := func(conn *websocket.Conn, msg *cdproto.Message, writeCh chan cdproto.Message, done chan struct{}) {
 		if msg.SessionID == "" && msg.Method != "" {
@@ -116,6 +130,8 @@ func TestConnectionCreateSession(t *testing.T) {
 	server := ws.NewServer(t, ws.WithCDPHandler("/cdp", handler, &cmdsReceived))
 
 	t.Run("create session for target", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)

--- a/common/context_test.go
+++ b/common/context_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestContextWithDoneChan(t *testing.T) {
+	t.Parallel()
+
 	done := make(chan struct{})
 	ctx := contextWithDoneChan(context.Background(), done)
 	close(done)

--- a/common/element_handle_test.go
+++ b/common/element_handle_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestErrorFromDOMError(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		in       string
 		sentinel bool // if it returns the same error value
@@ -156,6 +158,8 @@ func TestQueryAll(t *testing.T) {
 	}
 
 	t.Run("eval_call", func(t *testing.T) {
+		t.Parallel()
+
 		const selector = "body"
 
 		_, _ = (&ElementHandle{}).queryAll(

--- a/common/event_emitter_test.go
+++ b/common/event_emitter_test.go
@@ -14,6 +14,8 @@ func TestEventEmitterSpecificEvent(t *testing.T) {
 	t.Parallel()
 
 	t.Run("add event handler", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		emitter := NewBaseEventEmitter(ctx)
 		ch := make(chan Event)
@@ -29,6 +31,8 @@ func TestEventEmitterSpecificEvent(t *testing.T) {
 	})
 
 	t.Run("remove event handler", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		cancelCtx, cancelFn := context.WithCancel(ctx)
 		emitter := NewBaseEventEmitter(cancelCtx)
@@ -45,6 +49,8 @@ func TestEventEmitterSpecificEvent(t *testing.T) {
 	})
 
 	t.Run("emit event", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		emitter := NewBaseEventEmitter(ctx)
 		ch := make(chan Event, 1)
@@ -64,6 +70,8 @@ func TestEventEmitterAllEvents(t *testing.T) {
 	t.Parallel()
 
 	t.Run("add catch-all event handler", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		emitter := NewBaseEventEmitter(ctx)
 		ch := make(chan Event)
@@ -78,6 +86,8 @@ func TestEventEmitterAllEvents(t *testing.T) {
 	})
 
 	t.Run("remove catch-all event handler", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		emitter := NewBaseEventEmitter(ctx)
 		cancelCtx, cancelFn := context.WithCancel(ctx)
@@ -93,6 +103,8 @@ func TestEventEmitterAllEvents(t *testing.T) {
 	})
 
 	t.Run("emit event", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		emitter := NewBaseEventEmitter(ctx)
 		ch := make(chan Event, 1)
@@ -113,6 +125,8 @@ func TestBaseEventEmitter(t *testing.T) {
 	t.Parallel()
 
 	t.Run("order of emitted events kept", func(t *testing.T) {
+		t.Parallel()
+
 		// Test description
 		//
 		// 1. Emit many events from the emitWorker.
@@ -120,8 +134,6 @@ func TestBaseEventEmitter(t *testing.T) {
 		//
 		// Success criteria: Ensure that the ordering of events is
 		//                   received in the order they're emitted.
-
-		t.Parallel()
 
 		eventName := "AtomicIntEvent"
 		maxInt := 100
@@ -168,6 +180,8 @@ func TestBaseEventEmitter(t *testing.T) {
 	})
 
 	t.Run("order of emitted different event types kept", func(t *testing.T) {
+		t.Parallel()
+
 		// Test description
 		//
 		// 1. Emit many different event types from the emitWorker.
@@ -175,8 +189,6 @@ func TestBaseEventEmitter(t *testing.T) {
 		//
 		// Success criteria: Ensure that the ordering of events is
 		//                   received in the order they're emitted.
-
-		t.Parallel()
 
 		eventName1 := "AtomicIntEvent1"
 		eventName2 := "AtomicIntEvent2"
@@ -231,6 +243,8 @@ func TestBaseEventEmitter(t *testing.T) {
 	})
 
 	t.Run("handler can emit without deadlocking", func(t *testing.T) {
+		t.Parallel()
+
 		// Test description
 		//
 		// 1. Emit many events from the emitWorker.
@@ -240,8 +254,6 @@ func TestBaseEventEmitter(t *testing.T) {
 		//
 		// Success criteria: No deadlock should occur between receiving,
 		//                   emitting, and receiving of events.
-
-		t.Parallel()
 
 		eventName1 := "AtomicIntEvent1"
 		eventName2 := "AtomicIntEvent2"

--- a/common/helpers_test.go
+++ b/common/helpers_test.go
@@ -27,6 +27,8 @@ func TestConvertArgument(t *testing.T) {
 	t.Parallel()
 
 	t.Run("int64", func(t *testing.T) {
+		t.Parallel()
+
 		execCtx, ctx, rt := newExecCtx()
 		var value int64 = 777
 		arg, _ := convertArgument(ctx, execCtx, rt.ToValue(value))
@@ -39,6 +41,8 @@ func TestConvertArgument(t *testing.T) {
 	})
 
 	t.Run("int64 maxint", func(t *testing.T) {
+		t.Parallel()
+
 		execCtx, ctx, rt := newExecCtx()
 
 		var value int64 = math.MaxInt32 + 1
@@ -51,6 +55,8 @@ func TestConvertArgument(t *testing.T) {
 	})
 
 	t.Run("float64", func(t *testing.T) {
+		t.Parallel()
+
 		execCtx, ctx, rt := newExecCtx()
 
 		var value float64 = 777.0
@@ -64,6 +70,8 @@ func TestConvertArgument(t *testing.T) {
 	})
 
 	t.Run("float64 unserializable values", func(t *testing.T) {
+		t.Parallel()
+
 		execCtx, ctx, rt := newExecCtx()
 
 		unserializableValues := []struct {
@@ -98,6 +106,8 @@ func TestConvertArgument(t *testing.T) {
 	})
 
 	t.Run("bool", func(t *testing.T) {
+		t.Parallel()
+
 		execCtx, ctx, rt := newExecCtx()
 
 		var value bool = true
@@ -111,6 +121,8 @@ func TestConvertArgument(t *testing.T) {
 	})
 
 	t.Run("string", func(t *testing.T) {
+		t.Parallel()
+
 		execCtx, ctx, rt := newExecCtx()
 		var value string = "hello world"
 		arg, _ := convertArgument(ctx, execCtx, rt.ToValue(value))
@@ -123,6 +135,8 @@ func TestConvertArgument(t *testing.T) {
 	})
 
 	t.Run("*BaseJSHandle", func(t *testing.T) {
+		t.Parallel()
+
 		execCtx, ctx, rt := newExecCtx()
 		log := log.NewNullLogger()
 
@@ -146,6 +160,8 @@ func TestConvertArgument(t *testing.T) {
 	})
 
 	t.Run("*BaseJSHandle wrong context", func(t *testing.T) {
+		t.Parallel()
+
 		execCtx, ctx, rt := newExecCtx()
 		log := log.NewNullLogger()
 
@@ -168,6 +184,8 @@ func TestConvertArgument(t *testing.T) {
 	})
 
 	t.Run("*BaseJSHandle is disposed", func(t *testing.T) {
+		t.Parallel()
+
 		execCtx, ctx, rt := newExecCtx()
 		log := log.NewNullLogger()
 
@@ -190,6 +208,8 @@ func TestConvertArgument(t *testing.T) {
 	})
 
 	t.Run("*BaseJSHandle as *ElementHandle", func(t *testing.T) {
+		t.Parallel()
+
 		execCtx, ctx, rt := newExecCtx()
 		log := log.NewNullLogger()
 

--- a/common/keyboard_test.go
+++ b/common/keyboard_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestSplit(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		keys string
 	}
@@ -62,16 +64,22 @@ func TestSplit(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := split(tt.args.keys)
+			t.Parallel()
 
+			got := split(tt.args.keys)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
 func TestKeyboardPress(t *testing.T) {
+	t.Parallel()
+
 	t.Run("panics when '' empty key passed in", func(t *testing.T) {
+		t.Parallel()
+
 		vu := k6test.NewVU(t)
 		k := NewKeyboard(vu.Context(), nil)
 		assert.Panics(t, func() { k.Press("", nil) })
@@ -79,6 +87,8 @@ func TestKeyboardPress(t *testing.T) {
 }
 
 func TestKeyDefinitionCode(t *testing.T) {
+	t.Parallel()
+
 	var (
 		vu = k6test.NewVU(t)
 		k  = NewKeyboard(vu.Context(), nil)
@@ -178,7 +188,10 @@ func TestKeyDefinitionCode(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(string(tt.key), func(t *testing.T) {
+			t.Parallel()
+
 			kd := k.keyDefinitionFromKey(tt.key)
 			assert.Contains(t, tt.expectedCodes, kd.Code)
 		})

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -118,6 +118,8 @@ func TestOnRequestPausedBlockedHostnames(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			blocked, err := k6types.NewNullHostnameTrie(tc.blockedHostnames)
 			require.NoError(t, err)
 
@@ -180,6 +182,8 @@ func TestOnRequestPausedBlockedIPs(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			blockedIPs := make([]*k6lib.IPNet, len(tc.blockedIPs))
 			for i, ipcidr := range tc.blockedIPs {
 				ipnet, err := k6lib.ParseCIDR(ipcidr)

--- a/common/page_test.go
+++ b/common/page_test.go
@@ -12,6 +12,8 @@ import (
 // tests. Since we don't yet have any of them, it makes sense to keep
 // this test.
 func TestPageLocator(t *testing.T) {
+	t.Parallel()
+
 	const (
 		wantMainFrameID = "1"
 		wantSelector    = "span"

--- a/common/remote_object_test.go
+++ b/common/remote_object_test.go
@@ -20,6 +20,8 @@ func TestValueFromRemoteObject(t *testing.T) {
 	t.Parallel()
 
 	t.Run("unserializable value error", func(t *testing.T) {
+		t.Parallel()
+
 		vu := k6test.NewVU(t)
 		unserializableValue := runtime.UnserializableValue("a string instead")
 		remoteObject := &runtime.RemoteObject{
@@ -33,6 +35,8 @@ func TestValueFromRemoteObject(t *testing.T) {
 	})
 
 	t.Run("bigint parsing error", func(t *testing.T) {
+		t.Parallel()
+
 		vu := k6test.NewVU(t)
 		unserializableValue := runtime.UnserializableValue("a string instead")
 		remoteObject := &runtime.RemoteObject{
@@ -47,6 +51,8 @@ func TestValueFromRemoteObject(t *testing.T) {
 	})
 
 	t.Run("float64 unserializable values", func(t *testing.T) {
+		t.Parallel()
+
 		vu := k6test.NewVU(t)
 		unserializableValues := []struct {
 			value    string
@@ -87,6 +93,8 @@ func TestValueFromRemoteObject(t *testing.T) {
 	})
 
 	t.Run("primitive types", func(t *testing.T) {
+		t.Parallel()
+
 		primitiveTypes := []struct {
 			typ   runtime.Type
 			value any
@@ -130,6 +138,8 @@ func TestValueFromRemoteObject(t *testing.T) {
 	})
 
 	t.Run("remote object with ID", func(t *testing.T) {
+		t.Parallel()
+
 		remoteObjectID := runtime.RemoteObjectID("object_id_0123456789")
 		remoteObject := &runtime.RemoteObject{
 			Type:     "object",

--- a/common/request_test.go
+++ b/common/request_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestRequest(t *testing.T) {
 	t.Parallel()
+
 	ts := cdp.MonotonicTime(time.Now())
 	wt := cdp.TimeSinceEpoch(time.Now())
 	headers := map[string]any{"key": "value"}
@@ -38,6 +39,7 @@ func TestRequest(t *testing.T) {
 
 	t.Run("error_parse_url", func(t *testing.T) {
 		t.Parallel()
+
 		evt := &network.EventRequestWillBeSent{
 			RequestID: network.RequestID("1234"),
 			Request: &network.Request{

--- a/common/session_test.go
+++ b/common/session_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestSessionCreateSession(t *testing.T) {
+	t.Parallel()
+
 	const (
 		cdpTargetID         = "target_id_0123456789"
 		cdpBrowserContextID = "browser_context_id_0123456789"
@@ -81,6 +83,8 @@ func TestSessionCreateSession(t *testing.T) {
 	server := ws.NewServer(t, ws.WithCDPHandler("/cdp", handler, &cmdsReceived))
 
 	t.Run("send and recv session commands", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)

--- a/common/timeout_test.go
+++ b/common/timeout_test.go
@@ -7,27 +7,41 @@ import (
 )
 
 func TestTimeoutSettings(t *testing.T) {
+	t.Parallel()
+
 	t.Run("TimeoutSettings.NewTimeoutSettings", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("should work", testTimeoutSettingsNewTimeoutSettings)
 		t.Run("should work with parent", testTimeoutSettingsNewTimeoutSettingsWithParent)
 	})
 	t.Run("TimeoutSettings.setDefaultTimeout", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("should work", testTimeoutSettingsSetDefaultTimeout)
 	})
 	t.Run("TimeoutSettings.setDefaultNavigationTimeout", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("should work", testTimeoutSettingsSetDefaultNavigationTimeout)
 	})
 	t.Run("TimeoutSettings.navigationTimeout", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("should work", testTimeoutSettingsNavigationTimeout)
 		t.Run("should work with parent", testTimeoutSettingsNavigationTimeoutWithParent)
 	})
 	t.Run("TimeoutSettings.timeout", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("should work", testTimeoutSettingsTimeout)
 		t.Run("should work with parent", testTimeoutSettingsTimeoutWithParent)
 	})
 }
 
 func testTimeoutSettingsNewTimeoutSettings(t *testing.T) {
+	t.Parallel()
+
 	ts := NewTimeoutSettings(nil)
 	assert.Nil(t, ts.parent)
 	assert.Nil(t, ts.defaultTimeout)
@@ -35,6 +49,8 @@ func testTimeoutSettingsNewTimeoutSettings(t *testing.T) {
 }
 
 func testTimeoutSettingsNewTimeoutSettingsWithParent(t *testing.T) {
+	t.Parallel()
+
 	ts := NewTimeoutSettings(nil)
 	tsWithParent := NewTimeoutSettings(ts)
 	assert.Equal(t, ts, tsWithParent.parent)
@@ -43,18 +59,24 @@ func testTimeoutSettingsNewTimeoutSettingsWithParent(t *testing.T) {
 }
 
 func testTimeoutSettingsSetDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
 	ts := NewTimeoutSettings(nil)
 	ts.setDefaultTimeout(100)
 	assert.Equal(t, int64(100), *ts.defaultTimeout)
 }
 
 func testTimeoutSettingsSetDefaultNavigationTimeout(t *testing.T) {
+	t.Parallel()
+
 	ts := NewTimeoutSettings(nil)
 	ts.setDefaultNavigationTimeout(100)
 	assert.Equal(t, int64(100), *ts.defaultNavigationTimeout)
 }
 
 func testTimeoutSettingsNavigationTimeout(t *testing.T) {
+	t.Parallel()
+
 	ts := NewTimeoutSettings(nil)
 
 	// Assert default timeout value is used
@@ -66,6 +88,8 @@ func testTimeoutSettingsNavigationTimeout(t *testing.T) {
 }
 
 func testTimeoutSettingsNavigationTimeoutWithParent(t *testing.T) {
+	t.Parallel()
+
 	ts := NewTimeoutSettings(nil)
 	tsWithParent := NewTimeoutSettings(ts)
 
@@ -82,6 +106,8 @@ func testTimeoutSettingsNavigationTimeoutWithParent(t *testing.T) {
 }
 
 func testTimeoutSettingsTimeout(t *testing.T) {
+	t.Parallel()
+
 	ts := NewTimeoutSettings(nil)
 
 	// Assert default timeout value is used
@@ -93,6 +119,8 @@ func testTimeoutSettingsTimeout(t *testing.T) {
 }
 
 func testTimeoutSettingsTimeoutWithParent(t *testing.T) {
+	t.Parallel()
+
 	ts := NewTimeoutSettings(nil)
 	tsWithParent := NewTimeoutSettings(ts)
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -11,9 +11,13 @@ import (
 )
 
 func TestDirMake(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := os.TempDir()
 
 	t.Run("dir_provided", func(t *testing.T) {
+		t.Parallel()
+
 		dir, err := os.MkdirTemp("", "*")
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = os.RemoveAll(dir) })
@@ -30,6 +34,8 @@ func TestDirMake(t *testing.T) {
 	})
 
 	t.Run("dir_absent", func(t *testing.T) {
+		t.Parallel()
+
 		var s Dir
 		require.NoError(t, s.Make("", ""))
 		require.True(t, strings.HasPrefix(s.Dir, tmpDir))
@@ -44,6 +50,8 @@ func TestDirMake(t *testing.T) {
 	})
 
 	t.Run("dir_mk_err", func(t *testing.T) {
+		t.Parallel()
+
 		var s Dir
 		require.ErrorIs(t, s.Make("/NOT_EXISTING_DIRECTORY/K6/BROWSER", ""), fs.ErrNotExist)
 		assert.Empty(t, s.Dir)

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -38,6 +38,8 @@ func TestBrowserContextOptionsDefaultValues(t *testing.T) {
 }
 
 func TestBrowserContextOptionsDefaultViewport(t *testing.T) {
+	t.Parallel()
+
 	p := newTestBrowser(t).NewPage(nil)
 
 	viewportSize := p.ViewportSize()
@@ -46,6 +48,8 @@ func TestBrowserContextOptionsDefaultViewport(t *testing.T) {
 }
 
 func TestBrowserContextOptionsSetViewport(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 	bctx, err := tb.NewContext(tb.toGojaValue(struct {
 		Viewport common.Viewport `js:"viewport"`
@@ -66,6 +70,8 @@ func TestBrowserContextOptionsSetViewport(t *testing.T) {
 }
 
 func TestBrowserContextOptionsExtraHTTPHeaders(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t, withHTTPServer())
 	bctx, err := tb.NewContext(tb.toGojaValue(struct {
 		ExtraHTTPHeaders map[string]string `js:"extraHTTPHeaders"`

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -434,6 +434,8 @@ func TestBrowserContextCookies(t *testing.T) {
 }
 
 func TestK6Object(t *testing.T) {
+	t.Parallel()
+
 	b := newTestBrowser(t, withFileServer())
 	p := b.NewPage(nil)
 

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestBrowserNewPage(t *testing.T) {
+	t.Parallel()
+
 	b := newTestBrowser(t)
 	p1 := b.NewPage(nil)
 	c := b.Context()
@@ -47,6 +49,8 @@ func TestBrowserNewPage(t *testing.T) {
 }
 
 func TestBrowserNewContext(t *testing.T) {
+	t.Parallel()
+
 	b := newTestBrowser(t)
 	bc1, err := b.NewContext(nil)
 	assert.NoError(t, err)
@@ -186,6 +190,8 @@ func TestBrowserOn(t *testing.T) {
 
 // This only works for Chrome!
 func TestBrowserVersion(t *testing.T) {
+	t.Parallel()
+
 	const re = `^\d+\.\d+\.\d+\.\d+$`
 	r, _ := regexp.Compile(re)
 	ver := newTestBrowser(t).Version()
@@ -196,6 +202,8 @@ func TestBrowserVersion(t *testing.T) {
 // TODO: Improve this test, see:
 // https://github.com/grafana/xk6-browser/pull/51#discussion_r742696736
 func TestBrowserUserAgent(t *testing.T) {
+	t.Parallel()
+
 	b := newTestBrowser(t)
 
 	// testBrowserVersion() tests the version already
@@ -208,6 +216,8 @@ func TestBrowserUserAgent(t *testing.T) {
 }
 
 func TestBrowserCrashErr(t *testing.T) {
+	t.Parallel()
+
 	// create a new VU in an environment that requires a bad remote-debugging-port.
 	vu := k6test.NewVU(t, env.ConstLookup(env.BrowserArguments, "remote-debugging-port=99999"))
 
@@ -257,6 +267,9 @@ func TestBrowserLogIterationID(t *testing.T) {
 }
 
 func TestMultiBrowserPanic(t *testing.T) {
+	// this test should run sequentially.
+	// don't use t.Parallel() here.
+
 	var b1, b2 *testBrowser
 
 	// run it in a test to kick in the Cleanup() in testBrowser.
@@ -302,6 +315,8 @@ func TestBrowserMultiClose(t *testing.T) {
 }
 
 func TestMultiConnectToSingleBrowser(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t, withSkipClose())
 	defer tb.Close()
 

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestBrowserTypeConnect(t *testing.T) {
+	t.Parallel()
+
 	// Start a test browser so we can get its WS URL
 	// and use it to connect through BrowserType.Connect.
 	tb := newTestBrowser(t)
@@ -27,6 +29,8 @@ func TestBrowserTypeConnect(t *testing.T) {
 }
 
 func TestBrowserTypeLaunchToConnect(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 	bp := newTestBrowserProxy(t, tb)
 

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -54,6 +54,8 @@ var htmlInputButton = fmt.Sprintf(`
 `, mouseHelperScriptSource)
 
 func TestElementHandleBoundingBoxInvisibleElement(t *testing.T) {
+	t.Parallel()
+
 	p := newTestBrowser(t).NewPage(nil)
 
 	p.SetContent(`<div style="display:none">hello</div>`, nil)
@@ -63,6 +65,8 @@ func TestElementHandleBoundingBoxInvisibleElement(t *testing.T) {
 }
 
 func TestElementHandleBoundingBoxSVG(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
@@ -90,6 +94,8 @@ func TestElementHandleBoundingBoxSVG(t *testing.T) {
 }
 
 func TestElementHandleClick(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
@@ -112,6 +118,8 @@ func TestElementHandleClick(t *testing.T) {
 }
 
 func TestElementHandleClickWithNodeRemoved(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
@@ -137,6 +145,8 @@ func TestElementHandleClickWithNodeRemoved(t *testing.T) {
 }
 
 func TestElementHandleClickWithDetachedNode(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
@@ -162,6 +172,8 @@ func TestElementHandleClickWithDetachedNode(t *testing.T) {
 }
 
 func TestElementHandleClickConcealedLink(t *testing.T) {
+	t.Parallel()
+
 	const (
 		wantBefore = "🙈"
 		wantAfter  = "🐵"
@@ -200,6 +212,8 @@ func TestElementHandleClickConcealedLink(t *testing.T) {
 }
 
 func TestElementHandleNonClickable(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t, withFileServer())
 
 	bctx, err := tb.NewContext(nil)
@@ -216,6 +230,8 @@ func TestElementHandleNonClickable(t *testing.T) {
 }
 
 func TestElementHandleGetAttribute(t *testing.T) {
+	t.Parallel()
+
 	const want = "https://somewhere"
 
 	p := newTestBrowser(t).NewPage(nil)
@@ -231,6 +247,8 @@ func TestElementHandleGetAttribute(t *testing.T) {
 }
 
 func TestElementHandleInputValue(t *testing.T) {
+	t.Parallel()
+
 	p := newTestBrowser(t).NewPage(nil)
 
 	p.SetContent(`
@@ -262,6 +280,8 @@ func TestElementHandleInputValue(t *testing.T) {
 }
 
 func TestElementHandleIsChecked(t *testing.T) {
+	t.Parallel()
+
 	p := newTestBrowser(t).NewPage(nil)
 
 	p.SetContent(`<input type="checkbox" checked>`, nil)
@@ -279,6 +299,9 @@ func TestElementHandleIsChecked(t *testing.T) {
 }
 
 func TestElementHandleQueryAll(t *testing.T) {
+	// tests are faster than parallel execution.
+	// do not make this test parallel.
+
 	const (
 		wantLiLen = 2
 		query     = "li.ali"
@@ -315,6 +338,8 @@ func TestElementHandleQueryAll(t *testing.T) {
 }
 
 func TestElementHandleScreenshot(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
@@ -363,6 +388,8 @@ func TestElementHandleScreenshot(t *testing.T) {
 }
 
 func TestElementHandleWaitForSelector(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 	p.SetContent(`<div class="root"></div>`, nil)
@@ -391,6 +418,8 @@ func TestElementHandleWaitForSelector(t *testing.T) {
 }
 
 func TestElementHandlePress(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 
 	p := tb.NewPage(nil)

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -299,8 +299,7 @@ func TestElementHandleIsChecked(t *testing.T) {
 }
 
 func TestElementHandleQueryAll(t *testing.T) {
-	// tests are faster than parallel execution.
-	// do not make this test parallel.
+	t.Parallel()
 
 	const (
 		wantLiLen = 2
@@ -316,6 +315,8 @@ func TestElementHandleQueryAll(t *testing.T) {
   	`, nil)
 
 	t.Run("element_handle", func(t *testing.T) {
+		t.Parallel()
+
 		el, err := p.Query("#aul")
 		require.NoError(t, err)
 
@@ -325,12 +326,16 @@ func TestElementHandleQueryAll(t *testing.T) {
 		assert.Equal(t, wantLiLen, len(els))
 	})
 	t.Run("page", func(t *testing.T) {
+		t.Parallel()
+
 		els, err := p.QueryAll(query)
 		require.NoError(t, err)
 
 		assert.Equal(t, wantLiLen, len(els))
 	})
 	t.Run("frame", func(t *testing.T) {
+		t.Parallel()
+
 		els, err := p.MainFrame().QueryAll(query)
 		require.NoError(t, err)
 		assert.Equal(t, wantLiLen, len(els))

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -60,6 +60,8 @@ func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 }
 
 func TestWaitForFrameNavigation(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t, withHTTPServer())
 	p := tb.NewPage(nil)
 

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestFramePress(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 
 	p := tb.NewPage(nil)
@@ -144,6 +146,8 @@ func TestFrameNoPanicNavigateAndClickOnPageWithIFrames(t *testing.T) {
 }
 
 func TestFrameTitle(t *testing.T) {
+	t.Parallel()
+
 	p := newTestBrowser(t).NewPage(nil)
 	p.SetContent(`<html><head><title>Some title</title></head></html>`, nil)
 	assert.Equal(t, "Some title", p.MainFrame().Title())

--- a/tests/js_handle_get_properties_test.go
+++ b/tests/js_handle_get_properties_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestJSHandleGetProperties(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -12,7 +12,11 @@ import (
 )
 
 func TestKeyboardPress(t *testing.T) {
+	t.Parallel()
+
 	t.Run("all_keys", func(t *testing.T) {
+		t.Parallel()
+
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
@@ -26,6 +30,8 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("backspace", func(t *testing.T) {
+		t.Parallel()
+
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
@@ -43,6 +49,8 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("combo", func(t *testing.T) {
+		t.Parallel()
+
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
@@ -68,6 +76,7 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("meta", func(t *testing.T) {
+		t.Parallel()
 		t.Skip("FIXME") // See https://github.com/grafana/xk6-browser/issues/424
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
@@ -94,6 +103,8 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("type does not split on +", func(t *testing.T) {
+		t.Parallel()
+
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
@@ -108,6 +119,8 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("capitalization", func(t *testing.T) {
+		t.Parallel()
+
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
@@ -134,6 +147,8 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("type not affected by shift", func(t *testing.T) {
+		t.Parallel()
+
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
@@ -151,6 +166,8 @@ func TestKeyboardPress(t *testing.T) {
 	})
 
 	t.Run("newline", func(t *testing.T) {
+		t.Parallel()
+
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()
@@ -169,6 +186,8 @@ func TestKeyboardPress(t *testing.T) {
 
 	// Replicates the test from https://playwright.dev/docs/api/class-keyboard
 	t.Run("selection", func(t *testing.T) {
+		t.Parallel()
+
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
 		kb := p.GetKeyboard()

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -434,6 +434,8 @@ func TestLocatorElementState(t *testing.T) {
 }
 
 func TestLocatorPress(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 
 	p := tb.NewPage(nil)

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -31,6 +31,8 @@ func TestURLSkipRequest(t *testing.T) {
 }
 
 func TestBlockHostnames(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t, withHTTPServer(), withLogCache())
 
 	blocked, err := k6types.NewNullHostnameTrie([]string{"*.test"})
@@ -50,6 +52,8 @@ func TestBlockHostnames(t *testing.T) {
 }
 
 func TestBlockIPs(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t, withHTTPServer(), withLogCache())
 
 	ipnet, err := k6lib.ParseCIDR("10.0.0.0/8")
@@ -69,6 +73,8 @@ func TestBlockIPs(t *testing.T) {
 }
 
 func TestBasicAuth(t *testing.T) {
+	t.Parallel()
+
 	const (
 		validUser     = "validuser"
 		validPassword = "validpass"
@@ -104,11 +110,15 @@ func TestBasicAuth(t *testing.T) {
 	}
 
 	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+
 		resp := auth(t, validUser, validPassword)
 		require.NotNil(t, resp)
 		assert.Equal(t, http.StatusOK, int(resp.Status()))
 	})
 	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+
 		resp := auth(t, "invalidUser", "invalidPassword")
 		require.NotNil(t, resp)
 		assert.Equal(t, http.StatusUnauthorized, int(resp.Status()))

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -33,6 +33,8 @@ type jsFrameBaseOpts struct {
 const sampleHTML = `<div><b>Test</b><ol><li><i>One</i></li></ol></div>`
 
 func TestPageEmulateMedia(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
@@ -130,6 +132,8 @@ func TestPageEvaluate(t *testing.T) {
 }
 
 func TestPageGoto(t *testing.T) {
+	t.Parallel()
+
 	b := newTestBrowser(t, withFileServer())
 	p := b.NewPage(nil)
 
@@ -141,6 +145,8 @@ func TestPageGoto(t *testing.T) {
 }
 
 func TestPageGotoDataURI(t *testing.T) {
+	t.Parallel()
+
 	b := newTestBrowser(t)
 	p := b.NewPage(nil)
 
@@ -151,6 +157,8 @@ func TestPageGotoDataURI(t *testing.T) {
 }
 
 func TestPageGotoWaitUntilLoad(t *testing.T) {
+	t.Parallel()
+
 	b := newTestBrowser(t, withFileServer())
 	p := b.NewPage(nil)
 
@@ -174,6 +182,8 @@ func TestPageGotoWaitUntilLoad(t *testing.T) {
 }
 
 func TestPageGotoWaitUntilDOMContentLoaded(t *testing.T) {
+	t.Parallel()
+
 	b := newTestBrowser(t, withFileServer())
 	p := b.NewPage(nil)
 
@@ -293,6 +303,8 @@ func TestPageTextContent(t *testing.T) {
 }
 
 func TestPageInputValue(t *testing.T) {
+	t.Parallel()
+
 	p := newTestBrowser(t).NewPage(nil)
 
 	p.SetContent(`
@@ -313,6 +325,8 @@ func TestPageInputValue(t *testing.T) {
 
 // test for: https://github.com/grafana/xk6-browser/issues/132
 func TestPageInputSpecialCharacters(t *testing.T) {
+	t.Parallel()
+
 	p := newTestBrowser(t).NewPage(nil)
 
 	p.SetContent(`<input id="special">`, nil)
@@ -336,6 +350,10 @@ func TestPageInputSpecialCharacters(t *testing.T) {
 }
 
 func TestPageFill(t *testing.T) {
+	// these tests are not parallel by intention because
+	// they're testing the same page instance and they're
+	// faster when run sequentially.
+
 	p := newTestBrowser(t).NewPage(nil)
 	p.SetContent(`
 		<input id="text" type="text" value="something" />
@@ -368,6 +386,8 @@ func TestPageFill(t *testing.T) {
 }
 
 func TestPageIsChecked(t *testing.T) {
+	t.Parallel()
+
 	p := newTestBrowser(t).NewPage(nil)
 
 	p.SetContent(`<input type="checkbox" checked>`, nil)
@@ -378,6 +398,8 @@ func TestPageIsChecked(t *testing.T) {
 }
 
 func TestPageScreenshotFullpage(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
@@ -421,12 +443,16 @@ func TestPageScreenshotFullpage(t *testing.T) {
 }
 
 func TestPageTitle(t *testing.T) {
+	t.Parallel()
+
 	p := newTestBrowser(t).NewPage(nil)
 	p.SetContent(`<html><head><title>Some title</title></head></html>`, nil)
 	assert.Equal(t, "Some title", p.Title())
 }
 
 func TestPageSetExtraHTTPHeaders(t *testing.T) {
+	t.Parallel()
+
 	b := newTestBrowser(t, withHTTPServer())
 
 	p := b.NewPage(nil)
@@ -644,6 +670,8 @@ func TestPageWaitForLoadState(t *testing.T) {
 
 // See: The issue #187 for details.
 func TestPageWaitForNavigationErrOnCtxDone(t *testing.T) {
+	t.Parallel()
+
 	b := newTestBrowser(t)
 	p := b.NewPage(nil)
 	go b.cancelContext()
@@ -653,6 +681,8 @@ func TestPageWaitForNavigationErrOnCtxDone(t *testing.T) {
 }
 
 func TestPagePress(t *testing.T) {
+	t.Parallel()
+
 	tb := newTestBrowser(t)
 
 	p := tb.NewPage(nil)
@@ -667,6 +697,8 @@ func TestPagePress(t *testing.T) {
 }
 
 func TestPageURL(t *testing.T) {
+	t.Parallel()
+
 	b := newTestBrowser(t, withHTTPServer())
 
 	p := b.NewPage(nil)

--- a/tests/webvital_test.go
+++ b/tests/webvital_test.go
@@ -15,6 +15,8 @@ import (
 // are being emitted when navigating and interacting with
 // a web page.
 func TestWebVitalMetric(t *testing.T) {
+	t.Parallel()
+
 	var (
 		samples  = make(chan k6metrics.SampleContainer)
 		browser  = newTestBrowser(t, withFileServer(), withSamples(samples))
@@ -74,6 +76,8 @@ func TestWebVitalMetric(t *testing.T) {
 }
 
 func TestWebVitalMetricNoInteraction(t *testing.T) {
+	t.Parallel()
+
 	var (
 		samples  = make(chan k6metrics.SampleContainer)
 		browser  = newTestBrowser(t, withFileServer(), withSamples(samples))


### PR DESCRIPTION
## What?

1. Makes unit and integration tests run in parallel.
2. Makes some CI optimizations, considering that this is an optimization PR. Let me know if that part deserves another PR.

## Why?

1. The current tests take about 1 minute to run (locally), and there is no reason to run tests sequentially.
2. This also lets us detect race conditions much faster and prevent unintended deadlocks in code.
3. The E2E runner is hard to debug when running without the `-q` flag. With the flag, the result looks clearer to read and debug without the k6 banner and progress bar.

Here are the results after this change (On a 10-core machine):

```
Before: ~48s
After : ~24s

===Before===
ok      github.com/grafana/xk6-browser/browser  1.853s
ok      github.com/grafana/xk6-browser/common   1.669s
ok      github.com/grafana/xk6-browser/chromium 1.511s
ok      github.com/grafana/xk6-browser/tests    46.902s

===After===
ok      github.com/grafana/xk6-browser/browser  0.956s
ok      github.com/grafana/xk6-browser/common   0.689s
ok      github.com/grafana/xk6-browser/chromium 0.251s
ok      github.com/grafana/xk6-browser/tests    23.150s
```

On CI, it's the same because our runner runs on a 2-core. We can make this much faster if/when we run it on a more powerful runner. 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates #1018
