### PR TITLE
Refactor options to const

### DIFF
--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -34,7 +34,7 @@ type BrowserContext interface {
 	SetOffline(offline bool)
 	StorageState(opts goja.Value)
 	Unroute(url goja.Value, handler goja.Callable)
-	WaitForEvent(event string, optsOrPredicate goja.Value) any
+	WaitForEvent(event string, optsOrPredicate goja.Value) (any, error)
 }
 
 // Cookie represents a browser cookie.

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -366,7 +366,7 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 
 func (b *BrowserContext) waitForEvent(event waitForEventType, predicateFn goja.Callable, timeout time.Duration) (any, error) {
 	if event != waitForEventTypePage {
-		return nil, fmt.Errorf("%q is the only event that is supported, you passed in %q", waitForEventTypePage, event)
+		return nil, fmt.Errorf("incorrect event %q, %q is the only event supported", event, waitForEventTypePage)
 	}
 
 	evCancelCtx, evCancelFn := context.WithCancel(b.ctx)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -345,7 +345,7 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 	b.logger.Debugf("BrowserContext:WaitForEvent", "bctxid:%v event:%q", b.id, event)
 
 	parsedOpts := NewWaitForEventOptions(
-		b.browser.browserOpts.Timeout * time.Second,
+		b.timeoutSettings.timeout(),
 	)
 	if err := parsedOpts.Parse(b.ctx, optsOrPredicate); err != nil {
 		k6ext.Panic(b.ctx, "parsing waitForEvent options: %w", err)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -342,7 +342,6 @@ func (b *BrowserContext) Unroute(url goja.Value, handler goja.Callable) {
 
 // WaitForEvent waits for event.
 func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) (any, error) {
-	// TODO: This public API needs Promise support (as return value) to be useful in JS!
 	b.logger.Debugf("BrowserContext:WaitForEvent", "bctxid:%v event:%q", b.id, event)
 
 	parsedOpts := NewWaitForEventOptions(

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -364,7 +364,11 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 	return b.waitForEvent(waitForEventType(event), parsedOpts.PredicateFn, parsedOpts.Timeout)
 }
 
-func (b *BrowserContext) waitForEvent(event waitForEventType, predicateFn goja.Callable, timeout time.Duration) (any, error) {
+func (b *BrowserContext) waitForEvent(
+	event waitForEventType,
+	predicateFn goja.Callable,
+	timeout time.Duration,
+) (any, error) {
 	if event != waitForEventTypePage {
 		return nil, fmt.Errorf("incorrect event %q, %q is the only event supported", event, waitForEventTypePage)
 	}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -418,19 +418,22 @@ func (b *BrowserContext) runWaitForEventHandler(
 				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextClose:return", "bctxid:%v", b.id)
 				return
 			}
-			if ev.typ == EventBrowserContextPage {
-				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage", "bctxid:%v", b.id)
-				p, _ = ev.data.(*Page)
 
-				if predicateFn == nil {
-					b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:return", "bctxid:%v", b.id)
-					return
-				}
+			if ev.typ != EventBrowserContextPage {
+				continue
+			}
 
-				if retVal, err := predicateFn(b.vu.Runtime().ToValue(p)); err == nil && retVal.ToBoolean() {
-					b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:predicateFn:return", "bctxid:%v", b.id)
-					return
-				}
+			b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage", "bctxid:%v", b.id)
+			p, _ = ev.data.(*Page)
+
+			if predicateFn == nil {
+				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:return", "bctxid:%v", b.id)
+				return
+			}
+
+			if retVal, err := predicateFn(b.vu.Runtime().ToValue(p)); err == nil && retVal.ToBoolean() {
+				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:predicateFn:return", "bctxid:%v", b.id)
+				return
 			}
 		}
 	}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -375,16 +376,14 @@ func (b *BrowserContext) waitForEvent(event string, predicateFn goja.Callable, t
 
 	select {
 	case <-b.ctx.Done():
-		b.logger.Debugf("BrowserContext:WaitForEvent:ctx.Done", "bctxid:%v event:%q", b.id, event)
+		return nil, errors.New("test iteration ended")
 	case <-time.After(timeout):
 		b.logger.Debugf("BrowserContext:WaitForEvent:timeout", "bctxid:%v event:%q", b.id, event)
+		return nil, fmt.Errorf("waitForEvent timed out after %v", timeout)
 	case evData := <-ch:
 		b.logger.Debugf("BrowserContext:WaitForEvent:evData", "bctxid:%v event:%q", b.id, event)
 		return evData, nil
 	}
-	b.logger.Debugf("BrowserContext:WaitForEvent:return nil", "bctxid:%v event:%q", b.id, event)
-
-	return nil, nil
 }
 
 func (b *BrowserContext) runWaitForEventHandler(

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -436,7 +436,10 @@ func (b *BrowserContext) runWaitForEventHandler(
 			}
 
 			if retVal, err := predicateFn(b.vu.Runtime().ToValue(p)); err == nil && retVal.ToBoolean() {
-				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:predicateFn:return", "bctxid:%v", b.id)
+				b.logger.Debugf(
+					"BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:predicateFn:return",
+					"bctxid:%v", b.id,
+				)
 				return
 			}
 		}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -31,6 +31,16 @@ var (
 	_ api.BrowserContext = &BrowserContext{}
 )
 
+// waitForEventType represents the event types that can be used when working
+// with the browserContext.waitForEvent API.
+type waitForEventType string
+
+const (
+	// waitForEventTypePage represents the page event which fires when a new
+	// page is created.
+	waitForEventTypePage = "page"
+)
+
 // BrowserContext stores context information for a single independent browser session.
 // A newly launched browser instance contains a default browser context.
 // Any browser context created aside from the default will be considered an "incognito"
@@ -351,12 +361,12 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 		return nil, fmt.Errorf("parsing waitForEvent options: %w", err)
 	}
 
-	return b.waitForEvent(event, parsedOpts.PredicateFn, parsedOpts.Timeout)
+	return b.waitForEvent(waitForEventType(event), parsedOpts.PredicateFn, parsedOpts.Timeout)
 }
 
-func (b *BrowserContext) waitForEvent(event string, predicateFn goja.Callable, timeout time.Duration) (any, error) {
-	if event != "page" {
-		return nil, fmt.Errorf("\"page\" is the only event that is supported, you passed in %q", event)
+func (b *BrowserContext) waitForEvent(event waitForEventType, predicateFn goja.Callable, timeout time.Duration) (any, error) {
+	if event != waitForEventTypePage {
+		return nil, fmt.Errorf("%q is the only event that is supported, you passed in %q", waitForEventTypePage, event)
 	}
 
 	evCancelCtx, evCancelFn := context.WithCancel(b.ctx)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -394,8 +394,8 @@ func (b *BrowserContext) waitForEvent(
 	}
 }
 
-// runWaitForEventHandler can work with a nil predicateFn.
-// If predicateFn is nil, it will return the response straight away.
+// runWaitForEventHandler can work with a nil predicateFn. If predicateFn is
+// nil it will return the response straight away.
 func (b *BrowserContext) runWaitForEventHandler(
 	ctx context.Context, evCancelFn func(), chEvHandler chan Event, out chan any, predicateFn goja.Callable,
 ) {
@@ -407,8 +407,8 @@ func (b *BrowserContext) runWaitForEventHandler(
 		out <- p
 		close(out)
 
-		// We wait for one matching event only,
-		// then remove event handler by cancelling context and stopping goroutine.
+		// We wait for one matching event only, then remove event handler by
+		// cancelling context and stopping goroutine.
 		evCancelFn()
 	}()
 

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -395,8 +395,8 @@ func (b *BrowserContext) waitForEvent(event waitForEventType, predicateFn goja.C
 func (b *BrowserContext) runWaitForEventHandler(
 	ctx context.Context, evCancelFn func(), chEvHandler chan Event, out chan any, predicateFn goja.Callable,
 ) {
-	b.logger.Debugf("BrowserContext:WaitForEvent:go():starts", "bctxid:%v", b.id)
-	defer b.logger.Debugf("BrowserContext:WaitForEvent:go():returns", "bctxid:%v", b.id)
+	b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():starts", "bctxid:%v", b.id)
+	defer b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():returns", "bctxid:%v", b.id)
 
 	var p *Page
 	defer func() {
@@ -411,24 +411,24 @@ func (b *BrowserContext) runWaitForEventHandler(
 	for {
 		select {
 		case <-ctx.Done():
-			b.logger.Debugf("BrowserContext:WaitForEvent:go():ctx:done", "bctxid:%v", b.id)
+			b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():ctx:done", "bctxid:%v", b.id)
 			return
 		case ev := <-chEvHandler:
 			if ev.typ == EventBrowserContextClose {
-				b.logger.Debugf("BrowserContext:WaitForEvent:go():EventBrowserContextClose:return", "bctxid:%v", b.id)
+				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextClose:return", "bctxid:%v", b.id)
 				return
 			}
 			if ev.typ == EventBrowserContextPage {
-				b.logger.Debugf("BrowserContext:WaitForEvent:go():EventBrowserContextPage", "bctxid:%v", b.id)
+				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage", "bctxid:%v", b.id)
 				p, _ = ev.data.(*Page)
 
 				if predicateFn == nil {
-					b.logger.Debugf("BrowserContext:WaitForEvent:go():EventBrowserContextPage:return", "bctxid:%v", b.id)
+					b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:return", "bctxid:%v", b.id)
 					return
 				}
 
 				if retVal, err := predicateFn(b.vu.Runtime().ToValue(p)); err == nil && retVal.ToBoolean() {
-					b.logger.Debugf("BrowserContext:WaitForEvent:go():EventBrowserContextPage:predicateFn:return", "bctxid:%v", b.id)
+					b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:predicateFn:return", "bctxid:%v", b.id)
 					return
 				}
 			}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -341,7 +341,7 @@ func (b *BrowserContext) Unroute(url goja.Value, handler goja.Callable) {
 }
 
 // WaitForEvent waits for event.
-func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) any {
+func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) (any, error) {
 	// TODO: This public API needs Promise support (as return value) to be useful in JS!
 	b.logger.Debugf("BrowserContext:WaitForEvent", "bctxid:%v event:%q", b.id, event)
 
@@ -349,15 +349,10 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 		b.timeoutSettings.timeout(),
 	)
 	if err := parsedOpts.Parse(b.ctx, optsOrPredicate); err != nil {
-		k6ext.Panic(b.ctx, "parsing waitForEvent options: %w", err)
+		return nil, fmt.Errorf("parsing waitForEvent options: %w", err)
 	}
 
-	resp, err := b.waitForEvent(event, parsedOpts.PredicateFn, parsedOpts.Timeout)
-	if err != nil {
-		k6ext.Panic(b.ctx, "waitForEvent failed: %w", err)
-	}
-
-	return resp
+	return b.waitForEvent(event, parsedOpts.PredicateFn, parsedOpts.Timeout)
 }
 
 func (b *BrowserContext) waitForEvent(event string, predicateFn goja.Callable, timeout time.Duration) (any, error) {

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -2,8 +2,8 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/grafana/xk6-browser/k6ext"
@@ -154,29 +154,25 @@ func NewWaitForEventOptions(defaultTimeout time.Duration) *WaitForEventOptions {
 // It can parse only a callable predicate function or an object
 // which contains a callable predicate function and a timeout.
 func (w *WaitForEventOptions) Parse(ctx context.Context, optsOrPredicate goja.Value) error {
-	var (
-		isCallable bool
-	)
+	var isCallable bool
 	if gojaValueExists(optsOrPredicate) {
-		switch optsOrPredicate.ExportType() {
-		case reflect.TypeOf(goja.Object{}):
-			rt := k6ext.Runtime(ctx)
-			opts := optsOrPredicate.ToObject(rt)
-			for _, k := range opts.Keys() {
-				switch k {
-				case "predicate":
-					w.PredicateFn, isCallable = goja.AssertFunction(opts.Get(k))
-					if !isCallable {
-						return fmt.Errorf("predicate function is not callable")
-					}
-				case "timeout":
-					w.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
+		rt := k6ext.Runtime(ctx)
+
+		w.PredicateFn, isCallable = goja.AssertFunction(optsOrPredicate)
+		if isCallable {
+			return nil
+		}
+
+		opts := optsOrPredicate.ToObject(rt)
+		for _, k := range opts.Keys() {
+			switch k {
+			case "predicate":
+				w.PredicateFn, isCallable = goja.AssertFunction(opts.Get(k))
+				if !isCallable {
+					return errors.New("predicate function is not callable")
 				}
-			}
-		default:
-			w.PredicateFn, isCallable = goja.AssertFunction(optsOrPredicate)
-			if !isCallable {
-				return fmt.Errorf("predicate function is not callable")
+			case "timeout": //nolint:goconst
+				w.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			}
 		}
 	}

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -175,7 +175,7 @@ func (w *WaitForEventOptions) Parse(ctx context.Context, optsOrPredicate goja.Va
 			if !isCallable {
 				return errors.New("predicate function is not callable")
 			}
-		case "timeout": //nolint:goconst
+		case OptionsTimeout:
 			w.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 		}
 	}

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -170,7 +170,7 @@ func (w *WaitForEventOptions) Parse(ctx context.Context, optsOrPredicate goja.Va
 	opts := optsOrPredicate.ToObject(rt)
 	for _, k := range opts.Keys() {
 		switch k {
-		case "predicate":
+		case OptionsPredicate:
 			w.PredicateFn, isCallable = goja.AssertFunction(opts.Get(k))
 			if !isCallable {
 				return errors.New("predicate function is not callable")

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -135,24 +135,23 @@ func (b *BrowserContextOptions) Parse(ctx context.Context, opts goja.Value) erro
 	return nil
 }
 
-// WaitForEventOptions are the options used by
-// the browserContext.waitForEvent API.
+// WaitForEventOptions are the options used by the browserContext.waitForEvent API.
 type WaitForEventOptions struct {
 	Timeout     time.Duration
 	PredicateFn goja.Callable
 }
 
-// NewWaitForEventOptions created a new instance of
-// WaitForEventOptions with a default timeout.
+// NewWaitForEventOptions created a new instance of WaitForEventOptions with a
+// default timeout.
 func NewWaitForEventOptions(defaultTimeout time.Duration) *WaitForEventOptions {
 	return &WaitForEventOptions{
 		Timeout: defaultTimeout,
 	}
 }
 
-// Parse will parse the options or a callable predicate function.
-// It can parse only a callable predicate function or an object
-// which contains a callable predicate function and a timeout.
+// Parse will parse the options or a callable predicate function. It can parse
+// only a callable predicate function or an object which contains a callable
+// predicate function and a timeout.
 func (w *WaitForEventOptions) Parse(ctx context.Context, optsOrPredicate goja.Value) error {
 	if !gojaValueExists(optsOrPredicate) {
 		return nil

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/grafana/xk6-browser/k6ext"
 
@@ -130,5 +131,27 @@ func (b *BrowserContextOptions) Parse(ctx context.Context, opts goja.Value) erro
 			}
 		}
 	}
+	return nil
+}
+
+// WaitForEventOptions are the options used by
+// the browserContext.waitForEvent API.
+type WaitForEventOptions struct {
+	Timeout     time.Duration
+	PredicateFn goja.Callable
+}
+
+// NewWaitForEventOptions created a new instance of
+// WaitForEventOptions with a default timeout.
+func NewWaitForEventOptions(defaultTimeout time.Duration) *WaitForEventOptions {
+	return &WaitForEventOptions{
+		Timeout: defaultTimeout,
+	}
+}
+
+// Parse will parse the options or a callable predicate function.
+// It can parse only a callable predicate function or an object
+// which contains a callable predicate function and a timeout.
+func (w *WaitForEventOptions) Parse(ctx context.Context, optsOrPredicate goja.Value) error {
 	return nil
 }

--- a/common/consts.go
+++ b/common/consts.go
@@ -23,4 +23,5 @@ const (
 	OptionsDelay          = "delay"
 	OptionsOmitBackground = "omitBackground"
 	OptionsType           = "type"
+	OptionsQuality        = "quality"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -29,4 +29,5 @@ const (
 	OptionsReferer        = "referer"
 	OptionsWaitUntil      = "waitUntil"
 	OptionsPolling        = "polling"
+	OptionsURL            = "url"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -22,4 +22,5 @@ const (
 	OptionsForce          = "force"
 	OptionsDelay          = "delay"
 	OptionsOmitBackground = "omitBackground"
+	OptionsType           = "type"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -20,4 +20,5 @@ const (
 	OptionsPredicate   = "predicate"
 	OptionsNoWaitAfter = "noWaitAfter"
 	OptionsForce       = "force"
+	OptionsDelay       = "delay"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -27,4 +27,5 @@ const (
 	OptionsPath           = "path"
 	OptionsStrict         = "strict"
 	OptionsReferer        = "referer"
+	OptionsWaitUntil      = "waitUntil"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -13,4 +13,8 @@ const (
 	// Life-cycle consts
 
 	LifeCycleNetworkIdleTimeout time.Duration = 500 * time.Millisecond
+
+	// Options consts.
+
+	OptionsTimeout = "timeout"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -25,4 +25,5 @@ const (
 	OptionsType           = "type"
 	OptionsQuality        = "quality"
 	OptionsPath           = "path"
+	OptionsStrict         = "strict"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -28,4 +28,5 @@ const (
 	OptionsStrict         = "strict"
 	OptionsReferer        = "referer"
 	OptionsWaitUntil      = "waitUntil"
+	OptionsPolling        = "polling"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -31,4 +31,5 @@ const (
 	OptionsPolling        = "polling"
 	OptionsURL            = "url"
 	OptionsButton         = "button"
+	OptionsClickCount     = "clickCount"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -19,4 +19,5 @@ const (
 	OptionsTimeout     = "timeout"
 	OptionsPredicate   = "predicate"
 	OptionsNoWaitAfter = "noWaitAfter"
+	OptionsForce       = "force"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -30,4 +30,5 @@ const (
 	OptionsWaitUntil      = "waitUntil"
 	OptionsPolling        = "polling"
 	OptionsURL            = "url"
+	OptionsButton         = "button"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -24,4 +24,5 @@ const (
 	OptionsOmitBackground = "omitBackground"
 	OptionsType           = "type"
 	OptionsQuality        = "quality"
+	OptionsPath           = "path"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -16,5 +16,6 @@ const (
 
 	// Options consts.
 
-	OptionsTimeout = "timeout"
+	OptionsTimeout   = "timeout"
+	OptionsPredicate = "predicate"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -16,6 +16,7 @@ const (
 
 	// Options consts.
 
-	OptionsTimeout   = "timeout"
-	OptionsPredicate = "predicate"
+	OptionsTimeout     = "timeout"
+	OptionsPredicate   = "predicate"
+	OptionsNoWaitAfter = "noWaitAfter"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -16,9 +16,10 @@ const (
 
 	// Options consts.
 
-	OptionsTimeout     = "timeout"
-	OptionsPredicate   = "predicate"
-	OptionsNoWaitAfter = "noWaitAfter"
-	OptionsForce       = "force"
-	OptionsDelay       = "delay"
+	OptionsTimeout        = "timeout"
+	OptionsPredicate      = "predicate"
+	OptionsNoWaitAfter    = "noWaitAfter"
+	OptionsForce          = "force"
+	OptionsDelay          = "delay"
+	OptionsOmitBackground = "omitBackground"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -32,4 +32,5 @@ const (
 	OptionsURL            = "url"
 	OptionsButton         = "button"
 	OptionsClickCount     = "clickCount"
+	OptionsModifiers      = "modifiers"
 )

--- a/common/consts.go
+++ b/common/consts.go
@@ -26,4 +26,5 @@ const (
 	OptionsQuality        = "quality"
 	OptionsPath           = "path"
 	OptionsStrict         = "strict"
+	OptionsReferer        = "referer"
 )

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -127,7 +127,7 @@ func (o *ElementHandleBaseOptions) Parse(ctx context.Context, opts goja.Value) e
 			o.Force = gopts.Get(k).ToBoolean()
 		case "noWaitAfter": //nolint:goconst
 			o.NoWaitAfter = gopts.Get(k).ToBoolean()
-		case "timeout":
+		case OptionsTimeout:
 			o.Timeout = time.Duration(gopts.Get(k).ToInteger()) * time.Millisecond
 		}
 	}
@@ -310,7 +310,7 @@ func (o *ElementHandlePressOptions) Parse(ctx context.Context, opts goja.Value) 
 				o.Delay = opts.Get(k).ToInteger()
 			case "noWaitAfter":
 				o.NoWaitAfter = opts.Get(k).ToBoolean()
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			}
 		}
@@ -354,7 +354,7 @@ func (o *ElementHandleScreenshotOptions) Parse(ctx context.Context, opts goja.Va
 					o.Format = f
 					formatSpecified = true
 				}
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			}
 		}
@@ -441,7 +441,7 @@ func (o *ElementHandleTypeOptions) Parse(ctx context.Context, opts goja.Value) e
 				o.Delay = opts.Get(k).ToInteger()
 			case "noWaitAfter":
 				o.NoWaitAfter = opts.Get(k).ToBoolean()
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			}
 		}
@@ -469,7 +469,7 @@ func (o *ElementHandleWaitForElementStateOptions) Parse(ctx context.Context, opt
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			}
 		}

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -347,7 +347,7 @@ func (o *ElementHandleScreenshotOptions) Parse(ctx context.Context, opts goja.Va
 				o.OmitBackground = opts.Get(k).ToBoolean()
 			case "path":
 				o.Path = opts.Get(k).String()
-			case "quality":
+			case OptionsQuality:
 				o.Quality = opts.Get(k).ToInteger()
 			case OptionsType:
 				if f, ok := imageFormatToID[opts.Get(k).String()]; ok {

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -125,7 +125,7 @@ func (o *ElementHandleBaseOptions) Parse(ctx context.Context, opts goja.Value) e
 		switch k {
 		case "force":
 			o.Force = gopts.Get(k).ToBoolean()
-		case "noWaitAfter": //nolint:goconst
+		case OptionsNoWaitAfter:
 			o.NoWaitAfter = gopts.Get(k).ToBoolean()
 		case OptionsTimeout:
 			o.Timeout = time.Duration(gopts.Get(k).ToInteger()) * time.Millisecond
@@ -308,7 +308,7 @@ func (o *ElementHandlePressOptions) Parse(ctx context.Context, opts goja.Value) 
 			switch k {
 			case "delay":
 				o.Delay = opts.Get(k).ToInteger()
-			case "noWaitAfter":
+			case OptionsNoWaitAfter:
 				o.NoWaitAfter = opts.Get(k).ToBoolean()
 			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
@@ -439,7 +439,7 @@ func (o *ElementHandleTypeOptions) Parse(ctx context.Context, opts goja.Value) e
 			switch k {
 			case "delay":
 				o.Delay = opts.Get(k).ToInteger()
-			case "noWaitAfter":
+			case OptionsNoWaitAfter:
 				o.NoWaitAfter = opts.Get(k).ToBoolean()
 			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -343,7 +343,7 @@ func (o *ElementHandleScreenshotOptions) Parse(ctx context.Context, opts goja.Va
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "omitBackground":
+			case OptionsOmitBackground:
 				o.OmitBackground = opts.Get(k).ToBoolean()
 			case "path":
 				o.Path = opts.Get(k).String()

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -387,7 +387,7 @@ func (o *ElementHandleSetCheckedOptions) Parse(ctx context.Context, opts goja.Va
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "strict":
+			case OptionsStrict:
 				o.Strict = opts.Get(k).ToBoolean()
 			}
 		}

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -196,7 +196,7 @@ func (o *ElementHandleClickOptions) Parse(ctx context.Context, opts goja.Value) 
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "button":
+			case OptionsButton:
 				o.Button = opts.Get(k).String()
 			case "clickCount":
 				o.ClickCount = opts.Get(k).ToInteger()
@@ -240,7 +240,7 @@ func (o *ElementHandleDblclickOptions) Parse(ctx context.Context, opts goja.Valu
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "button":
+			case OptionsButton:
 				o.Button = opts.Get(k).String()
 			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -345,7 +345,7 @@ func (o *ElementHandleScreenshotOptions) Parse(ctx context.Context, opts goja.Va
 			switch k {
 			case OptionsOmitBackground:
 				o.OmitBackground = opts.Get(k).ToBoolean()
-			case "path":
+			case OptionsPath:
 				o.Path = opts.Get(k).String()
 			case OptionsQuality:
 				o.Quality = opts.Get(k).ToInteger()

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -349,7 +349,7 @@ func (o *ElementHandleScreenshotOptions) Parse(ctx context.Context, opts goja.Va
 				o.Path = opts.Get(k).String()
 			case "quality":
 				o.Quality = opts.Get(k).ToInteger()
-			case "type":
+			case OptionsType:
 				if f, ok := imageFormatToID[opts.Get(k).String()]; ok {
 					o.Format = f
 					formatSpecified = true

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -123,7 +123,7 @@ func (o *ElementHandleBaseOptions) Parse(ctx context.Context, opts goja.Value) e
 	gopts := opts.ToObject(k6ext.Runtime(ctx))
 	for _, k := range gopts.Keys() {
 		switch k {
-		case "force":
+		case OptionsForce:
 			o.Force = gopts.Get(k).ToBoolean()
 		case OptionsNoWaitAfter:
 			o.NoWaitAfter = gopts.Get(k).ToBoolean()

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -202,7 +202,7 @@ func (o *ElementHandleClickOptions) Parse(ctx context.Context, opts goja.Value) 
 				o.ClickCount = opts.Get(k).ToInteger()
 			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()
-			case "modifiers":
+			case OptionsModifiers:
 				var m []string
 				if err := rt.ExportTo(opts.Get(k), &m); err != nil {
 					return err
@@ -244,7 +244,7 @@ func (o *ElementHandleDblclickOptions) Parse(ctx context.Context, opts goja.Valu
 				o.Button = opts.Get(k).String()
 			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()
-			case "modifiers":
+			case OptionsModifiers:
 				var m []string
 				if err := rt.ExportTo(opts.Get(k), &m); err != nil {
 					return err
@@ -280,7 +280,7 @@ func (o *ElementHandleHoverOptions) Parse(ctx context.Context, opts goja.Value) 
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "modifiers":
+			case OptionsModifiers:
 				var m []string
 				if err := rt.ExportTo(opts.Get(k), &m); err != nil {
 					return err
@@ -411,7 +411,7 @@ func (o *ElementHandleTapOptions) Parse(ctx context.Context, opts goja.Value) er
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "modifiers":
+			case OptionsModifiers:
 				var m []string
 				if err := rt.ExportTo(opts.Get(k), &m); err != nil {
 					return err

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -198,7 +198,7 @@ func (o *ElementHandleClickOptions) Parse(ctx context.Context, opts goja.Value) 
 			switch k {
 			case OptionsButton:
 				o.Button = opts.Get(k).String()
-			case "clickCount":
+			case OptionsClickCount:
 				o.ClickCount = opts.Get(k).ToInteger()
 			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -200,7 +200,7 @@ func (o *ElementHandleClickOptions) Parse(ctx context.Context, opts goja.Value) 
 				o.Button = opts.Get(k).String()
 			case "clickCount":
 				o.ClickCount = opts.Get(k).ToInteger()
-			case "delay":
+			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()
 			case "modifiers":
 				var m []string
@@ -242,7 +242,7 @@ func (o *ElementHandleDblclickOptions) Parse(ctx context.Context, opts goja.Valu
 			switch k {
 			case "button":
 				o.Button = opts.Get(k).String()
-			case "delay":
+			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()
 			case "modifiers":
 				var m []string
@@ -306,7 +306,7 @@ func (o *ElementHandlePressOptions) Parse(ctx context.Context, opts goja.Value) 
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "delay":
+			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()
 			case OptionsNoWaitAfter:
 				o.NoWaitAfter = opts.Get(k).ToBoolean()
@@ -437,7 +437,7 @@ func (o *ElementHandleTypeOptions) Parse(ctx context.Context, opts goja.Value) e
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "delay":
+			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()
 			case OptionsNoWaitAfter:
 				o.NoWaitAfter = opts.Get(k).ToBoolean()

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -153,7 +153,7 @@ func (o *FrameBaseOptions) Parse(ctx context.Context, opts goja.Value) error {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "strict":
+			case OptionsStrict:
 				o.Strict = opts.Get(k).ToBoolean()
 			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
@@ -179,7 +179,7 @@ func (o *FrameCheckOptions) Parse(ctx context.Context, opts goja.Value) error {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "strict":
+			case OptionsStrict:
 				o.Strict = opts.Get(k).ToBoolean()
 			}
 		}
@@ -203,7 +203,7 @@ func (o *FrameClickOptions) Parse(ctx context.Context, opts goja.Value) error {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "strict":
+			case OptionsStrict:
 				o.Strict = opts.Get(k).ToBoolean()
 			}
 		}
@@ -227,7 +227,7 @@ func (o *FrameDblclickOptions) Parse(ctx context.Context, opts goja.Value) error
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "strict":
+			case OptionsStrict:
 				o.Strict = opts.Get(k).ToBoolean()
 			}
 		}
@@ -251,7 +251,7 @@ func (o *FrameFillOptions) Parse(ctx context.Context, opts goja.Value) error {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "strict":
+			case OptionsStrict:
 				o.Strict = opts.Get(k).ToBoolean()
 			}
 		}
@@ -304,7 +304,7 @@ func (o *FrameHoverOptions) Parse(ctx context.Context, opts goja.Value) error {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "strict":
+			case OptionsStrict:
 				o.Strict = opts.Get(k).ToBoolean()
 			}
 		}
@@ -458,7 +458,7 @@ func (o *FrameSelectOptionOptions) Parse(ctx context.Context, opts goja.Value) e
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "strict":
+			case OptionsStrict:
 				o.Strict = opts.Get(k).ToBoolean()
 			}
 		}
@@ -517,7 +517,7 @@ func (o *FrameTapOptions) Parse(ctx context.Context, opts goja.Value) error {
 					return err
 				}
 				o.Modifiers = m
-			case "strict":
+			case OptionsStrict:
 				o.Strict = opts.Get(k).ToBoolean()
 			}
 		}
@@ -567,7 +567,7 @@ func (o *FrameUncheckOptions) Parse(ctx context.Context, opts goja.Value) error 
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "strict":
+			case OptionsStrict:
 				o.Strict = opts.Get(k).ToBoolean()
 			}
 		}
@@ -687,7 +687,7 @@ func (o *FrameWaitForSelectorOptions) Parse(ctx context.Context, opts goja.Value
 				} else {
 					return fmt.Errorf("%q is not a valid DOM state", state)
 				}
-			case "strict":
+			case OptionsStrict:
 				o.Strict = opts.Get(k).ToBoolean()
 			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -511,7 +511,7 @@ func (o *FrameTapOptions) Parse(ctx context.Context, opts goja.Value) error {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "modifiers":
+			case OptionsModifiers:
 				var m []string
 				if err := rt.ExportTo(opts.Get(k), &m); err != nil {
 					return err

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -594,7 +594,7 @@ func (o *FrameWaitForFunctionOptions) Parse(ctx context.Context, opts goja.Value
 			switch k {
 			case OptionsTimeout:
 				o.Timeout = time.Duration(v.ToInteger()) * time.Millisecond
-			case "polling":
+			case OptionsPolling:
 				switch v.ExportType().Kind() { //nolint: exhaustive
 				case reflect.Int64:
 					o.Polling = PollingInterval

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -273,7 +273,7 @@ func (o *FrameGotoOptions) Parse(ctx context.Context, opts goja.Value) error {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "referer":
+			case OptionsReferer:
 				o.Referer = opts.Get(k).String()
 			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -277,7 +277,7 @@ func (o *FrameGotoOptions) Parse(ctx context.Context, opts goja.Value) error {
 				o.Referer = opts.Get(k).String()
 			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
-			case "waitUntil":
+			case OptionsWaitUntil:
 				lifeCycle := opts.Get(k).String()
 				if err := o.WaitUntil.UnmarshalText([]byte(lifeCycle)); err != nil {
 					return fmt.Errorf("parsing goto options: %w", err)
@@ -482,7 +482,7 @@ func (o *FrameSetContentOptions) Parse(ctx context.Context, opts goja.Value) err
 			switch k {
 			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
-			case "waitUntil":
+			case OptionsWaitUntil:
 				lifeCycle := opts.Get(k).String()
 				if err := o.WaitUntil.UnmarshalText([]byte(lifeCycle)); err != nil {
 					return fmt.Errorf("parsing setContent options: %w", err)
@@ -654,7 +654,7 @@ func (o *FrameWaitForNavigationOptions) Parse(ctx context.Context, opts goja.Val
 				o.URL = opts.Get(k).String()
 			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
-			case "waitUntil":
+			case OptionsWaitUntil:
 				lifeCycle := opts.Get(k).String()
 				if err := o.WaitUntil.UnmarshalText([]byte(lifeCycle)); err != nil {
 					return fmt.Errorf("parsing waitForNavigation options: %w", err)

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -155,7 +155,7 @@ func (o *FrameBaseOptions) Parse(ctx context.Context, opts goja.Value) error {
 			switch k {
 			case "strict":
 				o.Strict = opts.Get(k).ToBoolean()
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			}
 		}
@@ -275,7 +275,7 @@ func (o *FrameGotoOptions) Parse(ctx context.Context, opts goja.Value) error {
 			switch k {
 			case "referer":
 				o.Referer = opts.Get(k).String()
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			case "waitUntil":
 				lifeCycle := opts.Get(k).String()
@@ -480,7 +480,7 @@ func (o *FrameSetContentOptions) Parse(ctx context.Context, opts goja.Value) err
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			case "waitUntil":
 				lifeCycle := opts.Get(k).String()
@@ -592,7 +592,7 @@ func (o *FrameWaitForFunctionOptions) Parse(ctx context.Context, opts goja.Value
 		for _, k := range opts.Keys() {
 			v := opts.Get(k)
 			switch k {
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(v.ToInteger()) * time.Millisecond
 			case "polling":
 				switch v.ExportType().Kind() { //nolint: exhaustive
@@ -628,7 +628,7 @@ func (o *FrameWaitForLoadStateOptions) Parse(ctx context.Context, opts goja.Valu
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			}
 		}
@@ -652,7 +652,7 @@ func (o *FrameWaitForNavigationOptions) Parse(ctx context.Context, opts goja.Val
 			switch k {
 			case "url":
 				o.URL = opts.Get(k).String()
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			case "waitUntil":
 				lifeCycle := opts.Get(k).String()
@@ -689,7 +689,7 @@ func (o *FrameWaitForSelectorOptions) Parse(ctx context.Context, opts goja.Value
 				}
 			case "strict":
 				o.Strict = opts.Get(k).ToBoolean()
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			}
 		}

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -650,7 +650,7 @@ func (o *FrameWaitForNavigationOptions) Parse(ctx context.Context, opts goja.Val
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "url":
+			case OptionsURL:
 				o.URL = opts.Get(k).String()
 			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond

--- a/common/keyboard_options.go
+++ b/common/keyboard_options.go
@@ -24,7 +24,7 @@ func (o *KeyboardOptions) Parse(ctx context.Context, opts goja.Value) error {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "delay":
+			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()
 			}
 		}

--- a/common/mouse_options.go
+++ b/common/mouse_options.go
@@ -42,7 +42,7 @@ func (o *MouseClickOptions) Parse(ctx context.Context, opts goja.Value) error {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "button":
+			case OptionsButton:
 				o.Button = opts.Get(k).String()
 			case "clickCount":
 				o.ClickCount = opts.Get(k).ToInteger()
@@ -74,7 +74,7 @@ func (o *MouseDblClickOptions) Parse(ctx context.Context, opts goja.Value) error
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "button":
+			case OptionsButton:
 				o.Button = opts.Get(k).String()
 			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()
@@ -103,7 +103,7 @@ func (o *MouseDownUpOptions) Parse(ctx context.Context, opts goja.Value) error {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "button":
+			case OptionsButton:
 				o.Button = opts.Get(k).String()
 			case "clickCount":
 				o.ClickCount = opts.Get(k).ToInteger()

--- a/common/mouse_options.go
+++ b/common/mouse_options.go
@@ -44,7 +44,7 @@ func (o *MouseClickOptions) Parse(ctx context.Context, opts goja.Value) error {
 			switch k {
 			case OptionsButton:
 				o.Button = opts.Get(k).String()
-			case "clickCount":
+			case OptionsClickCount:
 				o.ClickCount = opts.Get(k).ToInteger()
 			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()
@@ -105,7 +105,7 @@ func (o *MouseDownUpOptions) Parse(ctx context.Context, opts goja.Value) error {
 			switch k {
 			case OptionsButton:
 				o.Button = opts.Get(k).String()
-			case "clickCount":
+			case OptionsClickCount:
 				o.ClickCount = opts.Get(k).ToInteger()
 			}
 		}

--- a/common/mouse_options.go
+++ b/common/mouse_options.go
@@ -46,7 +46,7 @@ func (o *MouseClickOptions) Parse(ctx context.Context, opts goja.Value) error {
 				o.Button = opts.Get(k).String()
 			case "clickCount":
 				o.ClickCount = opts.Get(k).ToInteger()
-			case "delay":
+			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()
 			}
 		}
@@ -76,7 +76,7 @@ func (o *MouseDblClickOptions) Parse(ctx context.Context, opts goja.Value) error
 			switch k {
 			case "button":
 				o.Button = opts.Get(k).String()
-			case "delay":
+			case OptionsDelay:
 				o.Delay = opts.Get(k).ToInteger()
 			}
 		}

--- a/common/page_options.go
+++ b/common/page_options.go
@@ -121,7 +121,7 @@ func (o *PageScreenshotOptions) Parse(ctx context.Context, opts goja.Value) erro
 				o.OmitBackground = opts.Get(k).ToBoolean()
 			case "path":
 				o.Path = opts.Get(k).String()
-			case "quality":
+			case OptionsQuality:
 				o.Quality = opts.Get(k).ToInteger()
 			case OptionsType:
 				if f, ok := imageFormatToID[opts.Get(k).String()]; ok {

--- a/common/page_options.go
+++ b/common/page_options.go
@@ -117,7 +117,7 @@ func (o *PageScreenshotOptions) Parse(ctx context.Context, opts goja.Value) erro
 				}
 			case "fullPage":
 				o.FullPage = opts.Get(k).ToBoolean()
-			case "omitBackground":
+			case OptionsOmitBackground:
 				o.OmitBackground = opts.Get(k).ToBoolean()
 			case "path":
 				o.Path = opts.Get(k).String()

--- a/common/page_options.go
+++ b/common/page_options.go
@@ -71,7 +71,7 @@ func (o *PageReloadOptions) Parse(ctx context.Context, opts goja.Value) error {
 		opts := opts.ToObject(rt)
 		for _, k := range opts.Keys() {
 			switch k {
-			case "waitUntil":
+			case OptionsWaitUntil:
 				lifeCycle := opts.Get(k).String()
 				if l, ok := lifecycleEventToID[lifeCycle]; ok {
 					o.WaitUntil = l

--- a/common/page_options.go
+++ b/common/page_options.go
@@ -119,7 +119,7 @@ func (o *PageScreenshotOptions) Parse(ctx context.Context, opts goja.Value) erro
 				o.FullPage = opts.Get(k).ToBoolean()
 			case OptionsOmitBackground:
 				o.OmitBackground = opts.Get(k).ToBoolean()
-			case "path":
+			case OptionsPath:
 				o.Path = opts.Get(k).String()
 			case OptionsQuality:
 				o.Quality = opts.Get(k).ToInteger()

--- a/common/page_options.go
+++ b/common/page_options.go
@@ -123,7 +123,7 @@ func (o *PageScreenshotOptions) Parse(ctx context.Context, opts goja.Value) erro
 				o.Path = opts.Get(k).String()
 			case "quality":
 				o.Quality = opts.Get(k).ToInteger()
-			case "type":
+			case OptionsType:
 				if f, ok := imageFormatToID[opts.Get(k).String()]; ok {
 					o.Format = f
 					formatSpecified = true

--- a/common/page_options.go
+++ b/common/page_options.go
@@ -78,7 +78,7 @@ func (o *PageReloadOptions) Parse(ctx context.Context, opts goja.Value) error {
 				} else {
 					return fmt.Errorf("%q is not a valid lifecycle", lifeCycle)
 				}
-			case "timeout":
+			case OptionsTimeout:
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			}
 		}

--- a/examples/waitForEvent.js
+++ b/examples/waitForEvent.js
@@ -1,0 +1,41 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+}
+
+export default async function() {
+  const context = browser.newContext()
+
+  // We want to wait for two page creations
+  // before carrying on.
+  var counter = 0
+  const promise = context.waitForEvent("page", { predicate: page => {
+    if (++counter == 2) {
+      return true
+    }
+    return false
+  } })
+  
+  // Now we create two pages.
+  const page = context.newPage()
+  const page2 = context.newPage()
+
+  // We await for the page creation
+  // events to be processed and the
+  // predicate to pass.
+  await promise
+  console.log('predicate passed')
+
+  page.close()
+  page2.close()
+};

--- a/examples/waitForEvent.js
+++ b/examples/waitForEvent.js
@@ -16,8 +16,7 @@ export const options = {
 export default async function() {
   const context = browser.newContext()
 
-  // We want to wait for two page creations
-  // before carrying on.
+  // We want to wait for two page creations before carrying on.
   var counter = 0
   const promise = context.waitForEvent("page", { predicate: page => {
     if (++counter == 2) {
@@ -30,9 +29,8 @@ export default async function() {
   const page = context.newPage()
   const page2 = context.newPage()
 
-  // We await for the page creation
-  // events to be processed and the
-  // predicate to pass.
+  // We await for the page creation events to be processed and the predicate
+  // to pass.
   await promise
   console.log('predicate passed')
 

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -721,7 +721,7 @@ func TestBrowserContextWaitForEvent(t *testing.T) {
 		{
 			name:    "fails when event other than page passed in",
 			event:   "browser",
-			wantErr: "\"page\" is the only event that is supported, you passed in \"browser\"",
+			wantErr: "incorrect event \"browser\", \"page\" is the only event supported",
 		},
 		{
 			name:            "fails due to timeout",

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -700,31 +700,37 @@ func TestBrowserContextWaitForEvent(t *testing.T) {
 		wantErr         string
 	}{
 		{
-			name:  "successfully wait for page creation",
+			// No predicate or options.
+			name:  "success",
 			event: "page",
 		},
 		{
-			name:            "successfully wait for page creation with only predicate",
+			// With a predicate function but not options.
+			name:            "success_with_predicate",
 			event:           "page",
 			optsOrPredicate: &optsOrPredicate{justPredicate: stringPtr("() => true;")},
 		},
 		{
-			name:            "successfully wait for page creation with predicate in option",
+			// With a predicate function in an option object.
+			name:            "success_with_option_predicate",
 			event:           "page",
 			optsOrPredicate: &optsOrPredicate{predicate: stringPtr("() => true;")},
 		},
 		{
-			name:            "successfully wait for page creation with predicate and timeout in option",
+			// With a predicate function and a new timeout in an option object.
+			name:            "success_with_option_predicate_timeout",
 			event:           "page",
 			optsOrPredicate: &optsOrPredicate{predicate: stringPtr("() => true;"), timeout: int64Ptr(1000)},
 		},
 		{
-			name:    "fails when event other than page passed in",
+			// Fails when an event other than "page" is passed in.
+			name:    "fails_incorrect_event",
 			event:   "browser",
 			wantErr: "incorrect event \"browser\", \"page\" is the only event supported",
 		},
 		{
-			name:            "fails due to timeout",
+			// Fails when the timeout fires while waiting on waitForEvent.
+			name:            "fails_timeout",
 			event:           "page",
 			optsOrPredicate: &optsOrPredicate{predicate: stringPtr("() => false;"), timeout: int64Ptr(10)},
 			wantErr:         "waitForEvent timed out after 10ms",

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -751,9 +751,13 @@ func TestBrowserContextWaitForEvent(t *testing.T) {
 			defer cancel()
 
 			var p1, p2 api.Page
+			// We need to run waitForEvent in parallel to the page creation.
+			// If we run them synchronously then waitForEvent will wait
+			// indefinitely and eventually the test will timeout.
 			err = tb.run(
 				ctx,
 				func() error {
+					// Call waitForEvent.
 					op := optsOrPredicateToGojaValue(t, tb, tc.optsOrPredicate)
 					resp, err := bc.WaitForEvent(tc.event, op)
 					if resp != nil {
@@ -764,23 +768,31 @@ func TestBrowserContextWaitForEvent(t *testing.T) {
 					return err
 				},
 				func() error {
+					// Call newPage.
 					var err error
 					p2, err = bc.NewPage()
 					return err
 				},
 			)
 
+			// For the happy paths.
 			if tc.wantErr == "" {
 				assert.NoError(t, err)
+				// We want to make sure that the page that was created with
+				// newPage matches the return value from waitForEvent.
 				assert.Equal(t, p1.MainFrame().ID(), p2.MainFrame().ID())
 				return
 			}
 
+			// For the failure cases.
 			assert.ErrorContains(t, err, tc.wantErr)
 		})
 	}
 }
 
+// optsOrPredicate is a helper type to enable us to package up the optional
+// arguments which could either be a predicate function, or the options object
+// which contains a predicate function and a timeout.
 type optsOrPredicate struct {
 	predicate     *string
 	timeout       *int64
@@ -799,19 +811,26 @@ func int64Ptr(value int64) *int64 {
 	return int64Pointer
 }
 
+// optsOrPredicateToGojaValue will take optsOrPredicate and correctly define the
+// optional options where necessary. It will either return nil, a predicate
+// function or an options object.
 func optsOrPredicateToGojaValue(t *testing.T, tb *testBrowser, op *optsOrPredicate) goja.Value {
 	t.Helper()
 
+	// Options or predicate are undefined.
 	if op == nil {
 		return nil
 	}
 
+	// The optional argument is a predicate function.
 	if op.justPredicate != nil {
 		predicate, err := tb.runJavaScript(*op.justPredicate)
 		require.NoError(t, err)
 		return predicate
 	}
 
+	// The option argument is a options object with only the predicate function
+	// defined but no timeout.
 	if op.predicate != nil && op.timeout == nil {
 		predicate, err := tb.runJavaScript(*op.predicate)
 		require.NoError(t, err)
@@ -825,6 +844,7 @@ func optsOrPredicateToGojaValue(t *testing.T, tb *testBrowser, op *optsOrPredica
 		return opts.ToObject(tb.runtime())
 	}
 
+	// The option argument is a options object with only timeout.
 	if op.predicate == nil && op.timeout != nil {
 		opts := tb.toGojaValue(struct {
 			Timeout int64
@@ -835,6 +855,8 @@ func optsOrPredicateToGojaValue(t *testing.T, tb *testBrowser, op *optsOrPredica
 		return opts.ToObject(tb.runtime())
 	}
 
+	// The option argument is a options object with both a predicate function
+	// and a timeout.
 	predicate, err := tb.runJavaScript(*op.predicate)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## What?

This refactors the key strings to consts.

## Why?

The main reason is to avoid typos when writing out new option parsers or working with options in other ways. Note thought that I've not done a refactor for all configs, e.g. the options for [newContext](https://github.com/grafana/xk6-browser/blob/main/common/browser_context_options.go#L51-L134).

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Motivated by: [comment](https://github.com/grafana/xk6-browser/pull/1042#discussion_r1332854807).