### PR TITLE
Add support for traces metadata

### DIFF
--- a/browser/module.go
+++ b/browser/module.go
@@ -24,6 +24,7 @@ type (
 		PidRegistry    *pidRegistry
 		remoteRegistry *remoteRegistry
 		initOnce       *sync.Once
+		tracesMetadata map[string]string
 	}
 
 	// JSModule exposes the properties available to the JS script.
@@ -93,6 +94,10 @@ func (m *RootModule) initialize(vu k6modules.VU) {
 	m.remoteRegistry, err = newRemoteRegistry(initEnv.LookupEnv)
 	if err != nil {
 		k6ext.Abort(vu.Context(), "failed to create remote registry: %v", err)
+	}
+	m.tracesMetadata, err = parseTracesMetadata(initEnv.LookupEnv)
+	if err != nil {
+		k6ext.Abort(vu.Context(), "parsing browser traces metadata: %v", err)
 	}
 	if _, ok := initEnv.LookupEnv(env.EnableProfiling); ok {
 		go startDebugServer()

--- a/browser/module.go
+++ b/browser/module.go
@@ -67,9 +67,15 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 	return &ModuleInstance{
 		mod: &JSModule{
 			Browser: mapBrowserToGoja(moduleVU{
-				VU:                vu,
-				pidRegistry:       m.PidRegistry,
-				browserRegistry:   newBrowserRegistry(context.Background(), vu, m.remoteRegistry, m.PidRegistry),
+				VU:          vu,
+				pidRegistry: m.PidRegistry,
+				browserRegistry: newBrowserRegistry(
+					context.Background(),
+					vu,
+					m.remoteRegistry,
+					m.PidRegistry,
+					m.tracesMetadata,
+				),
 				taskQueueRegistry: newTaskQueueRegistry(vu),
 			}),
 			Devices:         common.GetDevices(),

--- a/browser/registry.go
+++ b/browser/registry.go
@@ -458,6 +458,27 @@ func (r *tracesRegistry) stop() {
 	}
 }
 
+func parseTracesMetadata(envLookup env.LookupFunc) (map[string]string, error) {
+	var (
+		ok bool
+		v  string
+		m  = make(map[string]string)
+	)
+	if v, ok = envLookup(env.TracesMetadata); !ok {
+		return m, nil
+	}
+
+	for _, elem := range strings.Split(v, ",") {
+		kv := strings.Split(elem, "=")
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("%q is not a valid key=value metadata", elem)
+		}
+		m[kv[0]] = kv[1]
+	}
+
+	return m, nil
+}
+
 type taskQueueRegistry struct {
 	vu k6modules.VU
 

--- a/browser/registry_test.go
+++ b/browser/registry_test.go
@@ -206,7 +206,7 @@ func TestBrowserRegistry(t *testing.T) {
 		var (
 			ctx             = context.Background()
 			vu              = k6test.NewVU(t)
-			browserRegistry = newBrowserRegistry(ctx, vu, remoteRegistry, &pidRegistry{})
+			browserRegistry = newBrowserRegistry(ctx, vu, remoteRegistry, &pidRegistry{}, nil)
 		)
 
 		vu.ActivateVU()
@@ -248,7 +248,7 @@ func TestBrowserRegistry(t *testing.T) {
 		var (
 			ctx             = context.Background()
 			vu              = k6test.NewVU(t)
-			browserRegistry = newBrowserRegistry(ctx, vu, remoteRegistry, &pidRegistry{})
+			browserRegistry = newBrowserRegistry(ctx, vu, remoteRegistry, &pidRegistry{}, nil)
 		)
 
 		vu.ActivateVU()
@@ -283,7 +283,7 @@ func TestBrowserRegistry(t *testing.T) {
 		var (
 			ctx             = context.Background()
 			vu              = k6test.NewVU(t)
-			browserRegistry = newBrowserRegistry(ctx, vu, remoteRegistry, &pidRegistry{})
+			browserRegistry = newBrowserRegistry(ctx, vu, remoteRegistry, &pidRegistry{}, nil)
 		)
 
 		vu.ActivateVU()

--- a/env/env.go
+++ b/env/env.go
@@ -65,6 +65,14 @@ const (
 	LogCategoryFilter = "K6_BROWSER_LOG_CATEGORY_FILTER"
 )
 
+// Tracing.
+const (
+	// TracesMetadata is an environment variable that can be used to
+	// set additional metadata to be included in the generated traces.
+	// The format must comply with: key1=value1,key2=value2,...
+	TracesMetadata = "K6_BROWSER_TRACES_METADATA"
+)
+
 // LookupFunc defines a function to look up a key from the environment.
 type LookupFunc func(key string) (string, bool)
 


### PR DESCRIPTION
## What?

Adds support for traces metadata, which allows users to specify extra _key-value_ fields to be included as attributes for the generated traces.

## Why?

Allows to define extra attributes that can then be used to query traces from the backend (e.g.: Tempo).

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [X] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Related: #1100 
