### PR TITLE
Move taskqueue to mapping layer

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -433,7 +433,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 			})
 		},
 		"close": func(opts goja.Value) error {
-			vu.taskQueueRegistry.close(p.GetTargetID())
+			vu.taskQueueRegistry.close(p.TargetID())
 
 			return p.Close(opts) //nolint:wrapcheck
 		},
@@ -507,7 +507,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 		},
 		"mouse": rt.ToValue(p.GetMouse()).ToObject(rt),
 		"on": func(event string, handler goja.Callable) error {
-			tq := vu.taskQueueRegistry.get(p.GetTargetID())
+			tq := vu.taskQueueRegistry.get(p.TargetID())
 
 			mapMsgAndHandleEvent := func(m *common.ConsoleMessage) error {
 				mapping := mapConsoleMessage(vu, m)
@@ -671,7 +671,7 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 				var runInTaskQueue func(p *common.Page) (bool, error)
 				if parsedOpts.PredicateFn != nil {
 					runInTaskQueue = func(p *common.Page) (bool, error) {
-						tq := vu.taskQueueRegistry.get(p.GetTargetID())
+						tq := vu.taskQueueRegistry.get(p.TargetID())
 
 						var rtn bool
 						var err error

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -509,7 +509,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 				_, err := handler(goja.Undefined(), vu.Runtime().ToValue(mapping))
 				return err
 			}
-			runInTaskQueue := func(m *api.ConsoleMessage) error {
+			runInTaskQueue := func(m *common.ConsoleMessage) {
 				tq := taskqueue.New(vu.RegisterCallback)
 				tq.Queue(func() error {
 					if err := mapMsgAndHandleEvent(m); err != nil {
@@ -518,7 +518,6 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 					return nil
 				})
 				tq.Close()
-				return nil
 			}
 
 			return p.On(event, runInTaskQueue) //nolint:wrapcheck

--- a/browser/module.go
+++ b/browser/module.go
@@ -65,11 +65,12 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 	return &ModuleInstance{
 		mod: &JSModule{
 			Browser: mapBrowserToGoja(moduleVU{
-				VU:              vu,
-				pidRegistry:     m.PidRegistry,
-				browserRegistry: newBrowserRegistry(vu, m.remoteRegistry, m.PidRegistry),
-				tqMu:            &sync.RWMutex{},
-				tq:              make(map[string]*taskqueue.TaskQueue),
+				VU:                vu,
+				pidRegistry:       m.PidRegistry,
+				browserRegistry:   newBrowserRegistry(vu, m.remoteRegistry, m.PidRegistry),
+				tqMu:              &sync.RWMutex{},
+				tq:                make(map[string]*taskqueue.TaskQueue),
+				taskQueueRegistry: newTaskQueueRegistry(vu),
 			}),
 			Devices: common.GetDevices(),
 		},

--- a/browser/module.go
+++ b/browser/module.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/dop251/goja"
+	"github.com/mstoykov/k6-taskqueue-lib/taskqueue"
 
 	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/env"
@@ -68,6 +69,7 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 				pidRegistry:     m.PidRegistry,
 				browserRegistry: newBrowserRegistry(vu, m.remoteRegistry, m.PidRegistry),
 				tqMu:            &sync.RWMutex{},
+				tq:              make(map[string]*taskqueue.TaskQueue),
 			}),
 			Devices: common.GetDevices(),
 		},

--- a/browser/module.go
+++ b/browser/module.go
@@ -67,6 +67,7 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 				VU:              vu,
 				pidRegistry:     m.PidRegistry,
 				browserRegistry: newBrowserRegistry(vu, m.remoteRegistry, m.PidRegistry),
+				tqMu:            &sync.RWMutex{},
 			}),
 			Devices: common.GetDevices(),
 		},

--- a/browser/module.go
+++ b/browser/module.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/dop251/goja"
-	"github.com/mstoykov/k6-taskqueue-lib/taskqueue"
 
 	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/env"
