### PR TITLE
Fix error on page.query when no matches with given selector

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -253,6 +253,12 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping {
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}
+		// ElementHandle can be null when the selector does not match any elements.
+		// We do not want to map nil elementHandles since the expectation is a
+		// null result in the test script for this case.
+		if eh == nil {
+			return nil, nil //nolint:nilnil
+		}
 		ehm := mapElementHandle(vu, eh)
 		return ehm, nil
 	}
@@ -395,6 +401,12 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 		eh, err := f.Query(selector)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
+		}
+		// ElementHandle can be null when the selector does not match any elements.
+		// We do not want to map nil elementHandles since the expectation is a
+		// null result in the test script for this case.
+		if eh == nil {
+			return nil, nil //nolint:nilnil
 		}
 		ehm := mapElementHandle(vu, eh)
 		return ehm, nil
@@ -593,6 +605,12 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 		eh, err := p.Query(selector)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
+		}
+		// ElementHandle can be null when the selector does not match any elements.
+		// We do not want to map nil elementHandles since the expectation is a
+		// null result in the test script for this case.
+		if eh == nil {
+			return nil, nil //nolint:nilnil
 		}
 		ehm := mapElementHandle(vu, eh)
 		return ehm, nil

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1042,7 +1042,7 @@ func (h *ElementHandle) Query(selector string) (*ElementHandle, error) {
 		return nil, fmt.Errorf("querying selector %q: %w", selector, err)
 	}
 	if result == nil {
-		return nil, fmt.Errorf("querying selector %q", selector)
+		return nil, nil //nolint:nilnil
 	}
 	handle, ok := result.(JSHandleAPI)
 	if !ok {

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -439,3 +439,15 @@ func TestElementHandlePress(t *testing.T) {
 
 	require.Equal(t, "AbC", el.InputValue(nil))
 }
+
+func TestElementHandleQuery(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBrowser(t).NewPage(nil)
+	p.SetContent(`<div id="foo">hello</div>`, nil)
+
+	element, err := p.Query("bar")
+
+	require.NoError(t, err)
+	require.Nil(t, element)
+}


### PR DESCRIPTION
## What?

This fixes the issue where `Page.Query` (`page.$`) returned an error when no elements match the given selector.

## Why?

The actual expectation in this scenario, is for the API to return `nil`.

This was tested with the following script:

<details>
  <summary>Click me</summary>

  ```js
  import { browser } from 'k6/experimental/browser';
  
  export const options = {
    scenarios: {
      ui: {
        executor: 'shared-iterations',
        iterations: 1,
        options: {
          browser: {
            type: 'chromium'
          },
        },
      },
    },
  }
  
  export default async function () {
    const page = browser.newPage();
  
    await page.goto("https://test.k6.io");
  
    const result = page.$('input[name="login"]');
    if (!result) {
      console.log("It's null, hooray!");
    }
  
    page.close();
  }
  ```

</details>

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: [#982](https://github.com/grafana/xk6-browser/issues/982)