### PR TITLE
Mitigate risk of panic on parse of remote object during console.log

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -616,16 +616,13 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 		}
 		*/
 
-	parsedObjects := make([]any, 0, len(event.Args))
+	parsedObjects := make([]string, 0, len(event.Args))
 	for _, robj := range event.Args {
-		i, err := parseRemoteObject(robj)
-		if err != nil {
-			handleParseRemoteObjectErr(fs.ctx, err, l)
-		}
+		i := parseConsoleRemoteObject(fs.logger, robj)
 		parsedObjects = append(parsedObjects, i)
 	}
 
-	l = l.WithField("objects", parsedObjects)
+	l = l.WithField("stringObjects", parsedObjects)
 
 	switch event.Type {
 	case "log", "info":

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -619,8 +619,8 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 
 	parsedObjects := make([]string, 0, len(event.Args))
 	for _, robj := range event.Args {
-		i := parseConsoleRemoteObject(fs.logger, robj)
-		parsedObjects = append(parsedObjects, i)
+		s := parseConsoleRemoteObject(fs.logger, robj)
+		parsedObjects = append(parsedObjects, s)
 	}
 
 	l = l.WithField("stringObjects", parsedObjects)

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -10,10 +10,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grafana/xk6-browser/k6ext"
-	"github.com/grafana/xk6-browser/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/xk6-browser/k6ext"
+	"github.com/grafana/xk6-browser/log"
 
 	k6modules "go.k6.io/k6/js/modules"
 	k6metrics "go.k6.io/k6/metrics"

--- a/common/page.go
+++ b/common/page.go
@@ -1374,9 +1374,9 @@ func (p *Page) consoleMsgFromConsoleEvent(e *cdpruntime.EventConsoleAPICalled) (
 	)
 
 	for _, robj := range e.Args {
-		i := parseConsoleRemoteObject(p.logger, robj)
+		s := parseConsoleRemoteObject(p.logger, robj)
 
-		objects = append(objects, i)
+		objects = append(objects, s)
 		objectHandles = append(objectHandles, NewJSHandle(
 			p.ctx, p.session, execCtx, execCtx.Frame(), robj, p.logger,
 		))

--- a/common/page.go
+++ b/common/page.go
@@ -1369,19 +1369,12 @@ func (p *Page) consoleMsgFromConsoleEvent(e *cdpruntime.EventConsoleAPICalled) (
 	}
 
 	var (
-		l = p.logger.WithTime(e.Timestamp.Time()).
-			WithField("source", "browser").
-			WithField("browser_source", "console-api")
-
-		objects       = make([]any, 0, len(e.Args))
+		objects       = make([]string, 0, len(e.Args))
 		objectHandles = make([]JSHandleAPI, 0, len(e.Args))
 	)
 
 	for _, robj := range e.Args {
-		i, err := parseRemoteObject(robj)
-		if err != nil {
-			handleParseRemoteObjectErr(p.ctx, err, l)
-		}
+		i := parseConsoleRemoteObject(p.logger, robj)
 
 		objects = append(objects, i)
 		objectHandles = append(objectHandles, NewJSHandle(
@@ -1424,7 +1417,7 @@ func (p *Page) sessionID() (sid target.SessionID) {
 
 // textForConsoleEvent generates the text representation for a consoleAPICalled event
 // mimicking Playwright's behavior.
-func textForConsoleEvent(e *cdpruntime.EventConsoleAPICalled, args []any) string {
+func textForConsoleEvent(e *cdpruntime.EventConsoleAPICalled, args []string) string {
 	if e.Type.String() == "dir" || e.Type.String() == "dirxml" ||
 		e.Type.String() == "table" {
 		if len(e.Args) > 0 {
@@ -1434,17 +1427,5 @@ func textForConsoleEvent(e *cdpruntime.EventConsoleAPICalled, args []any) string
 		return ""
 	}
 
-	// args is a mix of string and non strings, so using fmt.Sprint(args...)
-	// might not add spaces between all elements, therefore use a strings.Builder
-	// and handle format and concatenation
-	var b strings.Builder
-	for i, a := range args {
-		format := " %v"
-		if i == 0 {
-			format = "%v"
-		}
-		b.WriteString(fmt.Sprintf(format, a))
-	}
-
-	return b.String()
+	return strings.Join(args, " ")
 }

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -196,7 +196,7 @@ func valueFromRemoteObject(ctx context.Context, robj *cdpruntime.RemoteObject) (
 func parseConsoleRemoteObjectPreview(logger *log.Logger, op *cdpruntime.ObjectPreview) string {
 	obj := make(map[string]string)
 	if op.Overflow {
-		logger.Warnf("parseConsoleRemoteObjectPreview", "object is too large and will be parsed partially")
+		logger.Infof("parseConsoleRemoteObjectPreview", "object is too large and will be parsed partially")
 	}
 
 	for _, p := range op.Properties {

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -163,6 +163,8 @@ func parseExceptionDetails(exc *cdpruntime.ExceptionDetails) string {
 	return errMsg
 }
 
+// parseRemoteObject is to be used by callers that require the string value
+// to be parsed to a go type.
 func parseRemoteObject(obj *cdpruntime.RemoteObject) (any, error) {
 	if obj.UnserializableValue == "" {
 		return parseRemoteObjectValue(obj.Type, obj.Subtype, string(obj.Value), obj.Preview)

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -162,7 +162,7 @@ func parseExceptionDetails(exc *cdpruntime.ExceptionDetails) string {
 }
 
 // parseRemoteObject is to be used by callers that require the string value
-// to be parsed to a go type.
+// to be parsed to a Go type.
 func parseRemoteObject(obj *cdpruntime.RemoteObject) (any, error) {
 	if obj.UnserializableValue == "" {
 		return parseRemoteObjectValue(obj.Type, obj.Subtype, string(obj.Value), obj.Preview)

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -14,7 +13,6 @@ import (
 
 	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/dop251/goja"
-	"github.com/sirupsen/logrus"
 )
 
 type objectOverflowError struct{}
@@ -190,29 +188,6 @@ func valueFromRemoteObject(ctx context.Context, robj *cdpruntime.RemoteObject) (
 		return goja.Undefined(), err
 	}
 	return k6ext.Runtime(ctx).ToValue(val), err
-}
-
-func handleParseRemoteObjectErr(ctx context.Context, err error, logger *logrus.Entry) {
-	var (
-		ooe *objectOverflowError
-		ope *objectPropertyParseError
-	)
-	var merr *multiError
-	if !errors.As(err, &merr) {
-		// If this panics it's a bug :)
-		k6ext.Panic(ctx, "parsing remote object value: %w", err)
-	}
-	for _, e := range merr.Errors {
-		switch {
-		case errors.As(e, &ooe):
-			logger.Warn(ooe)
-		case errors.As(e, &ope):
-			logger.WithError(ope).Error()
-		default:
-			// If this panics it's a bug :)
-			k6ext.Panic(ctx, "parsing remote object value: %w", e)
-		}
-	}
 }
 
 func parseConsoleRemoteObjectPreview(logger *log.Logger, op *cdpruntime.ObjectPreview) string {

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -179,6 +179,9 @@ func parseRemoteObject(obj *cdpruntime.RemoteObject) (any, error) {
 		return math.Inf(-1), nil
 	}
 
+	// We should never get here, as previous switch statement should
+	// be exhaustive and contain all possible unserializable values.
+	// See: https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-UnserializableValue
 	return nil, UnserializableValueError{obj.UnserializableValue}
 }
 

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -221,10 +221,6 @@ func parseConsoleRemoteObjectValue(
 	op *cdpruntime.ObjectPreview,
 ) string {
 	switch t {
-	case cdpruntime.TypeNumber:
-	case cdpruntime.TypeBoolean:
-	case cdpruntime.TypeSymbol:
-	case cdpruntime.TypeBigint:
 	case cdpruntime.TypeAccessor:
 		return "accessor"
 	case cdpruntime.TypeFunction:
@@ -246,6 +242,12 @@ func parseConsoleRemoteObjectValue(
 		}
 	case cdpruntime.TypeUndefined:
 		return "undefined"
+	// The following cases are here to clarify that all cases have been
+	// considered, but that the result will return val without processing it.
+	case cdpruntime.TypeNumber:
+	case cdpruntime.TypeBoolean:
+	case cdpruntime.TypeSymbol:
+	case cdpruntime.TypeBigint:
 	}
 
 	return val

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -215,7 +215,6 @@ func handleParseRemoteObjectErr(ctx context.Context, err error, logger *logrus.E
 	}
 }
 
-//nolint:unused
 func parseConsoleRemoteObjectPreview(logger *log.Logger, op *cdpruntime.ObjectPreview) string {
 	obj := make(map[string]string)
 	if op.Overflow {
@@ -235,7 +234,7 @@ func parseConsoleRemoteObjectPreview(logger *log.Logger, op *cdpruntime.ObjectPr
 	return string(bb)
 }
 
-//nolint:cyclop,unused
+//nolint:cyclop
 func parseConsoleRemoteObjectValue(
 	logger *log.Logger,
 	t cdpruntime.Type,
@@ -277,8 +276,6 @@ func parseConsoleRemoteObjectValue(
 // parseConsoleRemoteObject is to be used by callers that are working with
 // console messages that are written to Chrome's console by the website under
 // test.
-//
-//nolint:unused
 func parseConsoleRemoteObject(logger *log.Logger, obj *cdpruntime.RemoteObject) string {
 	if obj.UnserializableValue != "" {
 		return obj.UnserializableValue.String()

--- a/log/logger.go
+++ b/log/logger.go
@@ -2,7 +2,6 @@
 package log
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
@@ -184,17 +183,6 @@ type consoleLogFormatter struct {
 // Format assembles a message from marshalling elements in the "objects" field
 // to JSON separated by space, and deletes the field when done.
 func (f *consoleLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	if objects, ok := entry.Data["objects"].([]any); ok {
-		var msg []string
-		for _, obj := range objects {
-			// TODO: Log error?
-			if o, err := json.Marshal(obj); err == nil {
-				msg = append(msg, string(o))
-			}
-		}
-		entry.Message = strings.Join(msg, " ")
-		delete(entry.Data, "objects")
-	}
 	if stringObjects, ok := entry.Data["stringObjects"].([]string); ok {
 		entry.Message = strings.Join(stringObjects, " ")
 		delete(entry.Data, "stringObjects")

--- a/log/logger.go
+++ b/log/logger.go
@@ -195,5 +195,9 @@ func (f *consoleLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		entry.Message = strings.Join(msg, " ")
 		delete(entry.Data, "objects")
 	}
+	if stringObjects, ok := entry.Data["stringObjects"].([]string); ok {
+		entry.Message = strings.Join(stringObjects, " ")
+		delete(entry.Data, "stringObjects")
+	}
 	return f.Formatter.Format(entry)
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -18,36 +18,16 @@ func TestConsoleLogFormatter(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		objects  []any
-		expected string
+		stringObjects []string
+		expected      string
 	}{
-		{objects: nil, expected: ""},
+		{stringObjects: nil, expected: ""},
 		{
-			objects: []any{
-				map[string]any{"one": 1, "two": "two"},
-				map[string]any{"nested": map[string]any{
-					"sub": float64(7.777),
-				}},
+			stringObjects: []string{
+				`{"one":1,"two":"two"}`,
+				`{"nested":{"sub":7.777}}`,
 			},
 			expected: `{"one":1,"two":"two"} {"nested":{"sub":7.777}}`,
-		},
-		{
-			// The first object can't be serialized to JSON, so it will be
-			// skipped in the output.
-			objects: []any{
-				map[string]any{"one": 1, "fail": make(chan int)},
-				map[string]any{"two": 2},
-			},
-			expected: `{"two":2}`,
-		},
-		{
-			// Mixed objects and primitive values
-			objects: []any{
-				map[string]any{"one": 1},
-				"someString",
-				42,
-			},
-			expected: `{"one":1} "someString" 42`,
 		},
 	}
 
@@ -55,8 +35,8 @@ func TestConsoleLogFormatter(t *testing.T) {
 
 	for _, tc := range testCases {
 		var data logrus.Fields
-		if tc.objects != nil {
-			data = logrus.Fields{"objects": tc.objects}
+		if tc.stringObjects != nil {
+			data = logrus.Fields{"stringObjects": tc.stringObjects}
 		}
 		out, err := fmtr.Format(&logrus.Entry{Data: data})
 		require.NoError(t, err)

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -943,7 +943,7 @@ func TestPageOn(t *testing.T) { //nolint:gocognit
 			name:      "on console.time",
 			consoleFn: "() => { console.time('k6'); console.timeEnd('k6'); }",
 			assertFn: func(cm *common.ConsoleMessage) bool {
-				return cm.Type == "timeEnd" && strings.HasPrefix(cm.Text, "k6: 0.0") &&
+				return cm.Type == "timeEnd" && strings.HasPrefix(cm.Text, "k6: 0.") &&
 					cm.Page.URL() == blankPage
 			},
 		},

--- a/tests/remote_obj_test.go
+++ b/tests/remote_obj_test.go
@@ -1,0 +1,115 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/common"
+)
+
+func TestConsoleLogParse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		log  string
+		want string
+	}{
+		{
+			name: "number", log: "1", want: "1",
+		},
+		{
+			name: "string", log: `"some string"`, want: "some string",
+		},
+		{
+			name: "bool", log: "true", want: "true",
+		},
+		{
+			name: "empty_array", log: "[]", want: "{}", // TODO: Improve this output
+		},
+		{
+			name: "empty_object", log: "{}", want: "{}",
+		},
+		{
+			name: "filled_object", log: `{"foo":{"bar1":"bar2"}}`, want: `{"foo":"Object"}`,
+		},
+		{
+			name: "filled_array", log: `["foo","bar"]`, want: `{"0":"foo","1":"bar"}`,
+		},
+		{
+			name: "filled_array", log: `() => true`, want: `function()`,
+		},
+		{
+			name: "empty", log: "", want: "",
+		},
+		{
+			name: "null", log: "null", want: "null",
+		},
+		{
+			name: "undefined", log: "undefined", want: "undefined",
+		},
+		{
+			name: "bigint", log: `BigInt("2")`, want: "2n",
+		},
+		{
+			name: "unwrapped_bigint", log: "3n", want: "3n",
+		},
+		{
+			name: "float", log: "3.14", want: "3.14",
+		},
+		{
+			name: "scientific_notation", log: "123e-5", want: "0.00123",
+		},
+		{
+			name: "partially_parsed",
+			log:  "window",
+			want: `{"document":"#document","location":"Location","name":"","self":"Window","window":"Window"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tb := newTestBrowser(t, withFileServer())
+			p := tb.NewPage(nil)
+
+			done := make(chan bool)
+
+			eventHandler := func(cm *common.ConsoleMessage) {
+				defer close(done)
+				assert.Equal(t, tt.want, cm.Text)
+			}
+
+			// eventHandler will be called from a separate goroutine from within
+			// the page's async event loop. This is why we need to wait on done
+			// to close.
+			err := p.On("console", eventHandler)
+			require.NoError(t, err)
+
+			if tt.log == "" {
+				p.Evaluate(tb.toGojaValue(`() => console.log("")`))
+			} else {
+				p.Evaluate(tb.toGojaValue(fmt.Sprintf("() => console.log(%s)", tt.log)))
+			}
+
+			var (
+				assertTO bool
+				testTO   = 2500 * time.Millisecond
+			)
+
+			select {
+			case <-done:
+			case <-time.After(testTO):
+				assertTO = true
+			}
+
+			assert.False(t, assertTO, "test timed out before event handlers were called")
+		})
+	}
+}

--- a/tests/remote_obj_test.go
+++ b/tests/remote_obj_test.go
@@ -98,18 +98,11 @@ func TestConsoleLogParse(t *testing.T) {
 				p.Evaluate(tb.toGojaValue(fmt.Sprintf("() => console.log(%s)", tt.log)))
 			}
 
-			var (
-				assertTO bool
-				testTO   = 2500 * time.Millisecond
-			)
-
 			select {
 			case <-done:
-			case <-time.After(testTO):
-				assertTO = true
+			case <-time.After(2500 * time.Millisecond):
+				assert.Fail(t, "test timed out before event handler was called")
 			}
-
-			assert.False(t, assertTO, "test timed out before event handlers were called")
 		})
 	}
 }


### PR DESCRIPTION
## What?

This change reduces the risk of a panic occurring when the website under test uses `console.log` to print logs.

## Why?

Currently there is an unknown case where a panic can occur when an object from console.log is unmarshaled and fails with an invalid JSON error. So this isn't fixing the issue but mitigating the risk. This is done by not needing to parse the console.log text at all. The reason behind this choice is that when a user prints something to the console, they don't tend to need the object to be parsed.

Other areas of the module still rely on the existing parse logic which does still attempt to unmarshal the object which is returned when working with APIs such as `JSONValue` and `Eval`.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/987