### PR TITLE
Add block fixup commits GH workflow

### DIFF
--- a/.github/workflows/block-fixup.yml
+++ b/.github/workflows/block-fixup.yml
@@ -1,0 +1,12 @@
+name: Block fixup commits
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
## What?

Adds a new GH workflow which purpose is to avoid mistakenly introducing fixup commits in the main branch when merging PRs.

## Why?

Considering our development workflow, introducing fixup commits in the main branch is a mistake that can be made more or less easily, so it's better to have automation set up to prevent it and avoid "polluting" the main branch.

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Closes https://github.com/grafana/xk6-browser/issues/1053.
