### PR TITLE
Use force and noWaitAfter in frame.newAction

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -2001,7 +2001,7 @@ func (f *Frame) newAction(
 			}
 			return
 		}
-		f := handle.newAction(states, fn, false, false, timeout)
+		f := handle.newAction(states, fn, force, noWaitAfter, timeout)
 		f(apiCtx, resultCh, errCh)
 	}
 }


### PR DESCRIPTION
## What?

The two input arguments `force` and `noWaitAfter` were not being used by `frame.newAction`, and instead were being overriden to always be `false` for both flags.

## Why?

Some of the APIs that call through to `frame.newAction` (such as `isVisible`) do not need to:

1. wait for a navigation, which is what `noWaitAfter` controls;
2. wait for actionability checks (attached to dom, visible, stable and enabled) and instead should be actioned upon straight away, which is what `force` controls.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/981