### PR TITLE
Fix reload & setContent to use navigation timeout

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -1429,7 +1429,7 @@ func (f *Frame) SetContent(html string, opts goja.Value) {
 	f.log.Debugf("Frame:SetContent", "fid:%s furl:%q", f.ID(), f.URL())
 
 	parsedOpts := NewFrameSetContentOptions(
-		time.Duration(f.manager.timeoutSettings.navigationTimeout()) * time.Second,
+		f.manager.timeoutSettings.navigationTimeout(),
 	)
 	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
 		k6ext.Panic(f.ctx, "parsing set content options: %w", err)

--- a/common/frame.go
+++ b/common/frame.go
@@ -1428,7 +1428,9 @@ func (f *Frame) selectOption(selector string, values goja.Value, opts *FrameSele
 func (f *Frame) SetContent(html string, opts goja.Value) {
 	f.log.Debugf("Frame:SetContent", "fid:%s furl:%q", f.ID(), f.URL())
 
-	parsedOpts := NewFrameSetContentOptions(f.defaultTimeout())
+	parsedOpts := NewFrameSetContentOptions(
+		time.Duration(f.manager.timeoutSettings.navigationTimeout()) * time.Second,
+	)
 	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
 		k6ext.Panic(f.ctx, "parsing set content options: %w", err)
 	}

--- a/common/page.go
+++ b/common/page.go
@@ -862,7 +862,7 @@ func (p *Page) Reload(opts goja.Value) api.Response {
 
 	parsedOpts := NewPageReloadOptions(
 		LifecycleEventLoad,
-		time.Duration(p.timeoutSettings.navigationTimeout())*time.Second,
+		p.timeoutSettings.navigationTimeout(),
 	)
 	if err := parsedOpts.Parse(p.ctx, opts); err != nil {
 		k6ext.Panic(p.ctx, "parsing reload options: %w", err)

--- a/common/page.go
+++ b/common/page.go
@@ -860,7 +860,10 @@ func (p *Page) QueryAll(selector string) ([]api.ElementHandle, error) {
 func (p *Page) Reload(opts goja.Value) api.Response {
 	p.logger.Debugf("Page:Reload", "sid:%v", p.sessionID())
 
-	parsedOpts := NewPageReloadOptions(LifecycleEventLoad, p.defaultTimeout())
+	parsedOpts := NewPageReloadOptions(
+		LifecycleEventLoad,
+		time.Duration(p.timeoutSettings.navigationTimeout())*time.Second,
+	)
 	if err := parsedOpts.Parse(p.ctx, opts); err != nil {
 		k6ext.Panic(p.ctx, "parsing reload options: %w", err)
 	}


### PR DESCRIPTION
## What?

The following page APIs were not using the correct timeout:

```js
page.reload()
page.setContent()
```

## Why?

These methods should work with the default navigation instead of the default timeout to match the behaviour in [Playwright](https://playwright.dev/docs/api/class-page#page-set-default-navigation-timeout).

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
