### PR TITLE
Add `browser.closeContext()`

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -716,7 +716,7 @@ func mapConsoleMessage(vu moduleVU, cm *common.ConsoleMessage) mapping {
 }
 
 // mapBrowser to the JS module.
-func mapBrowser(vu moduleVU) mapping {
+func mapBrowser(vu moduleVU) mapping { //nolint:funlen
 	rt := vu.Runtime()
 	return mapping{
 		"context": func() (*common.BrowserContext, error) {
@@ -725,6 +725,13 @@ func mapBrowser(vu moduleVU) mapping {
 				return nil, err
 			}
 			return b.Context(), nil
+		},
+		"closeContext": func() error {
+			b, err := vu.browser()
+			if err != nil {
+				return err
+			}
+			return b.CloseContext() //nolint:wrapcheck
 		},
 		"isConnected": func() (bool, error) {
 			b, err := vu.browser()

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -244,6 +244,7 @@ func isCustomMapping(customMappings map[string]string, typ, method string) (stri
 type browserAPI interface {
 	Close()
 	Context() *common.BrowserContext
+	CloseContext()
 	IsConnected() bool
 	NewContext(opts goja.Value) (*common.BrowserContext, error)
 	NewPage(opts goja.Value) (*common.Page, error)

--- a/common/browser.go
+++ b/common/browser.go
@@ -486,6 +486,16 @@ func (b *Browser) Close() {
 	b.conn.Close()
 }
 
+// CloseContext is a short-cut function to close the current browser's context.
+// If there is no active browser context, it returns an error.
+func (b *Browser) CloseContext() error {
+	if b.context == nil {
+		return errors.New("cannot close context as none is active in browser")
+	}
+	b.context.Close()
+	return nil
+}
+
 // Context returns the current browser context or nil.
 func (b *Browser) Context() *BrowserContext {
 	return b.context

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -343,3 +343,30 @@ func TestMultiConnectToSingleBrowser(t *testing.T) {
 	err = p2.Close(nil)
 	require.NoError(t, err, "failed to close page #2")
 }
+
+func TestCloseContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("close_context", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t)
+		_, err := tb.NewContext(nil)
+		require.NoError(t, err)
+
+		assert.NotNil(t, tb.Context())
+
+		err = tb.CloseContext()
+		require.NoError(t, err)
+
+		assert.Nil(t, tb.Context())
+	})
+
+	t.Run("err_no_context", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t)
+		assert.Nil(t, tb.Context())
+		assert.Error(t, tb.CloseContext())
+	})
+}


### PR DESCRIPTION
## What?

Adds a new `browser.closeContext()` function, which is a handier method to close the current active browser context instead of the more "convoluted" `browser.context().close()`.

## Why?

Improve UX now that an iteration is limited to a single browser context, therefore extra creation/closing actions might be required.

## Checklist
- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [X] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)
Updates #1041.
