### PR TITLE
Fix request interception navigation deadlock

### DIFF
--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -378,7 +378,7 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 	// goroutine here, we need to spawn a new goroutine to allow the requestPaused
 	// messages to be processed by the NetworkManager.
 	//
-	// This happens when the main page request redirection before it finishes loading.
+	// This happens when the main page request redirects before it finishes loading.
 	// So the new redirect request will be blocked until the main page finishes loading.
 	// The main page will wait forever since its subrequest is blocked.
 	go emitResponseMetrics()

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -356,14 +356,32 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 	}
 
 	req.responseEndTiming = float64(event.Timestamp.Time().Unix()-req.timestamp.Unix()) * 1000
+	m.deleteRequestByID(event.RequestID)
+	m.frameManager.requestFinished(req)
+
 	// Skip data and blob URLs when emitting metrics, since they're internal to the browser.
-	if !isInternalURL(req.url) {
+	if isInternalURL(req.url) {
+		return
+	}
+	emitResponseMetrics := func() {
 		req.responseMu.RLock()
 		m.emitResponseMetrics(req.response, req)
 		req.responseMu.RUnlock()
 	}
-	m.deleteRequestByID(rid)
-	m.frameManager.requestFinished(req)
+	if !req.allowInterception {
+		emitResponseMetrics()
+		return
+	}
+	// When request interception is enabled, we need to process requestPaused messages
+	// from CDP in order to get the response for the request. However, we can't process
+	// them until the request is unblocked. Since we're blocking the NetworkManager
+	// goroutine here, we need to spawn a new goroutine to allow the requestPaused
+	// messages to be processed by the NetworkManager.
+	//
+	// This happens when the main page request redirection before it finishes loading.
+	// So the new redirect request will be blocked until the main page finishes loading.
+	// The main page will wait forever since its subrequest is blocked.
+	go emitResponseMetrics()
 }
 
 // requestForOnLoadingFinished returns the request for the given request ID.

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -1,9 +1,11 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -123,4 +125,78 @@ func TestBasicAuth(t *testing.T) {
 		require.NotNil(t, resp)
 		assert.Equal(t, http.StatusUnauthorized, int(resp.Status()))
 	})
+}
+
+// See issue #1072 for more details.
+func TestInterceptBeforePageLoad(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withHTTPServer())
+
+	// changing the main frame to another URL will trigger a redirect
+	// before the page is loaded. this will cause a deadlock because
+	// the page's response body won't be available yet due to request
+	// interception.
+	//
+	// the reason for this is that the browser will intercept the
+	// request and pause it, but the response body won't be available
+	// until the page is loaded, which won't happen because the
+	// request is paused.
+	tb.withHandler("/neverFinishesLoading", func(w http.ResponseWriter, r *http.Request) {
+		const runBeforePageOnLoad = `
+			// immediately redirect to another page before the page is
+			// loaded. browsers wait for scripts to finish executing
+			// before firing the load event, so this will cause the
+			// page to never finish loading.
+			window.location.href='/trap';
+		`
+		fmt.Fprintf(w, `
+			<html>
+				<head>
+					<script>
+						%s
+					</script>
+				</head>
+				<body />
+			</html>
+		`, runBeforePageOnLoad)
+	})
+
+	// this handler will be called before the main page is loaded
+	tb.withHandler("/trap", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	})
+
+	// go to the main page and wait for the redirect to happen
+	// before the page is loaded (LifecycleEventDOMContentLoad).
+	gotoPage := func() error {
+		p := tb.NewPage(nil)
+
+		opts := &common.FrameGotoOptions{
+			WaitUntil: common.LifecycleEventDOMContentLoad,
+			Timeout:   common.DefaultTimeout,
+		}
+		_, err := p.Goto(
+			tb.url("/neverFinishesLoading"),
+			tb.toGojaValue(opts),
+		)
+
+		return err
+	}
+
+	// enable interception to pause the redirect in the main page
+	blocked, err := k6types.NewNullHostnameTrie([]string{"foo.com"})
+	require.NoError(t, err)
+	tb.vu.State().Options.BlockedHostnames = blocked
+
+	// go to the main page and cut short with a timeout
+	// if it takes too long. in a buggy case, this will
+	// deadlock and never return.
+	//
+	// a five seconds timeout is plenty for this bug to
+	// manifest.
+	ctx, cancel := context.WithTimeout(tb.ctx, 5*time.Second)
+	defer cancel()
+	err = tb.run(ctx, gotoPage)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## What?

Fixes the request interception deadlock while navigating to another page before loading the current page.

* Please take a look at #1072 for more details.
* Please see #1084 for a prior refactoring work for this PR.

## Why?

To make complex websites that use many internal iframes and navigations work (like SPAs).

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Fixes #1072
