### PR TITLE
Fix BigInt remote object parsing

### DIFF
--- a/tests/remote_obj_test.go
+++ b/tests/remote_obj_test.go
@@ -135,7 +135,7 @@ func TestEvalRemoteObjectParse(t *testing.T) {
 			name: "filled_object", eval: `{return {foo:"bar"};}`, want: map[string]any{"foo": "bar"},
 		},
 		{
-			name: "filled_array", eval: `{return ["foo","bar"];}`, want: []interface{}{0: "foo", 1: "bar"},
+			name: "filled_array", eval: `{return ["foo","bar"];}`, want: []any{0: "foo", 1: "bar"},
 		},
 		{
 			name: "filled_array", eval: `() => true`, want: `function()`,
@@ -161,6 +161,7 @@ func TestEvalRemoteObjectParse(t *testing.T) {
 		{
 			name: "scientific_notation", eval: "123e-5", want: 0.00123,
 		},
+		// TODO:
 		// {
 		// 	// This test is ignored until https://github.com/grafana/xk6-browser/issues/1132
 		// 	// has been resolved.

--- a/tests/remote_obj_test.go
+++ b/tests/remote_obj_test.go
@@ -149,14 +149,12 @@ func TestEvalRemoteObjectParse(t *testing.T) {
 		{
 			name: "undefined", eval: "undefined", want: goja.Undefined(),
 		},
-		// {
-		// 	// Commented out until fix applied
-		// 	name: "bigint", eval: `BigInt("2")`, want: "2n",
-		// },
-		// {
-		// 	// Commented out until fix applied
-		// 	name: "unwrapped_bigint", eval: "3n", want: "3n",
-		// },
+		{
+			name: "bigint", eval: `BigInt("2")`, want: 2,
+		},
+		{
+			name: "unwrapped_bigint", eval: "3n", want: 3,
+		},
 		{
 			name: "float", eval: "3.14", want: 3.14,
 		},


### PR DESCRIPTION
## What?

This ensures that BigInt remote objects are parsed.

## Why?

For an unknown reason BigInts are being set as `UnserializableValue` instead of the expected `Value`. This ensures that we correctly deal with the case of BigInt when it is a `UnserializableValue`.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/987