### PR TITLE
Fix propagation of page timeout

### DIFF
--- a/common/page.go
+++ b/common/page.go
@@ -138,7 +138,7 @@ func NewPage(
 	}
 
 	var err error
-	p.frameManager = NewFrameManager(ctx, s, &p, bctx.timeoutSettings, p.logger)
+	p.frameManager = NewFrameManager(ctx, s, &p, p.timeoutSettings, p.logger)
 	p.mainFrameSession, err = NewFrameSession(ctx, s, &p, nil, tid, p.logger)
 	if err != nil {
 		p.logger.Debugf("Page:NewPage:NewFrameSession:return", "sid:%v tid:%v err:%v",

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -605,4 +606,59 @@ func TestK6Object(t *testing.T) {
 	k6ObjGoja := b.toGojaValue(k6Obj)
 
 	assert.False(t, k6ObjGoja.Equals(goja.Null()))
+}
+
+func TestBrowserContextTimeout(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                     string
+		defaultTimeout           time.Duration
+		defaultNavigationTimeout time.Duration
+	}{
+		{
+			name:           "fail when timeout exceeds default timeout",
+			defaultTimeout: 1 * time.Millisecond,
+		},
+		{
+			name:                     "fail when timeout exceeds default navigation timeout",
+			defaultNavigationTimeout: 1 * time.Millisecond,
+		},
+		{
+			name:                     "default navigation timeout supersedes default timeout",
+			defaultTimeout:           30 * time.Second,
+			defaultNavigationTimeout: 1 * time.Millisecond,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tb := newTestBrowser(t, withHTTPServer())
+
+			tb.withHandler("/slow", func(w http.ResponseWriter, _ *http.Request) {
+				time.Sleep(1000 * time.Millisecond)
+				fmt.Fprintf(w, `sorry for being so slow`)
+			})
+
+			bc, err := tb.NewContext(nil)
+			require.NoError(t, err)
+
+			if tc.defaultTimeout != 0 {
+				bc.SetDefaultTimeout(tc.defaultTimeout.Milliseconds())
+			}
+			if tc.defaultNavigationTimeout != 0 {
+				bc.SetDefaultNavigationTimeout(tc.defaultNavigationTimeout.Milliseconds())
+			}
+
+			p, err := bc.NewPage()
+			require.NoError(t, err)
+
+			res, err := p.Goto(tb.url("/slow"), nil)
+			require.Nil(t, res)
+			assert.ErrorContains(t, err, "timed out after")
+		})
+	}
 }


### PR DESCRIPTION
## What?

When working with the following APIs, the timeout was being set, but it wasn't then being propagated to the underlying `frameManager` and `frame`s which meant that APIs the relied on the timeout were always working with the default 30 second timeout or the timeout set in the `browserContext`.

```js
page.setDefaultTimeout()
page.setDefaultNavigationTimeout()
```

## Why?

We want to be able to set the timeouts on the `page` and affect it's APIs, while also having a different timeout on its `browserContext`. This is the behaviour that we want, and at the moment the setting of timeouts through the `page` object does nothing.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [X] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Closes: https://github.com/grafana/xk6-browser/issues/940