### PR TITLE
Move main-next to main

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -249,7 +249,7 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping {
 		},
 	}
 	maps["$"] = func(selector string) (mapping, error) {
-		eh, err := eh.Query(selector)
+		eh, err := eh.Query(selector, false)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}
@@ -398,7 +398,7 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 		"waitForTimeout": f.WaitForTimeout,
 	}
 	maps["$"] = func(selector string) (mapping, error) {
-		eh, err := f.Query(selector)
+		eh, err := f.Query(selector, false)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -249,7 +249,7 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping {
 		},
 	}
 	maps["$"] = func(selector string) (mapping, error) {
-		eh, err := eh.Query(selector, false)
+		eh, err := eh.Query(selector, common.StrictModeOff)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}
@@ -398,7 +398,7 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 		"waitForTimeout": f.WaitForTimeout,
 	}
 	maps["$"] = func(selector string) (mapping, error) {
-		eh, err := f.Query(selector, false)
+		eh, err := f.Query(selector, common.StrictModeOff)
 		if err != nil {
 			return nil, err //nolint:wrapcheck
 		}

--- a/chromium/browser.go
+++ b/chromium/browser.go
@@ -1,3 +1,4 @@
+// Package chromium is responsible for launching a Chrome browser process and managing its lifetime.
 package chromium
 
 import (

--- a/common/consts.go
+++ b/common/consts.go
@@ -13,4 +13,8 @@ const (
 	// Life-cycle consts
 
 	LifeCycleNetworkIdleTimeout time.Duration = 500 * time.Millisecond
+
+	// API default consts.
+
+	StrictModeOff = false
 )

--- a/common/doc.go
+++ b/common/doc.go
@@ -1,3 +1,3 @@
-// Package common contains the implementation of API elements that do not
-// depend on the browser type.
+// Package common provides the main logic of the browser module.
+// This package will be split into multiple packages in the future.
 package common

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1029,15 +1029,15 @@ func (h *ElementHandle) Query(selector string) (*ElementHandle, error) {
 		k6ext.Panic(h.ctx, "parsing selector %q: %w", selector, err)
 	}
 	fn := `
-		(node, injected, selector) => {
-			return injected.querySelector(selector, node || document, false);
+		(node, injected, selector, strict) => {
+			return injected.querySelector(selector, strict, node || document);
 		}
 	`
 	opts := evalOptions{
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector)
+	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector, false)
 	if err != nil {
 		return nil, fmt.Errorf("querying selector %q: %w", selector, err)
 	}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -386,8 +386,8 @@ func (h *ElementHandle) isHidden(apiCtx context.Context, timeout time.Duration) 
 	return h.waitForElementState(apiCtx, []string{"hidden"}, timeout)
 }
 
