### PR TITLE
Remove the timeout option from isVisible and isHidden

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -386,8 +386,8 @@ func (h *ElementHandle) isHidden(apiCtx context.Context, timeout time.Duration) 
 	return h.waitForElementState(apiCtx, []string{"hidden"}, timeout)
 }
 
-func (h *ElementHandle) isVisible(apiCtx context.Context, timeout time.Duration) (bool, error) {
-	return h.waitForElementState(apiCtx, []string{"visible"}, timeout)
+func (h *ElementHandle) isVisible(apiCtx context.Context) (bool, error) {
+	return h.waitForElementState(apiCtx, []string{"visible"}, 0)
 }
 
 func (h *ElementHandle) offsetPosition(apiCtx context.Context, offset *Position) (*Position, error) {
@@ -958,7 +958,7 @@ func (h *ElementHandle) IsHidden() bool {
 
 // IsVisible checks if the element is visible.
 func (h *ElementHandle) IsVisible() bool {
-	result, err := h.isVisible(h.ctx, 0)
+	result, err := h.isVisible(h.ctx)
 	if err != nil && !errors.Is(err, ErrTimedOut) { // We don't care anout timeout errors here!
 		k6ext.Panic(h.ctx, "checking element is visible: %w", err)
 	}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -382,8 +382,8 @@ func (h *ElementHandle) isEnabled(apiCtx context.Context, timeout time.Duration)
 	return h.waitForElementState(apiCtx, []string{"enabled"}, timeout)
 }
 
-func (h *ElementHandle) isHidden(apiCtx context.Context, timeout time.Duration) (bool, error) {
-	return h.waitForElementState(apiCtx, []string{"hidden"}, timeout)
+func (h *ElementHandle) isHidden(apiCtx context.Context) (bool, error) {
+	return h.waitForElementState(apiCtx, []string{"hidden"}, 0)
 }
 
 func (h *ElementHandle) isVisible(apiCtx context.Context) (bool, error) {
@@ -949,7 +949,7 @@ func (h *ElementHandle) IsEnabled() bool {
 
 // IsHidden checks if the element is hidden.
 func (h *ElementHandle) IsHidden() bool {
-	result, err := h.isHidden(h.ctx, 0)
+	result, err := h.isHidden(h.ctx)
 	if err != nil && !errors.Is(err, ErrTimedOut) { // We don't care anout timeout errors here!
 		k6ext.Panic(h.ctx, "checking element is hidden: %w", err)
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -1292,8 +1292,8 @@ func (f *Frame) IsVisible(selector string, opts goja.Value) (bool, error) {
 
 func (f *Frame) isVisible(selector string, opts *FrameIsVisibleOptions) (bool, error) {
 	isVisible := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
-		v, err := handle.isVisible(apiCtx, 0) // Zero timeout when checking state
-		if errors.Is(err, ErrTimedOut) {      // We don't care about timeout errors here!
+		v, err := handle.isVisible(apiCtx) // Zero timeout when checking state
+		if errors.Is(err, ErrTimedOut) {   // We don't care about timeout errors here!
 			return v, nil
 		}
 		return v, err

--- a/common/frame.go
+++ b/common/frame.go
@@ -1278,7 +1278,7 @@ func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, err
 func (f *Frame) IsVisible(selector string, opts goja.Value) (bool, error) {
 	f.log.Debugf("Frame:IsVisible", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	popts := NewFrameIsVisibleOptions(f.defaultTimeout())
+	popts := NewFrameIsVisibleOptions()
 	if err := popts.Parse(f.ctx, opts); err != nil {
 		return false, fmt.Errorf("parsing is visible options: %w", err)
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -1259,8 +1259,8 @@ func (f *Frame) IsHidden(selector string, opts goja.Value) (bool, error) {
 
 func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, error) {
 	isHidden := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
-		v, err := handle.isHidden(apiCtx, 0) // Zero timeout when checking state
-		if errors.Is(err, ErrTimedOut) {     // We don't care about timeout errors here!
+		v, err := handle.isHidden(apiCtx) // Zero timeout when checking state
+		if errors.Is(err, ErrTimedOut) {  // We don't care about timeout errors here!
 			return v, nil
 		}
 		return v, err

--- a/common/frame.go
+++ b/common/frame.go
@@ -1245,7 +1245,7 @@ func (f *Frame) isDisabled(selector string, opts *FrameIsDisabledOptions) (bool,
 func (f *Frame) IsHidden(selector string, opts goja.Value) (bool, error) {
 	f.log.Debugf("Frame:IsHidden", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	popts := NewFrameIsHiddenOptions(f.defaultTimeout())
+	popts := NewFrameIsHiddenOptions()
 	if err := popts.Parse(f.ctx, opts); err != nil {
 		return false, fmt.Errorf("parsing is hidden options: %w", err)
 	}

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -82,7 +82,7 @@ type FrameIsHiddenOptions struct {
 }
 
 type FrameIsVisibleOptions struct {
-	FrameBaseOptions
+	Strict bool `json:"strict"`
 }
 
 type FramePressOptions struct {
@@ -468,15 +468,21 @@ func (o *FrameIsHiddenOptions) Parse(ctx context.Context, opts goja.Value) error
 	return nil
 }
 
-func NewFrameIsVisibleOptions(defaultTimeout time.Duration) *FrameIsVisibleOptions {
-	return &FrameIsVisibleOptions{
-		FrameBaseOptions: *NewFrameBaseOptions(defaultTimeout),
-	}
+// NewFrameIsVisibleOptions creates and returns a new instance of FrameIsVisibleOptions.
+func NewFrameIsVisibleOptions() *FrameIsVisibleOptions {
+	return &FrameIsVisibleOptions{}
 }
 
 func (o *FrameIsVisibleOptions) Parse(ctx context.Context, opts goja.Value) error {
-	if err := o.FrameBaseOptions.Parse(ctx, opts); err != nil {
-		return err
+	rt := k6ext.Runtime(ctx)
+	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
+		opts := opts.ToObject(rt)
+		for _, k := range opts.Keys() {
+			switch k {
+			case "strict":
+				o.Strict = opts.Get(k).ToBoolean()
+			}
+		}
 	}
 	return nil
 }

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -773,3 +773,19 @@ func NewFrameDispatchEventOptions(defaultTimeout time.Duration) *FrameDispatchEv
 		FrameBaseOptions: NewFrameBaseOptions(defaultTimeout),
 	}
 }
+
+func parseStrict(ctx context.Context, opts goja.Value) bool {
+	var strict bool
+
+	rt := k6ext.Runtime(ctx)
+	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
+		opts := opts.ToObject(rt)
+		for _, k := range opts.Keys() {
+			if k == "strict" {
+				strict = opts.Get(k).ToBoolean()
+			}
+		}
+	}
+
+	return strict
+}

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -78,7 +78,7 @@ type FrameIsEnabledOptions struct {
 }
 
 type FrameIsHiddenOptions struct {
-	FrameBaseOptions
+	Strict bool `json:"strict"`
 }
 
 type FrameIsVisibleOptions struct {
@@ -455,15 +455,21 @@ func (o *FrameIsEnabledOptions) Parse(ctx context.Context, opts goja.Value) erro
 	return nil
 }
 
-func NewFrameIsHiddenOptions(defaultTimeout time.Duration) *FrameIsHiddenOptions {
-	return &FrameIsHiddenOptions{
-		FrameBaseOptions: *NewFrameBaseOptions(defaultTimeout),
-	}
+// NewFrameIsHiddenOptions creates and returns a new instance of FrameIsHiddenOptions.
+func NewFrameIsHiddenOptions() *FrameIsHiddenOptions {
+	return &FrameIsHiddenOptions{}
 }
 
 func (o *FrameIsHiddenOptions) Parse(ctx context.Context, opts goja.Value) error {
-	if err := o.FrameBaseOptions.Parse(ctx, opts); err != nil {
-		return err
+	rt := k6ext.Runtime(ctx)
+	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
+		opts := opts.ToObject(rt)
+		for _, k := range opts.Keys() {
+			switch k {
+			case "strict":
+				o.Strict = opts.Get(k).ToBoolean()
+			}
+		}
 	}
 	return nil
 }

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -223,19 +223,10 @@ func NewFrameCheckOptions(defaultTimeout time.Duration) *FrameCheckOptions {
 }
 
 func (o *FrameCheckOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -247,19 +238,10 @@ func NewFrameClickOptions(defaultTimeout time.Duration) *FrameClickOptions {
 }
 
 func (o *FrameClickOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleClickOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -271,19 +253,10 @@ func NewFrameDblClickOptions(defaultTimeout time.Duration) *FrameDblclickOptions
 }
 
 func (o *FrameDblclickOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleDblclickOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -295,19 +268,10 @@ func NewFrameFillOptions(defaultTimeout time.Duration) *FrameFillOptions {
 }
 
 func (o *FrameFillOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleBaseOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -348,19 +312,10 @@ func NewFrameHoverOptions(defaultTimeout time.Duration) *FrameHoverOptions {
 }
 
 func (o *FrameHoverOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleHoverOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -461,16 +416,7 @@ func NewFrameIsHiddenOptions() *FrameIsHiddenOptions {
 }
 
 func (o *FrameIsHiddenOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -480,16 +426,7 @@ func NewFrameIsVisibleOptions() *FrameIsVisibleOptions {
 }
 
 func (o *FrameIsVisibleOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -514,19 +451,10 @@ func NewFrameSelectOptionOptions(defaultTimeout time.Duration) *FrameSelectOptio
 }
 
 func (o *FrameSelectOptionOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleBaseOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -623,19 +551,10 @@ func NewFrameUncheckOptions(defaultTimeout time.Duration) *FrameUncheckOptions {
 }
 
 func (o *FrameUncheckOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 

--- a/common/locator.go
+++ b/common/locator.go
@@ -246,26 +246,15 @@ func (l *Locator) IsVisible() (bool, error) {
 
 // IsHidden returns true if the element matches the locator's
 // selector and is hidden. Otherwise, returns false.
-func (l *Locator) IsHidden(opts goja.Value) (bool, error) {
-	l.log.Debugf("Locator:IsHidden", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+func (l *Locator) IsHidden() (bool, error) {
+	l.log.Debugf("Locator:IsHidden", "fid:%s furl:%q sel:%q", l.frame.ID(), l.frame.URL(), l.selector)
 
-	copts := NewFrameIsHiddenOptions()
-	if err := copts.Parse(l.ctx, opts); err != nil {
-		return false, fmt.Errorf("parsing is hidden options: %w", err)
-	}
-	hidden, err := l.isHidden(copts)
+	hidden, err := l.frame.isHidden(l.selector, &FrameIsHiddenOptions{Strict: true})
 	if err != nil {
 		return false, fmt.Errorf("checking is %q hidden: %w", l.selector, err)
 	}
 
 	return hidden, nil
-}
-
-// isHidden is like IsHidden but takes parsed options and does not
-// throw an error.
-func (l *Locator) isHidden(opts *FrameIsHiddenOptions) (bool, error) {
-	opts.Strict = true
-	return l.frame.isHidden(l.selector, opts)
 }
 
 // Fill out the element using locator's selector with strict mode on.

--- a/common/locator.go
+++ b/common/locator.go
@@ -233,26 +233,15 @@ func (l *Locator) isDisabled(opts *FrameIsDisabledOptions) (bool, error) {
 
 // IsVisible returns true if the element matches the locator's
 // selector and is visible. Otherwise, returns false.
-func (l *Locator) IsVisible(opts goja.Value) bool {
-	l.log.Debugf("Locator:IsVisible", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+func (l *Locator) IsVisible() bool {
+	l.log.Debugf("Locator:IsVisible", "fid:%s furl:%q sel:%q", l.frame.ID(), l.frame.URL(), l.selector)
 
-	copts := NewFrameIsVisibleOptions()
-	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parsing is visible options: %w", err)
-	}
-	visible, err := l.isVisible(copts)
+	visible, err := l.frame.isVisible(l.selector, &FrameIsVisibleOptions{Strict: true})
 	if err != nil {
 		k6ext.Panic(l.ctx, "checking is %q visible: %w", l.selector, err)
 	}
 
 	return visible
-}
-
-// isVisible is like IsVisible but takes parsed options and does not
-// throw an error.
-func (l *Locator) isVisible(opts *FrameIsVisibleOptions) (bool, error) {
-	opts.Strict = true
-	return l.frame.isVisible(l.selector, opts)
 }
 
 // IsHidden returns true if the element matches the locator's

--- a/common/locator.go
+++ b/common/locator.go
@@ -233,15 +233,15 @@ func (l *Locator) isDisabled(opts *FrameIsDisabledOptions) (bool, error) {
 
 // IsVisible returns true if the element matches the locator's
 // selector and is visible. Otherwise, returns false.
-func (l *Locator) IsVisible() bool {
+func (l *Locator) IsVisible() (bool, error) {
 	l.log.Debugf("Locator:IsVisible", "fid:%s furl:%q sel:%q", l.frame.ID(), l.frame.URL(), l.selector)
 
 	visible, err := l.frame.isVisible(l.selector, &FrameIsVisibleOptions{Strict: true})
 	if err != nil {
-		k6ext.Panic(l.ctx, "checking is %q visible: %w", l.selector, err)
+		return false, fmt.Errorf("checking is %q visible: %w", l.selector, err)
 	}
 
-	return visible
+	return visible, nil
 }
 
 // IsHidden returns true if the element matches the locator's

--- a/common/locator.go
+++ b/common/locator.go
@@ -249,7 +249,7 @@ func (l *Locator) IsVisible() (bool, error) {
 func (l *Locator) IsHidden(opts goja.Value) (bool, error) {
 	l.log.Debugf("Locator:IsHidden", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
 
-	copts := NewFrameIsHiddenOptions(l.frame.defaultTimeout())
+	copts := NewFrameIsHiddenOptions()
 	if err := copts.Parse(l.ctx, opts); err != nil {
 		return false, fmt.Errorf("parsing is hidden options: %w", err)
 	}

--- a/common/locator.go
+++ b/common/locator.go
@@ -236,7 +236,7 @@ func (l *Locator) isDisabled(opts *FrameIsDisabledOptions) (bool, error) {
 func (l *Locator) IsVisible(opts goja.Value) bool {
 	l.log.Debugf("Locator:IsVisible", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
 
-	copts := NewFrameIsVisibleOptions(l.frame.defaultTimeout())
+	copts := NewFrameIsVisibleOptions()
 	if err := copts.Parse(l.ctx, opts); err != nil {
 		k6ext.Panic(l.ctx, "parsing is visible options: %w", err)
 	}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -354,7 +354,7 @@ func TestLocatorElementState(t *testing.T) {
 		{
 			"visible",
 			`() => document.getElementById('inputText').style.visibility = 'hidden'`,
-			func(l *common.Locator) bool { return l.IsVisible() },
+			func(l *common.Locator) bool { resp, _ := l.IsVisible(); return resp },
 		},
 	}
 

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -344,7 +344,7 @@ func TestLocatorElementState(t *testing.T) {
 		{
 			"hidden",
 			`() => document.getElementById('inputText').style.visibility = 'hidden'`,
-			func(l *common.Locator) bool { resp, _ := l.IsHidden(nil); return !resp },
+			func(l *common.Locator) bool { resp, _ := l.IsHidden(); return !resp },
 		},
 		{
 			"readOnly",

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -354,7 +354,7 @@ func TestLocatorElementState(t *testing.T) {
 		{
 			"visible",
 			`() => document.getElementById('inputText').style.visibility = 'hidden'`,
-			func(l *common.Locator) bool { return l.IsVisible(nil) },
+			func(l *common.Locator) bool { return l.IsVisible() },
 		},
 	}
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1270,9 +1270,7 @@ func TestPageIsVisible(t *testing.T) {
 			name:     "first_div",
 			selector: "div",
 			options: common.FrameIsVisibleOptions{
-				FrameBaseOptions: common.FrameBaseOptions{
-					Strict: true,
-				},
+				Strict: true,
 			},
 			wantErr: "error:strictmodeviolation",
 		},
@@ -1337,9 +1335,7 @@ func TestPageIsHidden(t *testing.T) {
 			name:     "first_div",
 			selector: "div",
 			options: common.FrameIsVisibleOptions{
-				FrameBaseOptions: common.FrameBaseOptions{
-					Strict: true,
-				},
+				Strict: true,
 			},
 			wantErr: "error:strictmodeviolation",
 		},


### PR DESCRIPTION
## What?

This remove the `timeout` option from `isVisible` and `isHidden` which are part of `elementHandle`, `frame`, `page` and `locator` APIs.

## Why?

`isVisible` and `isHidden` no longer wait for an element match for the given selector, and so it doesn't make sense to parse and try to work with a timeout parameter.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/981