### PR TITLE
Fix isHidden

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -1251,7 +1251,7 @@ func (f *Frame) IsHidden(selector string, opts goja.Value) (bool, error) {
 	}
 	hidden, err := f.isHidden(selector, popts)
 	if err != nil {
-		return false, fmt.Errorf("checking is %q hidden: %w", selector, err)
+		return false, err
 	}
 
 	return hidden, nil

--- a/common/frame.go
+++ b/common/frame.go
@@ -1306,7 +1306,7 @@ func (f *Frame) isVisible(selector string, opts *FrameIsVisibleOptions) (bool, e
 		}
 		return v, err
 	}
-	v, err := f.runActionOnSelector(f.ctx, selector, opts.Strict, isVisible)
+	v, err := f.runActionOnSelector(f.ctx, selector, opts.Strict, isVisible, func() bool { return false })
 	if err != nil {
 		return false, fmt.Errorf("checking is %q visible: %w", selector, err)
 	}
@@ -1966,7 +1966,7 @@ type frameExecutionContext interface {
 }
 
 func (f *Frame) runActionOnSelector(
-	ctx context.Context, selector string, strict bool, fn elementHandleActionFunc,
+	ctx context.Context, selector string, strict bool, fn elementHandleActionFunc, nullResponder func() bool,
 ) (bool, error) {
 	handle, err := f.Query(selector, strict)
 	if err != nil {
@@ -1974,7 +1974,7 @@ func (f *Frame) runActionOnSelector(
 	}
 	if handle == nil {
 		f.log.Debugf("Frame:runActionOnSelector:nilHandler", "fid:%s furl:%q selector:%s", f.ID(), f.URL(), selector)
-		return false, nil
+		return nullResponder(), err
 	}
 
 	v, err := fn(ctx, handle)

--- a/common/frame.go
+++ b/common/frame.go
@@ -1265,20 +1265,12 @@ func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, err
 		}
 		return v, err
 	}
-	act := f.newAction(
-		selector, DOMElementStateAttached, opts.Strict, isHidden, []string{}, false, true, opts.Timeout,
-	)
-	v, err := call(f.ctx, act, opts.Timeout)
+	v, err := f.runActionOnSelector(f.ctx, selector, opts.Strict, isHidden, func() bool { return true })
 	if err != nil {
-		return false, errorFromDOMError(err)
+		return false, fmt.Errorf("checking is %q hidden: %w", selector, err)
 	}
 
-	bv, ok := v.(bool)
-	if !ok {
-		return false, fmt.Errorf("checking is %q hidden: unexpected type %T", selector, v)
-	}
-
-	return bv, nil
+	return v, nil
 }
 
 // IsVisible returns true if the first element that matches the selector

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -397,13 +397,6 @@ func TestLocatorElementState(t *testing.T) {
 		{
 			"IsDisabled", func(l *common.Locator, tb *testBrowser) { l.IsDisabled(timeout(tb)) },
 		},
-		{
-			"IsHidden", func(l *common.Locator, tb *testBrowser) {
-				if _, err := l.IsHidden(timeout(tb)); err != nil {
-					panic(err)
-				}
-			},
-		},
 	}
 	for _, tt := range sanityTests {
 		tt := tt

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1302,3 +1302,70 @@ func TestPageIsVisible(t *testing.T) {
 		})
 	}
 }
+
+func TestPageIsHidden(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		selector string
+		options  common.FrameIsVisibleOptions
+		want     bool
+		wantErr  string
+	}{
+		{
+			name:     "hidden",
+			selector: "div[id=my-div-3]",
+			want:     true,
+		},
+		{
+			name:     "visible",
+			selector: "div[id=my-div]",
+			want:     false,
+		},
+		{
+			name:     "not_found",
+			selector: "div[id=does-not-exist]",
+			want:     true,
+		},
+		{
+			name:     "first_div",
+			selector: "div",
+			want:     false,
+		},
+		{
+			name:     "first_div",
+			selector: "div",
+			options: common.FrameIsVisibleOptions{
+				FrameBaseOptions: common.FrameBaseOptions{
+					Strict: true,
+				},
+			},
+			wantErr: "error:strictmodeviolation",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tb := newTestBrowser(t, withFileServer())
+
+			page := tb.NewPage(nil)
+
+			_, err := page.Goto(tb.staticURL("visible.html"), nil)
+			require.NoError(t, err)
+
+			got, err := page.IsHidden(tc.selector, tb.toGojaValue(tc.options))
+
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## What?

This fixes `isHidden` so that it does not wait for an element to match with the given selector, and returns straight away. This makes the `timeout` option obsolete.

## Why?

There are two reason to make this change:
1. It doesn't make sense to wait for an element to match before checking whether it is hidden;
2. It will match Playwrights behaviour which is what some users will expect.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/981