### PR TITLE
Fix injected script's Shadow DOM parsing

### DIFF
--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -248,6 +248,8 @@ class InjectedScript {
       );
       result = result.concat(shadowRootResults);
     }
+
+    if (!root.hasChildNodes()) return result;
     
     for (let i = 0; i < root.children.length; i++) {
       const childElement = root.children[i];

--- a/tests/static/wait_for.html
+++ b/tests/static/wait_for.html
@@ -1,0 +1,15 @@
+<html lang="en">
+    <head></head>
+    <body>
+        <div id='my-div' style='display: none;'>My DIV</div>
+        <script>
+            function showDiv() {
+                setTimeout(function() {
+                    document.getElementById('my-div').style.display = 'block';
+                }, 200);
+            }
+            
+            showDiv();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## What?

Fixes the` _exploreShadowDOM` function defined in the `js/injected_script.js` to check for root's children before recursively exploring them.

## Why?

This bug was producing sporadic deadlocks in `frame.waitForSelector` method.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)
Closes #1046 .
