### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
         dependency-type: "all"
       - dependency-name: "github.com/chromedp/cdproto"
         dependency-type: "all"
-      - dependency-name: "github.com/mailru/easyjson"
-        dependency-type: "all"
       - dependency-name: "github.com/mstoykov/k6-taskqueue-lib"
         dependency-type: "all"
       - dependency-name: "github.com/stretchr/testify"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,6 @@ updates:
         dependency-type: "all"
       - dependency-name: "github.com/mccutchen/go-httpbin"
         dependency-type: "all"
-      - dependency-name: "github.com/dop251/goja"
-        dependency-type: "all"
     target-branch: "main"
     commit-message:
       prefix: "Bump "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
         dependency-type: "all"
       - dependency-name: "github.com/mccutchen/go-httpbin"
         dependency-type: "all"
+      - dependency-name: "github.com/dop251/goja"
+        dependency-type: "all"
     target-branch: "main"
     commit-message:
       prefix: "Bump "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-name: "go.k6.io/k6"
+        dependency-type: "all"
+      - dependency-name: "github.com/chromedp/cdproto"
+        dependency-type: "all"
+      - dependency-name: "github.com/mailru/easyjson"
+        dependency-type: "all"
+      - dependency-name: "github.com/mstoykov/k6-taskqueue-lib"
+        dependency-type: "all"
+      - dependency-name: "github.com/stretchr/testify"
+        dependency-type: "all"
+      - dependency-name: "github.com/gorilla/websocket"
+        dependency-type: "all"
+      - dependency-name: "github.com/mccutchen/go-httpbin"
+        dependency-type: "all"
+    target-branch: "main"
+    commit-message:
+      prefix: "Bump "
+      include: scope
+    assignees:
+      - "octocat"
+    reviewers:
+      - "inancgumus"
+      - "ankur22"
+      - "ka3de"


### PR DESCRIPTION
## What?

Adds Github dependabot for our repository.

## Why?

To keep our dependencies up to date, like k6-core, CDP proto, etc.

We usually do this manually, which can be a hassle and causes our dependencies go stale:
- #1047, #975, #907, #830, #740, #739, ...

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas