### PR TITLE
Add tracing

### DIFF
--- a/browser/module.go
+++ b/browser/module.go
@@ -2,6 +2,7 @@
 package browser
 
 import (
+	"context"
 	"log"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec
@@ -67,7 +68,7 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 			Browser: mapBrowserToGoja(moduleVU{
 				VU:                vu,
 				pidRegistry:       m.PidRegistry,
-				browserRegistry:   newBrowserRegistry(vu, m.remoteRegistry, m.PidRegistry),
+				browserRegistry:   newBrowserRegistry(context.Background(), vu, m.remoteRegistry, m.PidRegistry),
 				taskQueueRegistry: newTaskQueueRegistry(vu),
 			}),
 			Devices:         common.GetDevices(),

--- a/browser/registry.go
+++ b/browser/registry.go
@@ -279,7 +279,8 @@ func (r *browserRegistry) handleIterEvents(eventsCh <-chan *k6event.Event, unsub
 			// we have to initialize traces registry on the first VU iteration
 			// so we can get access to the k6 TracerProvider.
 			r.initTracesRegistry()
-			b, err := r.buildFn(ctx)
+			tracedCtx := r.tr.startIterationTrace(ctx, data)
+			b, err := r.buildFn(tracedCtx)
 			if err != nil {
 				e.Done()
 				k6ext.Abort(vuCtx, "error building browser on IterStart: %v", err)
@@ -291,6 +292,7 @@ func (r *browserRegistry) handleIterEvents(eventsCh <-chan *k6event.Event, unsub
 			r.setBrowser(data.Iteration, b)
 		case k6event.IterEnd:
 			r.deleteBrowser(data.Iteration)
+			r.tr.endIterationTrace(data.Iteration)
 		default:
 			r.vu.State().Logger.Warnf("received unexpected event type: %v", e.Type)
 		}

--- a/browser/registry_test.go
+++ b/browser/registry_test.go
@@ -218,12 +218,22 @@ func TestBrowserRegistry(t *testing.T) {
 		assert.Equal(t, 3, len(browserRegistry.m))
 		browserRegistry.mu.RUnlock()
 
+		// Verify iteration traces are started
+		browserRegistry.tr.mu.Lock()
+		assert.Equal(t, 3, len(browserRegistry.tr.m))
+		browserRegistry.tr.mu.Unlock()
+
 		// Send IterEnd events
 		vu.EndIteration(t, k6test.WithIteration(0))
 		vu.EndIteration(t, k6test.WithIteration(1))
 		vu.EndIteration(t, k6test.WithIteration(2))
 
 		// Verify there are no browsers left
+		browserRegistry.mu.RLock()
+		assert.Equal(t, 0, len(browserRegistry.m))
+		browserRegistry.mu.RUnlock()
+
+		// Verify iteration traces have been ended
 		browserRegistry.mu.RLock()
 		assert.Equal(t, 0, len(browserRegistry.m))
 		browserRegistry.mu.RUnlock()

--- a/browser/registry_test.go
+++ b/browser/registry_test.go
@@ -203,8 +203,11 @@ func TestBrowserRegistry(t *testing.T) {
 	t.Run("init_and_close_browsers_on_iter_events", func(t *testing.T) {
 		t.Parallel()
 
-		vu := k6test.NewVU(t)
-		browserRegistry := newBrowserRegistry(vu, remoteRegistry, &pidRegistry{})
+		var (
+			ctx             = context.Background()
+			vu              = k6test.NewVU(t)
+			browserRegistry = newBrowserRegistry(ctx, vu, remoteRegistry, &pidRegistry{})
+		)
 
 		vu.ActivateVU()
 
@@ -242,8 +245,11 @@ func TestBrowserRegistry(t *testing.T) {
 	t.Run("close_browsers_on_exit_event", func(t *testing.T) {
 		t.Parallel()
 
-		vu := k6test.NewVU(t)
-		browserRegistry := newBrowserRegistry(vu, remoteRegistry, &pidRegistry{})
+		var (
+			ctx             = context.Background()
+			vu              = k6test.NewVU(t)
+			browserRegistry = newBrowserRegistry(ctx, vu, remoteRegistry, &pidRegistry{})
+		)
 
 		vu.ActivateVU()
 
@@ -274,8 +280,11 @@ func TestBrowserRegistry(t *testing.T) {
 	t.Run("unsubscribe_on_non_browser_vu", func(t *testing.T) {
 		t.Parallel()
 
-		vu := k6test.NewVU(t)
-		browserRegistry := newBrowserRegistry(vu, remoteRegistry, &pidRegistry{})
+		var (
+			ctx             = context.Background()
+			vu              = k6test.NewVU(t)
+			browserRegistry = newBrowserRegistry(ctx, vu, remoteRegistry, &pidRegistry{})
+		)
 
 		vu.ActivateVU()
 

--- a/common/browser.go
+++ b/common/browser.go
@@ -509,7 +509,7 @@ func (b *Browser) IsConnected() bool {
 
 // NewContext creates a new incognito-like browser context.
 func (b *Browser) NewContext(opts goja.Value) (*BrowserContext, error) {
-	_, span := GetTracer(b.ctx).TraceAPICall(b.ctx, "", "browser.newContext")
+	_, span := TraceAPICall(b.ctx, "", "browser.newContext")
 	defer span.End()
 
 	if b.context != nil {
@@ -542,7 +542,7 @@ func (b *Browser) NewContext(opts goja.Value) (*BrowserContext, error) {
 
 // NewPage creates a new tab in the browser window.
 func (b *Browser) NewPage(opts goja.Value) (*Page, error) {
-	_, span := GetTracer(b.ctx).TraceAPICall(b.ctx, "", "browser.newPage")
+	_, span := TraceAPICall(b.ctx, "", "browser.newPage")
 	defer span.End()
 
 	browserCtx, err := b.NewContext(opts)

--- a/common/browser.go
+++ b/common/browser.go
@@ -509,6 +509,9 @@ func (b *Browser) IsConnected() bool {
 
 // NewContext creates a new incognito-like browser context.
 func (b *Browser) NewContext(opts goja.Value) (*BrowserContext, error) {
+	_, span := GetTracer(b.ctx).TraceAPICall(b.ctx, "", "browser.newContext")
+	defer span.End()
+
 	if b.context != nil {
 		return nil, errors.New("existing browser context must be closed before creating a new one")
 	}
@@ -539,6 +542,9 @@ func (b *Browser) NewContext(opts goja.Value) (*BrowserContext, error) {
 
 // NewPage creates a new tab in the browser window.
 func (b *Browser) NewPage(opts goja.Value) (*Page, error) {
+	_, span := GetTracer(b.ctx).TraceAPICall(b.ctx, "", "browser.newPage")
+	defer span.End()
+
 	browserCtx, err := b.NewContext(opts)
 	if err != nil {
 		return nil, fmt.Errorf("new page: %w", err)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -264,7 +264,7 @@ func (b *BrowserContext) NewCDPSession() any { // TODO: implement
 // NewPage creates a new page inside this browser context.
 func (b *BrowserContext) NewPage() (*Page, error) {
 	b.logger.Debugf("BrowserContext:NewPage", "bctxid:%v", b.id)
-	_, span := GetTracer(b.ctx).TraceAPICall(b.ctx, "", "browserContext.newPage")
+	_, span := TraceAPICall(b.ctx, "", "browserContext.newPage")
 	defer span.End()
 
 	p, err := b.browser.newPageInContext(b.id)

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -264,6 +264,8 @@ func (b *BrowserContext) NewCDPSession() any { // TODO: implement
 // NewPage creates a new page inside this browser context.
 func (b *BrowserContext) NewPage() (*Page, error) {
 	b.logger.Debugf("BrowserContext:NewPage", "bctxid:%v", b.id)
+	_, span := GetTracer(b.ctx).TraceAPICall(b.ctx, "", "browserContext.newPage")
+	defer span.End()
 
 	p, err := b.browser.newPageInContext(b.id)
 	if err != nil {

--- a/common/context.go
+++ b/common/context.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"context"
+
+	browsertrace "github.com/grafana/xk6-browser/trace"
 )
 
 type ctxKey int
@@ -10,6 +12,7 @@ const (
 	ctxKeyBrowserOptions ctxKey = iota
 	ctxKeyHooks
 	ctxKeyIterationID
+	ctxKeyTracer
 )
 
 func WithHooks(ctx context.Context, hooks *Hooks) context.Context {
@@ -48,6 +51,23 @@ func GetBrowserOptions(ctx context.Context) *BrowserOptions {
 	}
 	if bo, ok := v.(*BrowserOptions); ok {
 		return bo
+	}
+	return nil
+}
+
+// WithTracer adds the given tracer to the context.
+func WithTracer(ctx context.Context, tracer *browsertrace.Tracer) context.Context {
+	return context.WithValue(ctx, ctxKeyTracer, tracer)
+}
+
+// GetTracer returns the tracer attached to the context, or nil if not found.
+func GetTracer(ctx context.Context) *browsertrace.Tracer {
+	v := ctx.Value(ctxKeyTracer)
+	if v == nil {
+		return nil
+	}
+	if tracer, ok := v.(*browsertrace.Tracer); ok {
+		return tracer
 	}
 	return nil
 }

--- a/common/context.go
+++ b/common/context.go
@@ -2,8 +2,6 @@ package common
 
 import (
 	"context"
-
-	browsertrace "github.com/grafana/xk6-browser/trace"
 )
 
 type ctxKey int
@@ -56,17 +54,17 @@ func GetBrowserOptions(ctx context.Context) *BrowserOptions {
 }
 
 // WithTracer adds the given tracer to the context.
-func WithTracer(ctx context.Context, tracer *browsertrace.Tracer) context.Context {
+func WithTracer(ctx context.Context, tracer Tracer) context.Context {
 	return context.WithValue(ctx, ctxKeyTracer, tracer)
 }
 
 // GetTracer returns the tracer attached to the context, or nil if not found.
-func GetTracer(ctx context.Context) *browsertrace.Tracer {
+func GetTracer(ctx context.Context) Tracer {
 	v := ctx.Value(ctxKeyTracer)
 	if v == nil {
 		return nil
 	}
-	if tracer, ok := v.(*browsertrace.Tracer); ok {
+	if tracer, ok := v.(Tracer); ok {
 		return tracer
 	}
 	return nil

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1171,7 +1171,7 @@ func (h *ElementHandle) setChecked(apiCtx context.Context, checked bool, p *Posi
 }
 
 func (h *ElementHandle) Screenshot(opts goja.Value) goja.ArrayBuffer {
-	spanCtx, span := GetTracer(h.ctx).TraceAPICall(
+	spanCtx, span := TraceAPICall(
 		h.ctx,
 		h.frame.page.targetID.String(),
 		"elementHandle.screenshot",

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -9,13 +9,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/xk6-browser/common/js"
-	"github.com/grafana/xk6-browser/k6ext"
-
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
 	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/dop251/goja"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/grafana/xk6-browser/common/js"
+	"github.com/grafana/xk6-browser/k6ext"
 )
 
 const resultDone = "done"
@@ -1170,13 +1171,21 @@ func (h *ElementHandle) setChecked(apiCtx context.Context, checked bool, p *Posi
 }
 
 func (h *ElementHandle) Screenshot(opts goja.Value) goja.ArrayBuffer {
+	spanCtx, span := GetTracer(h.ctx).TraceAPICall(
+		h.ctx,
+		h.frame.page.targetID.String(),
+		"elementHandle.screenshot",
+	)
+	defer span.End()
+
 	rt := h.execCtx.vu.Runtime()
 	parsedOpts := NewElementHandleScreenshotOptions(h.defaultTimeout())
 	if err := parsedOpts.Parse(h.ctx, opts); err != nil {
 		k6ext.Panic(h.ctx, "parsing screenshot options: %w", err)
 	}
+	span.SetAttributes(attribute.String("path", parsedOpts.Path))
 
-	s := newScreenshotter(h.ctx)
+	s := newScreenshotter(spanCtx)
 	buf, err := s.screenshotElement(h, parsedOpts)
 	if err != nil {
 		k6ext.Panic(h.ctx, "taking screenshot: %w", err)

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -350,7 +350,7 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 		},
 	})
 
-	_, span := GetTracer(fs.ctx).TraceEvent(
+	_, span := TraceEvent(
 		fs.ctx, fs.targetID.String(), "web_vital", wv.SpanID,
 		trace.WithAttributes(attribute.Float64(wv.Name, value), attribute.String("rating", wv.Rating)))
 	defer span.End()
@@ -751,7 +751,7 @@ func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {
 	// Trace navigation only for the main frame.
 	// TODO: How will this affect sub frames such as iframes?
 	if isMainFrame := frame.ParentID == ""; isMainFrame {
-		_, fs.mainFrameSpan = GetTracer(fs.ctx).TraceNavigation(
+		_, fs.mainFrameSpan = TraceNavigation(
 			fs.ctx, fs.targetID.String(), frame.URL,
 			trace.WithAttributes(attribute.String("url", frame.URL)),
 		)

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -314,6 +314,7 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 		NumEntries     json.Number
 		NavigationType string
 		URL            string
+		SpanID         string
 	}{}
 
 	if err := json.Unmarshal([]byte(object), &wv); err != nil {
@@ -348,6 +349,11 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 			},
 		},
 	})
+
+	_, span := GetTracer(fs.ctx).TraceEvent(
+		fs.ctx, fs.targetID.String(), "web_vital", wv.SpanID,
+		trace.WithAttributes(attribute.Float64(wv.Name, value), attribute.String("rating", wv.Rating)))
+	defer span.End()
 
 	return nil
 }

--- a/common/js/web_vital_init.js
+++ b/common/js/web_vital_init.js
@@ -8,6 +8,12 @@ function print(metric) {
     numEntries: metric.entries.length,
     navigationType: metric.navigationType,
     url: window.location.href,
+    // To be able to associate a Web Vital measurement to the PageNavigation
+    // span, we need to collect the span ID that was previously set in the
+    // page after the navigation, and pass it back to k6 browser included in
+    // the WV event so the measurement can be correctly linked to the page
+    // navigation span
+    spanID: window.k6SpanId,
   }
   window.k6browserSendWebVitalMetric(JSON.stringify(m))
 }

--- a/common/locator.go
+++ b/common/locator.go
@@ -39,6 +39,8 @@ func NewLocator(ctx context.Context, selector string, f *Frame, l *log.Logger) *
 // Click on an element using locator's selector with strict mode on.
 func (l *Locator) Click(opts goja.Value) error {
 	l.log.Debugf("Locator:Click", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+	_, span := GetTracer(l.ctx).TraceAPICall(l.ctx, l.frame.page.targetID.String(), "locator.click")
+	defer span.End()
 
 	copts := NewFrameClickOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
@@ -495,6 +497,8 @@ func (l *Locator) Type(text string, opts goja.Value) {
 		"Locator:Type", "fid:%s furl:%q sel:%q text:%q opts:%+v",
 		l.frame.ID(), l.frame.URL(), l.selector, text, opts,
 	)
+	_, span := GetTracer(l.ctx).TraceAPICall(l.ctx, l.frame.page.targetID.String(), "locator.type")
+	defer span.End()
 
 	var err error
 	defer func() { panicOrSlowMo(l.ctx, err) }()

--- a/common/locator.go
+++ b/common/locator.go
@@ -39,7 +39,7 @@ func NewLocator(ctx context.Context, selector string, f *Frame, l *log.Logger) *
 // Click on an element using locator's selector with strict mode on.
 func (l *Locator) Click(opts goja.Value) error {
 	l.log.Debugf("Locator:Click", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
-	_, span := GetTracer(l.ctx).TraceAPICall(l.ctx, l.frame.page.targetID.String(), "locator.click")
+	_, span := TraceAPICall(l.ctx, l.frame.page.targetID.String(), "locator.click")
 	defer span.End()
 
 	copts := NewFrameClickOptions(l.frame.defaultTimeout())
@@ -497,7 +497,7 @@ func (l *Locator) Type(text string, opts goja.Value) {
 		"Locator:Type", "fid:%s furl:%q sel:%q text:%q opts:%+v",
 		l.frame.ID(), l.frame.URL(), l.selector, text, opts,
 	)
-	_, span := GetTracer(l.ctx).TraceAPICall(l.ctx, l.frame.page.targetID.String(), "locator.type")
+	_, span := TraceAPICall(l.ctx, l.frame.page.targetID.String(), "locator.type")
 	defer span.End()
 
 	var err error

--- a/common/page.go
+++ b/common/page.go
@@ -658,7 +658,7 @@ func (p *Page) Click(selector string, opts goja.Value) error {
 // Close closes the page.
 func (p *Page) Close(opts goja.Value) error {
 	p.logger.Debugf("Page:Close", "sid:%v", p.sessionID())
-	_, span := GetTracer(p.ctx).TraceAPICall(p.ctx, p.targetID.String(), "page.close")
+	_, span := TraceAPICall(p.ctx, p.targetID.String(), "page.close")
 	defer span.End()
 
 	// forcing the pagehide event to trigger web vitals metrics.
@@ -864,7 +864,7 @@ func (p *Page) GoForward(_ goja.Value) *Response {
 // Goto will navigate the page to the specified URL and return a HTTP response object.
 func (p *Page) Goto(url string, opts goja.Value) (*Response, error) {
 	p.logger.Debugf("Page:Goto", "sid:%v url:%q", p.sessionID(), url)
-	_, span := GetTracer(p.ctx).TraceAPICall(
+	_, span := TraceAPICall(
 		p.ctx,
 		p.targetID.String(),
 		"page.goto",
@@ -1021,7 +1021,7 @@ func (p *Page) QueryAll(selector string) ([]*ElementHandle, error) {
 // Reload will reload the current page.
 func (p *Page) Reload(opts goja.Value) *Response { //nolint:funlen,cyclop
 	p.logger.Debugf("Page:Reload", "sid:%v", p.sessionID())
-	_, span := GetTracer(p.ctx).TraceAPICall(p.ctx, p.targetID.String(), "page.reload")
+	_, span := TraceAPICall(p.ctx, p.targetID.String(), "page.reload")
 	defer span.End()
 
 	parsedOpts := NewPageReloadOptions(
@@ -1106,7 +1106,7 @@ func (p *Page) Route(url goja.Value, handler goja.Callable) {
 
 // Screenshot will instruct Chrome to save a screenshot of the current page and save it to specified file.
 func (p *Page) Screenshot(opts goja.Value) goja.ArrayBuffer {
-	spanCtx, span := GetTracer(p.ctx).TraceAPICall(p.ctx, p.targetID.String(), "page.screenshot")
+	spanCtx, span := TraceAPICall(p.ctx, p.targetID.String(), "page.screenshot")
 	defer span.End()
 
 	parsedOpts := NewPageScreenshotOptions()
@@ -1290,7 +1290,7 @@ func (p *Page) WaitForLoadState(state string, opts goja.Value) {
 // WaitForNavigation waits for the given navigation lifecycle event to happen.
 func (p *Page) WaitForNavigation(opts goja.Value) (*Response, error) {
 	p.logger.Debugf("Page:WaitForNavigation", "sid:%v", p.sessionID())
-	_, span := GetTracer(p.ctx).TraceAPICall(p.ctx, p.targetID.String(), "page.waitForNavigation")
+	_, span := TraceAPICall(p.ctx, p.targetID.String(), "page.waitForNavigation")
 	defer span.End()
 
 	return p.frameManager.MainFrame().WaitForNavigation(opts)

--- a/common/trace.go
+++ b/common/trace.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Tracer defines the interface with the tracing methods used in the common package.
+type Tracer interface {
+	TraceAPICall(
+		ctx context.Context, targetID string, spanName string, opts ...trace.SpanStartOption,
+	) (context.Context, trace.Span)
+	TraceNavigation(
+		ctx context.Context, targetID string, url string, opts ...trace.SpanStartOption,
+	) (context.Context, trace.Span)
+	TraceEvent(
+		ctx context.Context, targetID string, eventName string, spanID string, opts ...trace.SpanStartOption,
+	) (context.Context, trace.Span)
+}

--- a/common/trace.go
+++ b/common/trace.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/trace"
+
+	browsertrace "github.com/grafana/xk6-browser/trace"
 )
 
 // Tracer defines the interface with the tracing methods used in the common package.
@@ -17,4 +19,40 @@ type Tracer interface {
 	TraceEvent(
 		ctx context.Context, targetID string, eventName string, spanID string, opts ...trace.SpanStartOption,
 	) (context.Context, trace.Span)
+}
+
+// TraceAPICall is a helper method that retrieves the Tracer from the given ctx and
+// calls its TraceAPICall implementation. If the Tracer is not present in the given
+// ctx, it returns a noopSpan and the given context.
+func TraceAPICall(
+	ctx context.Context, targetID string, spanName string, opts ...trace.SpanStartOption,
+) (context.Context, trace.Span) {
+	if tracer := GetTracer(ctx); tracer != nil {
+		return tracer.TraceAPICall(ctx, targetID, spanName, opts...)
+	}
+	return ctx, browsertrace.NoopSpan{}
+}
+
+// TraceNavigation is a helper method that retrieves the Tracer from the given ctx and
+// calls its TraceNavigation implementation. If the Tracer is not present in the given
+// ctx, it returns a noopSpan and the given context.
+func TraceNavigation(
+	ctx context.Context, targetID string, url string, opts ...trace.SpanStartOption,
+) (context.Context, trace.Span) {
+	if tracer := GetTracer(ctx); tracer != nil {
+		return tracer.TraceNavigation(ctx, targetID, url, opts...)
+	}
+	return ctx, browsertrace.NoopSpan{}
+}
+
+// TraceEvent is a helper method that retrieves the Tracer from the given ctx and
+// calls its TraceEvent implementation. If the Tracer is not present in the given
+// ctx, it returns a noopSpan and the given context.
+func TraceEvent(
+	ctx context.Context, targetID string, eventName string, spanID string, options ...trace.SpanStartOption,
+) (context.Context, trace.Span) {
+	if tracer := GetTracer(ctx); tracer != nil {
+		return tracer.TraceEvent(ctx, targetID, eventName, spanID, options...)
+	}
+	return ctx, browsertrace.NoopSpan{}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	go.k6.io/k6 v0.48.0
+	go.opentelemetry.io/otel v1.19.0
+	go.opentelemetry.io/otel/trace v1.19.0
 	golang.org/x/net v0.17.0
 	golang.org/x/sync v0.3.0
 	gopkg.in/guregu/null.v3 v3.3.0
@@ -48,13 +50,11 @@ require (
 	github.com/tidwall/gjson v1.17.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	go.opentelemetry.io/otel v1.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.19.0 // indirect
-	go.opentelemetry.io/otel/trace v1.19.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/k6ext/k6test/vu.go
+++ b/k6ext/k6test/vu.go
@@ -19,6 +19,7 @@ import (
 	k6lib "go.k6.io/k6/lib"
 	k6executor "go.k6.io/k6/lib/executor"
 	k6testutils "go.k6.io/k6/lib/testutils"
+	k6trace "go.k6.io/k6/lib/trace"
 	k6metrics "go.k6.io/k6/metrics"
 )
 
@@ -131,7 +132,7 @@ type WithSamples chan k6metrics.SampleContainer
 // opts can be one of the following:
 //   - WithSamplesListener: a bidirectional channel that will be used to emit metrics.
 //   - env.LookupFunc: a lookup function that will be used to lookup environment variables.
-func NewVU(tb testing.TB, opts ...any) *VU {
+func NewVU(tb testing.TB, opts ...any) *VU { //nolint:funlen
 	tb.Helper()
 
 	var (
@@ -188,6 +189,7 @@ func NewVU(tb testing.TB, opts ...any) *VU {
 		Samples:        samples,
 		Tags:           k6lib.NewVUStateTags(tags.With("group", root.Path)),
 		BuiltinMetrics: k6metrics.RegisterBuiltinMetrics(k6metrics.NewRegistry()),
+		TracerProvider: k6trace.NewNoopTracerProvider(),
 	}
 
 	ctx := k6ext.WithVU(testRT.VU.CtxField, testRT.VU)

--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -1,0 +1,239 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/xk6-browser/browser"
+	"github.com/grafana/xk6-browser/k6ext/k6test"
+	browsertrace "github.com/grafana/xk6-browser/trace"
+
+	k6lib "go.k6.io/k6/lib"
+)
+
+const html = `
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Clickable link test</title>
+</head>
+
+<body>
+	<div class="main">
+		<h3>Click Counter</h3>
+		<button id="clickme">Click me: 0</button>
+		<h3>Type input</h3>
+		<input type="text" id="typeme">
+	</div>
+    <script>
+	var button = document.getElementById("clickme"),
+	count = 0;
+	button.onclick = function() {
+		count += 1;
+		button.innerHTML = "Click me: " + count;
+	};
+    </script>
+</body>
+
+</html>
+`
+
+// TestTracing verifies that all methods instrumented to generate
+// traces behave correctly.
+func TestTracing(t *testing.T) {
+	t.Parallel()
+
+	// Init tracing mocks
+	tracer := &mockTracer{
+		spans: make(map[string]struct{}),
+	}
+	tp := &mockTracerProvider{
+		tracer: tracer,
+	}
+	// Start test server
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, html)
+		},
+	))
+
+	// Initialize VU and browser module
+	vu := k6test.NewVU(t, k6test.WithTracerProvider(tp))
+
+	rt := vu.Runtime()
+	root := browser.New()
+	mod := root.NewModuleInstance(vu)
+	jsMod, ok := mod.Exports().Default.(*browser.JSModule)
+	require.Truef(t, ok, "unexpected default mod export type %T", mod.Exports().Default)
+	require.NoError(t, rt.Set("browser", jsMod.Browser))
+	vu.ActivateVU()
+
+	// Run the test
+	vu.StartIteration(t)
+	require.NoError(t, tracer.verifySpans("iteration"))
+	setupTestTracing(t, rt)
+
+	testCases := []struct {
+		name  string
+		js    string
+		spans []string
+	}{
+		{
+			name: "browser.newPage",
+			js:   "page = browser.newPage()",
+			spans: []string{
+				"browser.newPage",
+				"browser.newContext",
+				"browserContext.newPage",
+			},
+		},
+		{
+			name: "page.goto",
+			js:   fmt.Sprintf("page.goto('%s')", ts.URL),
+			spans: []string{
+				"page.goto",
+				fmt.Sprintf("%s/", ts.URL), // Navigation span
+			},
+		},
+		{
+			name: "web_vital",
+			js:   "sleep(100);", // Wait for async WebVitals processing
+			spans: []string{
+				"web_vital",
+			},
+		},
+		{
+			name: "page.screenshot",
+			js:   "page.screenshot();",
+			spans: []string{
+				"page.screenshot",
+			},
+		},
+		{
+			name: "locator.click",
+			js:   "page.locator('#clickme').click();",
+			spans: []string{
+				"locator.click",
+			},
+		},
+		{
+			name: "locator.type",
+			js:   "page.locator('input#typeme').type('test');",
+			spans: []string{
+				"locator.type",
+			},
+		},
+		{
+			name: "page.reload",
+			js: `await Promise.all([
+					page.waitForNavigation(),
+					page.reload(),
+			  	]);`,
+			spans: []string{
+				"page.reload",
+				"page.waitForNavigation",
+			},
+		},
+		{
+			name: "page.close",
+			js:   "page.close()",
+			spans: []string{
+				"page.close",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		assertJSInEventLoop(t, vu, tc.js)
+		require.NoError(t, tracer.verifySpans(tc.spans...))
+	}
+}
+
+func setupTestTracing(t *testing.T, rt *goja.Runtime) {
+	t.Helper()
+
+	// Declare a global page var that we can use
+	// throughout the test cases
+	_, err := rt.RunString("var page;")
+	require.NoError(t, err)
+
+	// Set a sleep function so we can use it to wait
+	// for async WebVitals processing
+	err = rt.Set("sleep", func(d int) {
+		time.Sleep(time.Duration(d) * time.Millisecond)
+	})
+	require.NoError(t, err)
+}
+
+func assertJSInEventLoop(t *testing.T, vu *k6test.VU, js string) {
+	t.Helper()
+
+	f := fmt.Sprintf(
+		"test = async function() { %s; }",
+		js)
+
+	rt := vu.Runtime()
+	_, err := rt.RunString(f)
+	require.NoError(t, err)
+
+	test, ok := goja.AssertFunction(rt.Get("test"))
+	require.True(t, ok)
+
+	err = vu.Loop.Start(func() error {
+		_, err := test(goja.Undefined())
+		return err
+	})
+	require.NoError(t, err)
+}
+
+type mockTracerProvider struct {
+	k6lib.TracerProvider
+
+	tracer trace.Tracer
+}
+
+func (m *mockTracerProvider) Tracer(
+	name string, options ...trace.TracerOption,
+) trace.Tracer {
+	return m.tracer
+}
+
+type mockTracer struct {
+	mu    sync.Mutex
+	spans map[string]struct{}
+}
+
+func (m *mockTracer) Start(
+	ctx context.Context, spanName string, opts ...trace.SpanStartOption,
+) (context.Context, trace.Span) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.spans[spanName] = struct{}{}
+
+	return ctx, browsertrace.NoopSpan{}
+}
+
+func (m *mockTracer) verifySpans(spanNames ...string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, sn := range spanNames {
+		if _, ok := m.spans[sn]; !ok {
+			return fmt.Errorf("%q span was not found", sn)
+		}
+		delete(m.spans, sn)
+	}
+
+	return nil
+}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -1,0 +1,166 @@
+// Package trace provides tracing instrumentation tailored for k6 browser needs.
+package trace
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	k6lib "go.k6.io/k6/lib"
+)
+
+const tracerName = "browser"
+
+// liveSpan represents an active span associated with a page navigation.
+//
+// Because a frame navigation and WebVitals event parsing happen async
+// (see frame_session/onFrameNavigated and frame_session/parseAndEmitWebVitalMetric)
+// there is not a reference to the last span generated from these methods, therefore
+// we have to keep a reference to the active span for each frame from the tracer
+// and make this accessible for these methods.
+type liveSpan struct {
+	ctx  context.Context
+	span trace.Span
+}
+
+// Tracer represents a traces generator tailored to k6 browser needs.
+// Specifically implements methods to generate spans for navigations, API calls and page events,
+// accepting input parameters that allow correlating async operations, such as Web Vitals events,
+// with the page to which they belong to.
+type Tracer struct {
+	trace.Tracer
+
+	liveSpansMu sync.RWMutex
+	liveSpans   map[string]*liveSpan
+}
+
+// NewTracer creates a new Tracer from the given TracerProvider.
+func NewTracer(tp k6lib.TracerProvider, options ...trace.TracerOption) *Tracer {
+	return &Tracer{
+		Tracer:    tp.Tracer(tracerName, options...),
+		liveSpans: make(map[string]*liveSpan),
+	}
+}
+
+// TraceAPICall adds a new span to the current liveSpan for the given targetID and returns it. It
+// is the caller's responsibility to close the generated span.
+// If there is not a liveSpan for the given targetID, the new span is created based on the given
+// context, which means that it might be a root span or not depending if the context already wraps
+// a span.
+func (t *Tracer) TraceAPICall(
+	ctx context.Context, targetID string, spanName string, opts ...trace.SpanStartOption,
+) (context.Context, trace.Span) {
+	t.liveSpansMu.Lock()
+	defer t.liveSpansMu.Unlock()
+
+	ls := t.liveSpans[targetID]
+	if ls == nil {
+		return t.Start(ctx, spanName, opts...)
+	}
+
+	return t.Start(ls.ctx, spanName, opts...)
+}
+
+// TraceNavigation is only to be used when a frame has navigated.
+// It records a new liveSpan for the given targetID which identifies the frame that
+// has navigated. If there was already a liveSpan for the given targetID, it is closed
+// before creating the new one, otherwise it's the caller's responsibility to close the
+// generated span.
+// Posterior calls to TraceEvent or TraceAPICall given the same targetID will try to
+// associate new spans for these actions to the liveSpan created in this call.
+func (t *Tracer) TraceNavigation(
+	ctx context.Context, targetID string, url string, opts ...trace.SpanStartOption,
+) (context.Context, trace.Span) {
+	t.liveSpansMu.Lock()
+	defer t.liveSpansMu.Unlock()
+
+	// TODO: Should we keep track of all spans, even ones that are closed, to
+	// ensure we associate web vitals to the spans in the current iteration?
+
+	ls := t.liveSpans[targetID]
+	if ls != nil {
+		// If there is a previous live span
+		// for the targetID, end it
+		ls.span.End()
+	} else {
+		ls = &liveSpan{}
+	}
+
+	ls.ctx, ls.span = t.Start(ctx, url, opts...)
+	t.liveSpans[targetID] = ls
+
+	return ls.ctx, ls.span
+}
+
+// TraceEvent creates a new span representing the specified event and associates it with the current
+// liveSpan for the given targetID only if the spanID matches with the liveSpan.
+// It is the caller's responsibility to close the generated span.
+//
+// If no liveSpan is found for the given targetID, the action is ignored and a noopSpan is returned.
+// If the given spanID does not match the one for the current liveSpan associated with the targetID,
+// it means the specified target has navigated, generating a new span for that navigation, therefore
+// the event is not associated with that span, and instead a noopSpan is returned.
+func (t *Tracer) TraceEvent(
+	ctx context.Context, targetID string, eventName string, spanID string, opts ...trace.SpanStartOption,
+) (context.Context, trace.Span) {
+	t.liveSpansMu.Lock()
+	defer t.liveSpansMu.Unlock()
+
+	ls := t.liveSpans[targetID]
+	if ls == nil {
+		// If there is not a liveSpan for the given targetID,
+		// avoid associating the event with the root span possibly
+		// wrapped in ctx, and instead return a noopSpan
+		return ctx, NoopSpan{}
+	}
+
+	sid := ls.span.SpanContext().SpanID().String()
+	if sid != spanID {
+		// If the given spanID does not match the current liveSpan for
+		// targetID, it means the target has navigated to a different
+		// page than the one the event should be associated with.
+		// Therefore avoid associating the event with the current span,
+		// and return a noopSpan instead
+		return ctx, NoopSpan{}
+	}
+
+	return t.Start(ls.ctx, eventName, opts...)
+}
+
+// NoopSpan represents a noop span.
+type NoopSpan struct {
+	trace.Span
+}
+
+// SpanContext returns a void span context.
+func (NoopSpan) SpanContext() trace.SpanContext { return trace.SpanContext{} }
+
+// IsRecording returns false.
+func (NoopSpan) IsRecording() bool { return false }
+
+// SetStatus is noop.
+func (NoopSpan) SetStatus(codes.Code, string) {}
+
+// SetError is noop.
+func (NoopSpan) SetError(bool) {}
+
+// SetAttributes is noop.
+func (NoopSpan) SetAttributes(...attribute.KeyValue) {}
+
+// End is noop.
+func (NoopSpan) End(...trace.SpanEndOption) {}
+
+// RecordError is noop.
+func (NoopSpan) RecordError(error, ...trace.EventOption) {}
+
+// AddEvent is noop.
+func (NoopSpan) AddEvent(string, ...trace.EventOption) {}
+
+// SetName is noop.
+func (NoopSpan) SetName(string) {}
+
+// TracerProvider returns a noop tracer provider.
+func (NoopSpan) TracerProvider() trace.TracerProvider { return trace.NewNoopTracerProvider() }


### PR DESCRIPTION
## What?

This PR uses the tracing instrumentation provided by k6 through the `VU.State` in order to generate traces that represent the inner workings of k6 browser.

## Why?

Tracing has been chosen as the best suited method in order to build a timeline view of a k6 browser test, which can provide a more visual representation of a browser test along with the metrics associated for each action, such as specific WebVitals measurements per navigation, errors produced, etc.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [X] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Related: https://github.com/grafana/k6/pull/3445
