### PR TITLE
Fix dblClick

### DIFF
--- a/common/mouse.go
+++ b/common/mouse.go
@@ -59,30 +59,6 @@ func (m *Mouse) click(x float64, y float64, opts *MouseClickOptions) error {
 	return nil
 }
 
-func (m *Mouse) dblClick(x float64, y float64, opts *MouseDblClickOptions) error {
-	mouseDownUpOpts := opts.ToMouseDownUpOptions()
-	if err := m.move(x, y, NewMouseMoveOptions()); err != nil {
-		return err
-	}
-	for i := 0; i < 2; i++ {
-		if err := m.down(x, y, mouseDownUpOpts); err != nil {
-			return err
-		}
-		if opts.Delay != 0 {
-			t := time.NewTimer(time.Duration(opts.Delay) * time.Millisecond)
-			select {
-			case <-m.ctx.Done():
-				t.Stop()
-			case <-t.C:
-			}
-		}
-		if err := m.up(x, y, mouseDownUpOpts); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (m *Mouse) down(x float64, y float64, opts *MouseDownUpOptions) error {
 	m.button = input.MouseButton(opts.Button)
 	action := input.DispatchMouseEvent(input.MousePressed, m.x, m.y).
@@ -141,7 +117,7 @@ func (m *Mouse) DblClick(x float64, y float64, opts goja.Value) {
 	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
 		k6ext.Panic(m.ctx, "parsing double click options: %w", err)
 	}
-	if err := m.dblClick(x, y, mouseOpts); err != nil {
+	if err := m.click(x, y, mouseOpts.ToMouseClickOptions()); err != nil {
 		k6ext.Panic(m.ctx, "double clicking on x:%f y:%f: %w", x, y, err)
 	}
 }

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -40,19 +40,21 @@ func (m *Mouse) click(x float64, y float64, opts *MouseClickOptions) error {
 	if err := m.move(x, y, NewMouseMoveOptions()); err != nil {
 		return err
 	}
-	if err := m.down(x, y, mouseDownUpOpts); err != nil {
-		return err
-	}
-	if opts.Delay != 0 {
-		t := time.NewTimer(time.Duration(opts.Delay) * time.Millisecond)
-		select {
-		case <-m.ctx.Done():
-			t.Stop()
-		case <-t.C:
+	for i := 0; i < int(mouseDownUpOpts.ClickCount); i++ {
+		if err := m.down(x, y, mouseDownUpOpts); err != nil {
+			return err
 		}
-	}
-	if err := m.up(x, y, mouseDownUpOpts); err != nil {
-		return err
+		if opts.Delay != 0 {
+			t := time.NewTimer(time.Duration(opts.Delay) * time.Millisecond)
+			select {
+			case <-m.ctx.Done():
+				t.Stop()
+			case <-t.C:
+			}
+		}
+		if err := m.up(x, y, mouseDownUpOpts); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -112,13 +112,11 @@ func (m *Mouse) move(x float64, y float64, opts *MouseMoveOptions) error {
 }
 
 func (m *Mouse) up(x float64, y float64, opts *MouseDownUpOptions) error {
-	var button input.MouseButton = input.Left
-	var clickCount int64 = 1
 	m.button = input.None
 	action := input.DispatchMouseEvent(input.MouseReleased, m.x, m.y).
-		WithButton(button).
+		WithButton(input.MouseButton(opts.Button)).
 		WithModifiers(input.Modifier(m.keyboard.modifiers)).
-		WithClickCount(clickCount)
+		WithClickCount(opts.ClickCount)
 	if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
 		return err
 	}

--- a/common/mouse_options.go
+++ b/common/mouse_options.go
@@ -84,9 +84,12 @@ func (o *MouseDblClickOptions) Parse(ctx context.Context, opts goja.Value) error
 	return nil
 }
 
-func (o *MouseDblClickOptions) ToMouseDownUpOptions() *MouseDownUpOptions {
-	o2 := NewMouseDownUpOptions()
+// ToMouseClickOptions converts MouseDblClickOptions to a MouseClickOptions.
+func (o *MouseDblClickOptions) ToMouseClickOptions() *MouseClickOptions {
+	o2 := NewMouseClickOptions()
 	o2.Button = o.Button
+	o2.ClickCount = 2
+	o2.Delay = o.Delay
 	return o2
 }
 

--- a/tests/mouse_test.go
+++ b/tests/mouse_test.go
@@ -1,0 +1,25 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMouseDblClick(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBrowser(t, withFileServer())
+	p := b.NewPage(nil)
+	_, err := p.Goto(b.staticURL("dbl_click.html"), nil)
+	require.NoError(t, err)
+
+	p.Mouse.DblClick(35, 17, nil)
+
+	v := p.Evaluate(b.toGojaValue(`() => window.dblclick`))
+	assert.True(t, b.asGojaBool(v), "failed to double click the link")
+
+	got := p.InnerText("#counter", nil)
+	assert.Equal(t, "2", got)
+}

--- a/tests/static/dbl_click.html
+++ b/tests/static/dbl_click.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Clickable link test</title>
+</head>
+
+<body>
+    <a id="linkdbl" href="#" ondblclick="event.preventDefault()" onclick="incrementCounter()">Dblclick</a>
+    Counter: <span id="counter">0</span>
+
+    <script>
+        window.dblclick = false;
+
+        document.querySelector('#linkdbl').addEventListener(
+            'dblclick', e => { window.dblclick = true }, false
+        );
+
+        var counter = 0;
+        function incrementCounter() {
+            document.getElementById("counter").textContent = ++counter;
+        }
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
## What?

Fixes the behaviour of the `dblClick` API calls from `locator`, `page`, `elementHandle` and `frame` (they all share the same logic which is implemented in `mouse`).

## Why?

When a `dblClick` API call is made, it needs to perform two things:
1. Ensure a `onDblClick` event is initiated and any listeners receive the event. This was already part of the implementation.
2. Ensure that double the mouse actions are performed so that an element is clicked on twice, e.g. a counter increments from 0 to 2. This was missing.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Playwright reference: https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/input.ts#L199-L219

Updates: https://github.com/grafana/xk6-browser/issues/469