### PR TITLE
Provide a better error message when Chromium isn't found

### DIFF
--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -247,8 +247,13 @@ func (b *BrowserType) allocate(
 	return common.NewLocalBrowserProcess(bProcCtx, path, args, dataDir, bProcCtxCancel, logger) //nolint: wrapcheck
 }
 
-// ErrChromeNotInstalled is returned when the Chrome executable is not found.
-var ErrChromeNotInstalled = errors.New("neither chrome nor chromium is installed on this system")
+var (
+	// ErrChromeNotInstalled is returned when the Chrome executable is not found.
+	ErrChromeNotInstalled = errors.New("neither chrome nor chromium is installed on this system")
+
+	// ErrChromeNotFoundAtPath is returned when the Chrome executable is not found at the given path.
+	ErrChromeNotFoundAtPath = errors.New("neither chrome nor chromium found on the path")
+)
 
 // executablePath returns the path where the extension expects to find the browser executable.
 func executablePath(
@@ -261,7 +266,7 @@ func executablePath(
 		if _, err := lookPath(path); err == nil {
 			return path, nil
 		}
-		return "", ErrChromeNotInstalled
+		return "", fmt.Errorf("%w: %s", ErrChromeNotFoundAtPath, path)
 	}
 
 	// find the browser executable in the default paths below

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -239,7 +239,7 @@ func (b *BrowserType) allocate(
 		return nil, err
 	}
 
-	path, ok := ExecutablePath(opts.ExecutablePath, b.envLookupper, exec.LookPath)
+	path, ok := executablePath(opts.ExecutablePath, b.envLookupper, exec.LookPath)
 	if !ok {
 		return nil, ErrChromeNotInstalled
 	}
@@ -250,8 +250,8 @@ func (b *BrowserType) allocate(
 // ErrChromeNotInstalled is returned when the Chrome executable is not found.
 var ErrChromeNotInstalled = errors.New("chromium is not installed on this system")
 
-// ExecutablePath returns the path where the extension expects to find the browser executable.
-func ExecutablePath(
+// executablePath returns the path where the extension expects to find the browser executable.
+func executablePath(
 	path string,
 	env env.LookupFunc,
 	lookPath func(file string) (string, error), // os.LookPath

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -248,7 +248,7 @@ func (b *BrowserType) allocate(
 }
 
 // ErrChromeNotInstalled is returned when the Chrome executable is not found.
-var ErrChromeNotInstalled = errors.New("chrome or chromium is not installed on this system")
+var ErrChromeNotInstalled = errors.New("neither chrome nor chromium is installed on this system")
 
 // executablePath returns the path where the extension expects to find the browser executable.
 func executablePath(

--- a/chromium/browser_type.go
+++ b/chromium/browser_type.go
@@ -248,7 +248,7 @@ func (b *BrowserType) allocate(
 }
 
 // ErrChromeNotInstalled is returned when the Chrome executable is not found.
-var ErrChromeNotInstalled = errors.New("chromium is not installed on this system")
+var ErrChromeNotInstalled = errors.New("chrome or chromium is not installed on this system")
 
 // executablePath returns the path where the extension expects to find the browser executable.
 func executablePath(

--- a/chromium/browser_type_test.go
+++ b/chromium/browser_type_test.go
@@ -230,7 +230,7 @@ func TestExecutablePath(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			path, ok := ExecutablePath(tt.path, tt.userProfile, tt.lookPath)
+			path, ok := executablePath(tt.path, tt.userProfile, tt.lookPath)
 			assert.Equal(t, tt.wantPath, path)
 			assert.Equal(t, tt.wantOK, ok)
 		})

--- a/chromium/browser_type_test.go
+++ b/chromium/browser_type_test.go
@@ -174,14 +174,14 @@ func TestExecutablePath(t *testing.T) {
 		userProfile      env.LookupFunc                    // user profile folder lookup
 
 		wantPath string
-		wantErr  bool
+		wantErr  error
 	}{
 		"without_chromium": {
 			userProvidedPath: "",
 			lookPath:         fileNotExists,
 			userProfile:      env.EmptyLookup,
 			wantPath:         "",
-			wantErr:          true,
+			wantErr:          ErrChromeNotInstalled,
 		},
 		"with_chromium": {
 			userProvidedPath: "",
@@ -193,14 +193,14 @@ func TestExecutablePath(t *testing.T) {
 			},
 			userProfile: env.EmptyLookup,
 			wantPath:    chromiumExecutable,
-			wantErr:     false,
+			wantErr:     nil,
 		},
 		"without_chromium_in_user_path": {
 			userProvidedPath: userProvidedPath,
 			lookPath:         fileNotExists,
 			userProfile:      env.EmptyLookup,
 			wantPath:         "",
-			wantErr:          true,
+			wantErr:          ErrChromeNotFoundAtPath,
 		},
 		"with_chromium_in_user_path": {
 			userProvidedPath: userProvidedPath,
@@ -212,14 +212,14 @@ func TestExecutablePath(t *testing.T) {
 			},
 			userProfile: env.EmptyLookup,
 			wantPath:    userProvidedPath,
-			wantErr:     false,
+			wantErr:     nil,
 		},
 		"without_chromium_in_user_profile": {
 			userProvidedPath: "",
 			lookPath:         fileNotExists,
 			userProfile:      env.ConstLookup("USERPROFILE", `home`),
 			wantPath:         "",
-			wantErr:          true,
+			wantErr:          ErrChromeNotInstalled,
 		},
 		"with_chromium_in_user_profile": {
 			userProvidedPath: "",
@@ -231,7 +231,7 @@ func TestExecutablePath(t *testing.T) {
 			},
 			userProfile: env.ConstLookup("USERPROFILE", `home`),
 			wantPath:    filepath.Join("home", `AppData\Local\Google\Chrome\Application\chrome.exe`),
-			wantErr:     false,
+			wantErr:     nil,
 		},
 	}
 	for name, tt := range tests {
@@ -243,8 +243,8 @@ func TestExecutablePath(t *testing.T) {
 
 			assert.Equal(t, tt.wantPath, path)
 
-			if tt.wantErr {
-				assert.Error(t, err)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
 				return
 			}
 			assert.NoError(t, err)


### PR DESCRIPTION
## What?

1. Provides a new error message telling users they must install Chromium on their system to run browser tests.
2. Moves `BrowserContext.ExecutablePath` to `ExecutablePath`.

## Why?

1. The current error message is confusing and just says: _"exec: no command"_.
2. To make `ExecutablePath` testable to prevent future regressions.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates #1136