### PR TITLE
Fix array console output

### DIFF
--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -248,6 +248,25 @@ func parseConsoleRemoteObjectPreview(logger *log.Logger, op *cdpruntime.ObjectPr
 	return string(bb)
 }
 
+func parseConsoleRemoteArrayPreview(logger *log.Logger, op *cdpruntime.ObjectPreview) string {
+	arr := make([]any, 0)
+	if op.Overflow {
+		logger.Warnf("parseConsoleRemoteArrayPreview", "array is too large and will be parsed partially")
+	}
+
+	for _, p := range op.Properties {
+		val := parseConsoleRemoteObjectValue(logger, p.Type, p.Subtype, p.Value, p.ValuePreview)
+		arr = append(arr, val)
+	}
+
+	bb, err := json.Marshal(arr)
+	if err != nil {
+		logger.Errorf("parseConsoleRemoteArrayPreview", "failed to marshal array to string: %v", err)
+	}
+
+	return string(bb)
+}
+
 //nolint:cyclop
 func parseConsoleRemoteObjectValue(
 	logger *log.Logger,

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -249,7 +249,7 @@ func parseConsoleRemoteObjectPreview(logger *log.Logger, op *cdpruntime.ObjectPr
 }
 
 func parseConsoleRemoteArrayPreview(logger *log.Logger, op *cdpruntime.ObjectPreview) string {
-	arr := make([]any, 0)
+	arr := make([]any, 0, len(op.Properties))
 	if op.Overflow {
 		logger.Warnf("parseConsoleRemoteArrayPreview", "array is too large and will be parsed partially")
 	}

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -287,6 +287,9 @@ func parseConsoleRemoteObjectValue(
 		}
 	case cdpruntime.TypeObject:
 		if op != nil {
+			if st == "array" {
+				return parseConsoleRemoteArrayPreview(logger, op)
+			}
 			return parseConsoleRemoteObjectPreview(logger, op)
 		}
 		if val == "Object" {

--- a/tests/remote_obj_test.go
+++ b/tests/remote_obj_test.go
@@ -30,7 +30,7 @@ func TestConsoleLogParse(t *testing.T) {
 			name: "bool", log: "true", want: "true",
 		},
 		{
-			name: "empty_array", log: "[]", want: "{}", // TODO: Improve this output
+			name: "empty_array", log: "[]", want: "[]",
 		},
 		{
 			name: "empty_object", log: "{}", want: "{}",
@@ -39,7 +39,7 @@ func TestConsoleLogParse(t *testing.T) {
 			name: "filled_object", log: `{"foo":{"bar1":"bar2"}}`, want: `{"foo":"Object"}`,
 		},
 		{
-			name: "filled_array", log: `["foo","bar"]`, want: `{"0":"foo","1":"bar"}`,
+			name: "filled_array", log: `["foo","bar"]`, want: `["foo","bar"]`,
 		},
 		{
 			name: "filled_array", log: `() => true`, want: `function()`,


### PR DESCRIPTION
## What?

This changes the way the output of an array with `console.out` is parsed which affects the display from:

```
{"0":"foo","1":"bar"}
```

to:

```
["foo","bar"]
```

## Why?

To better represent the array type when it is printed to the console.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/987