@@ -68,8 +67,6 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 				VU:                vu,
 				pidRegistry:       m.PidRegistry,
 				browserRegistry:   newBrowserRegistry(vu, m.remoteRegistry, m.PidRegistry),
-				tqMu:              &sync.RWMutex{},
-				tq:                make(map[string]*taskqueue.TaskQueue),
 				taskQueueRegistry: newTaskQueueRegistry(vu),
 			}),
 			Devices: common.GetDevices(),

--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -24,6 +24,8 @@ type moduleVU struct {
 
 	tqMu *sync.RWMutex
 	tq   map[string]*taskqueue.TaskQueue
+
+	*taskQueueRegistry
 }
 
 // browser returns the VU browser instance for the current iteration.

--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -23,7 +23,7 @@ type moduleVU struct {
 	*browserRegistry
 
 	tqMu *sync.RWMutex
-	tq   *taskqueue.TaskQueue
+	tq   map[string]*taskqueue.TaskQueue
 }
 
 // browser returns the VU browser instance for the current iteration.

--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -3,6 +3,8 @@ package browser
 import (
 	"context"
 
+	"github.com/mstoykov/k6-taskqueue-lib/taskqueue"
+
 	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/k6ext"
 
@@ -18,6 +20,8 @@ type moduleVU struct {
 
 	*pidRegistry
 	*browserRegistry
+
+	tq *taskqueue.TaskQueue
 }
 
 // browser returns the VU browser instance for the current iteration.

--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -2,9 +2,6 @@ package browser
 
 import (
 	"context"
-	"sync"
-
-	"github.com/mstoykov/k6-taskqueue-lib/taskqueue"
 
 	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/k6ext"
@@ -21,9 +18,6 @@ type moduleVU struct {
 
 	*pidRegistry
 	*browserRegistry
-
-	tqMu *sync.RWMutex
-	tq   map[string]*taskqueue.TaskQueue
 
 	*taskQueueRegistry
 }

--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"context"
+	"sync"
 
 	"github.com/mstoykov/k6-taskqueue-lib/taskqueue"
 
@@ -21,7 +22,8 @@ type moduleVU struct {
 	*pidRegistry
 	*browserRegistry
 
-	tq *taskqueue.TaskQueue
+	tqMu *sync.RWMutex
+	tq   *taskqueue.TaskQueue
 }
 
 // browser returns the VU browser instance for the current iteration.

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -408,7 +408,7 @@ func (b *BrowserContext) waitForEvent(
 	ch := make(chan any)
 	errCh := make(chan error)
 
-	go b.runWaitForEventHandler(evCancelCtx, chEvHandler, ch, errCh, predicateFn)
+	go b.runWaitForEventHandler(evCancelCtx, chEvHandler, predicateFn, ch, errCh)
 
 	b.on(evCancelCtx, []string{EventBrowserContextPage}, chEvHandler)
 
@@ -430,7 +430,9 @@ func (b *BrowserContext) waitForEvent(
 // runWaitForEventHandler can work with a nil predicateFn. If predicateFn is
 // nil it will return the response straight away.
 func (b *BrowserContext) runWaitForEventHandler(
-	ctx context.Context, chEvHandler chan Event, out chan<- any, errOut chan<- error, predicateFn func(p *Page) (bool, error),
+	ctx context.Context,
+	chEvHandler chan Event, predicateFn func(p *Page) (bool, error),
+	out chan<- any, errOut chan<- error,
 ) {
 	b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():starts", "bctxid:%v", b.id)
 	defer b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():returns", "bctxid:%v", b.id)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -468,7 +468,13 @@ func (b *BrowserContext) runWaitForEventHandler(
 				return
 			}
 
-			if retVal, err := predicateFn(p); err == nil && retVal {
+			retVal, err := predicateFn(p)
+			if err != nil {
+				errOut <- fmt.Errorf("predicate function failed: %w", err)
+				return
+			}
+
+			if retVal {
 				b.logger.Debugf(
 					"BrowserContext:runWaitForEventHandler:go():EventBrowserContextPage:predicateFn:return",
 					"bctxid:%v", b.id,

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -380,6 +380,11 @@ func (b *BrowserContext) Unroute(url goja.Value, handler goja.Callable) {
 	k6ext.Panic(b.ctx, "BrowserContext.unroute(url, handler) has not been implemented yet")
 }
 
+// Timeout will return the default timeout or the one set by the user.
+func (b *BrowserContext) Timeout() time.Duration {
+	return b.timeoutSettings.timeout()
+}
+
 // WaitForEvent waits for event.
 func (b *BrowserContext) WaitForEvent(event string, optsOrPredicate goja.Value) (any, error) {
 	b.logger.Debugf("BrowserContext:WaitForEvent", "bctxid:%v event:%q", b.id, event)

--- a/common/page.go
+++ b/common/page.go
@@ -1270,9 +1270,9 @@ func (p *Page) Workers() []*Worker {
 	return workers
 }
 
-// GetTargetID retrieve the unique id that is associated to this page.
+// TargetID retrieve the unique id that is associated to this page.
 // For internal use only.
-func (p *Page) GetTargetID() string {
+func (p *Page) TargetID() string {
 	return p.targetID.String()
 }
 

--- a/common/page.go
+++ b/common/page.go
@@ -1270,6 +1270,12 @@ func (p *Page) Workers() []*Worker {
 	return workers
 }
 
+// GetTargetID retrieve the unique id that is associated to this page.
+// For internal use only.
+func (p *Page) GetTargetID() string {
+	return p.targetID.String()
+}
+
 func (p *Page) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICalled) {
 	// If there are no handlers for EventConsoleAPICalled, return
 	p.eventHandlersMu.RLock()

--- a/common/page.go
+++ b/common/page.go
@@ -179,7 +179,7 @@ func NewEmulatedSize(viewport *Viewport, screen *Screen) *EmulatedSize {
 	}
 }
 
-type consoleEventHandlerFunc func(*ConsoleMessage) error
+type consoleEventHandlerFunc func(*ConsoleMessage)
 
 // ConsoleMessage represents a page console message.
 type ConsoleMessage struct {
@@ -946,7 +946,7 @@ func (p *Page) MainFrame() *Frame {
 // On subscribes to a page event for which the given handler will be executed
 // passing in the ConsoleMessage associated with the event.
 // The only accepted event value is 'console'.
-func (p *Page) On(event string, handler func(*ConsoleMessage) error) error {
+func (p *Page) On(event string, handler func(*ConsoleMessage)) error {
 	if event != eventPageConsoleAPICalled {
 		return fmt.Errorf("unknown page event: %q, must be %q", event, eventPageConsoleAPICalled)
 	}

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -777,7 +777,8 @@ func TestBrowserContextWaitForEvent(t *testing.T) {
 			select {
 			case <-waitDone:
 			case <-ctx.Done():
-				err = ctx.Err()
+				err := ctx.Err()
+				require.NoError(t, err)
 			}
 
 			if tc.wantErr == "" {


### PR DESCRIPTION
## What?

This PR moves the taskqueue to the mapping layer. The change will affect `page.on` and `browserContext.waitForEvent`.

## Why?

As we work more with goja and it's runtime, it is starting to find its way into our business logic code. This make maintaining the project more difficult due to having to work with raw `goja.Value` and (more recently) the event loop and `taskqueue`. One of these areas that we do not want in the business logic is most definitely the `taskqueue` which was introduced when we added `page.on`. `page.on` requires a predicate method on the goja runtime since the function is written in JS. Since the goja runtime is not thread safe we need to work with the `taskqueue`. Working with the `taskqueue` in the business logic makes reasoning, maintaining and writing tests very tricky since various components need to be orchestrated in multiple goroutines.

This change forces the creation and deletion of the `taskqueue` in the mapping layer. This change also forces us to convert `goja.Value`s to native go structs, which has enabled us to move some goja code out of the business logic (specifically for `browsercontext.waitForEvent`). We can verify that the changes work with JS test scripts, whereas the business logic can be tested with native go code using either unit or integration tests with less go routine orchestration.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
