### PR TITLE
Refactor isHidden to return an error

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -1242,19 +1242,19 @@ func (f *Frame) isDisabled(selector string, opts *FrameIsDisabledOptions) (bool,
 
 // IsHidden returns true if the first element that matches the selector
 // is hidden. Otherwise, returns false.
-func (f *Frame) IsHidden(selector string, opts goja.Value) bool {
+func (f *Frame) IsHidden(selector string, opts goja.Value) (bool, error) {
 	f.log.Debugf("Frame:IsHidden", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
 	popts := NewFrameIsHiddenOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parsing is hidden options: %w", err)
+		return false, fmt.Errorf("parsing is hidden options: %w", err)
 	}
 	hidden, err := f.isHidden(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "checking is %q hidden: %w", selector, err)
+		return false, fmt.Errorf("checking is %q hidden: %w", selector, err)
 	}
 
-	return hidden
+	return hidden, nil
 }
 
 func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, error) {

--- a/common/locator.go
+++ b/common/locator.go
@@ -257,19 +257,19 @@ func (l *Locator) isVisible(opts *FrameIsVisibleOptions) (bool, error) {
 
 // IsHidden returns true if the element matches the locator's
 // selector and is hidden. Otherwise, returns false.
-func (l *Locator) IsHidden(opts goja.Value) bool {
+func (l *Locator) IsHidden(opts goja.Value) (bool, error) {
 	l.log.Debugf("Locator:IsHidden", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
 
 	copts := NewFrameIsHiddenOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parsing is hidden options: %w", err)
+		return false, fmt.Errorf("parsing is hidden options: %w", err)
 	}
 	hidden, err := l.isHidden(copts)
 	if err != nil {
-		k6ext.Panic(l.ctx, "checking is %q hidden: %w", l.selector, err)
+		return false, fmt.Errorf("checking is %q hidden: %w", l.selector, err)
 	}
 
-	return hidden
+	return hidden, nil
 }
 
 // isHidden is like IsHidden but takes parsed options and does not

--- a/common/page.go
+++ b/common/page.go
@@ -909,7 +909,10 @@ func (p *Page) IsEnabled(selector string, opts goja.Value) bool {
 	return p.MainFrame().IsEnabled(selector, opts)
 }
 
-func (p *Page) IsHidden(selector string, opts goja.Value) bool {
+// IsHidden will look for an element in the dom with given selector and see if
+// the element is hidden. It will not wait for a match to occur. If no elements
+// match `false` will be returned.
+func (p *Page) IsHidden(selector string, opts goja.Value) (bool, error) {
 	p.logger.Debugf("Page:IsHidden", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().IsHidden(selector, opts)

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -344,7 +344,7 @@ func TestLocatorElementState(t *testing.T) {
 		{
 			"hidden",
 			`() => document.getElementById('inputText').style.visibility = 'hidden'`,
-			func(l *common.Locator) bool { return !l.IsHidden(nil) },
+			func(l *common.Locator) bool { resp, _ := l.IsHidden(nil); return !resp },
 		},
 		{
 			"readOnly",
@@ -398,7 +398,11 @@ func TestLocatorElementState(t *testing.T) {
 			"IsDisabled", func(l *common.Locator, tb *testBrowser) { l.IsDisabled(timeout(tb)) },
 		},
 		{
-			"IsHidden", func(l *common.Locator, tb *testBrowser) { l.IsHidden(timeout(tb)) },
+			"IsHidden", func(l *common.Locator, tb *testBrowser) {
+				if _, err := l.IsHidden(timeout(tb)); err != nil {
+					panic(err)
+				}
+			},
 		},
 	}
 	for _, tt := range sanityTests {


### PR DESCRIPTION
## What?

This refactors `isHidden` for `locator`, `page`, `frame` and `elementHandle`.

## Why?

Returning an error is a safer way to work instead pf performing a panic which could have unexpected consequences.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/688
Updates: https://github.com/grafana/xk6-browser/issues/981