### PR TITLE
Add throttleNetwork on page

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -544,6 +544,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 		"setViewportSize":             p.SetViewportSize,
 		"tap":                         p.Tap,
 		"textContent":                 p.TextContent,
+		"throttleNetwork":             p.ThrottleNetwork,
 		"title":                       p.Title,
 		"touchscreen":                 rt.ToValue(p.GetTouchscreen()).ToObject(rt),
 		"type":                        p.Type,

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -343,6 +343,7 @@ type pageAPI interface {
 	SetViewportSize(viewportSize goja.Value)
 	Tap(selector string, opts goja.Value)
 	TextContent(selector string, opts goja.Value) string
+	ThrottleNetwork(common.NetworkProfile) error
 	Title() string
 	Type(selector string, text string, opts goja.Value)
 	Uncheck(selector string, opts goja.Value)

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -1022,6 +1022,12 @@ func (fs *FrameSession) updateOffline(initial bool) {
 	}
 }
 
+func (fs *FrameSession) throttleNetwork(networkProfile NetworkProfile) error {
+	fs.logger.Debugf("NewFrameSession:throttleNetwork", "sid:%v tid:%v", fs.session.ID(), fs.targetID)
+
+	return fs.networkManager.ThrottleNetwork(networkProfile)
+}
+
 func (fs *FrameSession) updateRequestInterception(enable bool) error {
 	fs.logger.Debugf("NewFrameSession:updateRequestInterception",
 		"sid:%v tid:%v on:%v",

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -28,6 +28,18 @@ import (
 	"github.com/dop251/goja"
 )
 
+// NetworkProfile is used in ThrottleNetwork.
+type NetworkProfile struct {
+	// Minimum latency from request sent to response headers received (ms).
+	Latency float64
+
+	// Maximal aggregated download throughput (bytes/sec). -1 disables download throttling.
+	DownloadThroughput float64
+
+	// Maximal aggregated upload throughput (bytes/sec). -1 disables upload throttling.
+	UploadThroughput float64
+}
+
 // Credentials holds HTTP authentication credentials.
 type Credentials struct {
 	Username string `js:"username"`

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -742,6 +742,22 @@ func (m *NetworkManager) SetOfflineMode(offline bool) {
 	}
 }
 
+// ThrottleNetwork changes the network attributes in chrome to simulate slower
+// networks e.g. a slow 3G connection.
+func (m *NetworkManager) ThrottleNetwork(networkProfile NetworkProfile) error {
+	action := network.EmulateNetworkConditions(
+		m.offline,
+		networkProfile.Latency,
+		networkProfile.DownloadThroughput,
+		networkProfile.UploadThroughput,
+	)
+	if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
+		return fmt.Errorf("throttling network: %w", err)
+	}
+
+	return nil
+}
+
 // SetUserAgent overrides the browser user agent string.
 func (m *NetworkManager) SetUserAgent(userAgent string) {
 	action := emulation.SetUserAgentOverride(userAgent)

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -34,18 +34,18 @@ type NetworkProfile struct {
 	Latency float64
 
 	// Maximal aggregated download throughput (bytes/sec). -1 disables download throttling.
-	DownloadThroughput float64
+	Download float64
 
 	// Maximal aggregated upload throughput (bytes/sec). -1 disables upload throttling.
-	UploadThroughput float64
+	Upload float64
 }
 
 // NewNetworkProfile creates a non-throttled network profile.
 func NewNetworkProfile() NetworkProfile {
 	return NetworkProfile{
-		Latency:            0,
-		DownloadThroughput: -1,
-		UploadThroughput:   -1,
+		Latency:  0,
+		Download: -1,
+		Upload:   -1,
 	}
 }
 
@@ -750,8 +750,8 @@ func (m *NetworkManager) SetOfflineMode(offline bool) {
 	action := network.EmulateNetworkConditions(
 		m.offline,
 		m.networkProfile.Latency,
-		m.networkProfile.DownloadThroughput,
-		m.networkProfile.UploadThroughput,
+		m.networkProfile.Download,
+		m.networkProfile.Upload,
 	)
 	if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
 		k6ext.Panic(m.ctx, "setting offline mode: %w", err)
@@ -769,8 +769,8 @@ func (m *NetworkManager) ThrottleNetwork(networkProfile NetworkProfile) error {
 	action := network.EmulateNetworkConditions(
 		m.offline,
 		m.networkProfile.Latency,
-		m.networkProfile.DownloadThroughput,
-		m.networkProfile.UploadThroughput,
+		m.networkProfile.Download,
+		m.networkProfile.Upload,
 	)
 	if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
 		return fmt.Errorf("throttling network: %w", err)

--- a/common/page.go
+++ b/common/page.go
@@ -1173,6 +1173,17 @@ func (p *Page) Title() string {
 // ThrottleNetwork will slow the network down to simulate a slow network e.g.
 // simulating a slow 3G connection.
 func (p *Page) ThrottleNetwork(networkProfile NetworkProfile) error {
+	p.logger.Debugf("Page:ThrottleNetwork", "sid:%v", p.sessionID())
+
+	p.frameSessionsMu.RLock()
+	defer p.frameSessionsMu.RUnlock()
+
+	for _, fs := range p.frameSessions {
+		if err := fs.throttleNetwork(networkProfile); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/common/page.go
+++ b/common/page.go
@@ -1170,6 +1170,12 @@ func (p *Page) Title() string {
 	return gojaValueToString(p.ctx, p.Evaluate(v))
 }
 
+// ThrottleNetwork will slow the network down to simulate a slow network e.g.
+// simulating a slow 3G connection.
+func (p *Page) ThrottleNetwork(networkProfile NetworkProfile) error {
+	return nil
+}
+
 func (p *Page) Type(selector string, text string, opts goja.Value) {
 	p.logger.Debugf("Page:Type", "sid:%v selector:%s text:%s", p.sessionID(), selector, text)
 

--- a/examples/throttle.js
+++ b/examples/throttle.js
@@ -45,8 +45,8 @@ export async function throttled() {
   try {
     page.throttleNetwork({
       latency: 750,
-      downloadThroughput: 250,
-      uploadThroughput: 250,
+      download: 250,
+      upload: 250,
     });
 
     await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });

--- a/examples/throttle.js
+++ b/examples/throttle.js
@@ -1,0 +1,56 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    normal: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+      exec: 'normal',
+    },
+    throttled: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+      exec: 'throttled',
+    },
+  },
+  thresholds: {
+    'browser_http_req_duration{scenario:normal}': ['p(99)<500'],
+    'browser_http_req_duration{scenario:throttled}': ['p(99)<1500'],
+  },
+}
+
+export async function normal() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+  } finally {
+    page.close();
+  }
+}
+
+export async function throttled() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    page.throttleNetwork({
+      latency: 750,
+      downloadThroughput: 250,
+      uploadThroughput: 250,
+    });
+
+    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+  } finally {
+    page.close();
+  }
+}

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1093,9 +1093,9 @@ func TestPageThrottleNetwork(t *testing.T) {
 		{
 			name: "none",
 			networkProfile: common.NetworkProfile{
-				Latency:            0,
-				DownloadThroughput: -1,
-				UploadThroughput:   -1,
+				Latency:  0,
+				Download: -1,
+				Upload:   -1,
 			},
 		},
 		{
@@ -1104,9 +1104,9 @@ func TestPageThrottleNetwork(t *testing.T) {
 			// measured and used to assert that Latency has been correctly used.
 			name: "latency",
 			networkProfile: common.NetworkProfile{
-				Latency:            100,
-				DownloadThroughput: -1,
-				UploadThroughput:   -1,
+				Latency:  100,
+				Download: -1,
+				Upload:   -1,
 			},
 			wantMinRoundTripDuration: 100,
 		},
@@ -1114,24 +1114,24 @@ func TestPageThrottleNetwork(t *testing.T) {
 			// In the ping.html file, an async ping request is made, the ping response
 			// returns the request body (around a 1MB). The time it takes to perform the
 			// roundtrip of calling ping and getting the response body is measured and
-			// used to assert that DownloadThroughput has been correctly used.
-			name: "download_throughput",
+			// used to assert that Download has been correctly used.
+			name: "download",
 			networkProfile: common.NetworkProfile{
-				Latency:            0,
-				DownloadThroughput: 1000,
-				UploadThroughput:   -1,
+				Latency:  0,
+				Download: 1000,
+				Upload:   -1,
 			},
 			wantMinRoundTripDuration: 1000,
 		},
 		{
 			// In the ping.html file, an async ping request is made with around a 1MB body.
 			// The time it takes to perform the roundtrip of calling ping is measured
-			// and used to assert that UploadThroughput has been correctly used.
-			name: "upload_throughput",
+			// and used to assert that Upload has been correctly used.
+			name: "upload",
 			networkProfile: common.NetworkProfile{
-				Latency:            0,
-				DownloadThroughput: -1,
-				UploadThroughput:   1000,
+				Latency:  0,
+				Download: -1,
+				Upload:   1000,
 			},
 			wantMinRoundTripDuration: 1000,
 		},

--- a/tests/static/ping.html
+++ b/tests/static/ping.html
@@ -1,0 +1,29 @@
+<html>
+  <head>
+    <title>Ping duration test</title>
+  </head>
+  <body>
+    <div id="waiting">NA</div>
+    <script>
+        asd()
+
+        async function asd() {
+            var sendDate = (new Date()).getTime();
+
+            var receiveDate = 0;
+            await fetch('/ping', {
+                method: 'POST',
+                body: JSON.stringify('0'.repeat(1024))
+            })
+            .then(response => response.json())
+            .then(data => {
+                receiveDate = (new Date()).getTime();
+            })
+            
+            var responseTimeMs = receiveDate - sendDate;
+
+            document.getElementById("waiting").innerHTML = `<div id="result">${responseTimeMs}</div>`;
+        }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What?

This adds a new `throttleNetwork` API on `page` which throttles the network from chrome's perspective.

## Why?

A good use case for throttling the network is to see (within a lab environment) how the frontend reacts when the network is slow, e.g. on a slow 3G connection. With new measurements under a constraint network, users will be able to fine tune their website so that the most important information is returned in an acceptable timeframe.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates https://github.com/grafana/xk6-browser/issues/887