### PR TITLE
Add Clear to locator

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -41,6 +41,16 @@ func mapBrowserToGoja(vu moduleVU) *goja.Object {
 // mapLocator API to the JS module.
 func mapLocator(vu moduleVU, lo *common.Locator) mapping {
 	return mapping{
+		"clear": func(opts goja.Value) error {
+			ctx := vu.Context()
+
+			copts := common.NewFrameFillOptions(lo.Timeout())
+			if err := copts.Parse(ctx, opts); err != nil {
+				return fmt.Errorf("parsing clear options: %w", err)
+			}
+
+			return lo.Clear(copts) //nolint:wrapcheck
+		},
 		"click": func(opts goja.Value) *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				err := lo.Click(opts)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -511,6 +511,7 @@ type responseAPI interface {
 
 // locatorAPI represents a way to find element(s) on a page at any moment.
 type locatorAPI interface {
+	Clear(opts *common.FrameFillOptions) error
 	Click(opts goja.Value) error
 	Dblclick(opts goja.Value)
 	Check(opts goja.Value)

--- a/common/locator.go
+++ b/common/locator.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/log"
@@ -49,6 +50,11 @@ func (l *Locator) Clear(opts *FrameFillOptions) error {
 	}
 
 	return nil
+}
+
+// Timeout will return the default timeout or the one set by the user.
+func (l *Locator) Timeout() time.Duration {
+	return l.frame.defaultTimeout()
 }
 
 // Click on an element using locator's selector with strict mode on.

--- a/common/locator.go
+++ b/common/locator.go
@@ -36,6 +36,21 @@ func NewLocator(ctx context.Context, selector string, f *Frame, l *log.Logger) *
 	}
 }
 
+// Clear will clear the input field.
+// This works with the Fill API and fills the input field with an empty string.
+func (l *Locator) Clear(opts *FrameFillOptions) error {
+	l.log.Debugf(
+		"Locator:Clear", "fid:%s furl:%q sel:%q opts:%+v",
+		l.frame.ID(), l.frame.URL(), l.selector, opts,
+	)
+
+	if err := l.fill("", opts); err != nil {
+		return fmt.Errorf("clearing %q: %w", l.selector, err)
+	}
+
+	return nil
+}
+
 // Click on an element using locator's selector with strict mode on.
 func (l *Locator) Click(opts goja.Value) error {
 	l.log.Debugf("Locator:Click", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"testing"
+	"time"
 
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
@@ -51,6 +52,19 @@ func TestLocator(t *testing.T) {
 					l.Uncheck(nil)
 					require.False(t, l.IsChecked(nil))
 				})
+			},
+		},
+		{
+			"Clear", func(tb *testBrowser, p *common.Page) {
+				const value = "fill me up"
+				l := p.Locator("#inputText", nil)
+
+				l.Fill(value, nil)
+				require.Equal(t, value, p.InputValue("#inputText", nil))
+
+				err := l.Clear(common.NewFrameFillOptions(l.Timeout()))
+				assert.NoError(t, err)
+				assert.Equal(t, "", p.InputValue("#inputText", nil))
 			},
 		},
 		{
@@ -234,6 +248,15 @@ func TestLocator(t *testing.T) {
 	}{
 		{
 			"Check", func(l *common.Locator, tb *testBrowser) { l.Check(timeout(tb)) },
+		},
+		{
+			"Clear", func(l *common.Locator, tb *testBrowser) {
+				err := l.Clear(common.NewFrameFillOptions(100 * time.Millisecond))
+				if err != nil {
+					// TODO: remove panic and update tests when all locator methods return error.
+					panic(err)
+				}
+			},
 		},
 		{
 			"Click", func(l *common.Locator, tb *testBrowser) {


### PR DESCRIPTION
## What?

This adds a new method `clear` to the `locator` class. This works with the existing `Fill` method which is in the `locator` class. Resources that contributed to the implementation can be found by following the links below:
- https://playwright.dev/docs/api/class-locator
- https://github.com/microsoft/playwright/blob/e30c0a6ff7c48a3abc55eab63fa15d31f6241280/packages/playwright-core/src/client/locator.ts#L130

## Why?

When typing or filling textboxes or input fields, it's useful to clear existing fields in case they already have values.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [X] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/1114