### PR TITLE
POC: Fix for waitForEvent predicate 

### DIFF
--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -439,10 +439,6 @@ func (b *BrowserContext) runWaitForEventHandler(
 				return
 			}
 
-			// TODO: Find a better place to instantiate a page/context/iteration
-			//       scoped taskqueue.
-			p.createTaskQueue()
-
 			tempPassed := make(chan bool)
 			tempErrOut := make(chan error)
 			// TODO: Is this is a suitable place to add the predicate function to

--- a/common/page.go
+++ b/common/page.go
@@ -89,7 +89,7 @@ type Page struct {
 	routes           []api.Route
 	vu               k6modules.VU
 
-	tqOnce sync.Once
+	tqOnce *sync.Once
 	tq     *taskqueue.TaskQueue
 
 	logger *log.Logger
@@ -127,6 +127,7 @@ func NewPage(
 		routes:           make([]api.Route, 0),
 		vu:               k6ext.GetVU(ctx),
 		logger:           logger,
+		tqOnce:           &sync.Once{},
 	}
 
 	p.logger.Debugf("Page:NewPage", "sid:%v tid:%v backgroundPage:%t",

--- a/common/page.go
+++ b/common/page.go
@@ -801,6 +801,10 @@ func (p *Page) createTaskQueue() {
 	})
 }
 
+func (p *Page) queueTask(t taskqueue.Task) {
+	p.tq.Queue(t)
+}
+
 // On subscribes to a page event for which the given handler will be executed
 // passing in the ConsoleMessage associated with the event.
 // The only accepted event value is 'console'.


### PR DESCRIPTION
## What?

NOTE: This is a POC and what I wanted was for us to discuss where would be a better place for placing the taskqueue.

This fixes an issue with `waitForEvent` and forces the predicate function to be called on the taskqueue, just like how `page.on('console')` works.

## Why?

If you run the following test with the existing implementation of `waitForEvent` in `main` (a7598e135deecb7ac1f64bea605feb547fda345d), it will cause unexpected `nil` errors.

<details><summary>Test script</summary>

```js
import { browser } from 'k6/x/browser';

export const options = {
  scenarios: {
    browser: {
      executor: 'shared-iterations',
      options: {
        browser: {
            type: 'chromium',
        },
      },
    },
  },
}

export default async function() {
  for (var i = 0; i < 10; i++) {
    const context = browser.newContext()
    
    try {
      // We want to wait for two page creations before carrying on.
      var counter = 0
      const promise = context.waitForEvent("page", { predicate: page => {
        if (++counter >= 5) {
          console.log('predicate passed')
          return true
        }
        return false
      } })
      
      // Now we create two pages.
      const page = context.newPage()
      const page2 = context.newPage()
      const page3 = context.newPage()
      const page4 = context.newPage()
      const page5 = context.newPage()

      // We await for the page creation events to be processed and the predicate
      // to pass.
      console.log('wait for predicate')
      await promise

      page.close()
      page2.close()
      page3.close()
      page4.close()
      page5.close()
    } catch (e) {
      console.log('test failed: ' + e)
    } finally {
      context.close()
      console.log(`iteration ${i} completed`)
    }
  }
};
```

</details>

The reason is that js calls that are ran in the gojs context need to run on the taskqueue otherwise there will be race conditions and unexpected syntonisation issues, since goja seems to not be thread safe. I don't understand the full details of why but something similar was done for `page.on('console')`. After replicating the creation and queueing up of the predicate on the taskqueue the nil issue resolved themselves.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

https://github.com/grafana/xk6-browser/issues/1048