-func (h *ElementHandle) isVisible(apiCtx context.Context, timeout time.Duration) (bool, error) {
-	return h.waitForElementState(apiCtx, []string{"visible"}, timeout)
+func (h *ElementHandle) isVisible(apiCtx context.Context) (bool, error) {
+	return h.waitForElementState(apiCtx, []string{"visible"}, 0)
 }
 
 func (h *ElementHandle) offsetPosition(apiCtx context.Context, offset *Position) (*Position, error) {
@@ -958,7 +958,7 @@ func (h *ElementHandle) IsHidden() bool {
 
 // IsVisible checks if the element is visible.
 func (h *ElementHandle) IsVisible() bool {
-	result, err := h.isVisible(h.ctx, 0)
+	result, err := h.isVisible(h.ctx)
 	if err != nil && !errors.Is(err, ErrTimedOut) { // We don't care anout timeout errors here!
 		k6ext.Panic(h.ctx, "checking element is visible: %w", err)
 	}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -382,8 +382,8 @@ func (h *ElementHandle) isEnabled(apiCtx context.Context, timeout time.Duration)
 	return h.waitForElementState(apiCtx, []string{"enabled"}, timeout)
 }
 
-func (h *ElementHandle) isHidden(apiCtx context.Context, timeout time.Duration) (bool, error) {
-	return h.waitForElementState(apiCtx, []string{"hidden"}, timeout)
+func (h *ElementHandle) isHidden(apiCtx context.Context) (bool, error) {
+	return h.waitForElementState(apiCtx, []string{"hidden"}, 0)
 }
 
 func (h *ElementHandle) isVisible(apiCtx context.Context) (bool, error) {
@@ -949,7 +949,7 @@ func (h *ElementHandle) IsEnabled() bool {
 
 // IsHidden checks if the element is hidden.
 func (h *ElementHandle) IsHidden() bool {
-	result, err := h.isHidden(h.ctx, 0)
+	result, err := h.isHidden(h.ctx)
 	if err != nil && !errors.Is(err, ErrTimedOut) { // We don't care anout timeout errors here!
 		k6ext.Panic(h.ctx, "checking element is hidden: %w", err)
 	}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1023,7 +1023,7 @@ func (h *ElementHandle) Press(key string, opts goja.Value) {
 
 // Query runs "element.querySelector" within the page. If no element matches the selector,
 // the return value resolves to "null".
-func (h *ElementHandle) Query(selector string) (*ElementHandle, error) {
+func (h *ElementHandle) Query(selector string, strict bool) (*ElementHandle, error) {
 	parsedSelector, err := NewSelector(selector)
 	if err != nil {
 		k6ext.Panic(h.ctx, "parsing selector %q: %w", selector, err)
@@ -1037,7 +1037,7 @@ func (h *ElementHandle) Query(selector string) (*ElementHandle, error) {
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector, false)
+	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector, strict)
 	if err != nil {
 		return nil, fmt.Errorf("querying selector %q: %w", selector, err)
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -1306,20 +1306,12 @@ func (f *Frame) isVisible(selector string, opts *FrameIsVisibleOptions) (bool, e
 		}
 		return v, err
 	}
-	act := f.newAction(
-		selector, DOMElementStateAttached, opts.Strict, isVisible, []string{}, false, true, opts.Timeout,
-	)
-	v, err := call(f.ctx, act, opts.Timeout)
+	v, err := f.runActionOnSelector(f.ctx, selector, opts.Strict, isVisible)
 	if err != nil {
-		return false, errorFromDOMError(err)
+		return false, fmt.Errorf("checking is %q visible: %w", selector, err)
 	}
 
-	bv, ok := v.(bool)
-	if !ok {
-		return false, fmt.Errorf("checking is %q visible: unexpected type %T", selector, v)
-	}
-
-	return bv, nil
+	return v, nil
 }
 
 // ID returns the frame id.

--- a/common/frame.go
+++ b/common/frame.go
@@ -1355,14 +1355,14 @@ func (f *Frame) Name() string {
 
 // Query runs a selector query against the document tree, returning the first matching element or
 // "null" if no match is found.
-func (f *Frame) Query(selector string) (*ElementHandle, error) {
+func (f *Frame) Query(selector string, strict bool) (*ElementHandle, error) {
 	f.log.Debugf("Frame:Query", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
 	document, err := f.document()
 	if err != nil {
 		k6ext.Panic(f.ctx, "getting document: %w", err)
 	}
-	return document.Query(selector)
+	return document.Query(selector, strict)
 }
 
 // QueryAll runs a selector query against the document tree, returning all matching elements.

--- a/common/frame.go
+++ b/common/frame.go
@@ -2001,7 +2001,7 @@ func (f *Frame) newAction(
 			}
 			return
 		}
-		f := handle.newAction(states, fn, false, false, timeout)
+		f := handle.newAction(states, fn, force, noWaitAfter, timeout)
 		f(apiCtx, resultCh, errCh)
 	}
 }

--- a/common/frame.go
+++ b/common/frame.go
@@ -1973,6 +1973,31 @@ type frameExecutionContext interface {
 	ID() runtime.ExecutionContextID
 }
 
+func (f *Frame) runActionOnSelector(
+	ctx context.Context, selector string, strict bool, fn elementHandleActionFunc,
+) (bool, error) {
+	handle, err := f.Query(selector, strict)
+	if err != nil {
+		return false, fmt.Errorf("query: %w", err)
+	}
+	if handle == nil {
+		f.log.Debugf("Frame:runActionOnSelector:nilHandler", "fid:%s furl:%q selector:%s", f.ID(), f.URL(), selector)
+		return false, nil
+	}
+
+	v, err := fn(ctx, handle)
+	if err != nil {
+		return false, fmt.Errorf("calling function: %w", err)
+	}
+
+	bv, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("unexpected type %T", v)
+	}
+
+	return bv, nil
+}
+
 //nolint:unparam
 func (f *Frame) newAction(
 	selector string, state DOMElementState, strict bool, fn elementHandleActionFunc, states []string,

--- a/common/frame.go
+++ b/common/frame.go
@@ -1251,7 +1251,7 @@ func (f *Frame) IsHidden(selector string, opts goja.Value) (bool, error) {
 	}
 	hidden, err := f.isHidden(selector, popts)
 	if err != nil {
-		return false, fmt.Errorf("checking is %q hidden: %w", selector, err)
+		return false, err
 	}
 
 	return hidden, nil

--- a/common/frame.go
+++ b/common/frame.go
@@ -1306,7 +1306,7 @@ func (f *Frame) isVisible(selector string, opts *FrameIsVisibleOptions) (bool, e
 		}
 		return v, err
 	}
-	v, err := f.runActionOnSelector(f.ctx, selector, opts.Strict, isVisible)
+	v, err := f.runActionOnSelector(f.ctx, selector, opts.Strict, isVisible, func() bool { return false })
 	if err != nil {
 		return false, fmt.Errorf("checking is %q visible: %w", selector, err)
 	}
@@ -1966,7 +1966,7 @@ type frameExecutionContext interface {
 }
 
 func (f *Frame) runActionOnSelector(
-	ctx context.Context, selector string, strict bool, fn elementHandleActionFunc,
+	ctx context.Context, selector string, strict bool, fn elementHandleActionFunc, nullResponder func() bool,
 ) (bool, error) {
 	handle, err := f.Query(selector, strict)
 	if err != nil {
@@ -1974,7 +1974,7 @@ func (f *Frame) runActionOnSelector(
 	}
 	if handle == nil {
 		f.log.Debugf("Frame:runActionOnSelector:nilHandler", "fid:%s furl:%q selector:%s", f.ID(), f.URL(), selector)
-		return false, nil
+		return nullResponder(), err
 	}
 
 	v, err := fn(ctx, handle)

--- a/common/frame.go
+++ b/common/frame.go
@@ -1265,20 +1265,12 @@ func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, err
 		}
 		return v, err
 	}
-	act := f.newAction(
-		selector, DOMElementStateAttached, opts.Strict, isHidden, []string{}, false, true, opts.Timeout,
-	)
-	v, err := call(f.ctx, act, opts.Timeout)
+	v, err := f.runActionOnSelector(f.ctx, selector, opts.Strict, isHidden, func() bool { return true })
 	if err != nil {
-		return false, errorFromDOMError(err)
+		return false, fmt.Errorf("checking is %q hidden: %w", selector, err)
 	}
 
-	bv, ok := v.(bool)
-	if !ok {
-		return false, fmt.Errorf("checking is %q hidden: unexpected type %T", selector, v)
-	}
-
-	return bv, nil
+	return v, nil
 }
 
 // IsVisible returns true if the first element that matches the selector

--- a/common/frame.go
+++ b/common/frame.go
@@ -1292,8 +1292,8 @@ func (f *Frame) IsVisible(selector string, opts goja.Value) (bool, error) {
 
 func (f *Frame) isVisible(selector string, opts *FrameIsVisibleOptions) (bool, error) {
 	isVisible := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
-		v, err := handle.isVisible(apiCtx, 0) // Zero timeout when checking state
-		if errors.Is(err, ErrTimedOut) {      // We don't care about timeout errors here!
+		v, err := handle.isVisible(apiCtx) // Zero timeout when checking state
+		if errors.Is(err, ErrTimedOut) {   // We don't care about timeout errors here!
 			return v, nil
 		}
 		return v, err

--- a/common/frame.go
+++ b/common/frame.go
@@ -1278,7 +1278,7 @@ func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, err
 func (f *Frame) IsVisible(selector string, opts goja.Value) (bool, error) {
 	f.log.Debugf("Frame:IsVisible", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	popts := NewFrameIsVisibleOptions(f.defaultTimeout())
+	popts := NewFrameIsVisibleOptions()
 	if err := popts.Parse(f.ctx, opts); err != nil {
 		return false, fmt.Errorf("parsing is visible options: %w", err)
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -1242,19 +1242,19 @@ func (f *Frame) isDisabled(selector string, opts *FrameIsDisabledOptions) (bool,
 
 // IsHidden returns true if the first element that matches the selector
 // is hidden. Otherwise, returns false.
-func (f *Frame) IsHidden(selector string, opts goja.Value) bool {
+func (f *Frame) IsHidden(selector string, opts goja.Value) (bool, error) {
 	f.log.Debugf("Frame:IsHidden", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
 	popts := NewFrameIsHiddenOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parsing is hidden options: %w", err)
+		return false, fmt.Errorf("parsing is hidden options: %w", err)
 	}
 	hidden, err := f.isHidden(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "checking is %q hidden: %w", selector, err)
+		return false, fmt.Errorf("checking is %q hidden: %w", selector, err)
 	}
 
-	return hidden
+	return hidden, nil
 }
 
 func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, error) {

--- a/common/frame.go
+++ b/common/frame.go
@@ -1259,8 +1259,8 @@ func (f *Frame) IsHidden(selector string, opts goja.Value) (bool, error) {
 
 func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, error) {
 	isHidden := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
-		v, err := handle.isHidden(apiCtx, 0) // Zero timeout when checking state
-		if errors.Is(err, ErrTimedOut) {     // We don't care about timeout errors here!
+		v, err := handle.isHidden(apiCtx) // Zero timeout when checking state
+		if errors.Is(err, ErrTimedOut) {  // We don't care about timeout errors here!
 			return v, nil
 		}
 		return v, err

--- a/common/frame.go
+++ b/common/frame.go
@@ -1283,19 +1283,19 @@ func (f *Frame) isHidden(selector string, opts *FrameIsHiddenOptions) (bool, err
 
 // IsVisible returns true if the first element that matches the selector
 // is visible. Otherwise, returns false.
-func (f *Frame) IsVisible(selector string, opts goja.Value) bool {
+func (f *Frame) IsVisible(selector string, opts goja.Value) (bool, error) {
 	f.log.Debugf("Frame:IsVisible", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
 	popts := NewFrameIsVisibleOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parsing is visible options: %w", err)
+		return false, fmt.Errorf("parsing is visible options: %w", err)
 	}
 	visible, err := f.isVisible(selector, popts)
 	if err != nil {
-		k6ext.Panic(f.ctx, "checking is %q visible: %w", selector, err)
+		return false, err
 	}
 
-	return visible
+	return visible, nil
 }
 
 func (f *Frame) isVisible(selector string, opts *FrameIsVisibleOptions) (bool, error) {

--- a/common/frame.go
+++ b/common/frame.go
@@ -1245,7 +1245,7 @@ func (f *Frame) isDisabled(selector string, opts *FrameIsDisabledOptions) (bool,
 func (f *Frame) IsHidden(selector string, opts goja.Value) (bool, error) {
 	f.log.Debugf("Frame:IsHidden", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	popts := NewFrameIsHiddenOptions(f.defaultTimeout())
+	popts := NewFrameIsHiddenOptions()
 	if err := popts.Parse(f.ctx, opts); err != nil {
 		return false, fmt.Errorf("parsing is hidden options: %w", err)
 	}

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -82,7 +82,7 @@ type FrameIsHiddenOptions struct {
 }
 
 type FrameIsVisibleOptions struct {
-	FrameBaseOptions
+	Strict bool `json:"strict"`
 }
 
 type FramePressOptions struct {
@@ -468,15 +468,21 @@ func (o *FrameIsHiddenOptions) Parse(ctx context.Context, opts goja.Value) error
 	return nil
 }
 
-func NewFrameIsVisibleOptions(defaultTimeout time.Duration) *FrameIsVisibleOptions {
-	return &FrameIsVisibleOptions{
-		FrameBaseOptions: *NewFrameBaseOptions(defaultTimeout),
-	}
+// NewFrameIsVisibleOptions creates and returns a new instance of FrameIsVisibleOptions.
+func NewFrameIsVisibleOptions() *FrameIsVisibleOptions {
+	return &FrameIsVisibleOptions{}
 }
 
 func (o *FrameIsVisibleOptions) Parse(ctx context.Context, opts goja.Value) error {
-	if err := o.FrameBaseOptions.Parse(ctx, opts); err != nil {
-		return err
+	rt := k6ext.Runtime(ctx)
+	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
+		opts := opts.ToObject(rt)
+		for _, k := range opts.Keys() {
+			switch k {
+			case "strict":
+				o.Strict = opts.Get(k).ToBoolean()
+			}
+		}
 	}
 	return nil
 }

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -773,3 +773,19 @@ func NewFrameDispatchEventOptions(defaultTimeout time.Duration) *FrameDispatchEv
 		FrameBaseOptions: NewFrameBaseOptions(defaultTimeout),
 	}
 }
+
+func parseStrict(ctx context.Context, opts goja.Value) bool {
+	var strict bool
+
+	rt := k6ext.Runtime(ctx)
+	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
+		opts := opts.ToObject(rt)
+		for _, k := range opts.Keys() {
+			if k == "strict" {
+				strict = opts.Get(k).ToBoolean()
+			}
+		}
+	}
+
+	return strict
+}

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -78,7 +78,7 @@ type FrameIsEnabledOptions struct {
 }
 
 type FrameIsHiddenOptions struct {
-	FrameBaseOptions
+	Strict bool `json:"strict"`
 }
 
 type FrameIsVisibleOptions struct {
@@ -455,15 +455,21 @@ func (o *FrameIsEnabledOptions) Parse(ctx context.Context, opts goja.Value) erro
 	return nil
 }
 
-func NewFrameIsHiddenOptions(defaultTimeout time.Duration) *FrameIsHiddenOptions {
-	return &FrameIsHiddenOptions{
-		FrameBaseOptions: *NewFrameBaseOptions(defaultTimeout),
-	}
+// NewFrameIsHiddenOptions creates and returns a new instance of FrameIsHiddenOptions.
+func NewFrameIsHiddenOptions() *FrameIsHiddenOptions {
+	return &FrameIsHiddenOptions{}
 }
 
 func (o *FrameIsHiddenOptions) Parse(ctx context.Context, opts goja.Value) error {
-	if err := o.FrameBaseOptions.Parse(ctx, opts); err != nil {
-		return err
+	rt := k6ext.Runtime(ctx)
+	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
+		opts := opts.ToObject(rt)
+		for _, k := range opts.Keys() {
+			switch k {
+			case "strict":
+				o.Strict = opts.Get(k).ToBoolean()
+			}
+		}
 	}
 	return nil
 }

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -223,19 +223,10 @@ func NewFrameCheckOptions(defaultTimeout time.Duration) *FrameCheckOptions {
 }
 
 func (o *FrameCheckOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -247,19 +238,10 @@ func NewFrameClickOptions(defaultTimeout time.Duration) *FrameClickOptions {
 }
 
 func (o *FrameClickOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleClickOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -271,19 +253,10 @@ func NewFrameDblClickOptions(defaultTimeout time.Duration) *FrameDblclickOptions
 }
 
 func (o *FrameDblclickOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleDblclickOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -295,19 +268,10 @@ func NewFrameFillOptions(defaultTimeout time.Duration) *FrameFillOptions {
 }
 
 func (o *FrameFillOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleBaseOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -348,19 +312,10 @@ func NewFrameHoverOptions(defaultTimeout time.Duration) *FrameHoverOptions {
 }
 
 func (o *FrameHoverOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleHoverOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -461,16 +416,7 @@ func NewFrameIsHiddenOptions() *FrameIsHiddenOptions {
 }
 
 func (o *FrameIsHiddenOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -480,16 +426,7 @@ func NewFrameIsVisibleOptions() *FrameIsVisibleOptions {
 }
 
 func (o *FrameIsVisibleOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -514,19 +451,10 @@ func NewFrameSelectOptionOptions(defaultTimeout time.Duration) *FrameSelectOptio
 }
 
 func (o *FrameSelectOptionOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleBaseOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 
@@ -623,19 +551,10 @@ func NewFrameUncheckOptions(defaultTimeout time.Duration) *FrameUncheckOptions {
 }
 
 func (o *FrameUncheckOptions) Parse(ctx context.Context, opts goja.Value) error {
-	rt := k6ext.Runtime(ctx)
 	if err := o.ElementHandleBasePointerOptions.Parse(ctx, opts); err != nil {
 		return err
 	}
-	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "strict":
-				o.Strict = opts.Get(k).ToBoolean()
-			}
-		}
-	}
+	o.Strict = parseStrict(ctx, opts)
 	return nil
 }
 

--- a/common/js/doc.go
+++ b/common/js/doc.go
@@ -1,0 +1,4 @@
+// Package js provides JavaScript code that the browser module evaluates on the browser.
+// The common package uses this package.
+// `injected_script.js` is injected into each execution context.
+package js

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -601,7 +601,7 @@ class InjectedScript {
     );
   }
 
-  querySelector(selector, root, strict) {
+  querySelector(selector, strict, root) {
     if (!root["querySelector"]) {
       return "error:notqueryablenode";
     }

--- a/common/locator.go
+++ b/common/locator.go
@@ -246,26 +246,15 @@ func (l *Locator) IsVisible() (bool, error) {
 
 // IsHidden returns true if the element matches the locator's
 // selector and is hidden. Otherwise, returns false.
-func (l *Locator) IsHidden(opts goja.Value) (bool, error) {
-	l.log.Debugf("Locator:IsHidden", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+func (l *Locator) IsHidden() (bool, error) {
+	l.log.Debugf("Locator:IsHidden", "fid:%s furl:%q sel:%q", l.frame.ID(), l.frame.URL(), l.selector)
 
-	copts := NewFrameIsHiddenOptions()
-	if err := copts.Parse(l.ctx, opts); err != nil {
-		return false, fmt.Errorf("parsing is hidden options: %w", err)
-	}
-	hidden, err := l.isHidden(copts)
+	hidden, err := l.frame.isHidden(l.selector, &FrameIsHiddenOptions{Strict: true})
 	if err != nil {
 		return false, fmt.Errorf("checking is %q hidden: %w", l.selector, err)
 	}
 
 	return hidden, nil
-}
-
-// isHidden is like IsHidden but takes parsed options and does not
-// throw an error.
-func (l *Locator) isHidden(opts *FrameIsHiddenOptions) (bool, error) {
-	opts.Strict = true
-	return l.frame.isHidden(l.selector, opts)
 }
 
 // Fill out the element using locator's selector with strict mode on.

--- a/common/locator.go
+++ b/common/locator.go
@@ -233,26 +233,15 @@ func (l *Locator) isDisabled(opts *FrameIsDisabledOptions) (bool, error) {
 
 // IsVisible returns true if the element matches the locator's
 // selector and is visible. Otherwise, returns false.
-func (l *Locator) IsVisible(opts goja.Value) bool {
-	l.log.Debugf("Locator:IsVisible", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
+func (l *Locator) IsVisible() bool {
+	l.log.Debugf("Locator:IsVisible", "fid:%s furl:%q sel:%q", l.frame.ID(), l.frame.URL(), l.selector)
 
-	copts := NewFrameIsVisibleOptions()
-	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parsing is visible options: %w", err)
-	}
-	visible, err := l.isVisible(copts)
+	visible, err := l.frame.isVisible(l.selector, &FrameIsVisibleOptions{Strict: true})
 	if err != nil {
 		k6ext.Panic(l.ctx, "checking is %q visible: %w", l.selector, err)
 	}
 
 	return visible
-}
-
-// isVisible is like IsVisible but takes parsed options and does not
-// throw an error.
-func (l *Locator) isVisible(opts *FrameIsVisibleOptions) (bool, error) {
-	opts.Strict = true
-	return l.frame.isVisible(l.selector, opts)
 }
 
 // IsHidden returns true if the element matches the locator's

--- a/common/locator.go
+++ b/common/locator.go
@@ -257,19 +257,19 @@ func (l *Locator) isVisible(opts *FrameIsVisibleOptions) (bool, error) {
 
 // IsHidden returns true if the element matches the locator's
 // selector and is hidden. Otherwise, returns false.
-func (l *Locator) IsHidden(opts goja.Value) bool {
+func (l *Locator) IsHidden(opts goja.Value) (bool, error) {
 	l.log.Debugf("Locator:IsHidden", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
 
 	copts := NewFrameIsHiddenOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		k6ext.Panic(l.ctx, "parsing is hidden options: %w", err)
+		return false, fmt.Errorf("parsing is hidden options: %w", err)
 	}
 	hidden, err := l.isHidden(copts)
 	if err != nil {
-		k6ext.Panic(l.ctx, "checking is %q hidden: %w", l.selector, err)
+		return false, fmt.Errorf("checking is %q hidden: %w", l.selector, err)
 	}
 
-	return hidden
+	return hidden, nil
 }
 
 // isHidden is like IsHidden but takes parsed options and does not

--- a/common/locator.go
+++ b/common/locator.go
@@ -233,15 +233,15 @@ func (l *Locator) isDisabled(opts *FrameIsDisabledOptions) (bool, error) {
 
 // IsVisible returns true if the element matches the locator's
 // selector and is visible. Otherwise, returns false.
-func (l *Locator) IsVisible() bool {
+func (l *Locator) IsVisible() (bool, error) {
 	l.log.Debugf("Locator:IsVisible", "fid:%s furl:%q sel:%q", l.frame.ID(), l.frame.URL(), l.selector)
 
 	visible, err := l.frame.isVisible(l.selector, &FrameIsVisibleOptions{Strict: true})
 	if err != nil {
-		k6ext.Panic(l.ctx, "checking is %q visible: %w", l.selector, err)
+		return false, fmt.Errorf("checking is %q visible: %w", l.selector, err)
 	}
 
-	return visible
+	return visible, nil
 }
 
 // IsHidden returns true if the element matches the locator's

--- a/common/locator.go
+++ b/common/locator.go
@@ -249,7 +249,7 @@ func (l *Locator) IsVisible() (bool, error) {
 func (l *Locator) IsHidden(opts goja.Value) (bool, error) {
 	l.log.Debugf("Locator:IsHidden", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
 
-	copts := NewFrameIsHiddenOptions(l.frame.defaultTimeout())
+	copts := NewFrameIsHiddenOptions()
 	if err := copts.Parse(l.ctx, opts); err != nil {
 		return false, fmt.Errorf("parsing is hidden options: %w", err)
 	}

--- a/common/locator.go
+++ b/common/locator.go
@@ -236,7 +236,7 @@ func (l *Locator) isDisabled(opts *FrameIsDisabledOptions) (bool, error) {
 func (l *Locator) IsVisible(opts goja.Value) bool {
 	l.log.Debugf("Locator:IsVisible", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
 
-	copts := NewFrameIsVisibleOptions(l.frame.defaultTimeout())
+	copts := NewFrameIsVisibleOptions()
 	if err := copts.Parse(l.ctx, opts); err != nil {
 		k6ext.Panic(l.ctx, "parsing is visible options: %w", err)
 	}

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -59,30 +59,6 @@ func (m *Mouse) click(x float64, y float64, opts *MouseClickOptions) error {
 	return nil
 }
 
-func (m *Mouse) dblClick(x float64, y float64, opts *MouseDblClickOptions) error {
-	mouseDownUpOpts := opts.ToMouseDownUpOptions()
-	if err := m.move(x, y, NewMouseMoveOptions()); err != nil {
-		return err
-	}
-	for i := 0; i < 2; i++ {
-		if err := m.down(x, y, mouseDownUpOpts); err != nil {
-			return err
-		}
-		if opts.Delay != 0 {
-			t := time.NewTimer(time.Duration(opts.Delay) * time.Millisecond)
-			select {
-			case <-m.ctx.Done():
-				t.Stop()
-			case <-t.C:
-			}
-		}
-		if err := m.up(x, y, mouseDownUpOpts); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (m *Mouse) down(x float64, y float64, opts *MouseDownUpOptions) error {
 	m.button = input.MouseButton(opts.Button)
 	action := input.DispatchMouseEvent(input.MousePressed, m.x, m.y).
@@ -141,7 +117,7 @@ func (m *Mouse) DblClick(x float64, y float64, opts goja.Value) {
 	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
 		k6ext.Panic(m.ctx, "parsing double click options: %w", err)
 	}
-	if err := m.dblClick(x, y, mouseOpts); err != nil {
+	if err := m.click(x, y, mouseOpts.ToMouseClickOptions()); err != nil {
 		k6ext.Panic(m.ctx, "double clicking on x:%f y:%f: %w", x, y, err)
 	}
 }

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -40,19 +40,21 @@ func (m *Mouse) click(x float64, y float64, opts *MouseClickOptions) error {
 	if err := m.move(x, y, NewMouseMoveOptions()); err != nil {
 		return err
 	}
-	if err := m.down(x, y, mouseDownUpOpts); err != nil {
-		return err
-	}
-	if opts.Delay != 0 {
-		t := time.NewTimer(time.Duration(opts.Delay) * time.Millisecond)
-		select {
-		case <-m.ctx.Done():
-			t.Stop()
-		case <-t.C:
+	for i := 0; i < int(mouseDownUpOpts.ClickCount); i++ {
+		if err := m.down(x, y, mouseDownUpOpts); err != nil {
+			return err
 		}
-	}
-	if err := m.up(x, y, mouseDownUpOpts); err != nil {
-		return err
+		if opts.Delay != 0 {
+			t := time.NewTimer(time.Duration(opts.Delay) * time.Millisecond)
+			select {
+			case <-m.ctx.Done():
+				t.Stop()
+			case <-t.C:
+			}
+		}
+		if err := m.up(x, y, mouseDownUpOpts); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/common/mouse.go
+++ b/common/mouse.go
@@ -112,13 +112,11 @@ func (m *Mouse) move(x float64, y float64, opts *MouseMoveOptions) error {
 }
 
 func (m *Mouse) up(x float64, y float64, opts *MouseDownUpOptions) error {
-	var button input.MouseButton = input.Left
-	var clickCount int64 = 1
 	m.button = input.None
 	action := input.DispatchMouseEvent(input.MouseReleased, m.x, m.y).
-		WithButton(button).
+		WithButton(input.MouseButton(opts.Button)).
 		WithModifiers(input.Modifier(m.keyboard.modifiers)).
-		WithClickCount(clickCount)
+		WithClickCount(opts.ClickCount)
 	if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
 		return err
 	}

--- a/common/mouse_options.go
+++ b/common/mouse_options.go
@@ -84,9 +84,12 @@ func (o *MouseDblClickOptions) Parse(ctx context.Context, opts goja.Value) error
 	return nil
 }
 
-func (o *MouseDblClickOptions) ToMouseDownUpOptions() *MouseDownUpOptions {
-	o2 := NewMouseDownUpOptions()
+// ToMouseClickOptions converts MouseDblClickOptions to a MouseClickOptions.
+func (o *MouseDblClickOptions) ToMouseClickOptions() *MouseClickOptions {
+	o2 := NewMouseClickOptions()
 	o2.Button = o.Button
+	o2.ClickCount = 2
+	o2.Delay = o.Delay
 	return o2
 }
 

--- a/common/page.go
+++ b/common/page.go
@@ -992,7 +992,7 @@ func (p *Page) Press(selector string, key string, opts goja.Value) {
 func (p *Page) Query(selector string) (*ElementHandle, error) {
 	p.logger.Debugf("Page:Query", "sid:%v selector:%s", p.sessionID(), selector)
 
-	return p.frameManager.MainFrame().Query(selector, false)
+	return p.frameManager.MainFrame().Query(selector, StrictModeOff)
 }
 
 // QueryAll returns all elements matching the specified selector.

--- a/common/page.go
+++ b/common/page.go
@@ -919,7 +919,9 @@ func (p *Page) IsHidden(selector string, opts goja.Value) bool {
 	return p.MainFrame().IsHidden(selector, opts)
 }
 
-func (p *Page) IsVisible(selector string, opts goja.Value) bool {
+// IsVisible will look for an element in the dom with given selector. It will
+// not wait for a match to occur. If no elements match `false` will be returned.
+func (p *Page) IsVisible(selector string, opts goja.Value) (bool, error) {
 	p.logger.Debugf("Page:IsVisible", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().IsVisible(selector, opts)

--- a/common/page.go
+++ b/common/page.go
@@ -913,7 +913,10 @@ func (p *Page) IsEnabled(selector string, opts goja.Value) bool {
 	return p.MainFrame().IsEnabled(selector, opts)
 }
 
-func (p *Page) IsHidden(selector string, opts goja.Value) bool {
+// IsHidden will look for an element in the dom with given selector and see if
+// the element is hidden. It will not wait for a match to occur. If no elements
+// match `false` will be returned.
+func (p *Page) IsHidden(selector string, opts goja.Value) (bool, error) {
 	p.logger.Debugf("Page:IsHidden", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().IsHidden(selector, opts)

--- a/common/page.go
+++ b/common/page.go
@@ -992,7 +992,7 @@ func (p *Page) Press(selector string, key string, opts goja.Value) {
 func (p *Page) Query(selector string) (*ElementHandle, error) {
 	p.logger.Debugf("Page:Query", "sid:%v selector:%s", p.sessionID(), selector)
 
-	return p.frameManager.MainFrame().Query(selector)
+	return p.frameManager.MainFrame().Query(selector, false)
 }
 
 // QueryAll returns all elements matching the specified selector.

--- a/keyboardlayout/layout.go
+++ b/keyboardlayout/layout.go
@@ -1,3 +1,4 @@
+// Package keyboardlayout provides keyboard key interpretation and layout validation.
 package keyboardlayout
 
 import (

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,3 +1,4 @@
+// Package log provides logging for the browser module.
 package log
 
 import (

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,3 +1,4 @@
+// Package storage provides data storage for the extension and user specific data.
 package storage
 
 import (

--- a/tests/doc.go
+++ b/tests/doc.go
@@ -1,2 +1,3 @@
-// Package tests contains integration tests.
+// Package tests provides integration tests.
+// The `testBrowser` type enables us to test the browser module with a real browser.
 package tests

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -354,7 +354,7 @@ func TestLocatorElementState(t *testing.T) {
 		{
 			"visible",
 			`() => document.getElementById('inputText').style.visibility = 'hidden'`,
-			func(l *common.Locator) bool { return l.IsVisible() },
+			func(l *common.Locator) bool { resp, _ := l.IsVisible(); return resp },
 		},
 	}
 

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -344,7 +344,7 @@ func TestLocatorElementState(t *testing.T) {
 		{
 			"hidden",
 			`() => document.getElementById('inputText').style.visibility = 'hidden'`,
-			func(l *common.Locator) bool { return !l.IsHidden(nil) },
+			func(l *common.Locator) bool { resp, _ := l.IsHidden(nil); return !resp },
 		},
 		{
 			"readOnly",
@@ -398,7 +398,11 @@ func TestLocatorElementState(t *testing.T) {
 			"IsDisabled", func(l *common.Locator, tb *testBrowser) { l.IsDisabled(timeout(tb)) },
 		},
 		{
-			"IsHidden", func(l *common.Locator, tb *testBrowser) { l.IsHidden(timeout(tb)) },
+			"IsHidden", func(l *common.Locator, tb *testBrowser) {
+				if _, err := l.IsHidden(timeout(tb)); err != nil {
+					panic(err)
+				}
+			},
 		},
 	}
 	for _, tt := range sanityTests {

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -398,9 +398,6 @@ func TestLocatorElementState(t *testing.T) {
 			"IsDisabled", func(l *common.Locator, tb *testBrowser) { l.IsDisabled(timeout(tb)) },
 		},
 		{
-			"IsVisible", func(l *common.Locator, tb *testBrowser) { l.IsVisible(timeout(tb)) },
-		},
-		{
 			"IsHidden", func(l *common.Locator, tb *testBrowser) { l.IsHidden(timeout(tb)) },
 		},
 	}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -344,7 +344,7 @@ func TestLocatorElementState(t *testing.T) {
 		{
 			"hidden",
 			`() => document.getElementById('inputText').style.visibility = 'hidden'`,
-			func(l *common.Locator) bool { resp, _ := l.IsHidden(nil); return !resp },
+			func(l *common.Locator) bool { resp, _ := l.IsHidden(); return !resp },
 		},
 		{
 			"readOnly",

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -354,7 +354,7 @@ func TestLocatorElementState(t *testing.T) {
 		{
 			"visible",
 			`() => document.getElementById('inputText').style.visibility = 'hidden'`,
-			func(l *common.Locator) bool { return l.IsVisible(nil) },
+			func(l *common.Locator) bool { return l.IsVisible() },
 		},
 	}
 

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -397,13 +397,6 @@ func TestLocatorElementState(t *testing.T) {
 		{
 			"IsDisabled", func(l *common.Locator, tb *testBrowser) { l.IsDisabled(timeout(tb)) },
 		},
-		{
-			"IsHidden", func(l *common.Locator, tb *testBrowser) {
-				if _, err := l.IsHidden(timeout(tb)); err != nil {
-					panic(err)
-				}
-			},
-		},
 	}
 	for _, tt := range sanityTests {
 		tt := tt

--- a/tests/mouse_test.go
+++ b/tests/mouse_test.go
@@ -1,0 +1,25 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMouseDblClick(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBrowser(t, withFileServer())
+	p := b.NewPage(nil)
+	_, err := p.Goto(b.staticURL("dbl_click.html"), nil)
+	require.NoError(t, err)
+
+	p.Mouse.DblClick(35, 17, nil)
+
+	v := p.Evaluate(b.toGojaValue(`() => window.dblclick`))
+	assert.True(t, b.asGojaBool(v), "failed to double click the link")
+
+	got := p.InnerText("#counter", nil)
+	assert.Equal(t, "2", got)
+}

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1309,9 +1309,7 @@ func TestPageIsVisible(t *testing.T) {
 			name:     "first_div",
 			selector: "div",
 			options: common.FrameIsVisibleOptions{
-				FrameBaseOptions: common.FrameBaseOptions{
-					Strict: true,
-				},
+				Strict: true,
 			},
 			wantErr: "error:strictmodeviolation",
 		},
@@ -1376,9 +1374,7 @@ func TestPageIsHidden(t *testing.T) {
 			name:     "first_div",
 			selector: "div",
 			options: common.FrameIsVisibleOptions{
-				FrameBaseOptions: common.FrameBaseOptions{
-					Strict: true,
-				},
+				Strict: true,
 			},
 			wantErr: "error:strictmodeviolation",
 		},

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1341,3 +1341,70 @@ func TestPageIsVisible(t *testing.T) {
 		})
 	}
 }
+
+func TestPageIsHidden(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		selector string
+		options  common.FrameIsVisibleOptions
+		want     bool
+		wantErr  string
+	}{
+		{
+			name:     "hidden",
+			selector: "div[id=my-div-3]",
+			want:     true,
+		},
+		{
+			name:     "visible",
+			selector: "div[id=my-div]",
+			want:     false,
+		},
+		{
+			name:     "not_found",
+			selector: "div[id=does-not-exist]",
+			want:     true,
+		},
+		{
+			name:     "first_div",
+			selector: "div",
+			want:     false,
+		},
+		{
+			name:     "first_div",
+			selector: "div",
+			options: common.FrameIsVisibleOptions{
+				FrameBaseOptions: common.FrameBaseOptions{
+					Strict: true,
+				},
+			},
+			wantErr: "error:strictmodeviolation",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tb := newTestBrowser(t, withFileServer())
+
+			page := tb.NewPage(nil)
+
+			_, err := page.Goto(tb.staticURL("visible.html"), nil)
+			require.NoError(t, err)
+
+			got, err := page.IsHidden(tc.selector, tb.toGojaValue(tc.options))
+
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/tests/static/dbl_click.html
+++ b/tests/static/dbl_click.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Clickable link test</title>
+</head>
+
+<body>
+    <a id="linkdbl" href="#" ondblclick="event.preventDefault()" onclick="incrementCounter()">Dblclick</a>
+    Counter: <span id="counter">0</span>
+
+    <script>
+        window.dblclick = false;
+
+        document.querySelector('#linkdbl').addEventListener(
+            'dblclick', e => { window.dblclick = true }, false
+        );
+
+        var counter = 0;
+        function incrementCounter() {
+            document.getElementById("counter").textContent = ++counter;
+        }
+    </script>
+</body>
+
+</html>

--- a/tests/static/visible.html
+++ b/tests/static/visible.html
@@ -1,0 +1,8 @@
+<html lang="en">
+    <head></head>
+    <body>
+        <div id='my-div'>My DIV</div>
+        <div id='my-div-2'>My DIV 2</div>
+        <div id='my-div-3' style='display: none;'>My DIV 3</div>
+    </body>
+</html>


### PR DESCRIPTION
Since the release of [k6 v0.48](https://github.com/grafana/k6/releases/tag/v0.48.0).

Existing PRs wanting to merge `main-next` can target `main` instead.