### PR TITLE
Merge network interception deadlock bug fix

### DIFF
--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -386,13 +386,28 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 	m.frameManager.requestFinished(req)
 
 	// Skip data and blob URLs when emitting metrics, since they're internal to the browser.
-	if !isInternalURL(req.url) {
+	if isInternalURL(req.url) {
+		return
+	}
+	emitResponseMetrics := func() {
 		req.responseMu.RLock()
 		m.emitResponseMetrics(req.response, req)
 		req.responseMu.RUnlock()
 	}
-	m.deleteRequestByID(rid)
-	m.frameManager.requestFinished(req)
+	if !req.allowInterception {
+		emitResponseMetrics()
+		return
+	}
+	// When request interception is enabled, we need to process requestPaused messages
+	// from CDP in order to get the response for the request. However, we can't process
+	// them until the request is unblocked. Since we're blocking the NetworkManager
+	// goroutine here, we need to spawn a new goroutine to allow the requestPaused
+	// messages to be processed by the NetworkManager.
+	//
+	// This happens when the main page request redirection before it finishes loading.
+	// So the new redirect request will be blocked until the main page finishes loading.
+	// The main page will wait forever since its subrequest is blocked.
+	go emitResponseMetrics()
 }
 
 // requestForOnLoadingFinished returns the request for the given request ID.

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -373,9 +373,7 @@ func (m *NetworkManager) onLoadingFailed(event *network.EventLoadingFailed) {
 }
 
 func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) {
-	rid := event.RequestID
-	req := m.requestForOnLoadingFinished(rid)
-
+	req := m.requestForOnLoadingFinished(event.RequestID)
 	// the request was not created yet.
 	if req == nil {
 		return

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -399,7 +399,7 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 func (m *NetworkManager) requestForOnLoadingFinished(rid network.RequestID) *Request {
 	r := m.requestFromID(rid)
 
-	// Immediately return if the request is not found.
+	// Immediately return if the request is found.
 	if r != nil {
 		return r
 	}
@@ -408,7 +408,7 @@ func (m *NetworkManager) requestForOnLoadingFinished(rid network.RequestID) *Req
 	if m.parent == nil {
 		return nil
 	}
-	// Main requests have matching loaderID and requestID.
+	// Requests eminating from the parent have matching requestIDs.
 	pr := m.parent.requestFromID(rid)
 	if pr == nil || pr.getDocumentID() != rid.String() {
 		return nil

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -404,7 +404,7 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 	// goroutine here, we need to spawn a new goroutine to allow the requestPaused
 	// messages to be processed by the NetworkManager.
 	//
-	// This happens when the main page request redirection before it finishes loading.
+	// This happens when the main page request redirects before it finishes loading.
 	// So the new redirect request will be blocked until the main page finishes loading.
 	// The main page will wait forever since its subrequest is blocked.
 	go emitResponseMetrics()


### PR DESCRIPTION
## What?

Rebases #1072 fixes for `main`. These were reviewed earlier in https://github.com/grafana/xk6-browser/pull/1084 and https://github.com/grafana/xk6-browser/pull/1078. The only difference is this commit that makes some cosmetic changes: 8f9a3858bf5cbf26fad4d6959927b3a8e4f84396.

## Why?

We should fix the deadlock behavior #1072 also on `main`.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updated: #1072