### PR TITLE
Refine PR and Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: xk6-browser Community Forum
-    url: https://community.k6.io/c/xk6-browser/14
+    url: https://community.grafana.com/c/grafana-k6/k6-browser/79
     about: Please ask and answer questions here.
   - name: xk6-browser Documentation
     url: https://github.com/grafana/k6-docs

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
-  - name: xk6-browser Community Forum
+  - name: Community Forum
     url: https://community.grafana.com/c/grafana-k6/k6-browser/79
     about: Please ask and answer questions here.
-  - name: xk6-browser Documentation
+  - name: Documentation
     url: https://github.com/grafana/k6-docs
     about: Please add any documentation related issues here.
-  - name: xk6-browser Migration Guide
+  - name: Migration Guide
     url: https://k6.io/docs/using-k6-browser/migrating-to-k6-v0-46/
     about: Please review the guide if you're migrating to k6 v0.46+ from an older version of xk6-browser.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: xk6-browser Documentation
     url: https://github.com/grafana/k6-docs
     about: Please add any documentation related issues here.
+  - name: xk6-browser Migration Guide
+    url: https://k6.io/docs/using-k6-browser/migrating-to-k6-v0-46/
+    about: Please review the guide if you're migrating to k6 v0.46+ from an older version of xk6-browser.

--- a/.github/ISSUE_TEMPLATE/team_issues.yaml
+++ b/.github/ISSUE_TEMPLATE/team_issues.yaml
@@ -1,0 +1,43 @@
+name: Team issue template
+description: This template is reserved for team members.
+title: "Keep the title concise. Use the common language we can use to identify the issue."
+body:
+  - type: textarea
+    attributes:
+      label: What?
+      description: A concise (or detailed) description of this issue's goal.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Why?
+      description: A concise (or detailed) explanation of why we need this issue.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Suggestion
+      description: Do you have a suggestion to close the issue?
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Tasks
+      description: Feel free to remove the tasklist items that are not relevant for this issue.
+      value: |
+        ```[tasklist]
+        ### Tasks
+        - [ ] Subissue
+        - [ ] PR
+        - [ ] Docs PR
+        - [ ] TypeScript Definitions PR
+        - [ ] Update the k6 release notes
+        ```
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Related PR(s)/Issue(s)
+      description: Related issues, PRs, external reference links, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/team_issues.yaml
+++ b/.github/ISSUE_TEMPLATE/team_issues.yaml
@@ -16,8 +16,8 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: Suggestion
-      description: Do you have a suggestion to close the issue?
+      label: How?
+      description: Do you have any suggestions/solutions on how to solve the issue?
     validations:
       required: false
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,14 +17,6 @@ and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
 - [ ] I have added tests for my changes
 - [ ] I have commented on my code, particularly in hard-to-understand areas
 
-<!--
-If relevant:
-- [ ] I have updated the k6 release notes: PR link
-- [ ] I have updated the k6 documentation: PR link
-- [ ] I have updated [k6 browser get started](https://k6.io/blog/get-started-with-k6-browser/) blog: PR link
-- [ ] Generated and updated the [TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/k6/experimental/browser)
--->
-
 ## Related PR(s)/Issue(s)
 
 <!-- Does it close an issue? -->


### PR DESCRIPTION
## What?

1. Refines the PR template.
2. Add an issue template for the internal team.
3. Updates the community forum link.
4. Adds the migration guide link to the new issue page.

I can't preview these templates, so IDK how they will look when rendered. **Update:** I found a suboptimal way. Go to the issue template file on the Github UI.

## Why?

To provide better workflow both for internal and external contributors.