### PR TITLE
Remove browser close event

### DIFF
--- a/api/browser_context.go
+++ b/api/browser_context.go
@@ -34,7 +34,7 @@ type BrowserContext interface {
 	SetOffline(offline bool)
 	StorageState(opts goja.Value)
 	Unroute(url goja.Value, handler goja.Callable)
-	WaitForEvent(event string, optsOrPredicate goja.Value) any
+	WaitForEvent(event string, optsOrPredicate goja.Value) (any, error)
 }
 
 // Cookie represents a browser cookie.

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -366,7 +366,7 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 
 func (b *BrowserContext) waitForEvent(event waitForEventType, predicateFn goja.Callable, timeout time.Duration) (any, error) {
 	if event != waitForEventTypePage {
-		return nil, fmt.Errorf("%q is the only event that is supported, you passed in %q", waitForEventTypePage, event)
+		return nil, fmt.Errorf("incorrect event %q, %q is the only event supported", event, waitForEventTypePage)
 	}
 
 	evCancelCtx, evCancelFn := context.WithCancel(b.ctx)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -345,7 +345,7 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 	b.logger.Debugf("BrowserContext:WaitForEvent", "bctxid:%v event:%q", b.id, event)
 
 	parsedOpts := NewWaitForEventOptions(
-		b.browser.browserOpts.Timeout * time.Second,
+		b.timeoutSettings.timeout(),
 	)
 	if err := parsedOpts.Parse(b.ctx, optsOrPredicate); err != nil {
 		k6ext.Panic(b.ctx, "parsing waitForEvent options: %w", err)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -342,7 +342,6 @@ func (b *BrowserContext) Unroute(url goja.Value, handler goja.Callable) {
 
 // WaitForEvent waits for event.
 func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) (any, error) {
-	// TODO: This public API needs Promise support (as return value) to be useful in JS!
 	b.logger.Debugf("BrowserContext:WaitForEvent", "bctxid:%v event:%q", b.id, event)
 
 	parsedOpts := NewWaitForEventOptions(

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -418,11 +418,6 @@ func (b *BrowserContext) runWaitForEventHandler(
 			b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():ctx:done", "bctxid:%v", b.id)
 			return
 		case ev := <-chEvHandler:
-			if ev.typ == EventBrowserContextClose {
-				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextClose:return", "bctxid:%v", b.id)
-				return
-			}
-
 			if ev.typ != EventBrowserContextPage {
 				continue
 			}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -364,7 +364,11 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 	return b.waitForEvent(waitForEventType(event), parsedOpts.PredicateFn, parsedOpts.Timeout)
 }
 
-func (b *BrowserContext) waitForEvent(event waitForEventType, predicateFn goja.Callable, timeout time.Duration) (any, error) {
+func (b *BrowserContext) waitForEvent(
+	event waitForEventType,
+	predicateFn goja.Callable,
+	timeout time.Duration,
+) (any, error) {
 	if event != waitForEventTypePage {
 		return nil, fmt.Errorf("incorrect event %q, %q is the only event supported", event, waitForEventTypePage)
 	}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -418,19 +418,22 @@ func (b *BrowserContext) runWaitForEventHandler(
 				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextClose:return", "bctxid:%v", b.id)
 				return
 			}
-			if ev.typ == EventBrowserContextPage {
-				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage", "bctxid:%v", b.id)
-				p, _ = ev.data.(*Page)
 
-				if predicateFn == nil {
-					b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:return", "bctxid:%v", b.id)
-					return
-				}
+			if ev.typ != EventBrowserContextPage {
+				continue
+			}
 
-				if retVal, err := predicateFn(b.vu.Runtime().ToValue(p)); err == nil && retVal.ToBoolean() {
-					b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:predicateFn:return", "bctxid:%v", b.id)
-					return
-				}
+			b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage", "bctxid:%v", b.id)
+			p, _ = ev.data.(*Page)
+
+			if predicateFn == nil {
+				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:return", "bctxid:%v", b.id)
+				return
+			}
+
+			if retVal, err := predicateFn(b.vu.Runtime().ToValue(p)); err == nil && retVal.ToBoolean() {
+				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:predicateFn:return", "bctxid:%v", b.id)
+				return
 			}
 		}
 	}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -375,16 +376,14 @@ func (b *BrowserContext) waitForEvent(event string, predicateFn goja.Callable, t
 
 	select {
 	case <-b.ctx.Done():
-		b.logger.Debugf("BrowserContext:WaitForEvent:ctx.Done", "bctxid:%v event:%q", b.id, event)
+		return nil, errors.New("test iteration ended")
 	case <-time.After(timeout):
 		b.logger.Debugf("BrowserContext:WaitForEvent:timeout", "bctxid:%v event:%q", b.id, event)
+		return nil, fmt.Errorf("waitForEvent timed out after %v", timeout)
 	case evData := <-ch:
 		b.logger.Debugf("BrowserContext:WaitForEvent:evData", "bctxid:%v event:%q", b.id, event)
 		return evData, nil
 	}
-	b.logger.Debugf("BrowserContext:WaitForEvent:return nil", "bctxid:%v event:%q", b.id, event)
-
-	return nil, nil
 }
 
 func (b *BrowserContext) runWaitForEventHandler(

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -436,7 +436,10 @@ func (b *BrowserContext) runWaitForEventHandler(
 			}
 
 			if retVal, err := predicateFn(b.vu.Runtime().ToValue(p)); err == nil && retVal.ToBoolean() {
-				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:predicateFn:return", "bctxid:%v", b.id)
+				b.logger.Debugf(
+					"BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:predicateFn:return",
+					"bctxid:%v", b.id,
+				)
 				return
 			}
 		}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -31,6 +31,16 @@ var (
 	_ api.BrowserContext = &BrowserContext{}
 )
 
+// waitForEventType represents the event types that can be used when working
+// with the browserContext.waitForEvent API.
+type waitForEventType string
+
+const (
+	// waitForEventTypePage represents the page event which fires when a new
+	// page is created.
+	waitForEventTypePage = "page"
+)
+
 // BrowserContext stores context information for a single independent browser session.
 // A newly launched browser instance contains a default browser context.
 // Any browser context created aside from the default will be considered an "incognito"
@@ -351,12 +361,12 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 		return nil, fmt.Errorf("parsing waitForEvent options: %w", err)
 	}
 
-	return b.waitForEvent(event, parsedOpts.PredicateFn, parsedOpts.Timeout)
+	return b.waitForEvent(waitForEventType(event), parsedOpts.PredicateFn, parsedOpts.Timeout)
 }
 
-func (b *BrowserContext) waitForEvent(event string, predicateFn goja.Callable, timeout time.Duration) (any, error) {
-	if event != "page" {
-		return nil, fmt.Errorf("\"page\" is the only event that is supported, you passed in %q", event)
+func (b *BrowserContext) waitForEvent(event waitForEventType, predicateFn goja.Callable, timeout time.Duration) (any, error) {
+	if event != waitForEventTypePage {
+		return nil, fmt.Errorf("%q is the only event that is supported, you passed in %q", waitForEventTypePage, event)
 	}
 
 	evCancelCtx, evCancelFn := context.WithCancel(b.ctx)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -394,8 +394,8 @@ func (b *BrowserContext) waitForEvent(
 	}
 }
 
-// runWaitForEventHandler can work with a nil predicateFn.
-// If predicateFn is nil, it will return the response straight away.
+// runWaitForEventHandler can work with a nil predicateFn. If predicateFn is
+// nil it will return the response straight away.
 func (b *BrowserContext) runWaitForEventHandler(
 	ctx context.Context, evCancelFn func(), chEvHandler chan Event, out chan any, predicateFn goja.Callable,
 ) {
@@ -407,8 +407,8 @@ func (b *BrowserContext) runWaitForEventHandler(
 		out <- p
 		close(out)
 
-		// We wait for one matching event only,
-		// then remove event handler by cancelling context and stopping goroutine.
+		// We wait for one matching event only, then remove event handler by
+		// cancelling context and stopping goroutine.
 		evCancelFn()
 	}()
 

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -395,8 +395,8 @@ func (b *BrowserContext) waitForEvent(event waitForEventType, predicateFn goja.C
 func (b *BrowserContext) runWaitForEventHandler(
 	ctx context.Context, evCancelFn func(), chEvHandler chan Event, out chan any, predicateFn goja.Callable,
 ) {
-	b.logger.Debugf("BrowserContext:WaitForEvent:go():starts", "bctxid:%v", b.id)
-	defer b.logger.Debugf("BrowserContext:WaitForEvent:go():returns", "bctxid:%v", b.id)
+	b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():starts", "bctxid:%v", b.id)
+	defer b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():returns", "bctxid:%v", b.id)
 
 	var p *Page
 	defer func() {
@@ -411,24 +411,24 @@ func (b *BrowserContext) runWaitForEventHandler(
 	for {
 		select {
 		case <-ctx.Done():
-			b.logger.Debugf("BrowserContext:WaitForEvent:go():ctx:done", "bctxid:%v", b.id)
+			b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():ctx:done", "bctxid:%v", b.id)
 			return
 		case ev := <-chEvHandler:
 			if ev.typ == EventBrowserContextClose {
-				b.logger.Debugf("BrowserContext:WaitForEvent:go():EventBrowserContextClose:return", "bctxid:%v", b.id)
+				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextClose:return", "bctxid:%v", b.id)
 				return
 			}
 			if ev.typ == EventBrowserContextPage {
-				b.logger.Debugf("BrowserContext:WaitForEvent:go():EventBrowserContextPage", "bctxid:%v", b.id)
+				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage", "bctxid:%v", b.id)
 				p, _ = ev.data.(*Page)
 
 				if predicateFn == nil {
-					b.logger.Debugf("BrowserContext:WaitForEvent:go():EventBrowserContextPage:return", "bctxid:%v", b.id)
+					b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:return", "bctxid:%v", b.id)
 					return
 				}
 
 				if retVal, err := predicateFn(b.vu.Runtime().ToValue(p)); err == nil && retVal.ToBoolean() {
-					b.logger.Debugf("BrowserContext:WaitForEvent:go():EventBrowserContextPage:predicateFn:return", "bctxid:%v", b.id)
+					b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:predicateFn:return", "bctxid:%v", b.id)
 					return
 				}
 			}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -341,7 +341,7 @@ func (b *BrowserContext) Unroute(url goja.Value, handler goja.Callable) {
 }
 
 // WaitForEvent waits for event.
-func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) any {
+func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) (any, error) {
 	// TODO: This public API needs Promise support (as return value) to be useful in JS!
 	b.logger.Debugf("BrowserContext:WaitForEvent", "bctxid:%v event:%q", b.id, event)
 
@@ -349,15 +349,10 @@ func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) 
 		b.timeoutSettings.timeout(),
 	)
 	if err := parsedOpts.Parse(b.ctx, optsOrPredicate); err != nil {
-		k6ext.Panic(b.ctx, "parsing waitForEvent options: %w", err)
+		return nil, fmt.Errorf("parsing waitForEvent options: %w", err)
 	}
 
-	resp, err := b.waitForEvent(event, parsedOpts.PredicateFn, parsedOpts.Timeout)
-	if err != nil {
-		k6ext.Panic(b.ctx, "waitForEvent failed: %w", err)
-	}
-
-	return resp
+	return b.waitForEvent(event, parsedOpts.PredicateFn, parsedOpts.Timeout)
 }
 
 func (b *BrowserContext) waitForEvent(event string, predicateFn goja.Callable, timeout time.Duration) (any, error) {

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -2,8 +2,8 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/grafana/xk6-browser/k6ext"
@@ -154,29 +154,25 @@ func NewWaitForEventOptions(defaultTimeout time.Duration) *WaitForEventOptions {
 // It can parse only a callable predicate function or an object
 // which contains a callable predicate function and a timeout.
 func (w *WaitForEventOptions) Parse(ctx context.Context, optsOrPredicate goja.Value) error {
-	var (
-		isCallable bool
-	)
+	var isCallable bool
 	if gojaValueExists(optsOrPredicate) {
-		switch optsOrPredicate.ExportType() {
-		case reflect.TypeOf(goja.Object{}):
-			rt := k6ext.Runtime(ctx)
-			opts := optsOrPredicate.ToObject(rt)
-			for _, k := range opts.Keys() {
-				switch k {
-				case "predicate":
-					w.PredicateFn, isCallable = goja.AssertFunction(opts.Get(k))
-					if !isCallable {
-						return fmt.Errorf("predicate function is not callable")
-					}
-				case "timeout":
-					w.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
+		rt := k6ext.Runtime(ctx)
+
+		w.PredicateFn, isCallable = goja.AssertFunction(optsOrPredicate)
+		if isCallable {
+			return nil
+		}
+
+		opts := optsOrPredicate.ToObject(rt)
+		for _, k := range opts.Keys() {
+			switch k {
+			case "predicate":
+				w.PredicateFn, isCallable = goja.AssertFunction(opts.Get(k))
+				if !isCallable {
+					return errors.New("predicate function is not callable")
 				}
-			}
-		default:
-			w.PredicateFn, isCallable = goja.AssertFunction(optsOrPredicate)
-			if !isCallable {
-				return fmt.Errorf("predicate function is not callable")
+			case "timeout": //nolint:goconst
+				w.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			}
 		}
 	}

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -135,24 +135,23 @@ func (b *BrowserContextOptions) Parse(ctx context.Context, opts goja.Value) erro
 	return nil
 }
 
-// WaitForEventOptions are the options used by
-// the browserContext.waitForEvent API.
+// WaitForEventOptions are the options used by the browserContext.waitForEvent API.
 type WaitForEventOptions struct {
 	Timeout     time.Duration
 	PredicateFn goja.Callable
 }
 
-// NewWaitForEventOptions created a new instance of
-// WaitForEventOptions with a default timeout.
+// NewWaitForEventOptions created a new instance of WaitForEventOptions with a
+// default timeout.
 func NewWaitForEventOptions(defaultTimeout time.Duration) *WaitForEventOptions {
 	return &WaitForEventOptions{
 		Timeout: defaultTimeout,
 	}
 }
 
-// Parse will parse the options or a callable predicate function.
-// It can parse only a callable predicate function or an object
-// which contains a callable predicate function and a timeout.
+// Parse will parse the options or a callable predicate function. It can parse
+// only a callable predicate function or an object which contains a callable
+// predicate function and a timeout.
 func (w *WaitForEventOptions) Parse(ctx context.Context, optsOrPredicate goja.Value) error {
 	if !gojaValueExists(optsOrPredicate) {
 		return nil

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/grafana/xk6-browser/k6ext"
 
@@ -130,5 +131,27 @@ func (b *BrowserContextOptions) Parse(ctx context.Context, opts goja.Value) erro
 			}
 		}
 	}
+	return nil
+}
+
+// WaitForEventOptions are the options used by
+// the browserContext.waitForEvent API.
+type WaitForEventOptions struct {
+	Timeout     time.Duration
+	PredicateFn goja.Callable
+}
+
+// NewWaitForEventOptions created a new instance of
+// WaitForEventOptions with a default timeout.
+func NewWaitForEventOptions(defaultTimeout time.Duration) *WaitForEventOptions {
+	return &WaitForEventOptions{
+		Timeout: defaultTimeout,
+	}
+}
+
+// Parse will parse the options or a callable predicate function.
+// It can parse only a callable predicate function or an object
+// which contains a callable predicate function and a timeout.
+func (w *WaitForEventOptions) Parse(ctx context.Context, optsOrPredicate goja.Value) error {
 	return nil
 }

--- a/common/event_emitter.go
+++ b/common/event_emitter.go
@@ -15,8 +15,7 @@ const (
 
 	// BrowserContext
 
-	EventBrowserContextClose string = "close"
-	EventBrowserContextPage  string = "page"
+	EventBrowserContextPage string = "page"
 
 	// Connection
 

--- a/examples/waitForEvent.js
+++ b/examples/waitForEvent.js
@@ -1,0 +1,41 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+}
+
+export default async function() {
+  const context = browser.newContext()
+
+  // We want to wait for two page creations
+  // before carrying on.
+  var counter = 0
+  const promise = context.waitForEvent("page", { predicate: page => {
+    if (++counter == 2) {
+      return true
+    }
+    return false
+  } })
+  
+  // Now we create two pages.
+  const page = context.newPage()
+  const page2 = context.newPage()
+
+  // We await for the page creation
+  // events to be processed and the
+  // predicate to pass.
+  await promise
+  console.log('predicate passed')
+
+  page.close()
+  page2.close()
+};

--- a/examples/waitForEvent.js
+++ b/examples/waitForEvent.js
@@ -16,8 +16,7 @@ export const options = {
 export default async function() {
   const context = browser.newContext()
 
-  // We want to wait for two page creations
-  // before carrying on.
+  // We want to wait for two page creations before carrying on.
   var counter = 0
   const promise = context.waitForEvent("page", { predicate: page => {
     if (++counter == 2) {
@@ -30,9 +29,8 @@ export default async function() {
   const page = context.newPage()
   const page2 = context.newPage()
 
-  // We await for the page creation
-  // events to be processed and the
-  // predicate to pass.
+  // We await for the page creation events to be processed and the predicate
+  // to pass.
   await promise
   console.log('predicate passed')
 

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -721,7 +721,7 @@ func TestBrowserContextWaitForEvent(t *testing.T) {
 		{
 			name:    "fails when event other than page passed in",
 			event:   "browser",
-			wantErr: "\"page\" is the only event that is supported, you passed in \"browser\"",
+			wantErr: "incorrect event \"browser\", \"page\" is the only event supported",
 		},
 		{
 			name:            "fails due to timeout",

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -700,31 +700,37 @@ func TestBrowserContextWaitForEvent(t *testing.T) {
 		wantErr         string
 	}{
 		{
-			name:  "successfully wait for page creation",
+			// No predicate or options.
+			name:  "success",
 			event: "page",
 		},
 		{
-			name:            "successfully wait for page creation with only predicate",
+			// With a predicate function but not options.
+			name:            "success_with_predicate",
 			event:           "page",
 			optsOrPredicate: &optsOrPredicate{justPredicate: stringPtr("() => true;")},
 		},
 		{
-			name:            "successfully wait for page creation with predicate in option",
+			// With a predicate function in an option object.
+			name:            "success_with_option_predicate",
 			event:           "page",
 			optsOrPredicate: &optsOrPredicate{predicate: stringPtr("() => true;")},
 		},
 		{
-			name:            "successfully wait for page creation with predicate and timeout in option",
+			// With a predicate function and a new timeout in an option object.
+			name:            "success_with_option_predicate_timeout",
 			event:           "page",
 			optsOrPredicate: &optsOrPredicate{predicate: stringPtr("() => true;"), timeout: int64Ptr(1000)},
 		},
 		{
-			name:    "fails when event other than page passed in",
+			// Fails when an event other than "page" is passed in.
+			name:    "fails_incorrect_event",
 			event:   "browser",
 			wantErr: "incorrect event \"browser\", \"page\" is the only event supported",
 		},
 		{
-			name:            "fails due to timeout",
+			// Fails when the timeout fires while waiting on waitForEvent.
+			name:            "fails_timeout",
 			event:           "page",
 			optsOrPredicate: &optsOrPredicate{predicate: stringPtr("() => false;"), timeout: int64Ptr(10)},
 			wantErr:         "waitForEvent timed out after 10ms",

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -751,9 +751,13 @@ func TestBrowserContextWaitForEvent(t *testing.T) {
 			defer cancel()
 
 			var p1, p2 api.Page
+			// We need to run waitForEvent in parallel to the page creation.
+			// If we run them synchronously then waitForEvent will wait
+			// indefinitely and eventually the test will timeout.
 			err = tb.run(
 				ctx,
 				func() error {
+					// Call waitForEvent.
 					op := optsOrPredicateToGojaValue(t, tb, tc.optsOrPredicate)
 					resp, err := bc.WaitForEvent(tc.event, op)
 					if resp != nil {
@@ -764,23 +768,31 @@ func TestBrowserContextWaitForEvent(t *testing.T) {
 					return err
 				},
 				func() error {
+					// Call newPage.
 					var err error
 					p2, err = bc.NewPage()
 					return err
 				},
 			)
 
+			// For the happy paths.
 			if tc.wantErr == "" {
 				assert.NoError(t, err)
+				// We want to make sure that the page that was created with
+				// newPage matches the return value from waitForEvent.
 				assert.Equal(t, p1.MainFrame().ID(), p2.MainFrame().ID())
 				return
 			}
 
+			// For the failure cases.
 			assert.ErrorContains(t, err, tc.wantErr)
 		})
 	}
 }
 
+// optsOrPredicate is a helper type to enable us to package up the optional
+// arguments which could either be a predicate function, or the options object
+// which contains a predicate function and a timeout.
 type optsOrPredicate struct {
 	predicate     *string
 	timeout       *int64
@@ -799,19 +811,26 @@ func int64Ptr(value int64) *int64 {
 	return int64Pointer
 }
 
+// optsOrPredicateToGojaValue will take optsOrPredicate and correctly define the
+// optional options where necessary. It will either return nil, a predicate
+// function or an options object.
 func optsOrPredicateToGojaValue(t *testing.T, tb *testBrowser, op *optsOrPredicate) goja.Value {
 	t.Helper()
 
+	// Options or predicate are undefined.
 	if op == nil {
 		return nil
 	}
 
+	// The optional argument is a predicate function.
 	if op.justPredicate != nil {
 		predicate, err := tb.runJavaScript(*op.justPredicate)
 		require.NoError(t, err)
 		return predicate
 	}
 
+	// The option argument is a options object with only the predicate function
+	// defined but no timeout.
 	if op.predicate != nil && op.timeout == nil {
 		predicate, err := tb.runJavaScript(*op.predicate)
 		require.NoError(t, err)
@@ -825,6 +844,7 @@ func optsOrPredicateToGojaValue(t *testing.T, tb *testBrowser, op *optsOrPredica
 		return opts.ToObject(tb.runtime())
 	}
 
+	// The option argument is a options object with only timeout.
 	if op.predicate == nil && op.timeout != nil {
 		opts := tb.toGojaValue(struct {
 			Timeout int64
@@ -835,6 +855,8 @@ func optsOrPredicateToGojaValue(t *testing.T, tb *testBrowser, op *optsOrPredica
 		return opts.ToObject(tb.runtime())
 	}
 
+	// The option argument is a options object with both a predicate function
+	// and a timeout.
 	predicate, err := tb.runJavaScript(*op.predicate)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## What?

This remove the browser close event and more importantly the usage of it in `waitForEvent`.

## Why?

Firstly it is confusing for anyone reading the code that it would seem that `waitForEvent` will unblock when a `close` event occurs. Secondly when a browserContext closes, it doesn't emit a `close` event. Other close actions such as `page.close` do emit a `close` event. We don't want unexpected unblocking when a close action of any type occurs. It feels safer to remove than to fix for now.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Discussion: https://github.com/grafana/xk6-browser/pull/1042#discussion_r1332925743
