### PR TITLE
Fix the check on examples/fillform.js

### DIFF
--- a/examples/fillform.js
+++ b/examples/fillform.js
@@ -39,7 +39,7 @@ export default async function() {
       page.locator('input[type="submit"]').click(),
     ]);
     check(page, {
-      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
     });
 
     // Check whether we receive cookies from the logged site.

--- a/examples/fillform.js
+++ b/examples/fillform.js
@@ -39,7 +39,7 @@ export default async function() {
       page.locator('input[type="submit"]').click(),
     ]);
     check(page, {
-      'header': page.locator('h2').textContent() == 'Welcome, admin!',
+      'header': page => page.locator('h2').textContent() == 'Welcome, admin!',
     });
 
     // Check whether we receive cookies from the logged site.


### PR DESCRIPTION
## What?

This change will fix the `check` in the [example/fillform.js](https://github.com/grafana/xk6-browser/blob/main/examples/fillform.js) test.

## Why?

`check` actually expects a function that returns a `boolean`, as is [documented](https://k6.io/docs/javascript-api/k6/check/). Although the `check` accepts the object as we've been using it, it's not correct. When users work with this example and the type definitions for k6, they will see a red line under the `'header'` in `check`, which will cause confusion and annoyance as to why our own examples have errors.

<img width="555" alt="Screenshot 2023-08-31 at 14 48 04" src="https://github.com/grafana/xk6-browser/assets/1112428/fb5970b2-7b32-4267-bfcd-51b4b6f400c4">

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas