### PR TITLE
Remove browser close event

### DIFF
--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -445,11 +445,6 @@ func (b *BrowserContext) runWaitForEventHandler(
 			b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():ctx:done", "bctxid:%v", b.id)
 			return
 		case ev := <-chEvHandler:
-			if ev.typ == EventBrowserContextClose {
-				b.logger.Debugf("BrowserContext:runWaitForEventHandler:go():EventBrowserContextClose:return", "bctxid:%v", b.id)
-				return
-			}
-
 			if ev.typ != EventBrowserContextPage {
 				continue
 			}

--- a/common/event_emitter.go
+++ b/common/event_emitter.go
@@ -12,8 +12,7 @@ const (
 
 	// BrowserContext
 
-	EventBrowserContextClose string = "close"
-	EventBrowserContextPage  string = "page"
+	EventBrowserContextPage string = "page"
 
 	// Connection
 


### PR DESCRIPTION
## What?

This remove the browser close event and more importantly the usage of it in `waitForEvent`.

## Why?

Firstly it is confusing for anyone reading the code that it would seem that `waitForEvent` will unblock when a `close` event occurs. Secondly when a browserContext closes, it doesn't emit a `close` event. Other close actions such as `page.close` do emit a `close` event. We don't want unexpected unblocking when a close action of any type occurs. It feels safer to remove than to fix for now.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Discussion: https://github.com/grafana/xk6-browser/pull/1042#discussion_r1332925743
