### PR TITLE
Fix the expiration bug while adding cookies

### DIFF
--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -464,13 +464,19 @@ func (b *BrowserContext) AddCookies(cookies []*api.Cookie) error {
 			const msg = "if cookie URL is not provided, both domain and path must be specified: %#v"
 			return fmt.Errorf(msg, c)
 		}
+		// calculate the cookie expiration date, session cookie if not set.
+		var ts *cdp.TimeSinceEpoch
+		if c.Expires > 0 {
+			t := cdp.TimeSinceEpoch(time.Unix(c.Expires, 0))
+			ts = &t
+		}
 		cookiesToSet = append(cookiesToSet, &network.CookieParam{
 			Name:     c.Name,
 			Value:    c.Value,
 			Domain:   c.Domain,
 			Path:     c.Path,
 			URL:      c.URL,
-			Expires:  nil, // TODO: fix this
+			Expires:  ts,
 			HTTPOnly: c.HTTPOnly,
 			Secure:   c.Secure,
 			SameSite: network.CookieSameSite(c.SameSite),

--- a/examples/cookies.js
+++ b/examples/cookies.js
@@ -29,12 +29,37 @@ export default async function () {
 
     // add some cookies to the browser context
     const unixTimeSinceEpoch = Math.round(new Date() / 1000);
-    const dayAfter = unixTimeSinceEpoch+60*60*24;
-    const dayBefore = unixTimeSinceEpoch-60*60*24;
-    context.addCookies([{name: 'testcookie', value: '1', sameSite: 'Strict', domain: '127.0.0.1', path: '/'}]);
-    context.addCookies([{name: 'testcookie2', value: '2', sameSite: 'Lax', domain: '127.0.0.1', path: '/', expires: dayAfter}]);
-    // won't set this cookie because it's expired
-    context.addCookies([{name: 'testcookie3', value: '3', sameSite: 'Lax', domain: '127.0.0.1', path: '/', expires: dayBefore}]);
+    const day = 60*60*24;
+    const dayAfter = unixTimeSinceEpoch+day;
+    const dayBefore = unixTimeSinceEpoch-day;
+    context.addCookies([
+      // this cookie expires at the end of the session
+      {
+        name: 'testcookie',
+        value: '1',
+        sameSite: 'Strict',
+        domain: '127.0.0.1',
+        path: '/',
+      },
+      // this cookie expires in a day
+      {
+        name: 'testcookie2', 
+        value: '2', 
+        sameSite: 'Lax', 
+        domain: '127.0.0.1', 
+        path: '/', 
+        expires: dayAfter,
+      },
+      // this cookie expires in the past, so it will be removed.
+      {
+        name: 'testcookie3',
+        value: '3',
+        sameSite: 'Lax',
+        domain: '127.0.0.1',
+        path: '/',
+        expires: dayBefore
+      }
+    ]);
 
     check(context.cookies().length, {
       'number of cookies should be 2': n => n === 2,

--- a/examples/cookies.js
+++ b/examples/cookies.js
@@ -28,8 +28,13 @@ export default async function () {
     });
 
     // add some cookies to the browser context
+    const unixTimeSinceEpoch = Math.round(new Date() / 1000);
+    const dayAfter = unixTimeSinceEpoch+60*60*24;
+    const dayBefore = unixTimeSinceEpoch-60*60*24;
     context.addCookies([{name: 'testcookie', value: '1', sameSite: 'Strict', domain: '127.0.0.1', path: '/'}]);
-    context.addCookies([{name: 'testcookie2', value: '2', sameSite: 'Lax', domain: '127.0.0.1', path: '/'}]);
+    context.addCookies([{name: 'testcookie2', value: '2', sameSite: 'Lax', domain: '127.0.0.1', path: '/', expires: dayAfter}]);
+    // won't set this cookie because it's expired
+    context.addCookies([{name: 'testcookie3', value: '3', sameSite: 'Lax', domain: '127.0.0.1', path: '/', expires: dayBefore}]);
 
     check(context.cookies().length, {
       'number of cookies should be 2': n => n === 2,


### PR DESCRIPTION
## What?

1. Fixes the expiration bug while adding cookies.
2. Add an expiring cookie example.
3. Fixes a bug in the test.

## Why?

Users won't set cookies with an expiration date. Now they can.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Closes #1025