### PR TITLE
Fix isVisible

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -1306,20 +1306,12 @@ func (f *Frame) isVisible(selector string, opts *FrameIsVisibleOptions) (bool, e
 		}
 		return v, err
 	}
-	act := f.newAction(
-		selector, DOMElementStateAttached, opts.Strict, isVisible, []string{}, false, true, opts.Timeout,
-	)
-	v, err := call(f.ctx, act, opts.Timeout)
+	v, err := f.runActionOnSelector(f.ctx, selector, opts.Strict, isVisible)
 	if err != nil {
-		return false, errorFromDOMError(err)
+		return false, fmt.Errorf("checking is %q visible: %w", selector, err)
 	}
 
-	bv, ok := v.(bool)
-	if !ok {
-		return false, fmt.Errorf("checking is %q visible: unexpected type %T", selector, v)
-	}
-
-	return bv, nil
+	return v, nil
 }
 
 // ID returns the frame id.

--- a/common/frame.go
+++ b/common/frame.go
@@ -1973,6 +1973,31 @@ type frameExecutionContext interface {
 	ID() runtime.ExecutionContextID
 }
 
+func (f *Frame) runActionOnSelector(
+	ctx context.Context, selector string, strict bool, fn elementHandleActionFunc,
+) (bool, error) {
+	handle, err := f.Query(selector, strict)
+	if err != nil {
+		return false, fmt.Errorf("query: %w", err)
+	}
+	if handle == nil {
+		f.log.Debugf("Frame:runActionOnSelector:nilHandler", "fid:%s furl:%q selector:%s", f.ID(), f.URL(), selector)
+		return false, nil
+	}
+
+	v, err := fn(ctx, handle)
+	if err != nil {
+		return false, fmt.Errorf("calling function: %w", err)
+	}
+
+	bv, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("unexpected type %T", v)
+	}
+
+	return bv, nil
+}
+
 //nolint:unparam
 func (f *Frame) newAction(
 	selector string, state DOMElementState, strict bool, fn elementHandleActionFunc, states []string,

--- a/common/frame.go
+++ b/common/frame.go
@@ -1283,19 +1283,19 @@ func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, err
 
 // IsVisible returns true if the first element that matches the selector
 // is visible. Otherwise, returns false.
-func (f *Frame) IsVisible(selector string, opts goja.Value) bool {
+func (f *Frame) IsVisible(selector string, opts goja.Value) (bool, error) {
 	f.log.Debugf("Frame:IsVisible", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
 	popts := NewFrameIsVisibleOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parsing is visible options: %w", err)
+		return false, fmt.Errorf("parsing is visible options: %w", err)
 	}
 	visible, err := f.isVisible(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "checking is %q visible: %w", selector, err)
+		return false, err
 	}
 
-	return visible
+	return visible, nil
 }
 
 func (f *Frame) isVisible(selector string, opts *FrameIsVisibleOptions) (bool, error) {

--- a/common/page.go
+++ b/common/page.go
@@ -915,7 +915,9 @@ func (p *Page) IsHidden(selector string, opts goja.Value) bool {
 	return p.MainFrame().IsHidden(selector, opts)
 }
 
-func (p *Page) IsVisible(selector string, opts goja.Value) bool {
+// IsVisible will look for an element in the dom with given selector. It will
+// not wait for a match to occur. If no elements match `false` will be returned.
+func (p *Page) IsVisible(selector string, opts goja.Value) (bool, error) {
 	p.logger.Debugf("Page:IsVisible", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().IsVisible(selector, opts)

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -398,9 +398,6 @@ func TestLocatorElementState(t *testing.T) {
 			"IsDisabled", func(l *common.Locator, tb *testBrowser) { l.IsDisabled(timeout(tb)) },
 		},
 		{
-			"IsVisible", func(l *common.Locator, tb *testBrowser) { l.IsVisible(timeout(tb)) },
-		},
-		{
 			"IsHidden", func(l *common.Locator, tb *testBrowser) { l.IsHidden(timeout(tb)) },
 		},
 	}

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1235,3 +1235,70 @@ func performPingTest(t *testing.T, tb *testBrowser, page *common.Page, iteration
 
 	return ms / int64(iterations)
 }
+
+func TestPageIsVisible(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		selector string
+		options  common.FrameIsVisibleOptions
+		want     bool
+		wantErr  string
+	}{
+		{
+			name:     "visible",
+			selector: "div[id=my-div]",
+			want:     true,
+		},
+		{
+			name:     "not_visible",
+			selector: "div[id=my-div-3]",
+			want:     false,
+		},
+		{
+			name:     "not_found",
+			selector: "div[id=does-not-exist]",
+			want:     false,
+		},
+		{
+			name:     "first_div",
+			selector: "div",
+			want:     true,
+		},
+		{
+			name:     "first_div",
+			selector: "div",
+			options: common.FrameIsVisibleOptions{
+				FrameBaseOptions: common.FrameBaseOptions{
+					Strict: true,
+				},
+			},
+			wantErr: "error:strictmodeviolation",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tb := newTestBrowser(t, withFileServer())
+
+			page := tb.NewPage(nil)
+
+			_, err := page.Goto(tb.staticURL("visible.html"), nil)
+			require.NoError(t, err)
+
+			got, err := page.IsVisible(tc.selector, tb.toGojaValue(tc.options))
+
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/tests/static/visible.html
+++ b/tests/static/visible.html
@@ -1,0 +1,8 @@
+<html lang="en">
+    <head></head>
+    <body>
+        <div id='my-div'>My DIV</div>
+        <div id='my-div-2'>My DIV 2</div>
+        <div id='my-div-3' style='display: none;'>My DIV 3</div>
+    </body>
+</html>


### PR DESCRIPTION
## What?

This fixes `isVisible` so that it does not wait for an element to match with the given selector, and returns straight away. This makes the `timeout` option obsolete.

## Why?

There are two reason to make this change:
1. It doesn't make sense to wait for an element to match before checking whether it is visible;
2. It will match Playwrights behaviour which is what some users will expect.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/981