### PR TITLE
Cookies: Fix Goja conversions

### DIFF
--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -41,16 +41,16 @@ type BrowserContext interface {
 //
 // https://datatracker.ietf.org/doc/html/rfc6265.
 type Cookie struct {
-	Name     string         `json:"name"`                   // Cookie name.
-	Value    string         `json:"value"`                  // Cookie value.
-	Domain   string         `json:"domain"`                 // Cookie domain.
-	Path     string         `json:"path"`                   // Cookie path.
+	Name     string         `js:"name" json:"name"`         // Cookie name.
+	Value    string         `js:"value" json:"value"`       // Cookie value.
+	Domain   string         `js:"domain" json:"domain"`     // Cookie domain.
+	Path     string         `js:"path" json:"path"`         // Cookie path.
 	HTTPOnly bool           `js:"httpOnly" json:"httpOnly"` // True if cookie is http-only.
-	Secure   bool           `json:"secure"`                 // True if cookie is secure.
+	Secure   bool           `js:"secure" json:"secure"`     // True if cookie is secure.
 	SameSite CookieSameSite `js:"sameSite" json:"sameSite"` // Cookie SameSite type.
 	URL      string         `js:"url" json:"url,omitempty"` // Cookie URL.
 	// Cookie expiration date as the number of seconds since the UNIX epoch.
-	Expires int64 `json:"expires"`
+	Expires int64 `js:"expires" json:"expires"`
 }
 
 // CookieSameSite represents the cookie's 'SameSite' status.

--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -41,15 +41,16 @@ type BrowserContext interface {
 //
 // https://datatracker.ietf.org/doc/html/rfc6265.
 type Cookie struct {
-	Name     string         `json:"name"`          // Cookie name.
-	Value    string         `json:"value"`         // Cookie value.
-	Domain   string         `json:"domain"`        // Cookie domain.
-	Path     string         `json:"path"`          // Cookie path.
-	Expires  int64          `json:"expires"`       // Cookie expiration date as the number of seconds since the UNIX epoch.
-	HTTPOnly bool           `json:"httpOnly"`      // True if cookie is http-only.
-	Secure   bool           `json:"secure"`        // True if cookie is secure.
-	SameSite CookieSameSite `json:"sameSite"`      // Cookie SameSite type.
-	URL      string         `json:"url,omitempty"` // Cookie URL.
+	Name     string         `json:"name"`                   // Cookie name.
+	Value    string         `json:"value"`                  // Cookie value.
+	Domain   string         `json:"domain"`                 // Cookie domain.
+	Path     string         `json:"path"`                   // Cookie path.
+	HTTPOnly bool           `js:"httpOnly" json:"httpOnly"` // True if cookie is http-only.
+	Secure   bool           `json:"secure"`                 // True if cookie is secure.
+	SameSite CookieSameSite `js:"sameSite" json:"sameSite"` // Cookie SameSite type.
+	URL      string         `js:"url" json:"url,omitempty"` // Cookie URL.
+	// Cookie expiration date as the number of seconds since the UNIX epoch.
+	Expires int64 `json:"expires"`
 }
 
 // CookieSameSite represents the cookie's 'SameSite' status.

--- a/examples/cookies.js
+++ b/examples/cookies.js
@@ -40,6 +40,8 @@ export default async function () {
         sameSite: 'Strict',
         domain: '127.0.0.1',
         path: '/',
+        httpOnly: true,
+        secure: true,
       },
       // this cookie expires in a day
       {
@@ -67,6 +69,12 @@ export default async function () {
     check(cookies[0], {
       'cookie 1 name should be testcookie': c => c.name === 'testcookie',
       'cookie 1 value should be 1': c => c.value === '1',
+      'cookie 1 should be session cookie': c => c.expires === -1,
+      'cookie 1 should have domain': c => c.domain === '127.0.0.1',
+      'cookie 1 should have path': c => c.path === '/',
+      'cookie 1 should have sameSite': c => c.sameSite == 'Strict',
+      'cookie 1 should be httpOnly': c => c.httpOnly === true,
+      'cookie 1 should be secure': c => c.secure === true,
     });
     check(cookies[1], {
       'cookie 2 name should be testcookie2': c => c.name === 'testcookie2',
@@ -94,7 +102,6 @@ export default async function () {
         url: 'https://baz.com'
       }
     ]);
-
     cookies = context.cookies('http://foo.com', 'https://baz.com');
     check(cookies.length, {
       'number of filtered cookies should be 2': n => n === 2,


### PR DESCRIPTION
## What?

Adds `js` struct tags to `api.Cookie` to allow Goja to convert `api.Cookie` values.

## Why?

Goja cannot convert `httpOnly` and `sameSite` fields while sending and retrieving cookies from the JavaScript side.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates: #6