### PR TITLE
Add predefined network profiles

### DIFF
--- a/browser/module.go
+++ b/browser/module.go
@@ -27,8 +27,9 @@ type (
 
 	// JSModule exposes the properties available to the JS script.
 	JSModule struct {
-		Browser *goja.Object
-		Devices map[string]common.Device
+		Browser         *goja.Object
+		Devices         map[string]common.Device
+		NetworkProfiles map[string]common.NetworkProfile `js:"networkProfiles"`
 	}
 
 	// ModuleInstance represents an instance of the JS module.
@@ -69,7 +70,8 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 				browserRegistry:   newBrowserRegistry(vu, m.remoteRegistry, m.PidRegistry),
 				taskQueueRegistry: newTaskQueueRegistry(vu),
 			}),
-			Devices: common.GetDevices(),
+			Devices:         common.GetDevices(),
+			NetworkProfiles: common.GetNetworkProfiles(),
 		},
 	}
 }

--- a/browser/module_test.go
+++ b/browser/module_test.go
@@ -20,4 +20,5 @@ func TestModuleNew(t *testing.T) {
 	require.NotNil(t, m.mod, "Module should be set")
 	require.NotNil(t, m.mod.Browser, "Browser should be set")
 	require.NotNil(t, m.mod.Devices, "Devices should be set")
+	require.NotNil(t, m.mod.NetworkProfiles, "Profiles should be set")
 }

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -28,27 +28,6 @@ import (
 	"github.com/dop251/goja"
 )
 
-// NetworkProfile is used in ThrottleNetwork.
-type NetworkProfile struct {
-	// Minimum latency from request sent to response headers received (ms).
-	Latency float64
-
-	// Maximal aggregated download throughput (bytes/sec). -1 disables download throttling.
-	Download float64
-
-	// Maximal aggregated upload throughput (bytes/sec). -1 disables upload throttling.
-	Upload float64
-}
-
-// NewNetworkProfile creates a non-throttled network profile.
-func NewNetworkProfile() NetworkProfile {
-	return NetworkProfile{
-		Latency:  0,
-		Download: -1,
-		Upload:   -1,
-	}
-}
-
 // Credentials holds HTTP authentication credentials.
 type Credentials struct {
 	Username string `js:"username"`

--- a/common/network_profile.go
+++ b/common/network_profile.go
@@ -31,14 +31,18 @@ func GetNetworkProfiles() map[string]NetworkProfile {
 			Latency:  0,
 		},
 		"Slow 3G": {
+			// (500 (Kb/s) * 1000 (to bits/s)) / 8 (to bytes/s)) * 0.8 (20% bandwidth loss)
 			Download: ((500 * 1000) / 8) * 0.8,
-			Upload:   ((500 * 1000) / 8) * 0.8,
-			Latency:  400 * 5,
+			// (500 (Kb/s) * 1000 (to bits/s)) / 8 (to bytes/s)) * 0.8 (20% bandwidth loss)
+			Upload:  ((500 * 1000) / 8) * 0.8,
+			Latency: 400 * 5,
 		},
 		"Fast 3G": {
+			// ((1.6 (Mb/s) * 1000 (to Kb/s) * 1000 (to bits/s)) / 8 (to bytes/s)) * 0.9 (10% bandwidth loss)
 			Download: ((1.6 * 1000 * 1000) / 8) * 0.9,
-			Upload:   ((750 * 1000) / 8) * 0.9,
-			Latency:  150 * 3.75,
+			// (750 (Kb/s) * 1000 (to bits/s)) / 8 (to bytes/s)) * 0.9 (10% bandwidth loss)
+			Upload:  ((750 * 1000) / 8) * 0.9,
+			Latency: 150 * 3.75,
 		},
 	}
 }

