### PR TITLE
Add remoteObjectParseError

### DIFF
--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -86,6 +86,24 @@ func multierror(err error, errs ...error) error {
 	return me
 }
 
+type remoteObjectParseError struct {
+	error
+	typ     string
+	subType string
+	val     string
+}
+
+// Error returns a string representation of the error.
+func (e *remoteObjectParseError) Error() string {
+	return fmt.Sprintf("parsing remote object with type: %s subtype: %s val: %s err: %s",
+		e.typ, e.subType, e.val, e.error.Error())
+}
+
+// Unwrap returns the wrapped parsing error.
+func (e *remoteObjectParseError) Unwrap() error {
+	return e.error
+}
+
 func parseRemoteObjectPreview(op *cdpruntime.ObjectPreview) (map[string]any, error) {
 	obj := make(map[string]any)
 	var result error

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -160,7 +160,12 @@ func parseRemoteObjectValue(
 
 	var v any
 	if err := json.Unmarshal([]byte(val), &v); err != nil {
-		return nil, err
+		return nil, &remoteObjectParseError{
+			error:   err,
+			typ:     string(t),
+			subType: string(st),
+			val:     val,
+		}
 	}
 
 	return v, nil


### PR DESCRIPTION
## What?

Adds a new `remoteObjectParseError` error type.

## Why?

For use when parsing of remote objects fails. It should hopefully help identify what exactly failed to parse.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/987