### PR TITLE
Fix browserContext.clearPermissions

### DIFF
--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -187,7 +187,7 @@ func (b *BrowserContext) ClearPermissions() error {
 	b.logger.Debugf("BrowserContext:ClearPermissions", "bctxid:%v", b.id)
 
 	action := cdpbrowser.ResetPermissions().WithBrowserContextID(b.id)
-	if err := action.Do(b.ctx); err != nil {
+	if err := action.Do(cdp.WithExecutor(b.ctx, b.browser.conn)); err != nil {
 		return fmt.Errorf("clearing permissions: %w", err)
 	}
 

--- a/examples/grant_permission.js
+++ b/examples/grant_permission.js
@@ -26,8 +26,9 @@ export default async function() {
   const page = context.newPage();
 
   try {
-    await page.goto('http://whatsmyuseragent.org/');
+    await page.goto('https://test.k6.io/');
     page.screenshot({ path: `example-chromium.png` });
+    context.clearPermissions();
   } finally {
     page.close();
   }

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -841,3 +841,32 @@ func TestBrowserContextGrantPermissions(t *testing.T) {
 		})
 	}
 }
+
+func TestBrowserContextClearPermissions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no_permissions_set", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t)
+		bCtx, err := tb.NewContext(nil)
+		require.NoError(t, err)
+
+		err = bCtx.ClearPermissions()
+		assert.NoError(t, err)
+	})
+
+	t.Run("permissions_set", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t)
+		bCtx, err := tb.NewContext(nil)
+		require.NoError(t, err)
+
+		err = bCtx.GrantPermissions([]string{"geolocation"}, common.NewGrantPermissionsOptions())
+		require.NoError(t, err)
+
+		err = bCtx.ClearPermissions()
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## What?

This fixes the error when `browserContext.clearPermissions` is called.

## Why?

It was erroring due to the CDP request not being setup correctly.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Closes: https://github.com/grafana/xk6-browser/issues/443