--- a/common/network_profile.go
+++ b/common/network_profile.go
@@ -26,14 +26,14 @@ func NewNetworkProfile() NetworkProfile {
 func GetNetworkProfiles() map[string]NetworkProfile {
 	return map[string]NetworkProfile{
 		"Slow 3G": {
-			DownloadThroughput: ((500 * 1000) / 8) * 0.8,
-			UploadThroughput:   ((500 * 1000) / 8) * 0.8,
-			Latency:            400 * 5,
+			Download: ((500 * 1000) / 8) * 0.8,
+			Upload:   ((500 * 1000) / 8) * 0.8,
+			Latency:  400 * 5,
 		},
 		"Fast 3G": {
-			DownloadThroughput: ((1.6 * 1000 * 1000) / 8) * 0.9,
-			UploadThroughput:   ((750 * 1000) / 8) * 0.9,
-			Latency:            150 * 3.75,
+			Download: ((1.6 * 1000 * 1000) / 8) * 0.9,
+			Upload:   ((750 * 1000) / 8) * 0.9,
+			Latency:  150 * 3.75,
 		},
 	}
 }

--- a/common/network_profile.go
+++ b/common/network_profile.go
@@ -25,6 +25,11 @@ func NewNetworkProfile() NetworkProfile {
 // throttle the network with page.throttleNetwork.
 func GetNetworkProfiles() map[string]NetworkProfile {
 	return map[string]NetworkProfile{
+		"No Throttling": {
+			Download: -1,
+			Upload:   -1,
+			Latency:  0,
+		},
 		"Slow 3G": {
 			Download: ((500 * 1000) / 8) * 0.8,
 			Upload:   ((500 * 1000) / 8) * 0.8,

--- a/common/network_profile.go
+++ b/common/network_profile.go
@@ -1,5 +1,26 @@
 package common
 
+// NetworkProfile is used in ThrottleNetwork.
+type NetworkProfile struct {
+	// Minimum latency from request sent to response headers received (ms).
+	Latency float64
+
+	// Maximal aggregated download throughput (bytes/sec). -1 disables download throttling.
+	Download float64
+
+	// Maximal aggregated upload throughput (bytes/sec). -1 disables upload throttling.
+	Upload float64
+}
+
+// NewNetworkProfile creates a non-throttled network profile.
+func NewNetworkProfile() NetworkProfile {
+	return NetworkProfile{
+		Latency:  0,
+		Download: -1,
+		Upload:   -1,
+	}
+}
+
 // GetNetworkProfiles returns NetworkProfiles which are ready to be used to
 // throttle the network with page.throttleNetwork.
 func GetNetworkProfiles() map[string]NetworkProfile {

--- a/common/network_profile.go
+++ b/common/network_profile.go
@@ -1,0 +1,7 @@
+package common
+
+// GetNetworkProfiles returns NetworkProfiles which are ready to be used to
+// throttle the network with page.throttleNetwork.
+func GetNetworkProfiles() map[string]NetworkProfile {
+	return map[string]NetworkProfile{}
+}

--- a/common/network_profile.go
+++ b/common/network_profile.go
@@ -24,5 +24,16 @@ func NewNetworkProfile() NetworkProfile {
 // GetNetworkProfiles returns NetworkProfiles which are ready to be used to
 // throttle the network with page.throttleNetwork.
 func GetNetworkProfiles() map[string]NetworkProfile {
-	return map[string]NetworkProfile{}
+	return map[string]NetworkProfile{
+		"Slow 3G": {
+			DownloadThroughput: ((500 * 1000) / 8) * 0.8,
+			UploadThroughput:   ((500 * 1000) / 8) * 0.8,
+			Latency:            400 * 5,
+		},
+		"Fast 3G": {
+			DownloadThroughput: ((1.6 * 1000 * 1000) / 8) * 0.9,
+			UploadThroughput:   ((750 * 1000) / 8) * 0.9,
+			Latency:            150 * 3.75,
+		},
+	}
 }

--- a/examples/throttle.js
+++ b/examples/throttle.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/x/browser';
+import { browser, networkProfiles } from 'k6/x/browser';
 
 export const options = {
   scenarios: {
@@ -32,7 +32,7 @@ export const options = {
   },
   thresholds: {
     'browser_http_req_duration{scenario:normal}': ['p(99)<500'],
-    'browser_http_req_duration{scenario:networkThrottled}': ['p(99)<1500'],
+    'browser_http_req_duration{scenario:networkThrottled}': ['p(99)<3000'],
     'iteration_duration{scenario:normal}': ['p(99)<4000'],
     'iteration_duration{scenario:cpuThrottled}': ['p(99)<10000'],
   },
@@ -54,11 +54,7 @@ export async function networkThrottled() {
   const page = context.newPage();
 
   try {
-    page.throttleNetwork({
-      latency: 750,
-      download: 250,
-      upload: 250,
-    });
+    page.throttleNetwork(networkProfiles['Slow 3G']);
 
     await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
   } finally {


### PR DESCRIPTION
## What?

Adding predefined network profiles `No Throttling`, `Slow 3G` and `Fast 3G`.

## Why?

These are the most commonly used during frontend testing when throttling network connections.

These could have been defined in the type definitions repo. To make it simpler for our users to work with these network profiles, it's defined in the browser module repo which will make it available for browser module users.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates https://github.com/grafana/xk6-browser/issues/887