### PR TITLE
Fix potential nil exception when getting frame

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -440,13 +440,13 @@ func (h *ElementHandle) ownerFrame(apiCtx context.Context) *Frame {
 	if frameId == "" {
 		return nil
 	}
-	frame := h.frame.page.frameManager.getFrameByID(frameId)
-	if frame != nil {
+	frame, found := h.frame.page.frameManager.getFrameByID(frameId)
+	if found {
 		return frame
 	}
 	for _, page := range h.frame.page.browserCtx.browser.pages {
-		frame = page.frameManager.getFrameByID(frameId)
-		if frame != nil {
+		frame, found = page.frameManager.getFrameByID(frameId)
+		if found {
 			return frame
 		}
 	}
@@ -766,7 +766,12 @@ func (h *ElementHandle) ContentFrame() (*Frame, error) {
 		return nil, fmt.Errorf("element is not an iframe")
 	}
 
-	return h.frame.manager.getFrameByID(node.FrameID), nil
+	frame, found := h.frame.manager.getFrameByID(node.FrameID)
+	if !found {
+		return nil, fmt.Errorf("frame not found for id")
+	}
+
+	return frame, nil
 }
 
 func (h *ElementHandle) Dblclick(opts goja.Value) {
@@ -1003,7 +1008,12 @@ func (h *ElementHandle) OwnerFrame() (*Frame, error) {
 		return nil, fmt.Errorf("no frame found for node: %w", err)
 	}
 
-	return h.frame.manager.getFrameByID(node.FrameID), nil
+	frame, found := h.frame.manager.getFrameByID(node.FrameID)
+	if !found {
+		return nil, fmt.Errorf("no frame found for id")
+	}
+
+	return frame, nil
 }
 
 func (h *ElementHandle) Press(key string, opts goja.Value) {

--- a/common/frame.go
+++ b/common/frame.go
@@ -377,8 +377,8 @@ func (f *Frame) onLoadingStopped() {
 }
 
 func (f *Frame) position() (*Position, error) {
-	frame := f.manager.getFrameByID(cdp.FrameID(f.page.targetID))
-	if frame == nil {
+	frame, found := f.manager.getFrameByID(cdp.FrameID(f.page.targetID))
+	if !found {
 		return nil, fmt.Errorf("could not find frame with id %s", f.page.targetID)
 	}
 	if frame == f.page.frameManager.MainFrame() {

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -458,10 +458,11 @@ func (m *NetworkManager) onRequest(event *network.EventRequestWillBeSent, interc
 	}
 
 	var frame *Frame = nil
+	var found bool
 	if event.FrameID != "" {
-		frame = m.frameManager.getFrameByID(event.FrameID)
+		frame, found = m.frameManager.getFrameByID(event.FrameID)
 	}
-	if frame == nil {
+	if !found {
 		m.logger.Debugf("NetworkManager:onRequest", "url:%s method:%s type:%s fid:%s frame is nil",
 			event.Request.URL, event.Request.Method, event.Initiator.Type, event.FrameID)
 	}


### PR DESCRIPTION
## What?

This change avoids the need to check for `nil` when getting the frame with an id, and reinforces a requirement to check with an addition of a `bool` return value to indicate whether the frame was found or not.

## Why?

When a part of the browser module needs to retrieve the frame given an id, it should check whether the frame is nil before using it. This is not safe, since it's easy to forget to check for nil, and so a new return value is also returned.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/1148