### PR TITLE
Override OTEL tracer Start() method to include metadata

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -48,6 +48,14 @@ func NewTracer(tp k6lib.TracerProvider, metadata map[string]string, options ...t
 	}
 }
 
+// Start overrides the underlying OTEL tracer method to include the tracer metadata.
+func (t *Tracer) Start(
+	ctx context.Context, spanName string, opts ...trace.SpanStartOption,
+) (context.Context, trace.Span) {
+	opts = append(opts, trace.WithAttributes(t.metadata...))
+	return t.Tracer.Start(ctx, spanName, opts...)
+}
+
 // TraceAPICall adds a new span to the current liveSpan for the given targetID and returns it. It
 // is the caller's responsibility to close the generated span.
 // If there is not a liveSpan for the given targetID, the new span is created based on the given


### PR DESCRIPTION
## What?

Modifies our tracer implementation to override and wrap the underlying OTEL tracer's `Start()` method so the extra traces metadata set by the `K6_BROWSER_TRACES_METADATA` environment variable are also including when using the OTEL tracer's `Start()` method directly.

## Why?

Fixes an issue for which the extra metadata set through `K6_BROWSER_TRACES_METADATA` was not included in the iteration root span.

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes _(As [mentioned](https://github.com/grafana/xk6-browser/pull/1104#issuecomment-1857568238) in #1104 unfortunately we can not extract attributes from a TracerOption)_
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)
#1104
