### PR TITLE
Refactor locator.click parse

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -52,17 +52,15 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping {
 
 			return lo.Clear(copts) //nolint:wrapcheck
 		},
-		"click": func(opts goja.Value) *goja.Promise {
+		"click": func(opts goja.Value) (*goja.Promise, error) {
 			popts, err := parseFrameClickOptions(vu.Context(), opts, lo.Timeout())
+			if err != nil {
+				return nil, err
+			}
 
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				if err != nil {
-					return nil, err
-				}
-
-				err = lo.Click(popts)
-				return nil, err //nolint:wrapcheck
-			})
+				return nil, lo.Click(popts) //nolint:wrapcheck
+			}), nil
 		},
 		"dblclick":      lo.Dblclick,
 		"check":         lo.Check,

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -53,8 +53,14 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping {
 			return lo.Clear(copts) //nolint:wrapcheck
 		},
 		"click": func(opts goja.Value) *goja.Promise {
+			popts, err := parseFrameClickOptions(vu.Context(), opts, lo.Timeout())
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				err := lo.Click(opts)
+				if err != nil {
+					return nil, err
+				}
+
+				err = lo.Click(popts)
 				return nil, err //nolint:wrapcheck
 			})
 		},

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/dop251/goja"
 
@@ -81,6 +82,16 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping {
 		"dispatchEvent": lo.DispatchEvent,
 		"waitFor":       lo.WaitFor,
 	}
+}
+
+func parseFrameClickOptions(
+	ctx context.Context, opts goja.Value, defaultTimeout time.Duration,
+) (*common.FrameClickOptions, error) {
+	copts := common.NewFrameClickOptions(defaultTimeout)
+	if err := copts.Parse(ctx, opts); err != nil {
+		return nil, fmt.Errorf("parsing click options: %w", err)
+	}
+	return copts, nil
 }
 
 // mapRequest to the JS module.

--- a/common/locator.go
+++ b/common/locator.go
@@ -58,16 +58,12 @@ func (l *Locator) Timeout() time.Duration {
 }
 
 // Click on an element using locator's selector with strict mode on.
-func (l *Locator) Click(opts goja.Value) error {
+func (l *Locator) Click(opts *FrameClickOptions) error {
 	l.log.Debugf("Locator:Click", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
 	_, span := TraceAPICall(l.ctx, l.frame.page.targetID.String(), "locator.click")
 	defer span.End()
 
-	copts := NewFrameClickOptions(l.frame.defaultTimeout())
-	if err := copts.Parse(l.ctx, opts); err != nil {
-		return fmt.Errorf("parsing click options: %w", err)
-	}
-	if err := l.click(copts); err != nil {
+	if err := l.click(opts); err != nil {
 		return fmt.Errorf("clicking on %q: %w", l.selector, err)
 	}
 

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -69,7 +69,8 @@ func TestLocator(t *testing.T) {
 		},
 		{
 			"Click", func(tb *testBrowser, p *common.Page) {
-				err := p.Locator("#link", nil).Click(nil)
+				l := p.Locator("#link", nil)
+				err := l.Click(common.NewFrameClickOptions(l.Timeout()))
 				require.NoError(t, err)
 				v := p.Evaluate(tb.toGojaValue(`() => window.result`))
 				require.True(t, tb.asGojaBool(v), "cannot not click the link")
@@ -260,7 +261,7 @@ func TestLocator(t *testing.T) {
 		},
 		{
 			"Click", func(l *common.Locator, tb *testBrowser) {
-				err := l.Click(timeout(tb))
+				err := l.Click(common.NewFrameClickOptions(100 * time.Millisecond))
 				if err != nil {
 					// TODO: remove panic and update tests when all locator methods return error.
 					panic(err)


### PR DESCRIPTION
## What?

Refactor `locator.click` so that it parses the goja value using the goja runtime on the main goja thread and not in a new goroutine.

## Why?

This will avoid race issues since the goja runtime is not thread safe since it is a JS interpreter that is single threaded.

I've also confirmed that this API doesn't work with goja anywhere else, including when working with `eval`, which is does since it uses `newPointerAction`, which calls `waitForSelector`, that calls ,`evalWithScript` and eventually `eval`, but since `returnByValue` is `false` it doesn't work with goja to transform the return value to a goja value.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1162