### PR TITLE
Update browser_web_vital_fcp max threshold

### DIFF
--- a/examples/multiple-scenario.js
+++ b/examples/multiple-scenario.js
@@ -27,7 +27,7 @@ export const options = {
     },
   },
   thresholds: {
-    browser_web_vital_fcp: ['max < 1000'],
+    browser_web_vital_fcp: ['max < 5000'],
     checks: ["rate==1.0"]
   }
 }


### PR DESCRIPTION
## What?

Increasing the max threshold from 1s to 5s for the `browser_web_vital_fcp` metric in the `multiple-scenario.js` example test script.

## Why?

We're seeing errors in the CI due to the test website being a bit slow since it's continuously being load tested. It feels like it's better to increase the threshold to account for a slow test site due to other load tests being performed against it.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
