### PR TITLE
Refactor NetworkManager.requestFromID

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -404,7 +404,7 @@ func (f *Frame) removeChildFrame(child *Frame) {
 	delete(f.childFrames, child)
 }
 
-func (f *Frame) requestByID(reqID network.RequestID) *Request {
+func (f *Frame) requestByID(reqID network.RequestID) (*Request, bool) {
 	frameSession := f.page.getFrameSession(cdp.FrameID(f.ID()))
 	if frameSession == nil {
 		frameSession = f.page.mainFrameSession

--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -451,9 +451,8 @@ func (m *FrameManager) requestFailed(req *Request, canceled bool) {
 	switch rc := len(ifr); {
 	case rc <= 10:
 		for reqID := range ifr {
-			req := frame.requestByID(reqID)
-
-			if req == nil {
+			req, ok := frame.requestByID(reqID)
+			if !ok {
 				m.logger.Debugf("FrameManager:requestFailed:rc<=10 request is nil",
 					"reqID:%s frameID:%s",
 					reqID, frame.ID())


### PR DESCRIPTION
## What?

This refactor forces the caller of `NetworkManager.requestFromID` to check the bool value.

## Why?

This makes it clearer that `requestFromID` could not find a `request` with the given id.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/577