### PR TITLE
Refactor traces attributes

### DIFF
--- a/browser/registry.go
+++ b/browser/registry.go
@@ -428,9 +428,9 @@ func (r *tracesRegistry) startIterationTrace(ctx context.Context, data k6event.I
 	}
 
 	spanCtx, span := r.tracer.Start(ctx, "iteration", oteltrace.WithAttributes(
-		attribute.Int64("number", data.Iteration),
-		attribute.Int64("vu", int64(data.VUID)),
-		attribute.String("scenario", data.ScenarioName),
+		attribute.Int64("test.iteration.number", data.Iteration),
+		attribute.Int64("test.vu", int64(data.VUID)),
+		attribute.String("test.scenario", data.ScenarioName),
 	))
 
 	r.m[data.Iteration] = &trace{

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1183,7 +1183,7 @@ func (h *ElementHandle) Screenshot(opts goja.Value) goja.ArrayBuffer {
 	if err := parsedOpts.Parse(h.ctx, opts); err != nil {
 		k6ext.Panic(h.ctx, "parsing screenshot options: %w", err)
 	}
-	span.SetAttributes(attribute.String("path", parsedOpts.Path))
+	span.SetAttributes(attribute.String("screenshot.path", parsedOpts.Path))
 
 	s := newScreenshotter(spanCtx)
 	buf, err := s.screenshotElement(h, parsedOpts)

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -352,8 +352,11 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 	})
 
 	_, span := TraceEvent(
-		fs.ctx, fs.targetID.String(), "web_vital", wv.SpanID,
-		trace.WithAttributes(attribute.Float64(wv.Name, value), attribute.String("rating", wv.Rating)))
+		fs.ctx, fs.targetID.String(), "web_vital", wv.SpanID, trace.WithAttributes(
+			attribute.String("web_vital.name", wv.Name),
+			attribute.Float64("web_vital.value", value),
+			attribute.String("web_vital.rating", wv.Rating),
+		))
 	defer span.End()
 
 	return nil
@@ -754,7 +757,7 @@ func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {
 
 	_, fs.mainFrameSpan = TraceNavigation(
 		fs.ctx, fs.targetID.String(), frame.URL,
-		trace.WithAttributes(attribute.String("url", frame.URL)),
+		trace.WithAttributes(attribute.String("navigation.url", frame.URL)),
 	)
 
 	var (

--- a/common/page.go
+++ b/common/page.go
@@ -868,7 +868,7 @@ func (p *Page) Goto(url string, opts goja.Value) (*Response, error) {
 		p.ctx,
 		p.targetID.String(),
 		"page.goto",
-		trace.WithAttributes(attribute.String("url", url)),
+		trace.WithAttributes(attribute.String("page.goto.url", url)),
 	)
 	defer span.End()
 
@@ -1113,7 +1113,7 @@ func (p *Page) Screenshot(opts goja.Value) goja.ArrayBuffer {
 	if err := parsedOpts.Parse(p.ctx, opts); err != nil {
 		k6ext.Panic(p.ctx, "parsing screenshot options: %w", err)
 	}
-	span.SetAttributes(attribute.String("path", parsedOpts.Path))
+	span.SetAttributes(attribute.String("screenshot.path", parsedOpts.Path))
 
 	s := newScreenshotter(spanCtx)
 	buf, err := s.screenshotPage(p, parsedOpts)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -12,7 +12,7 @@ import (
 	k6lib "go.k6.io/k6/lib"
 )
 
-const tracerName = "browser"
+const tracerName = "k6.browser"
 
 // liveSpan represents an active span associated with a page navigation.
 //


### PR DESCRIPTION
## What?

Rename traces attributes.

## Why?

 To better comply with conventions on attribute naming recommended by Open Telemetry. See [docs](https://opentelemetry.io/docs/specs/otel/common/attribute-naming/).

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#1100 
