### PR TITLE
Move goja option parsing out of frame and page goto opts

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -538,8 +538,8 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 		"goForward": p.GoForward,
 		"goto": func(url string, opts goja.Value) (*goja.Promise, error) {
 			gopts := common.NewFrameGotoOptions(
-				p.MainFrame().Referrer(),
-				p.MainFrame().NavigationTimeout(),
+				p.Referrer(),
+				p.NavigationTimeout(),
 			)
 			if err := gopts.Parse(vu.Context(), opts); err != nil {
 				return nil, fmt.Errorf("parsing page navigation options to %q: %w", url, err)

--- a/common/frame.go
+++ b/common/frame.go
@@ -952,12 +952,8 @@ func (f *Frame) NavigationTimeout() time.Duration {
 }
 
 // Goto will navigate the frame to the specified URL and return a HTTP response object.
-func (f *Frame) Goto(url string, opts goja.Value) (*Response, error) {
-	popts := NewFrameGotoOptions(f.Referrer(), f.NavigationTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return nil, fmt.Errorf("parsing frame navigation options to %q: %w", url, err)
-	}
-	resp, err := f.manager.NavigateFrame(f, url, popts)
+func (f *Frame) Goto(url string, opts *FrameGotoOptions) (*Response, error) {
+	resp, err := f.manager.NavigateFrame(f, url, opts)
 	if err != nil {
 		return nil, fmt.Errorf("navigating frame to %q: %w", url, err)
 	}

--- a/common/page.go
+++ b/common/page.go
@@ -862,7 +862,7 @@ func (p *Page) GoForward(_ goja.Value) *Response {
 }
 
 // Goto will navigate the page to the specified URL and return a HTTP response object.
-func (p *Page) Goto(url string, opts goja.Value) (*Response, error) {
+func (p *Page) Goto(url string, opts *FrameGotoOptions) (*Response, error) {
 	p.logger.Debugf("Page:Goto", "sid:%v url:%q", p.sessionID(), url)
 	_, span := TraceAPICall(
 		p.ctx,

--- a/common/page.go
+++ b/common/page.go
@@ -963,6 +963,19 @@ func (p *Page) MainFrame() *Frame {
 	return mf
 }
 
+// Referrer returns the page's referrer.
+// It's an internal method not to be exposed as a JS API.
+func (p *Page) Referrer() string {
+	nm := p.mainFrameSession.getNetworkManager()
+	return nm.extraHTTPHeaders["referer"]
+}
+
+// NavigationTimeout returns the page's navigation timeout.
+// It's an internal method not to be exposed as a JS API.
+func (p *Page) NavigationTimeout() time.Duration {
+	return p.frameManager.timeoutSettings.navigationTimeout()
+}
+
 // On subscribes to a page event for which the given handler will be executed
 // passing in the ConsoleMessage associated with the event.
 // The only accepted event value is 'console'.

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -86,7 +86,13 @@ func TestBrowserContextOptionsExtraHTTPHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	err = tb.awaitWithTimeout(time.Second*5, func() error {
-		resp, err := p.Goto(tb.url("/get"), nil)
+		opts := &common.FrameGotoOptions{
+			Timeout: common.DefaultTimeout,
+		}
+		resp, err := p.Goto(
+			tb.url("/get"),
+			opts,
+		)
 		if err != nil {
 			return err
 		}

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -551,7 +551,13 @@ func TestBrowserContextCookies(t *testing.T) {
 			// the setupHandler can set some cookies
 			// that will be received by the browser context.
 			tb.withHandler("/empty", tt.setupHandler)
-			_, err := p.Goto(tb.url("/empty"), nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: common.DefaultTimeout,
+			}
+			_, err := p.Goto(
+				tb.url("/empty"),
+				opts,
+			)
 			require.NoErrorf(t,
 				err, "failed to open an empty page",
 			)
@@ -626,7 +632,13 @@ func TestK6Object(t *testing.T) {
 	p := b.NewPage(nil)
 
 	url := b.staticURL("empty.html")
-	r, err := p.Goto(url, nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	r, err := p.Goto(
+		url,
+		opts,
+	)
 	require.NoError(t, err)
 	require.NotNil(t, r)
 
@@ -674,17 +686,24 @@ func TestBrowserContextTimeout(t *testing.T) {
 			bc, err := tb.NewContext(nil)
 			require.NoError(t, err)
 
-			if tc.defaultTimeout != 0 {
-				bc.SetDefaultTimeout(tc.defaultTimeout.Milliseconds())
-			}
-			if tc.defaultNavigationTimeout != 0 {
-				bc.SetDefaultNavigationTimeout(tc.defaultNavigationTimeout.Milliseconds())
-			}
-
 			p, err := bc.NewPage()
 			require.NoError(t, err)
 
-			res, err := p.Goto(tb.url("/slow"), nil)
+			var timeout time.Duration
+			if tc.defaultTimeout != 0 {
+				timeout = tc.defaultTimeout
+				bc.SetDefaultTimeout(tc.defaultTimeout.Milliseconds())
+			}
+			if tc.defaultNavigationTimeout != 0 {
+				timeout = tc.defaultNavigationTimeout
+				bc.SetDefaultNavigationTimeout(tc.defaultNavigationTimeout.Milliseconds())
+			}
+			res, err := p.Goto(
+				tb.url("/slow"),
+				&common.FrameGotoOptions{
+					Timeout: timeout,
+				},
+			)
 			require.Nil(t, res)
 			assert.ErrorContains(t, err, "timed out after")
 		})

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -194,7 +194,13 @@ func TestElementHandleClickConcealedLink(t *testing.T) {
 		cr := p.Evaluate(tb.toGojaValue(cmd))
 		return tb.asGojaValue(cr).String()
 	}
-	resp, err := p.Goto(tb.staticURL("/concealed_link.html"), nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	resp, err := p.Goto(
+		tb.staticURL("/concealed_link.html"),
+		opts,
+	)
 	require.NotNil(t, resp)
 	require.NoError(t, err)
 	require.Equal(t, wantBefore, clickResult())
@@ -214,7 +220,13 @@ func TestElementHandleNonClickable(t *testing.T) {
 	p, err := bctx.NewPage()
 	require.NoError(t, err)
 
-	resp, err := p.Goto(tb.staticURL("/non_clickable.html"), nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	resp, err := p.Goto(
+		tb.staticURL("/non_clickable.html"),
+		opts,
+	)
 	require.NotNil(t, resp)
 	require.NoError(t, err)
 

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -33,10 +33,10 @@ func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
 
-			opts := tb.toGojaValue(&common.FrameGotoOptions{
+			opts := &common.FrameGotoOptions{
 				WaitUntil: common.LifecycleEventNetworkIdle,
-				Timeout:   time.Duration(timeout.Milliseconds()), // interpreted as ms
-			})
+				Timeout:   timeout,
+			}
 			resp, err := p.Goto(tb.staticURL("/nav_in_doc.html"), opts)
 			require.NoError(t, err)
 			require.NotNil(t, resp)
@@ -90,10 +90,10 @@ func TestWaitForFrameNavigation(t *testing.T) {
 		`)
 	})
 
-	opts := tb.toGojaValue(&common.FrameGotoOptions{
+	opts := &common.FrameGotoOptions{
 		WaitUntil: common.LifecycleEventNetworkIdle,
 		Timeout:   common.DefaultTimeout,
-	})
+	}
 	_, err := p.Goto(tb.url("/first"), opts)
 	require.NoError(t, err)
 

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -49,15 +49,11 @@ func TestFrameDismissDialogBox(t *testing.T) {
 				p  = tb.NewPage(nil)
 			)
 
-			opts := tb.toGojaValue(struct {
-				WaitUntil string `js:"waitUntil"`
-			}{
-				WaitUntil: "networkidle",
-			})
-			_, err := p.Goto(
-				tb.staticURL("dialog.html?dialogType="+tt),
-				opts,
-			)
+			opts := &common.FrameGotoOptions{
+				WaitUntil: common.LifecycleEventNetworkIdle,
+				Timeout:   common.DefaultTimeout,
+			}
+			_, err := p.Goto(tb.staticURL("dialog.html?dialogType="+tt), opts)
 			require.NoError(t, err)
 
 			if tt == "beforeunload" {
@@ -91,14 +87,11 @@ func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 	)
 
 	p := tb.NewPage(nil)
-	_, err := p.Goto(
-		tb.staticURL("embedded_iframe.html"),
-		tb.toGojaValue(struct {
-			WaitUntil string `js:"waitUntil"`
-		}{
-			WaitUntil: "load",
-		}),
-	)
+	opts := &common.FrameGotoOptions{
+		WaitUntil: common.LifecycleEventDOMContentLoad,
+		Timeout:   common.DefaultTimeout,
+	}
+	_, err := p.Goto(tb.staticURL("embedded_iframe.html"), opts)
 	require.NoError(t, err)
 
 	result := p.TextContent("#doneDiv", nil)
@@ -129,7 +122,13 @@ func TestFrameNoPanicNavigateAndClickOnPageWithIFrames(t *testing.T) {
 		http.Redirect(w, r, tb.staticURL("iframe_signin.html"), http.StatusMovedPermanently)
 	})
 
-	_, err := p.Goto(tb.staticURL("iframe_home.html"), nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	_, err := p.Goto(
+		tb.staticURL("iframe_home.html"),
+		opts,
+	)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(tb.context(), 5*time.Second)

--- a/tests/launch_options_slowmo_test.go
+++ b/tests/launch_options_slowmo_test.go
@@ -92,7 +92,13 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
-				_, err := p.Goto(common.BlankPage, nil)
+				opts := &common.FrameGotoOptions{
+					Timeout: common.DefaultTimeout,
+				}
+				_, err := p.Goto(
+					common.BlankPage,
+					opts,
+				)
 				require.NoError(t, err)
 			})
 		})
@@ -222,7 +228,13 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f *common.Frame) {
-				_, _ = f.Goto(common.BlankPage, nil)
+				opts := &common.FrameGotoOptions{
+					Timeout: common.DefaultTimeout,
+				}
+				_, _ = f.Goto(
+					common.BlankPage,
+					opts,
+				)
 			})
 		})
 		t.Run("hover", func(t *testing.T) {

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -711,10 +711,10 @@ func assertHome(
 
 	var resolved, rejected bool
 	err := func() error {
-		opts := tb.toGojaValue(common.FrameGotoOptions{
+		opts := &common.FrameGotoOptions{
 			WaitUntil: waitUntil,
-			Timeout:   30 * time.Second,
-		})
+			Timeout:   common.DefaultTimeout,
+		}
 		_, err := p.Goto(tb.url("/home"), opts)
 		if err == nil {
 			resolved = true

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -234,7 +234,13 @@ func TestLocator(t *testing.T) {
 
 			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
-			_, err := p.Goto(tb.staticURL("locators.html"), nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: common.DefaultTimeout,
+			}
+			_, err := p.Goto(
+				tb.staticURL("locators.html"),
+				opts,
+			)
 			tt.do(tb, p)
 			require.NoError(t, err)
 		})
@@ -338,7 +344,13 @@ func TestLocator(t *testing.T) {
 			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
 
-			_, err := p.Goto(tb.staticURL("locators.html"), nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: common.DefaultTimeout,
+			}
+			_, err := p.Goto(
+				tb.staticURL("locators.html"),
+				opts,
+			)
 			require.NoError(t, err)
 
 			assert.Panics(t, func() {
@@ -390,7 +402,13 @@ func TestLocatorElementState(t *testing.T) {
 			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
 
-			_, err := p.Goto(tb.staticURL("locators.html"), nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: common.DefaultTimeout,
+			}
+			_, err := p.Goto(
+				tb.staticURL("locators.html"),
+				opts,
+			)
 			require.NoError(t, err)
 
 			l := p.Locator("#inputText", nil)
@@ -442,7 +460,13 @@ func TestLocatorElementState(t *testing.T) {
 			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
 
-			_, err := p.Goto(tb.staticURL("locators.html"), nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: common.DefaultTimeout,
+			}
+			_, err := p.Goto(
+				tb.staticURL("locators.html"),
+				opts,
+			)
 			assert.Panics(t, func() {
 				tt.do(p.Locator("a", nil), tb)
 			})
@@ -475,7 +499,13 @@ func TestLocatorShadowDOM(t *testing.T) {
 	tb := newTestBrowser(t, withFileServer())
 	p := tb.NewPage(nil)
 
-	_, err := p.Goto(tb.staticURL("shadow_dom_link.html"), nil)
+	popts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	_, err := p.Goto(
+		tb.staticURL("shadow_dom_link.html"),
+		popts,
+	)
 	require.NoError(t, err)
 	err = p.Click("#inner-link", common.NewFrameClickOptions(time.Second))
 	require.NoError(t, err)

--- a/tests/mouse_test.go
+++ b/tests/mouse_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/common"
 )
 
 func TestMouseDblClick(t *testing.T) {
@@ -12,7 +14,13 @@ func TestMouseDblClick(t *testing.T) {
 
 	b := newTestBrowser(t, withFileServer())
 	p := b.NewPage(nil)
-	_, err := p.Goto(b.staticURL("dbl_click.html"), nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	_, err := p.Goto(
+		b.staticURL("dbl_click.html"),
+		opts,
+	)
 	require.NoError(t, err)
 
 	p.Mouse.DblClick(35, 17, nil)

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -41,7 +41,13 @@ func TestNestedFrames(t *testing.T) {
 	defer tb.Browser.Close()
 
 	page := tb.NewPage(nil)
-	_, err := page.Goto(tb.staticURL("iframe_test_main.html"), nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	_, err := page.Goto(
+		tb.staticURL("iframe_test_main.html"),
+		opts,
+	)
 	require.NoError(t, err)
 
 	frame1Handle, err := page.WaitForSelector("iframe[id='iframe1']", nil)
@@ -177,7 +183,13 @@ func TestPageGoto(t *testing.T) {
 	p := b.NewPage(nil)
 
 	url := b.staticURL("empty.html")
-	r, err := p.Goto(url, nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	r, err := p.Goto(
+		url,
+		opts,
+	)
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	assert.Equal(t, url, r.URL(), `expected URL to be %q, result of navigation was %q`, url, r.URL())
@@ -189,7 +201,13 @@ func TestPageGotoDataURI(t *testing.T) {
 	b := newTestBrowser(t)
 	p := b.NewPage(nil)
 
-	r, err := p.Goto("data:text/html,hello", nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	r, err := p.Goto(
+		"data:text/html,hello",
+		opts,
+	)
 	require.NoError(t, err)
 	assert.Nil(t, r, `expected response to be nil`)
 	require.NoError(t, err)
@@ -201,11 +219,10 @@ func TestPageGotoWaitUntilLoad(t *testing.T) {
 	b := newTestBrowser(t, withFileServer())
 	p := b.NewPage(nil)
 
-	opts := b.toGojaValue(struct {
-		WaitUntil string `js:"waitUntil"`
-	}{
-		WaitUntil: "load",
-	})
+	opts := &common.FrameGotoOptions{
+		WaitUntil: common.LifecycleEventLoad,
+		Timeout:   common.DefaultTimeout,
+	}
 	_, err := p.Goto(b.staticURL("wait_until.html"), opts)
 	require.NoError(t, err)
 	var (
@@ -226,11 +243,10 @@ func TestPageGotoWaitUntilDOMContentLoaded(t *testing.T) {
 	b := newTestBrowser(t, withFileServer())
 	p := b.NewPage(nil)
 
-	opts := b.toGojaValue(struct {
-		WaitUntil string `js:"waitUntil"`
-	}{
-		WaitUntil: "domcontentloaded",
-	})
+	opts := &common.FrameGotoOptions{
+		WaitUntil: common.LifecycleEventDOMContentLoad,
+		Timeout:   common.DefaultTimeout,
+	}
 	_, err := p.Goto(b.staticURL("wait_until.html"), opts)
 	require.NoError(t, err)
 	var (
@@ -501,7 +517,13 @@ func TestPageSetExtraHTTPHeaders(t *testing.T) {
 	}
 	p.SetExtraHTTPHeaders(headers)
 
-	resp, err := p.Goto(b.url("/get"), nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	resp, err := p.Goto(
+		b.url("/get"),
+		opts,
+	)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -743,7 +765,13 @@ func TestPageURL(t *testing.T) {
 	p := b.NewPage(nil)
 	assert.Equal(t, common.BlankPage, p.URL())
 
-	resp, err := p.Goto(b.url("/get"), nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	resp, err := p.Goto(
+		b.url("/get"),
+		opts,
+	)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Regexp(t, "http://.*/get", p.URL())
@@ -1066,14 +1094,23 @@ func TestPageTimeout(t *testing.T) {
 
 			p := tb.NewPage(nil)
 
+			var timeout time.Duration
 			if tc.defaultTimeout != 0 {
+				timeout = tc.defaultTimeout
 				p.SetDefaultTimeout(tc.defaultTimeout.Milliseconds())
 			}
 			if tc.defaultNavigationTimeout != 0 {
+				timeout = tc.defaultNavigationTimeout
 				p.SetDefaultNavigationTimeout(tc.defaultNavigationTimeout.Milliseconds())
 			}
 
-			res, err := p.Goto(tb.url("/slow"), nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: timeout,
+			}
+			res, err := p.Goto(
+				tb.url("/slow"),
+				opts,
+			)
 			require.Nil(t, res)
 			assert.ErrorContains(t, err, "timed out after")
 		})
@@ -1123,7 +1160,13 @@ func TestPageWaitForSelector(t *testing.T) {
 			tb := newTestBrowser(t, withFileServer())
 
 			page := tb.NewPage(nil)
-			_, err := page.Goto(tb.staticURL(tc.url), nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: common.DefaultTimeout,
+			}
+			_, err := page.Goto(
+				tb.staticURL(tc.url),
+				opts,
+			)
 			require.NoError(t, err)
 
 			_, err = page.WaitForSelector(tc.selector, tb.toGojaValue(tc.opts))
@@ -1210,7 +1253,13 @@ func TestPageThrottleNetwork(t *testing.T) {
 			err := page.ThrottleNetwork(tc.networkProfile)
 			require.NoError(t, err)
 
-			_, err = page.Goto(tb.staticURL("ping.html"), nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: common.DefaultTimeout,
+			}
+			_, err = page.Goto(
+				tb.staticURL("ping.html"),
+				opts,
+			)
 			require.NoError(t, err)
 
 			selector := `div[id="result"]`
@@ -1270,7 +1319,13 @@ func performPingTest(t *testing.T, tb *testBrowser, page *common.Page, iteration
 	for i := 0; i < iterations; i++ {
 		start := time.Now()
 
-		_, err := page.Goto(tb.staticURL("ping.html"), nil)
+		opts := &common.FrameGotoOptions{
+			Timeout: common.DefaultTimeout,
+		}
+		_, err := page.Goto(
+			tb.staticURL("ping.html"),
+			opts,
+		)
 		require.NoError(t, err)
 
 		selector := `div[id="result"]`
@@ -1335,7 +1390,13 @@ func TestPageIsVisible(t *testing.T) {
 
 			page := tb.NewPage(nil)
 
-			_, err := page.Goto(tb.staticURL("visible.html"), nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: common.DefaultTimeout,
+			}
+			_, err := page.Goto(
+				tb.staticURL("visible.html"),
+				opts,
+			)
 			require.NoError(t, err)
 
 			got, err := page.IsVisible(tc.selector, tb.toGojaValue(tc.options))
@@ -1400,7 +1461,13 @@ func TestPageIsHidden(t *testing.T) {
 
 			page := tb.NewPage(nil)
 
-			_, err := page.Goto(tb.staticURL("visible.html"), nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: common.DefaultTimeout,
+			}
+			_, err := page.Goto(
+				tb.staticURL("visible.html"),
+				opts,
+			)
 			require.NoError(t, err)
 
 			got, err := page.IsHidden(tc.selector, tb.toGojaValue(tc.options))

--- a/tests/webvital_test.go
+++ b/tests/webvital_test.go
@@ -54,7 +54,13 @@ func TestWebVitalMetric(t *testing.T) {
 		}
 	}()
 
-	resp, err := page.Goto(browser.staticURL("/web_vitals.html"), nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	resp, err := page.Goto(
+		browser.staticURL("/web_vitals.html"),
+		opts,
+	)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -113,13 +119,15 @@ func TestWebVitalMetricNoInteraction(t *testing.T) {
 		}
 	}()
 
+	// wait until the page is completely loaded.
 	page := browser.NewPage(nil)
+	opts := &common.FrameGotoOptions{
+		WaitUntil: common.LifecycleEventDOMContentLoad,
+		Timeout:   common.DefaultTimeout,
+	}
 	resp, err := page.Goto(
 		browser.staticURL("web_vitals.html"),
-		browser.toGojaValue(map[string]any{
-			// wait until the page is completely loaded.
-			"waitUntil": "networkidle",
-		}),
+		opts,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, resp)


### PR DESCRIPTION
## What?

- Moves goja out of option parsing for `frame` and `page` `goto` to mapping.
- Updates tests accordingly.
- Adds two helpers: `Referrer` and `NavigationTimeout` for building options while mapping.

## Why?

See #1162 for the main reason. Also, the reason for doing both `frame` and `page` `goto` options in the same PR is that the code doesn't compile without the other. Or, it would require a lot of intermediary steps which would be confusing for the commit log.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates: #1176