### PR TITLE
Fix NPE on NavigateFrame

### DIFF
--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -584,7 +584,9 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *Frame
 		func(data any) bool {
 			newDocID := <-newDocIDCh
 			if evt, ok := data.(*NavigationEvent); ok {
-				return evt.newDocument.documentID == newDocID
+				if evt.newDocument != nil {
+					return evt.newDocument.documentID == newDocID
+				}
 			}
 			return false
 		})


### PR DESCRIPTION
## What?

Fixes a possible NPE in FrameManager.NavigateFrame's event handler to wait for the `navigation` event.
The newDocument field for a navigation event can be nil if the navigation happens within the same document.

## Why?

Bug.

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Closes #1105 
