### PR TITLE
Refactor page.click option parsing

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -475,11 +475,16 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 		"addStyleTag":   p.AddStyleTag,
 		"bringToFront":  p.BringToFront,
 		"check":         p.Check,
-		"click": func(selector string, opts goja.Value) *goja.Promise {
+		"click": func(selector string, opts goja.Value) (*goja.Promise, error) {
+			popts, err := parseFrameClickOptions(vu.Context(), opts, p.Timeout())
+			if err != nil {
+				return nil, err
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				err := p.Click(selector, opts)
+				err := p.Click(selector, popts)
 				return nil, err //nolint:wrapcheck
-			})
+			}), nil
 		},
 		"close": func(opts goja.Value) error {
 			vu.taskQueueRegistry.close(p.TargetID())

--- a/common/page.go
+++ b/common/page.go
@@ -649,15 +649,10 @@ func (p *Page) IsChecked(selector string, opts goja.Value) bool {
 }
 
 // Click clicks an element matching provided selector.
-func (p *Page) Click(selector string, opts goja.Value) error {
+func (p *Page) Click(selector string, opts *FrameClickOptions) error {
 	p.logger.Debugf("Page:Click", "sid:%v selector:%s", p.sessionID(), selector)
 
-	popts := NewFrameClickOptions(p.defaultTimeout())
-	if err := popts.Parse(p.ctx, opts); err != nil {
-		k6ext.Panic(p.ctx, "parsing click options %q: %w", selector, err)
-	}
-
-	return p.MainFrame().Click(selector, popts)
+	return p.MainFrame().Click(selector, opts)
 }
 
 // Close closes the page.

--- a/common/page.go
+++ b/common/page.go
@@ -1195,6 +1195,12 @@ func (p *Page) TextContent(selector string, opts goja.Value) string {
 	return p.MainFrame().TextContent(selector, opts)
 }
 
+// Timeout will return the default timeout or the one set by the user.
+// It's an internal method not to be exposed as a JS API.
+func (p *Page) Timeout() time.Duration {
+	return p.defaultTimeout()
+}
+
 func (p *Page) Title() string {
 	p.logger.Debugf("Page:Title", "sid:%v", p.sessionID())
 

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -199,7 +199,7 @@ func TestElementHandleClickConcealedLink(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, wantBefore, clickResult())
 
-	err = p.Click("#concealed", nil)
+	err = p.Click("#concealed", common.NewFrameClickOptions(p.Timeout()))
 	require.NoError(t, err)
 	require.Equal(t, wantAfter, clickResult())
 }
@@ -218,7 +218,7 @@ func TestElementHandleNonClickable(t *testing.T) {
 	require.NotNil(t, resp)
 	require.NoError(t, err)
 
-	err = p.Click("#non-clickable", nil)
+	err = p.Click("#non-clickable", common.NewFrameClickOptions(p.Timeout()))
 	require.Errorf(t, err, "element should not be clickable")
 }
 

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -49,7 +49,7 @@ func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 				return err
 			}
 			click := func() error {
-				return p.Click(tc.selector, nil)
+				return p.Click(tc.selector, common.NewFrameClickOptions(p.Timeout()))
 			}
 			ctx, cancel := context.WithTimeout(tb.ctx, timeout)
 			defer cancel()
@@ -105,7 +105,7 @@ func TestWaitForFrameNavigation(t *testing.T) {
 		return err
 	}
 	click := func() error {
-		return p.Click(`a`, nil)
+		return p.Click(`a`, common.NewFrameClickOptions(p.Timeout()))
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/env"
 )
 
@@ -60,7 +61,7 @@ func TestFrameDismissDialogBox(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt == "beforeunload" {
-				err = p.Click("#clickHere", nil)
+				err = p.Click("#clickHere", common.NewFrameClickOptions(p.Timeout()))
 				require.NoError(t, err)
 			}
 
@@ -136,7 +137,7 @@ func TestFrameNoPanicNavigateAndClickOnPageWithIFrames(t *testing.T) {
 
 	err = tb.run(
 		ctx,
-		func() error { return p.Click(`a[href="/iframeSignIn"]`, nil) },
+		func() error { return p.Click(`a[href="/iframeSignIn"]`, common.NewFrameClickOptions(p.Timeout())) },
 		func() error { _, err := p.WaitForNavigation(nil); return err },
 	)
 	require.NoError(t, err)

--- a/tests/launch_options_slowmo_test.go
+++ b/tests/launch_options_slowmo_test.go
@@ -31,7 +31,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
-				err := p.Click("button", nil)
+				err := p.Click("button", common.NewFrameClickOptions(p.Timeout()))
 				assert.NoError(t, err)
 			})
 		})

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -175,7 +175,7 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 					return err
 				}
 				click := func() error {
-					return p.Click(`a`, nil)
+					return p.Click(`a`, common.NewFrameClickOptions(p.Timeout()))
 				}
 
 				ctx, cancel := context.WithTimeout(tb.ctx, 5*time.Second)

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -474,11 +474,9 @@ func TestLocatorShadowDOM(t *testing.T) {
 
 	tb := newTestBrowser(t, withFileServer())
 	p := tb.NewPage(nil)
-	opts := tb.toGojaValue(jsFrameBaseOpts{Timeout: "1000"})
 
 	_, err := p.Goto(tb.staticURL("shadow_dom_link.html"), nil)
 	require.NoError(t, err)
-
-	err = p.Click("#inner-link", opts)
+	err = p.Click("#inner-link", common.NewFrameClickOptions(time.Second))
 	require.NoError(t, err)
 }

--- a/tests/webvital_test.go
+++ b/tests/webvital_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/xk6-browser/common"
+
 	k6metrics "go.k6.io/k6/metrics"
 )
 
@@ -61,7 +63,7 @@ func TestWebVitalMetric(t *testing.T) {
 	// also helps the web vital library to measure CLS.
 	err = browser.run(
 		ctx,
-		func() error { return page.Click("#clickMe", nil) },
+		func() error { return page.Click("#clickMe", common.NewFrameClickOptions(page.Timeout())) },
 		func() error { _, err := page.WaitForNavigation(nil); return err },
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## What?

This refactors the option parsing out of the promise and into the mapping layer for `page.click`.

## Why?

This will help mitigate the risk of a panic occurring due to multiple goroutines accessing the goja runtime (which is not thread safe) concurrently.

More works needs to be done to totally remove the goja runtime usage from within the `page.click` promise which can be tracked in https://github.com/grafana/xk6-browser/issues/1170.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1174