### PR TITLE
Refactor TraceNavigation

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -756,8 +756,7 @@ func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {
 	}
 
 	_, fs.mainFrameSpan = TraceNavigation(
-		fs.ctx, fs.targetID.String(), frame.URL,
-		trace.WithAttributes(attribute.String("navigation.url", frame.URL)),
+		fs.ctx, fs.targetID.String(), trace.WithAttributes(attribute.String("navigation.url", frame.URL)),
 	)
 
 	var (

--- a/common/trace.go
+++ b/common/trace.go
@@ -14,7 +14,7 @@ type Tracer interface {
 		ctx context.Context, targetID string, spanName string, opts ...trace.SpanStartOption,
 	) (context.Context, trace.Span)
 	TraceNavigation(
-		ctx context.Context, targetID string, url string, opts ...trace.SpanStartOption,
+		ctx context.Context, targetID string, opts ...trace.SpanStartOption,
 	) (context.Context, trace.Span)
 	TraceEvent(
 		ctx context.Context, targetID string, eventName string, spanID string, opts ...trace.SpanStartOption,
@@ -37,10 +37,10 @@ func TraceAPICall(
 // calls its TraceNavigation implementation. If the Tracer is not present in the given
 // ctx, it returns a noopSpan and the given context.
 func TraceNavigation(
-	ctx context.Context, targetID string, url string, opts ...trace.SpanStartOption,
+	ctx context.Context, targetID string, opts ...trace.SpanStartOption,
 ) (context.Context, trace.Span) {
 	if tracer := GetTracer(ctx); tracer != nil {
-		return tracer.TraceNavigation(ctx, targetID, url, opts...)
+		return tracer.TraceNavigation(ctx, targetID, opts...)
 	}
 	return ctx, browsertrace.NoopSpan{}
 }

--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -103,7 +103,7 @@ func TestTracing(t *testing.T) {
 			js:   fmt.Sprintf("page.goto('%s')", ts.URL),
 			spans: []string{
 				"page.goto",
-				fmt.Sprintf("%s/", ts.URL), // Navigation span
+				"navigation",
 			},
 		},
 		{

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -77,7 +77,7 @@ func (t *Tracer) TraceAPICall(
 // Posterior calls to TraceEvent or TraceAPICall given the same targetID will try to
 // associate new spans for these actions to the liveSpan created in this call.
 func (t *Tracer) TraceNavigation(
-	ctx context.Context, targetID string, url string, opts ...trace.SpanStartOption,
+	ctx context.Context, targetID string, opts ...trace.SpanStartOption,
 ) (context.Context, trace.Span) {
 	t.liveSpansMu.Lock()
 	defer t.liveSpansMu.Unlock()
@@ -96,7 +96,7 @@ func (t *Tracer) TraceNavigation(
 
 	opts = append(opts, trace.WithAttributes(t.metadata...))
 
-	ls.ctx, ls.span = t.Start(ctx, url, opts...)
+	ls.ctx, ls.span = t.Start(ctx, "navigation", opts...)
 	t.liveSpans[targetID] = ls
 
 	return ls.ctx, ls.span


### PR DESCRIPTION
## What?

Based on discussions in #1140 , a decision was made to, instead of using the URL as the span name for navigation spans, use the word 'navigation' to identify the action, following the same pattern as the rest of the spans. Due to this, and because a navigation span will always have that fixed span name, it is no longer necessary to accept the span name as input for the method.

## Why?

Even though the traces generated from k6 browser have some particularities to fit our needs, this change and the changes done in #1140 try to make our implementation more compliant with Open Telemetry conventions and recommendations. These changes will also improve traces searches.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [X] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#1100, #1140 
