### PR TITLE
Refactor query

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -249,7 +249,7 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping {
 		},
 	}
 	maps["$"] = func(selector string) (mapping, error) {
-		eh, err := eh.Query(selector)
+		eh, err := eh.Query(selector, false)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}
@@ -398,7 +398,7 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 		"waitForTimeout": f.WaitForTimeout,
 	}
 	maps["$"] = func(selector string) (mapping, error) {
-		eh, err := f.Query(selector)
+		eh, err := f.Query(selector, false)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -249,7 +249,7 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping {
 		},
 	}
 	maps["$"] = func(selector string) (mapping, error) {
-		eh, err := eh.Query(selector, false)
+		eh, err := eh.Query(selector, common.StrictModeOff)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}
@@ -398,7 +398,7 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 		"waitForTimeout": f.WaitForTimeout,
 	}
 	maps["$"] = func(selector string) (mapping, error) {
-		eh, err := f.Query(selector, false)
+		eh, err := f.Query(selector, common.StrictModeOff)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}

--- a/common/consts.go
+++ b/common/consts.go
@@ -13,4 +13,8 @@ const (
 	// Life-cycle consts
 
 	LifeCycleNetworkIdleTimeout time.Duration = 500 * time.Millisecond
+
+	// API default consts.
+
+	StrictModeOff = false
 )

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1029,15 +1029,15 @@ func (h *ElementHandle) Query(selector string) (*ElementHandle, error) {
 		k6ext.Panic(h.ctx, "parsing selector %q: %w", selector, err)
 	}
 	fn := `
-		(node, injected, selector) => {
-			return injected.querySelector(selector, node || document, false);
+		(node, injected, selector, strict) => {
+			return injected.querySelector(selector, strict, node || document);
 		}
 	`
 	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector)
+	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector, false)
 	if err != nil {
 		return nil, fmt.Errorf("querying selector %q: %w", selector, err)
 	}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1023,7 +1023,7 @@ func (h *ElementHandle) Press(key string, opts goja.Value) {
 
 // Query runs "element.querySelector" within the page. If no element matches the selector,
 // the return value resolves to "null".
-func (h *ElementHandle) Query(selector string) (*ElementHandle, error) {
+func (h *ElementHandle) Query(selector string, strict bool) (*ElementHandle, error) {
 	parsedSelector, err := NewSelector(selector)
 	if err != nil {
 		k6ext.Panic(h.ctx, "parsing selector %q: %w", selector, err)
@@ -1037,7 +1037,7 @@ func (h *ElementHandle) Query(selector string) (*ElementHandle, error) {
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector, false)
+	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector, strict)
 	if err != nil {
 		return nil, fmt.Errorf("querying selector %q: %w", selector, err)
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -1355,14 +1355,14 @@ func (f *Frame) Name() string {
 
 // Query runs a selector query against the document tree, returning the first matching element or
 // "null" if no match is found.
-func (f *Frame) Query(selector string) (*ElementHandle, error) {
+func (f *Frame) Query(selector string, strict bool) (*ElementHandle, error) {
 	f.log.Debugf("Frame:Query", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
 	document, err := f.document()
 	if err != nil {
 		k6ext.Panic(f.ctx, "getting document: %w", err)
 	}
-	return document.Query(selector)
+	return document.Query(selector, strict)
 }
 
 // QueryAll runs a selector query against the document tree, returning all matching elements.

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -601,7 +601,7 @@ class InjectedScript {
     );
   }
 
-  querySelector(selector, root, strict) {
+  querySelector(selector, strict, root) {
     if (!root["querySelector"]) {
       return "error:notqueryablenode";
     }

--- a/common/page.go
+++ b/common/page.go
@@ -988,7 +988,7 @@ func (p *Page) Press(selector string, key string, opts goja.Value) {
 func (p *Page) Query(selector string) (*ElementHandle, error) {
 	p.logger.Debugf("Page:Query", "sid:%v selector:%s", p.sessionID(), selector)
 
-	return p.frameManager.MainFrame().Query(selector, false)
+	return p.frameManager.MainFrame().Query(selector, StrictModeOff)
 }
 
 // QueryAll returns all elements matching the specified selector.

--- a/common/page.go
+++ b/common/page.go
@@ -988,7 +988,7 @@ func (p *Page) Press(selector string, key string, opts goja.Value) {
 func (p *Page) Query(selector string) (*ElementHandle, error) {
 	p.logger.Debugf("Page:Query", "sid:%v selector:%s", p.sessionID(), selector)
 
-	return p.frameManager.MainFrame().Query(selector)
+	return p.frameManager.MainFrame().Query(selector, false)
 }
 
 // QueryAll returns all elements matching the specified selector.


### PR DESCRIPTION
## What?

It refactors and updates the query API for `elementHandle` , `frame` and `page` so that we can enable `strict` mode. The change is internal only and doesn't affect the public API.

## Why?

The change is required so that in the future when we work on an API (such as `locator`) that needs to work with `query` but allow `strict` mode on.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/981