### PR TITLE
Add setInputFiles to ElementHandle

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1243,14 +1243,19 @@ func (h *ElementHandle) SelectText(opts goja.Value) {
 }
 
 // SetInputFiles sets the Files given in the opts into the <input type="file"> element.
-func (h *ElementHandle) SetInputFiles(opts goja.Value) {
+func (h *ElementHandle) SetInputFiles(files goja.Value, opts goja.Value) {
 	actionOpts := NewElementHandleSetInputFilesOptions(h.defaultTimeout())
 	if err := actionOpts.Parse(h.ctx, opts); err != nil {
 		k6ext.Panic(h.ctx, "parsing setInputFiles options: %w", err)
 	}
 
+	actionParam := &Files{}
+	if err := actionParam.Parse(h.ctx, files); err != nil {
+		k6ext.Panic(h.ctx, "parsing setInputFiles parameter: %w", err)
+	}
+
 	fn := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
-		return nil, handle.setInputFiles(apiCtx, actionOpts.Payload)
+		return nil, handle.setInputFiles(apiCtx, actionParam.Payload)
 	}
 	actFn := h.newAction([]string{}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
 	_, err := call(h.ctx, actFn, actionOpts.Timeout)

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1301,14 +1301,12 @@ func (h *ElementHandle) setInputFiles(apiCtx context.Context, payload []*File) e
 	if err != nil {
 		return err
 	}
-	v, ok := result.(goja.Value)
+	v, ok := result.(string)
 	if !ok {
 		return fmt.Errorf("unexpected type %T", result)
 	}
-	if v.ExportType().Kind() != reflect.String {
-		return fmt.Errorf("unexpected result type %s", v.ExportType().Kind().String())
-	} else if v.String() != "done" {
-		return errorFromDOMError(v.String())
+	if v != "done" {
+		return errorFromDOMError(v)
 	}
 
 	return nil

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1612,6 +1612,7 @@ func errorFromDOMError(v any) error {
 		"error:notfillablenumberinput": "cannot type text into input[type=number]",
 		"error:notvaliddate":           "malformed value",
 		"error:notinput":               "node is not an HTMLInputElement",
+		"error:notfile":                "node is not an input[type=file] element",
 		"error:hasnovalue":             "node is not an HTMLInputElement or HTMLTextAreaElement or HTMLSelectElement",
 		"error:notselect":              "element is not a <select> element",
 		"error:notcheckbox":            "not a checkbox or radio button",

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -84,13 +84,13 @@ type File struct {
 	Buffer   string `json:"buffer"`
 }
 
-// Files is the input parameter for ElementHandle.SetInputFiles
+// Files is the input parameter for ElementHandle.SetInputFiles.
 type Files struct {
 	Payload []*File `json:"payload"`
 }
 
-// ElementHandleSetInputFilesOption are options for ElementHandle.SetInputFiles.
-type ElementHandleSetInputFilesOption struct {
+// ElementHandleSetInputFilesOptions are options for ElementHandle.SetInputFiles.
+type ElementHandleSetInputFilesOptions struct {
 	ElementHandleBaseOptions
 }
 
@@ -198,8 +198,8 @@ func (o *ElementHandleCheckOptions) Parse(ctx context.Context, opts goja.Value) 
 }
 
 // NewElementHandleSetInputFilesOptions creates a new ElementHandleSetInputFilesOption.
-func NewElementHandleSetInputFilesOptions(defaultTimeout time.Duration) *ElementHandleSetInputFilesOption {
-	return &ElementHandleSetInputFilesOption{
+func NewElementHandleSetInputFilesOptions(defaultTimeout time.Duration) *ElementHandleSetInputFilesOptions {
+	return &ElementHandleSetInputFilesOptions{
 		ElementHandleBaseOptions: *NewElementHandleBaseOptions(defaultTimeout),
 	}
 }
@@ -227,7 +227,7 @@ func (f *Files) addFile(ctx context.Context, file goja.Value) error {
 	return nil
 }
 
-// Parse parses the Files struct from the given goja.Value
+// Parse parses the Files struct from the given goja.Value.
 func (f *Files) Parse(ctx context.Context, files goja.Value) error {
 	rt := k6ext.Runtime(ctx)
 	if !gojaValueExists(files) {
@@ -252,7 +252,7 @@ func (f *Files) Parse(ctx context.Context, files goja.Value) error {
 }
 
 // Parse parses the ElementHandleSetInputFilesOption from the given opts.
-func (o *ElementHandleSetInputFilesOption) Parse(ctx context.Context, opts goja.Value) error {
+func (o *ElementHandleSetInputFilesOptions) Parse(ctx context.Context, opts goja.Value) error {
 	if err := o.ElementHandleBaseOptions.Parse(ctx, opts); err != nil {
 		return err
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -1525,25 +1525,27 @@ func (f *Frame) SetContent(html string, opts goja.Value) {
 	applySlowMo(f.ctx)
 }
 
-// SetInputFiles is not implemented.
-func (f *Frame) SetInputFiles(selector string, files goja.Value, opts goja.Value) {
+// SetInputFiles sets input files for the selected element.
+func (f *Frame) SetInputFiles(selector string, files goja.Value, opts goja.Value) error {
 	f.log.Debugf("Frame:SetInputFiles", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
 	popts := NewFrameSetInputFilesOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parsing setInputFiles options: %w", err)
+		return fmt.Errorf("parsing setInputFiles options: %w", err)
 	}
 
 	pfiles := &Files{}
 	if err := pfiles.Parse(f.ctx, files); err != nil {
-		k6ext.Panic(f.ctx, "parsing setInputFiles parameter: %w", err)
+		return fmt.Errorf("parsing setInputFiles parameter: %w", err)
 	}
 
 	if err := f.setInputFiles(selector, pfiles, popts); err != nil {
-		k6ext.Panic(f.ctx, "setting input files on %q: %w", selector, err)
+		return fmt.Errorf("setting input files on %q: %w", selector, err)
 	}
 
 	applySlowMo(f.ctx)
+
+	return nil
 }
 
 // Tap the first element that matches the selector.

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -100,6 +100,12 @@ type FrameSetContentOptions struct {
 	WaitUntil LifecycleEvent `json:"waitUntil" js:"waitUntil"`
 }
 
+// FrameSetInputFilesOptions are options for Frame.setInputFiles.
+type FrameSetInputFilesOptions struct {
+	ElementHandleSetInputFilesOptions
+	Strict bool `json:"strict"`
+}
+
 type FrameTapOptions struct {
 	ElementHandleBasePointerOptions
 	Modifiers []string `json:"modifiers"`
@@ -483,6 +489,22 @@ func (o *FrameSetContentOptions) Parse(ctx context.Context, opts goja.Value) err
 		}
 	}
 
+	return nil
+}
+
+// NewFrameSetInputFilesOptions creates a new FrameSetInputFilesOptions.
+func NewFrameSetInputFilesOptions(defaultTimeout time.Duration) *FrameSetInputFilesOptions {
+	return &FrameSetInputFilesOptions{
+		ElementHandleSetInputFilesOptions: *NewElementHandleSetInputFilesOptions(defaultTimeout),
+		Strict:                            false,
+	}
+}
+
+// Parse parses FrameSetInputFilesOptions from goja.Value.
+func (o *FrameSetInputFilesOptions) Parse(ctx context.Context, opts goja.Value) error {
+	if err := o.ElementHandleSetInputFilesOptions.Parse(ctx, opts); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -432,6 +432,27 @@ class InjectedScript {
     node.dispatchEvent(event);
   }
 
+  setInputFiles(node, payloads) {
+    if (node.nodeType !== 1)
+      return "error:notelement";
+    if (node.nodeName.toLowerCase() !== "input")
+      return 'error:not input element';
+    const type = (node.getAttribute('type') || '').toLowerCase();
+    if (type !== 'file')
+      return 'error:Not an input[type=file] element';
+
+    const files = payloads.map(file => {
+      const bytes = Uint8Array.from(atob(file.buffer), c => c.charCodeAt(0));
+      return new File([bytes], file.name, { type: file.mimeType, lastModified: file.lastModifiedMs });
+    });
+    const dt = new DataTransfer();
+    for (const file of files)
+      dt.items.add(file);
+    node.files = dt.files;
+    node.dispatchEvent(new Event('input', { 'bubbles': true }));
+    node.dispatchEvent(new Event('change', { 'bubbles': true }));
+  }
+
   getElementBorderWidth(node) {
     if (
       node.nodeType !== 1 /*Node.ELEMENT_NODE*/ ||

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -433,16 +433,16 @@ class InjectedScript {
   }
 
   setInputFiles(node, payloads) {
-    if (node.nodeType !== 1)
+    if (node.nodeType !== Node.ELEMENT_NODE)
       return "error:notelement";
     if (node.nodeName.toLowerCase() !== "input")
-      return 'error:not input element';
+      return 'error:notinputelement';
     const type = (node.getAttribute('type') || '').toLowerCase();
     if (type !== 'file')
-      return 'error:Not an input[type=file] element';
+      return 'error:notinputfileelement';
 
     const dt = new DataTransfer();
-    if (payloads != null) {
+    if (payloads) {
       const files = payloads.map(file => {
         const bytes = Uint8Array.from(atob(file.buffer), c => c.charCodeAt(0));
         return new File([bytes], file.name, { type: file.mimeType, lastModified: file.lastModifiedMs });
@@ -453,6 +453,7 @@ class InjectedScript {
     node.files = dt.files;
     node.dispatchEvent(new Event('input', { 'bubbles': true }));
     node.dispatchEvent(new Event('change', { 'bubbles': true }));
+    return "done";
   }
 
   getElementBorderWidth(node) {

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -436,10 +436,10 @@ class InjectedScript {
     if (node.nodeType !== Node.ELEMENT_NODE)
       return "error:notelement";
     if (node.nodeName.toLowerCase() !== "input")
-      return 'error:notinputelement';
+      return 'error:notinput';
     const type = (node.getAttribute('type') || '').toLowerCase();
     if (type !== 'file')
-      return 'error:notinputfileelement';
+      return 'error:notfile';
 
     const dt = new DataTransfer();
     if (payloads) {

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -441,13 +441,15 @@ class InjectedScript {
     if (type !== 'file')
       return 'error:Not an input[type=file] element';
 
-    const files = payloads.map(file => {
-      const bytes = Uint8Array.from(atob(file.buffer), c => c.charCodeAt(0));
-      return new File([bytes], file.name, { type: file.mimeType, lastModified: file.lastModifiedMs });
-    });
     const dt = new DataTransfer();
-    for (const file of files)
-      dt.items.add(file);
+    if (payloads != null) {
+      const files = payloads.map(file => {
+        const bytes = Uint8Array.from(atob(file.buffer), c => c.charCodeAt(0));
+        return new File([bytes], file.name, { type: file.mimeType, lastModified: file.lastModifiedMs });
+      });
+      for (const file of files)
+        dt.items.add(file);
+    }
     node.files = dt.files;
     node.dispatchEvent(new Event('input', { 'bubbles': true }));
     node.dispatchEvent(new Event('change', { 'bubbles': true }));

--- a/common/page.go
+++ b/common/page.go
@@ -1169,11 +1169,11 @@ func (p *Page) SetExtraHTTPHeaders(headers map[string]string) {
 	p.updateExtraHTTPHeaders()
 }
 
-// SetInputFiles is not implemented.
-func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value) {
+// SetInputFiles sets input files for the selected element.
+func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value) error {
 	p.logger.Debugf("Page:SetInputFiles", "sid:%v selector:%s", p.sessionID(), selector)
 
-	p.MainFrame().SetInputFiles(selector, files, opts) //nolint:wrapcheck
+	return p.MainFrame().SetInputFiles(selector, files, opts)
 }
 
 // SetViewportSize will update the viewport width and height.

--- a/common/page.go
+++ b/common/page.go
@@ -1171,8 +1171,9 @@ func (p *Page) SetExtraHTTPHeaders(headers map[string]string) {
 
 // SetInputFiles is not implemented.
 func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value) {
-	k6ext.Panic(p.ctx, "Page.textContent(selector, opts) has not been implemented yet")
-	// TODO: needs slowMo
+	p.logger.Debugf("Page:SetInputFiles", "sid:%v selector:%s", p.sessionID(), selector)
+
+	p.MainFrame().SetInputFiles(selector, files, opts) //nolint:wrapcheck
 }
 
 // SetViewportSize will update the viewport width and height.

--- a/tests/setinputfiles_test.go
+++ b/tests/setinputfiles_test.go
@@ -1,0 +1,240 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/xk6-browser/common"
+)
+
+// TestSetInputFiles tests the SetInputFiles function.
+func TestSetInputFiles(t *testing.T) {
+	t.Parallel()
+
+	type file map[string]interface{}
+	type indexedFn func(idx int, propName string) interface{}
+	type testFn func(tb *testBrowser, page *common.Page, files goja.Value) error
+	type setupFn func(tb *testBrowser) (goja.Value, func())
+	type checkFn func(t *testing.T,
+		getFileCountFn func() interface{},
+		getFilePropFn indexedFn,
+		err error)
+
+	const (
+		propName = "name"
+		propType = "type"
+		propSize = "size"
+	)
+
+	pageContent := `
+	  <input type="file" id="upload">
+	`
+
+	defaultTestPage := func(tb *testBrowser, page *common.Page, files goja.Value) error {
+		return page.SetInputFiles("input", files, tb.toGojaValue(nil))
+	}
+	defaultTestElementHandle := func(tb *testBrowser, page *common.Page, files goja.Value) error {
+		handle, err := page.WaitForSelector("input", tb.toGojaValue(nil))
+		assert.NoError(t, err)
+		return handle.SetInputFiles(files, tb.toGojaValue(nil))
+	}
+
+	testCases := []struct {
+		name  string
+		setup setupFn
+		tests []testFn
+		check checkFn
+	}{
+		{
+			name: "set_one_file_with_object",
+			setup: func(tb *testBrowser) (goja.Value, func()) {
+				return tb.toGojaValue(file{"name": "test.json", "mimetype": "text/json", "buffer": "MDEyMzQ1Njc4OQ=="}), nil
+			},
+			tests: []testFn{defaultTestPage, defaultTestElementHandle},
+			check: func(t *testing.T, getFileCountFn func() interface{}, getFilePropFn indexedFn, err error) {
+				t.Helper()
+				assert.NoError(t, err)
+				// check if input has 1 file
+				assert.Equal(t, float64(1), getFileCountFn())
+				// check added file is correct
+				assert.Equal(t, "test.json", getFilePropFn(0, propName))
+				assert.Equal(t, float64(10), getFilePropFn(0, propSize))
+				assert.Equal(t, "text/json", getFilePropFn(0, propType))
+			},
+		},
+		{
+			name: "set_two_files_with_array_of_objects",
+			setup: func(tb *testBrowser) (goja.Value, func()) {
+				return tb.toGojaValue(
+					[]file{
+						{"name": "test.json", "mimetype": "text/json", "buffer": "MDEyMzQ1Njc4OQ=="},
+						{"name": "test.xml", "mimetype": "text/xml", "buffer": "MDEyMzQ1Njc4OTAxMjM0"},
+					}), nil
+			},
+			tests: []testFn{defaultTestPage, defaultTestElementHandle},
+			check: func(t *testing.T, getFileCountFn func() interface{}, getFilePropFn indexedFn, err error) {
+				t.Helper()
+				assert.NoError(t, err)
+				// check if input has 2 files
+				assert.Equal(t, float64(2), getFileCountFn())
+				// check added files are correct
+				assert.Equal(t, "test.json", getFilePropFn(0, propName))
+				assert.Equal(t, float64(10), getFilePropFn(0, propSize))
+				assert.Equal(t, "text/json", getFilePropFn(0, propType))
+				assert.Equal(t, "test.xml", getFilePropFn(1, propName))
+				assert.Equal(t, float64(15), getFilePropFn(1, propSize))
+				assert.Equal(t, "text/xml", getFilePropFn(1, propType))
+			},
+		},
+		{
+			name: "set_one_file_with_path",
+			setup: func(tb *testBrowser) (goja.Value, func()) {
+				tempFile, err := os.CreateTemp("", "*.json")
+				assert.NoError(t, err)
+				n, err := tempFile.Write([]byte("0123456789"))
+				assert.Equal(t, 10, n)
+				assert.NoError(t, err)
+				cleanupFunc := func() {
+					err := os.Remove(tempFile.Name())
+					assert.NoError(t, err)
+				}
+				return tb.toGojaValue(tempFile.Name()), cleanupFunc
+			},
+			tests: []testFn{defaultTestPage, defaultTestElementHandle},
+			check: func(t *testing.T, getFileCountFn func() interface{}, getFilePropFn indexedFn, err error) {
+				t.Helper()
+				assert.NoError(t, err)
+				// check if input has 1 file
+				assert.Equal(t, float64(1), getFileCountFn())
+				// check added file is correct
+				filename, ok := getFilePropFn(0, propName).(string)
+				assert.True(t, ok)
+				assert.Equal(t, ".json", filepath.Ext(filename))
+				assert.Equal(t, float64(10), getFilePropFn(0, propSize))
+				assert.Equal(t, "application/json", getFilePropFn(0, propType))
+			},
+		},
+		{
+			name: "set_two_files_with_path",
+			setup: func(tb *testBrowser) (goja.Value, func()) {
+				tempFile1, err := os.CreateTemp("", "*.json")
+				assert.NoError(t, err)
+				n, err := tempFile1.Write([]byte("0123456789"))
+				assert.Equal(t, 10, n)
+				assert.NoError(t, err)
+
+				tempFile2, err := os.CreateTemp("", "*.xml")
+				assert.NoError(t, err)
+				n, err = tempFile2.Write([]byte("012345678901234"))
+				assert.Equal(t, 15, n)
+				assert.NoError(t, err)
+				cleanupFunc := func() {
+					err := os.Remove(tempFile1.Name())
+					assert.NoError(t, err)
+					err = os.Remove(tempFile2.Name())
+					assert.NoError(t, err)
+				}
+
+				return tb.toGojaValue([]string{tempFile1.Name(), tempFile2.Name()}), cleanupFunc
+			},
+			tests: []testFn{defaultTestPage, defaultTestElementHandle},
+			check: func(t *testing.T, getFileCountFn func() interface{}, getFilePropFn indexedFn, err error) {
+				t.Helper()
+				assert.NoError(t, err)
+				// check if input has 2 files
+				assert.Equal(t, float64(2), getFileCountFn())
+				// check added files are correct
+				filename1, ok := getFilePropFn(0, propName).(string)
+				assert.True(t, ok)
+				assert.Equal(t, ".json", filepath.Ext(filename1))
+				assert.Equal(t, float64(10), getFilePropFn(0, propSize))
+				assert.Equal(t, "application/json", getFilePropFn(0, propType))
+				filename2, ok := getFilePropFn(1, propName).(string)
+				assert.True(t, ok)
+				assert.Equal(t, ".xml", filepath.Ext(filename2))
+				assert.Equal(t, float64(15), getFilePropFn(1, propSize))
+				assert.Equal(t, "text/xml; charset=utf-8", getFilePropFn(1, propType))
+			},
+		},
+		{
+			name: "set_nil",
+			setup: func(tb *testBrowser) (goja.Value, func()) {
+				return tb.toGojaValue(nil), nil
+			},
+			tests: []testFn{defaultTestPage, defaultTestElementHandle},
+			check: func(t *testing.T, getFileCountFn func() interface{}, getFilePropertyFn indexedFn, err error) {
+				t.Helper()
+				assert.NoError(t, err)
+				// check if input has 1 file
+				assert.Equal(t, float64(0), getFileCountFn())
+			},
+		},
+		{
+			name: "set_invalid_parameter",
+			setup: func(tb *testBrowser) (goja.Value, func()) {
+				return tb.toGojaValue([]int{12345}), nil
+			},
+			tests: []testFn{defaultTestPage, defaultTestElementHandle},
+			check: func(t *testing.T, getFileCountFn func() interface{}, getFilePropFn indexedFn, err error) {
+				t.Helper()
+				assert.ErrorContains(t, err, "invalid parameter type : int64")
+				// check if input has 0 file
+				assert.Equal(t, float64(0), getFileCountFn())
+			},
+		},
+		{
+			name: "set_file_not_exists",
+			setup: func(tb *testBrowser) (goja.Value, func()) {
+				tempFile, err := os.CreateTemp("", "*.json")
+				assert.NoError(t, err)
+				err = os.Remove(tempFile.Name())
+				assert.NoError(t, err)
+				return tb.toGojaValue(tempFile.Name()), nil
+			},
+			tests: []testFn{defaultTestPage, defaultTestElementHandle},
+			check: func(t *testing.T, getFileCountFn func() interface{}, getFilePropFn indexedFn, err error) {
+				t.Helper()
+				assert.ErrorContains(t, err, "reading file:")
+				assert.ErrorContains(t, err, "setting input files")
+				// check if input has 0 file
+				assert.Equal(t, float64(0), getFileCountFn())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		for _, test := range tc.tests {
+			test := test
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				tb := newTestBrowser(t)
+				defer tb.Browser.Close()
+				page := tb.NewPage(nil)
+				page.SetContent(pageContent, nil)
+
+				getFileCountFn := func() interface{} {
+					return page.Evaluate(`() => document.getElementById("upload").files.length`)
+				}
+
+				getFilePropertyFn := func(idx int, propName string) interface{} {
+					return page.Evaluate(
+						`(idx, propName) => document.getElementById("upload").files[idx][propName]`,
+						idx,
+						propName)
+				}
+
+				files, cleanup := tc.setup(tb)
+				if cleanup != nil {
+					defer cleanup()
+				}
+				err := test(tb, page, files)
+				tc.check(t, getFileCountFn, getFilePropertyFn, err)
+			})
+		}
+	}
+}


### PR DESCRIPTION
## What?

Add `setInputFiles` support.

## Test
Here is a test script you can test this functionality with

**index.html:** (served by e.g. ```python3 -m http.server 3080```)
```
<html>

<head>
    <script src="https://unpkg.com/dropzone@5/dist/min/dropzone.min.js"></script>
</head>

<body>
    <!-- Simple file upload form -->
    <form method="POST" action="/upload" enctype="multipart/form-data">
        <input type="file" name="upl" id="simple-upload" multiple />
        <input type="submit" value="Send" />
    </form>

    <!-- Dropzone.js -->
    <div id="dropzone"/>
    <script>
        let myDropzone = new Dropzone("div#dropzone", { url: "/upload", autoProcessQueue:false });
    </script>
</body>

</html>
```

**test.js:**
```
import { browser } from 'k6/experimental/browser';
import { check } from 'k6';

export const options = {
  scenarios: {
    ui: {
      executor: 'shared-iterations',
      vus: 1,
      iterations: 1,
      options: {
        browser: {
          type: 'chromium',
        },
      },
    },
  }
};

function getFileCount(page, id) {
  return page.evaluate((id) => {
    return document.getElementById(id).files.length;
  }, id);
}

function getFileProp(page, id, fileNo, prop) {
  return page.evaluate((id, fileNo, prop) => {
    return document.getElementById(id).files[fileNo][prop];
  }, id, fileNo, prop);
}

function getDropzoneFileCount(page) {
  return page.evaluate(() => {
    return myDropzone.files.length;
  });
}

function getDropzoneFileProp(page, fileNo, prop) {
  return page.evaluate((fileNo, prop) => {
    return myDropzone.files[fileNo][prop];
  }, fileNo, prop);
}

export default async function () {
  const page = browser.newPage();
  try {
    await page.goto('http://localhost:3080/');

    // test simple upload form
    page.setInputFiles('input[id="simple-upload"]', { name: 'test.json', mimetype: 'text/json', buffer: 'MDEyMzQ1Njc4OQ==' });
    check(getFileCount(page, 'simple-upload'), { 'file count is 1': (count) => count === 1 });
    check(getFileProp(page, 'simple-upload', 0, 'name'), { '1st file name is test.json': (prop) => prop === 'test.json' });
    check(getFileProp(page, 'simple-upload', 0, 'type'), { '1st file mimetype is text/json': (prop) => prop === 'text/json' });
    check(getFileProp(page, 'simple-upload', 0, 'size'), { '1st file size is 10': (prop) => prop === 10 });

    page.setInputFiles('input[id="simple-upload"]', [{ name: 'test.json', mimetype: 'text/json', buffer: 'MDEyMzQ1Njc4OQ==' }, { name: 'hello.txt', mimetype: 'text/plain', buffer: 'SGVsbG8gSzYgV29ybGQK' }]);
    check(getFileCount(page, 'simple-upload'), { 'file count is 2': (count) => count === 2 });
    check(getFileProp(page, 'simple-upload', 0, 'name'), { '1st file name is test.json': (prop) => prop === 'test.json' });
    check(getFileProp(page, 'simple-upload', 0, 'type'), { '1st file mimetype is text/json': (prop) => prop === 'text/json' });
    check(getFileProp(page, 'simple-upload', 0, 'size'), { '1st file size is 10': (prop) => prop === 10 });
    check(getFileProp(page, 'simple-upload', 1, 'name'), { '2nd file name is hello.txt': (prop) => prop === 'hello.txt' });
    check(getFileProp(page, 'simple-upload', 1, 'type'), { '2nd file mimetype is text/plain': (prop) => prop === 'text/plain' });
    check(getFileProp(page, 'simple-upload', 1, 'size'), { '2nd file size is 15': (prop) => prop === 15 });

    page.setInputFiles('input[id="simple-upload"]', null);
    check(getFileCount(page, 'simple-upload'), { 'file count is 0': (count) => count === 0 });

    page.setInputFiles('input[id="simple-upload"]', 'test.js');
    check(getFileCount(page, 'simple-upload'), { 'file count is 1': (count) => count === 1 });
    check(getFileProp(page, 'simple-upload', 0, 'name'), { '1st file name is test.js': (prop) => prop === 'test.js' });
    check(getFileProp(page, 'simple-upload', 0, 'type'), { '1st file mimetype is text/javascript; charset=utf-8': (prop) => prop === 'text/javascript; charset=utf-8' });
    check(getFileProp(page, 'simple-upload', 0, 'size'), { '1st file size is larger than 1000': (prop) => prop > 1000 });

    page.setInputFiles('input[id="simple-upload"]', ['test.js', 'test.js']);
    check(getFileCount(page, 'simple-upload'), { 'file count is 2': (count) => count === 2 });

    // test dropzone.js form
    page.setInputFiles('input[class="dz-hidden-input"]', { name: 'test.json', mimetype: 'text/json', buffer: 'MDEyMzQ1Njc4OQ==' });
    check(getDropzoneFileCount(page), { 'dropzone file count is 1': (count) => count === 1 });
    check(getDropzoneFileProp(page, 0, 'name'), { 'dropzone 1st file name is test.json': (prop) => prop === 'test.json' });
    check(getDropzoneFileProp(page, 0, 'type'), { 'dropzone 1st file mimetype is text/json': (prop) => prop === 'text/json' });
    check(getDropzoneFileProp(page, 0, 'size'), { 'dropzone 1st file size is 10': (prop) => prop === 10 });
  } finally {
    page.close();
  }
}

```

## Why?

Users can select input files for upload.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Closes: #384 