### PR TITLE
Refactor clearPermissions to return an error

### DIFF
--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -180,13 +180,15 @@ func (b *BrowserContext) Browser() *Browser {
 }
 
 // ClearPermissions clears any permission overrides.
-func (b *BrowserContext) ClearPermissions() {
+func (b *BrowserContext) ClearPermissions() error {
 	b.logger.Debugf("BrowserContext:ClearPermissions", "bctxid:%v", b.id)
 
 	action := cdpbrowser.ResetPermissions().WithBrowserContextID(b.id)
 	if err := action.Do(b.ctx); err != nil {
-		k6ext.Panic(b.ctx, "clearing permissions: %w", err)
+		return fmt.Errorf("clearing permissions: %w", err)
 	}
+
+	return nil
 }
 
 // Close shuts down the browser context.


### PR DESCRIPTION
## What?

Refactors `browserContext.clearPermission`.

## Why?

Brings it inline with how we implement the APIs:
1. Return an error instead of panicking.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Prerequist to https://github.com/grafana/xk6-browser/issues/443
