### PR TITLE
Refactor frame.click option parsing

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -334,11 +334,16 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 			}
 			return rt.ToValue(mcfs).ToObject(rt)
 		},
-		"click": func(selector string, opts goja.Value) *goja.Promise {
+		"click": func(selector string, opts goja.Value) (*goja.Promise, error) {
+			popts, err := parseFrameClickOptions(vu.Context(), opts, f.Timeout())
+			if err != nil {
+				return nil, err
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				err := f.Click(selector, opts)
+				err := f.Click(selector, popts)
 				return nil, err //nolint:wrapcheck
-			})
+			}), nil
 		},
 		"content":       f.Content,
 		"dblclick":      f.Dblclick,

--- a/common/frame.go
+++ b/common/frame.go
@@ -545,14 +545,10 @@ func (f *Frame) ChildFrames() []*Frame {
 }
 
 // Click clicks the first element found that matches selector.
-func (f *Frame) Click(selector string, opts goja.Value) error {
+func (f *Frame) Click(selector string, opts *FrameClickOptions) error {
 	f.log.Debugf("Frame:Click", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	popts := NewFrameClickOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parsing click options %q: %w", selector, err)
-	}
-	if err := f.click(selector, popts); err != nil {
+	if err := f.click(selector, opts); err != nil {
 		return fmt.Errorf("clicking on %q: %w", selector, err)
 	}
 

--- a/common/frame.go
+++ b/common/frame.go
@@ -1582,6 +1582,12 @@ func (f *Frame) textContent(selector string, opts *FrameTextContentOptions) (str
 	return gv.String(), nil
 }
 
+// Timeout will return the default timeout or the one set by the user.
+// It's an internal method not to be exposed as a JS API.
+func (f *Frame) Timeout() time.Duration {
+	return f.defaultTimeout()
+}
+
 // Title returns the title of the frame.
 func (f *Frame) Title() string {
 	f.log.Debugf("Frame:Title", "fid:%s furl:%q", f.ID(), f.URL())

--- a/common/page.go
+++ b/common/page.go
@@ -652,7 +652,12 @@ func (p *Page) IsChecked(selector string, opts goja.Value) bool {
 func (p *Page) Click(selector string, opts goja.Value) error {
 	p.logger.Debugf("Page:Click", "sid:%v selector:%s", p.sessionID(), selector)
 
-	return p.MainFrame().Click(selector, opts) //nolint:wrapcheck
+	popts := NewFrameClickOptions(p.defaultTimeout())
+	if err := popts.Parse(p.ctx, opts); err != nil {
+		k6ext.Panic(p.ctx, "parsing click options %q: %w", selector, err)
+	}
+
+	return p.MainFrame().Click(selector, popts)
 }
 
 // Close closes the page.

--- a/tests/launch_options_slowmo_test.go
+++ b/tests/launch_options_slowmo_test.go
@@ -172,7 +172,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f *common.Frame) {
-				err := f.Click("button", nil)
+				err := f.Click("button", common.NewFrameClickOptions(f.Timeout()))
 				assert.NoError(t, err)
 			})
 		})


### PR DESCRIPTION
## What?

This refactors the option parsing out of the promise and into the mapping layer for `frame.click`.

## Why?

This will help mitigate the risk of a panic occurring due to multiple goroutines accessing the goja runtime (which is not thread safe) concurrently.

More works needs to be done to totally remove the goja runtime usage from within the `frame.click` promise which can be tracked in https://github.com/grafana/xk6-browser/issues/1170.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1172