### PR TITLE
Fix WebVitals no interaction test

### DIFF
--- a/tests/webvital_test.go
+++ b/tests/webvital_test.go
@@ -112,7 +112,13 @@ func TestWebVitalMetricNoInteraction(t *testing.T) {
 	}()
 
 	page := browser.NewPage(nil)
-	resp, err := page.Goto(browser.staticURL("/web_vitals.html"), nil)
+	resp, err := page.Goto(
+		browser.staticURL("web_vitals.html"),
+		browser.toGojaValue(map[string]any{
+			// wait until the page is completely loaded.
+			"waitUntil": "networkidle",
+		}),
+	)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 


### PR DESCRIPTION
## What?

Fixes the flaky test by waiting until the page that it goes to completely loads.

## Why?

The test sometimes can't receive the WebVital metric emissions. This became evident thanks to #1018.

Failure example:
```go
--- FAIL: TestWebVitalMetricNoInteraction (0.83s)
    webvital_test.go:124: 
                Error Trace:    /Users/inanc/grafana/k6browser/main/tests/webvital_test.go:124
                Error:          Should be true
                Test:           TestWebVitalMetricNoInteraction
                Messages:       expected browser_web_vital_cls to have been measured and emitted
```

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas