### PR TITLE
Fix interacting with an element inside nested IFrames

### DIFF
--- a/common/page.go
+++ b/common/page.go
@@ -418,7 +418,11 @@ func (p *Page) getFrameElement(f *Frame) (handle *ElementHandle, _ error) {
 		return nil, errors.New("frame has been detached 1")
 	}
 
-	parentSession := p.getFrameSession(cdp.FrameID(parent.ID()))
+	rootFrame := f
+	for ; rootFrame.parentFrame != nil; rootFrame = rootFrame.parentFrame {
+	}
+
+	parentSession := p.getFrameSession(cdp.FrameID(rootFrame.ID()))
 	action := dom.GetFrameOwner(cdp.FrameID(f.ID()))
 	backendNodeId, _, err := action.Do(cdp.WithExecutor(p.ctx, parentSession.session))
 	if err != nil {

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -14,8 +14,6 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/writer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -38,15 +36,8 @@ const sampleHTML = `<div><b>Test</b><ol><li><i>One</i></li></ol></div>`
 func TestNestedFrames(t *testing.T) {
 	t.Parallel()
 
-	buf := bytes.NewBufferString("")
 	tb := newTestBrowser(t,
 		withFileServer(),
-		func(tb *testBrowser) {
-			if !tb.isBrowserTypeInitialized {
-				return
-			}
-			tb.vu.StateField.Logger.(*logrus.Logger).AddHook(&writer.Hook{Writer: buf, LogLevels: []logrus.Level{logrus.InfoLevel}})
-		},
 	)
 	defer tb.Browser.Close()
 
@@ -77,7 +68,8 @@ func TestNestedFrames(t *testing.T) {
 	err = button1Handle.Click(nil)
 	assert.Nil(t, err)
 
-	assert.Contains(t, buf.String(), "button1 clicked")
+	v := frame2.Evaluate(tb.toGojaValue(`() => window.buttonClicked`))
+	assert.True(t, tb.asGojaBool(v), "cannot not click the button")
 }
 
 func TestPageEmulateMedia(t *testing.T) {

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -69,7 +69,7 @@ func TestNestedFrames(t *testing.T) {
 	assert.Nil(t, err)
 
 	v := frame2.Evaluate(tb.toGojaValue(`() => window.buttonClicked`))
-	assert.True(t, tb.asGojaBool(v), "cannot not click the button")
+	assert.True(t, tb.asGojaBool(v), "button hasn't been clicked")
 }
 
 func TestPageEmulateMedia(t *testing.T) {

--- a/tests/static/iframe_test_main.html
+++ b/tests/static/iframe_test_main.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <iframe id="iframe1" src="iframe_test_nested1.html"></iframe>
+  </body>
+</html>

--- a/tests/static/iframe_test_nested1.html
+++ b/tests/static/iframe_test_nested1.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <iframe id="iframe2" src="iframe_test_nested2.html"></iframe>
+  </body>
+</html>

--- a/tests/static/iframe_test_nested2.html
+++ b/tests/static/iframe_test_nested2.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <button id="button1" onclick='console.log("button1 clicked");'></button>
+  </body>
+</html>

--- a/tests/static/iframe_test_nested2.html
+++ b/tests/static/iframe_test_nested2.html
@@ -1,5 +1,8 @@
 <html>
   <body>
-    <button id="button1" onclick='console.log("button1 clicked");'></button>
+    <script>
+      buttonClicked=false;
+    </script>
+    <button id="button1" onclick='buttonClicked=true;'></button>
   </body>
 </html>


### PR DESCRIPTION
## What?

`Page.getFrameElement` now finds the root frame. Only the root frame has a `FrameSession`.

## Why?

With k6 v0.47.0 github.com/grafana/xk6-browser@v1.1.0/common/page.go:274 panicked because the parent session was nil.

## Checklist

- [ ] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Closes: #1087
