### PR TITLE
Refactor NetworkManager.onLoadingFinished

### DIFF
--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -370,7 +370,7 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 func (m *NetworkManager) requestForOnLoadingFinished(rid network.RequestID) *Request {
 	r := m.requestFromID(rid)
 
-	// Immediately return if the request is not found.
+	// Immediately return if the request is found.
 	if r != nil {
 		return r
 	}
@@ -379,7 +379,7 @@ func (m *NetworkManager) requestForOnLoadingFinished(rid network.RequestID) *Req
 	if m.parent == nil {
 		return nil
 	}
-	// Main requests have matching loaderID and requestID.
+	// Requests eminating from the parent have matching requestIDs.
 	pr := m.parent.requestFromID(rid)
 	if pr == nil || pr.getDocumentID() != rid.String() {
 		return nil


### PR DESCRIPTION
## What?

Refactors `NetworkManager.onLoadingFinished` to fix linter warnings.

## Why?

This is before fixing bug #1072. Otherwise, We'd have to do the refactoring in #1078.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Related: #1078