### PR TITLE
Refactor parseConsoleRemoteObject to return error

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -625,7 +625,10 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 
 	parsedObjects := make([]string, 0, len(event.Args))
 	for _, robj := range event.Args {
-		s := parseConsoleRemoteObject(fs.logger, robj)
+		s, err := parseConsoleRemoteObject(fs.logger, robj)
+		if err != nil {
+			fs.logger.Errorf("onConsoleAPICalled", "failed to parse console message %v", err)
+		}
 		parsedObjects = append(parsedObjects, s)
 	}
 

--- a/common/page.go
+++ b/common/page.go
@@ -1398,7 +1398,10 @@ func (p *Page) consoleMsgFromConsoleEvent(e *cdpruntime.EventConsoleAPICalled) (
 	)
 
 	for _, robj := range e.Args {
-		s := parseConsoleRemoteObject(p.logger, robj)
+		s, err := parseConsoleRemoteObject(p.logger, robj)
+		if err != nil {
+			p.logger.Errorf("consoleMsgFromConsoleEvent", "failed to parse console message %v", err)
+		}
 
 		objects = append(objects, s)
 		objectHandles = append(objectHandles, NewJSHandle(

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -243,7 +243,7 @@ func parseConsoleRemoteObjectPreview(logger *log.Logger, op *cdpruntime.ObjectPr
 
 	bb, err := json.Marshal(obj)
 	if err != nil {
-		return "", fmt.Errorf("marshaling object to string: %w", err)
+		return "", fmt.Errorf("marshaling object %q to string: %w", obj, err)
 	}
 
 	return string(bb), nil
@@ -265,7 +265,7 @@ func parseConsoleRemoteArrayPreview(logger *log.Logger, op *cdpruntime.ObjectPre
 
 	bb, err := json.Marshal(arr)
 	if err != nil {
-		return "", fmt.Errorf("marshaling array to string: %w", err)
+		return "", fmt.Errorf("marshaling array %q to string: %w", arr, err)
 	}
 
 	return string(bb), nil


### PR DESCRIPTION
## What?

Returning an error from `parseConsoleRemoteObject` instead of logging an error.

## Why?

There is another use case for `parseConsoleRemoteObject`, which is when `JSONValue` is called. At the moment this API uses `valueFromRemoteObject` which returns a `goja.Value`.

Interestingly, the return value from `JSONValue` is always converted to string before being returned to the caller, so the extra step to convert to goja and then back to string is not needed.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/1168