### PR TITLE
Fix context.clearCookies

### DIFF
--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -502,7 +502,7 @@ func (b *BrowserContext) ClearCookies() error {
 	clearCookies := storage.
 		ClearCookies().
 		WithBrowserContextID(b.id)
-	if err := clearCookies.Do(b.ctx); err != nil {
+	if err := clearCookies.Do(cdp.WithExecutor(b.ctx, b.browser.conn)); err != nil {
 		return fmt.Errorf("clearing cookies: %w", err)
 	}
 	return nil

--- a/examples/cookies.js
+++ b/examples/cookies.js
@@ -114,6 +114,13 @@ export default async function () {
       'the second filtered cookie name should be baz': c => c.name === 'baz',
       'the second filtered cookie value should be 44': c => c.value === '44',
     });
+
+    // clear cookies
+    context.clearCookies();
+    cookies = context.cookies();
+    check(cookies.length, {
+      'number of cookies should be zero': n => n === 0,
+    });
   } finally {
     page.close();
   }

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -591,6 +591,32 @@ func TestBrowserContextCookies(t *testing.T) {
 	}
 }
 
+func TestBrowserContextClearCookies(t *testing.T) {
+	t.Parallel()
+
+	// add a cookie and clear it out
+
+	tb := newTestBrowser(t, withHTTPServer())
+	p := tb.NewPage(nil)
+	bctx := p.Context()
+
+	err := bctx.AddCookies(
+		[]*api.Cookie{
+			{
+				Name:  "test_cookie_name",
+				Value: "test_cookie_value",
+				URL:   "http://test.go",
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, bctx.ClearCookies())
+
+	cookies, err := bctx.Cookies()
+	require.NoError(t, err)
+	require.Emptyf(t, cookies, "want no cookies, but got: %#v", cookies)
+}
+
 func TestK6Object(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What?

Fixes the _"unable to clear cookies permissions: invalid context"_ error. This error occurs when `browserContext.clearCookies` is called. See #442 for details.

## Why?

The `clearCookies` method wasn't using the actual CDP connection.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Closes #442
