### PR TITLE
Refactor parsing of arguments for waitForFunction

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -411,21 +411,11 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 		"uncheck":       f.Uncheck,
 		"url":           f.URL,
 		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) (*goja.Promise, error) {
-			popts := common.NewFrameWaitForFunctionOptions(f.Timeout())
-			err := popts.Parse(vu.Context(), opts)
+			js, popts, pargs, err := parseWaitForFunctionArgs(
+				vu.Context(), f.Timeout(), pageFunc, opts, args...,
+			)
 			if err != nil {
-				return nil, fmt.Errorf("parsing waitForFunction options: %w", err)
-			}
-
-			js := pageFunc.ToString().String()
-			_, isCallable := goja.AssertFunction(pageFunc)
-			if !isCallable {
-				js = fmt.Sprintf("() => (%s)", js)
-			}
-
-			pargs := make([]any, 0, len(args))
-			for _, arg := range args {
-				pargs = append(pargs, arg.Export())
+				return nil, fmt.Errorf("frame waitForFunction: %w", err)
 			}
 
 			return k6ext.Promise(vu.Context(), func() (result any, reason error) {

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -410,10 +410,16 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 		"type":          f.Type,
 		"uncheck":       f.Uncheck,
 		"url":           f.URL,
-		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) *goja.Promise {
+		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) (*goja.Promise, error) {
+			popts := common.NewFrameWaitForFunctionOptions(f.Timeout())
+			err := popts.Parse(vu.Context(), opts)
+			if err != nil {
+				return nil, fmt.Errorf("parsing waitForFunction options: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
-				return f.WaitForFunction(pageFunc, opts, args...) //nolint:wrapcheck
-			})
+				return f.WaitForFunction(pageFunc, popts, args...) //nolint:wrapcheck
+			}), nil
 		},
 		"waitForLoadState": f.WaitForLoadState,
 		"waitForNavigation": func(opts goja.Value) *goja.Promise {

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/xk6-browser/k6ext"
 
 	k6common "go.k6.io/k6/js/common"
+	k6modules "go.k6.io/k6/js/modules"
 )
 
 // mapping is a type for mapping our module API to Goja.
@@ -492,6 +493,16 @@ func parseWaitForFunctionArgs(
 	}
 
 	return js, popts, pargs, nil
+}
+
+// MapPage will map a page for an integration test. It is only to be used for
+// internal testing purposes.
+func MapPage(vu k6modules.VU, p *common.Page) mapping {
+	ivu, ok := vu.(moduleVU)
+	if !ok {
+		ivu = moduleVU{VU: vu}
+	}
+	return mapPage(ivu, p)
 }
 
 // mapPage to the JS module.

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -650,10 +650,17 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 		"video":                       p.Video,
 		"viewportSize":                p.ViewportSize,
 		"waitForEvent":                p.WaitForEvent,
-		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) *goja.Promise {
+		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) (*goja.Promise, error) {
+			js, popts, pargs, err := parseWaitForFunctionArgs(
+				vu.Context(), p.Timeout(), pageFunc, opts, args...,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("page waitForFunction: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
-				return p.WaitForFunction(pageFunc, opts, args...) //nolint:wrapcheck
-			})
+				return p.WaitForFunction(js, popts, pargs...) //nolint:wrapcheck
+			}), nil
 		},
 		"waitForLoadState": p.WaitForLoadState,
 		"waitForNavigation": func(opts goja.Value) *goja.Promise {

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -481,6 +481,29 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 	return maps
 }
 
+func parseWaitForFunctionArgs(
+	ctx context.Context, timeout time.Duration, pageFunc, opts goja.Value, args ...goja.Value,
+) (string, *common.FrameWaitForFunctionOptions, []any, error) {
+	popts := common.NewFrameWaitForFunctionOptions(timeout)
+	err := popts.Parse(ctx, opts)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("parsing waitForFunction options: %w", err)
+	}
+
+	js := pageFunc.ToString().String()
+	_, isCallable := goja.AssertFunction(pageFunc)
+	if !isCallable {
+		js = fmt.Sprintf("() => (%s)", js)
+	}
+
+	pargs := make([]any, 0, len(args))
+	for _, arg := range args {
+		pargs = append(pargs, arg.Export())
+	}
+
+	return js, popts, pargs, nil
+}
+
 // mapPage to the JS module.
 //
 //nolint:funlen

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -417,8 +417,14 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return nil, fmt.Errorf("parsing waitForFunction options: %w", err)
 			}
 
+			js := pageFunc.ToString().String()
+			_, isCallable := goja.AssertFunction(pageFunc)
+			if !isCallable {
+				js = fmt.Sprintf("() => (%s)", js)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
-				return f.WaitForFunction(pageFunc, popts, args...) //nolint:wrapcheck
+				return f.WaitForFunction(js, popts, args...) //nolint:wrapcheck
 			}), nil
 		},
 		"waitForLoadState": f.WaitForLoadState,

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/xk6-browser/k6ext"
 
 	k6common "go.k6.io/k6/js/common"
-	k6modules "go.k6.io/k6/js/modules"
 )
 
 // mapping is a type for mapping our module API to Goja.
@@ -493,16 +492,6 @@ func parseWaitForFunctionArgs(
 	}
 
 	return js, popts, pargs, nil
-}
-
-// MapPage will map a page for an integration test. It is only to be used for
-// internal testing purposes.
-func MapPage(vu k6modules.VU, p *common.Page) mapping {
-	ivu, ok := vu.(moduleVU)
-	if !ok {
-		ivu = moduleVU{VU: vu}
-	}
-	return mapPage(ivu, p)
 }
 
 // mapPage to the JS module.

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -423,8 +423,13 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				js = fmt.Sprintf("() => (%s)", js)
 			}
 
+			pargs := make([]any, 0, len(args))
+			for _, arg := range args {
+				pargs = append(pargs, arg.Export())
+			}
+
 			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
-				return f.WaitForFunction(js, popts, args...) //nolint:wrapcheck
+				return f.WaitForFunction(js, popts, pargs...) //nolint:wrapcheck
 			}), nil
 		},
 		"waitForLoadState": f.WaitForLoadState,

--- a/common/frame.go
+++ b/common/frame.go
@@ -1643,14 +1643,8 @@ func (f *Frame) setURL(url string) {
 }
 
 // WaitForFunction waits for the given predicate to return a truthy value.
-func (f *Frame) WaitForFunction(fn goja.Value, opts goja.Value, jsArgs ...goja.Value) (any, error) {
+func (f *Frame) WaitForFunction(fn goja.Value, opts *FrameWaitForFunctionOptions, jsArgs ...goja.Value) (any, error) {
 	f.log.Debugf("Frame:WaitForFunction", "fid:%s furl:%q", f.ID(), f.URL())
-
-	parsedOpts := NewFrameWaitForFunctionOptions(f.defaultTimeout())
-	err := parsedOpts.Parse(f.ctx, opts)
-	if err != nil {
-		return nil, fmt.Errorf("parsing waitForFunction options: %w", err)
-	}
 
 	js := fn.ToString().String()
 	_, isCallable := goja.AssertFunction(fn)
@@ -1663,13 +1657,13 @@ func (f *Frame) WaitForFunction(fn goja.Value, opts goja.Value, jsArgs ...goja.V
 		args = append(args, a.Export())
 	}
 
-	var polling any = parsedOpts.Polling
-	if parsedOpts.Polling == PollingInterval {
-		polling = parsedOpts.Interval
+	var polling any = opts.Polling
+	if opts.Polling == PollingInterval {
+		polling = opts.Interval
 	}
 
 	result, err := f.waitForFunction(f.ctx, mainWorld, js,
-		polling, parsedOpts.Timeout, args...)
+		polling, opts.Timeout, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -1643,13 +1643,8 @@ func (f *Frame) setURL(url string) {
 }
 
 // WaitForFunction waits for the given predicate to return a truthy value.
-func (f *Frame) WaitForFunction(js string, opts *FrameWaitForFunctionOptions, jsArgs ...goja.Value) (any, error) {
+func (f *Frame) WaitForFunction(js string, opts *FrameWaitForFunctionOptions, jsArgs ...any) (any, error) {
 	f.log.Debugf("Frame:WaitForFunction", "fid:%s furl:%q", f.ID(), f.URL())
-
-	args := make([]any, 0, len(jsArgs))
-	for _, a := range jsArgs {
-		args = append(args, a.Export())
-	}
 
 	var polling any = opts.Polling
 	if opts.Polling == PollingInterval {
@@ -1657,7 +1652,7 @@ func (f *Frame) WaitForFunction(js string, opts *FrameWaitForFunctionOptions, js
 	}
 
 	result, err := f.waitForFunction(f.ctx, mainWorld, js,
-		polling, opts.Timeout, args...)
+		polling, opts.Timeout, jsArgs...)
 	if err != nil {
 		return nil, err
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -1643,14 +1643,8 @@ func (f *Frame) setURL(url string) {
 }
 
 // WaitForFunction waits for the given predicate to return a truthy value.
-func (f *Frame) WaitForFunction(fn goja.Value, opts *FrameWaitForFunctionOptions, jsArgs ...goja.Value) (any, error) {
+func (f *Frame) WaitForFunction(js string, opts *FrameWaitForFunctionOptions, jsArgs ...goja.Value) (any, error) {
 	f.log.Debugf("Frame:WaitForFunction", "fid:%s furl:%q", f.ID(), f.URL())
-
-	js := fn.ToString().String()
-	_, isCallable := goja.AssertFunction(fn)
-	if !isCallable {
-		js = fmt.Sprintf("() => (%s)", js)
-	}
 
 	args := make([]any, 0, len(jsArgs))
 	for _, a := range jsArgs {

--- a/common/page.go
+++ b/common/page.go
@@ -1283,7 +1283,13 @@ func (p *Page) WaitForEvent(event string, optsOrPredicate goja.Value) any {
 func (p *Page) WaitForFunction(fn, opts goja.Value, args ...goja.Value) (any, error) {
 	p.logger.Debugf("Page:WaitForFunction", "sid:%v", p.sessionID())
 
-	return p.frameManager.MainFrame().WaitForFunction(fn, opts, args...)
+	popts := NewFrameWaitForFunctionOptions(p.Timeout())
+	err := popts.Parse(p.ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("parsing waitForFunction options: %w", err)
+	}
+
+	return p.frameManager.MainFrame().WaitForFunction(fn, popts, args...)
 }
 
 // WaitForLoadState waits for the specified page life cycle event.

--- a/common/page.go
+++ b/common/page.go
@@ -1280,27 +1280,9 @@ func (p *Page) WaitForEvent(event string, optsOrPredicate goja.Value) any {
 }
 
 // WaitForFunction waits for the given predicate to return a truthy value.
-func (p *Page) WaitForFunction(fn, opts goja.Value, args ...goja.Value) (any, error) {
+func (p *Page) WaitForFunction(js string, opts *FrameWaitForFunctionOptions, jsArgs ...any) (any, error) {
 	p.logger.Debugf("Page:WaitForFunction", "sid:%v", p.sessionID())
-
-	popts := NewFrameWaitForFunctionOptions(p.Timeout())
-	err := popts.Parse(p.ctx, opts)
-	if err != nil {
-		return nil, fmt.Errorf("parsing waitForFunction options: %w", err)
-	}
-
-	js := fn.ToString().String()
-	_, isCallable := goja.AssertFunction(fn)
-	if !isCallable {
-		js = fmt.Sprintf("() => (%s)", js)
-	}
-
-	jsArgs := make([]any, 0, len(args))
-	for _, a := range args {
-		jsArgs = append(jsArgs, a.Export())
-	}
-
-	return p.frameManager.MainFrame().WaitForFunction(js, popts, jsArgs...)
+	return p.frameManager.MainFrame().WaitForFunction(js, opts, jsArgs...)
 }
 
 // WaitForLoadState waits for the specified page life cycle event.

--- a/common/page.go
+++ b/common/page.go
@@ -1295,7 +1295,12 @@ func (p *Page) WaitForFunction(fn, opts goja.Value, args ...goja.Value) (any, er
 		js = fmt.Sprintf("() => (%s)", js)
 	}
 
-	return p.frameManager.MainFrame().WaitForFunction(js, popts, args...)
+	jsArgs := make([]any, 0, len(args))
+	for _, a := range args {
+		jsArgs = append(jsArgs, a.Export())
+	}
+
+	return p.frameManager.MainFrame().WaitForFunction(js, popts, jsArgs...)
 }
 
 // WaitForLoadState waits for the specified page life cycle event.

--- a/common/page.go
+++ b/common/page.go
@@ -1289,7 +1289,13 @@ func (p *Page) WaitForFunction(fn, opts goja.Value, args ...goja.Value) (any, er
 		return nil, fmt.Errorf("parsing waitForFunction options: %w", err)
 	}
 
-	return p.frameManager.MainFrame().WaitForFunction(fn, popts, args...)
+	js := fn.ToString().String()
+	_, isCallable := goja.AssertFunction(fn)
+	if !isCallable {
+		js = fmt.Sprintf("() => (%s)", js)
+	}
+
+	return p.frameManager.MainFrame().WaitForFunction(js, popts, args...)
 }
 
 // WaitForLoadState waits for the specified page life cycle event.

--- a/k6ext/k6test/vu.go
+++ b/k6ext/k6test/vu.go
@@ -33,6 +33,7 @@ type VU struct {
 	Loop      *k6eventloop.EventLoop
 	toBeState *k6lib.State
 	samples   chan k6metrics.SampleContainer
+	TestRT    *k6modulestest.Runtime
 }
 
 // ToGojaValue is a convenience method for converting any value to a goja value.
@@ -203,5 +204,5 @@ func NewVU(tb testing.TB, opts ...any) *VU {
 	ctx = k6lib.WithScenarioState(ctx, &k6lib.ScenarioState{Name: "default"})
 	testRT.VU.CtxField = ctx
 
-	return &VU{VU: testRT.VU, Loop: testRT.EventLoop, toBeState: state, samples: samples}
+	return &VU{VU: testRT.VU, Loop: testRT.EventLoop, toBeState: state, samples: samples, TestRT: testRT}
 }

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/grafana/xk6-browser/browser"
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/k6ext/k6test"
 )
 
 type emulateMediaOpts struct {
@@ -696,6 +697,34 @@ func TestPageWaitForFunction(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, log, "ok: null")
 	})
+}
+
+// startIteration will work with the event system to start chrome and
+// (more importantly) set browser as the mapped browser instance which will
+// force all tests that work with this to go through the mapping layer.
+// This returns a cleanup function which should be deferred.
+func startIteration(t *testing.T) (*k6test.VU, *goja.Runtime, *[]string, func()) {
+	t.Helper()
+
+	vu := k6test.NewVU(t)
+	rt := vu.Runtime()
+
+	mod := browser.New().NewModuleInstance(vu)
+	jsMod, ok := mod.Exports().Default.(*browser.JSModule)
+	require.Truef(t, ok, "unexpected default mod export type %T", mod.Exports().Default)
+
+	// Setting the mapped browser into the vu's goja runtime.
+	require.NoError(t, rt.Set("browser", jsMod.Browser))
+
+	// Setting log, which is used by the callers to assert that certain actions
+	// have been made.
+	var log []string
+	require.NoError(t, rt.Set("log", func(s string) { log = append(log, s) }))
+
+	vu.ActivateVU()
+	vu.StartIteration(t)
+
+	return vu, rt, &log, func() { t.Helper(); vu.EndIteration(t) }
 }
 
 func TestPageWaitForLoadState(t *testing.T) {

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -727,6 +727,24 @@ func startIteration(t *testing.T) (*k6test.VU, *goja.Runtime, *[]string, func())
 	return vu, rt, &log, func() { t.Helper(); vu.EndIteration(t) }
 }
 
+func runJSInEventLoop(t *testing.T, vu *k6test.VU, js string) error {
+	t.Helper()
+
+	rt := vu.Runtime()
+	_, err := rt.RunString(js)
+	require.NoError(t, err)
+
+	test, ok := goja.AssertFunction(rt.Get("test"))
+	require.True(t, ok)
+
+	err = vu.Loop.Start(func() error {
+		_, err := test(goja.Undefined())
+		return err
+	})
+
+	return err
+}
+
 func TestPageWaitForLoadState(t *testing.T) {
 	t.Parallel()
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -524,19 +524,21 @@ func TestPageWaitForFunction(t *testing.T) {
 	// testing the polling functionality—not the response from
 	// waitForFunction.
 	script := `
-		let resp = await page.waitForFunction(%s, %s, %s)
-		log('ok: '+resp);`
+		var page;
+		const test = async function() {
+			page = browser.newPage();
+			let resp = await page.waitForFunction(%s, %s, %s);
+			log('ok: '+resp);
+		}
+		`
 
 	t.Run("ok_func_raf_default", func(t *testing.T) {
 		t.Parallel()
 
-		tb := newTestBrowser(t)
-		mp := browser.MapPage(tb.vu, tb.NewPage(nil))
-		var log []string
-		require.NoError(t, tb.runtime().Set("log", func(s string) { log = append(log, s) }))
-		require.NoError(t, tb.runtime().Set("page", mp))
+		vu, rt, log, cleanUp := startIteration(t)
+		defer cleanUp()
 
-		_, err := tb.runJavaScript(`fn = () => {
+		_, err := rt.RunString(`fn = () => {
 			if (typeof window._cnt == 'undefined') window._cnt = 0;
 			if (window._cnt >= 50) return true;
 			window._cnt++;
@@ -544,50 +546,43 @@ func TestPageWaitForFunction(t *testing.T) {
 		}`)
 		require.NoError(t, err)
 
-		err = assertJSInEventLoop(t, tb.vu, fmt.Sprintf(script, "fn", "{}", "null"))
+		err = runJSInEventLoop(t, vu, fmt.Sprintf(script, "fn", "{}", "null"))
 		require.NoError(t, err)
-		assert.Contains(t, log, "ok: null")
+		assert.Contains(t, *log, "ok: null")
 	})
 
 	t.Run("ok_func_raf_default_arg", func(t *testing.T) {
 		t.Parallel()
 
-		tb := newTestBrowser(t)
-		p := tb.NewPage(nil)
-		mp := browser.MapPage(tb.vu, p)
-		require.NoError(t, tb.runtime().Set("page", mp))
-		var log []string
-		require.NoError(t, tb.runtime().Set("log", func(s string) { log = append(log, s) }))
+		vu, rt, log, cleanUp := startIteration(t)
+		defer cleanUp()
 
-		_, err := tb.runJavaScript(`fn = arg => {
+		_, err := rt.RunString(`fn = arg => {
 			window._arg = arg;
 			return true;
 		}`)
 		require.NoError(t, err)
 
 		arg := "raf_arg"
-		err = assertJSInEventLoop(t, tb.vu, fmt.Sprintf(script, "fn", "{}", fmt.Sprintf("%q", arg)))
+		err = runJSInEventLoop(t, vu, fmt.Sprintf(script, "fn", "{}", fmt.Sprintf("%q", arg)))
 		require.NoError(t, err)
-		assert.Contains(t, log, "ok: null")
+		assert.Contains(t, *log, "ok: null")
 
-		argEvalJS := p.Evaluate(tb.toGojaValue("() => window._arg"))
-		argEval := tb.asGojaValue(argEvalJS)
+		argEval, err := rt.RunString(`page.evaluate(() => window._arg);`)
+		require.NoError(t, err)
+
 		var gotArg string
-		_ = tb.runtime().ExportTo(argEval, &gotArg)
+		_ = rt.ExportTo(argEval, &gotArg)
 		assert.Equal(t, arg, gotArg)
 	})
 
 	t.Run("ok_func_raf_default_args", func(t *testing.T) {
 		t.Parallel()
 
-		tb := newTestBrowser(t)
-		p := tb.NewPage(nil)
-		mp := browser.MapPage(tb.vu, p)
-		require.NoError(t, tb.runtime().Set("page", mp))
-		var log []string
-		require.NoError(t, tb.runtime().Set("log", func(s string) { log = append(log, s) }))
+		vu, rt, log, cleanUp := startIteration(t)
+		defer cleanUp()
 
-		_, err := tb.runJavaScript(`fn = (...args) => {
+		_, err := rt.RunString(`fn = (...args) => {
 			window._args = args;
 			return true;
 		}`)
@@ -597,40 +592,35 @@ func TestPageWaitForFunction(t *testing.T) {
 		argsJS, err := json.Marshal(args)
 		require.NoError(t, err)
 
-		err = assertJSInEventLoop(t, tb.vu, fmt.Sprintf(script, "fn", "{}", fmt.Sprintf("...%s", string(argsJS))))
+		err = runJSInEventLoop(t, vu, fmt.Sprintf(script, "fn", "{}", fmt.Sprintf("...%s", string(argsJS))))
 		require.NoError(t, err)
-		assert.Contains(t, log, "ok: null")
+		assert.Contains(t, *log, "ok: null")
 
-		argEvalJS := p.Evaluate(tb.toGojaValue("() => window._args"))
-		argEval := tb.asGojaValue(argEvalJS)
+		argEval, err := rt.RunString(`page.evaluate(() => window._args);`)
+		require.NoError(t, err)
+
 		var gotArgs []int
-		_ = tb.runtime().ExportTo(argEval, &gotArgs)
+		_ = rt.ExportTo(argEval, &gotArgs)
 		assert.Equal(t, args, gotArgs)
 	})
 
 	t.Run("err_expr_raf_timeout", func(t *testing.T) {
 		t.Parallel()
 
-		tb := newTestBrowser(t)
-		mp := browser.MapPage(tb.vu, tb.NewPage(nil))
-		rt := tb.vu.Runtime()
-		var log []string
-		require.NoError(t, rt.Set("log", func(s string) { log = append(log, s) }))
-		require.NoError(t, rt.Set("page", mp))
+		vu, _, _, cleanUp := startIteration(t)
+		defer cleanUp()
 
-		err := assertJSInEventLoop(t, tb.vu, fmt.Sprintf(script, "false", "{ polling: 'raf', timeout: 500, }", "null"))
+		err := runJSInEventLoop(t, vu, fmt.Sprintf(script, "false", "{ polling: 'raf', timeout: 500, }", "null"))
 		require.ErrorContains(t, err, "timed out after 500ms")
 	})
 
 	t.Run("err_wrong_polling", func(t *testing.T) {
 		t.Parallel()
 
-		tb := newTestBrowser(t)
-		mp := browser.MapPage(tb.vu, tb.NewPage(nil))
-		rt := tb.vu.Runtime()
-		require.NoError(t, rt.Set("page", mp))
+		vu, _, _, cleanUp := startIteration(t)
+		defer cleanUp()
 
-		err := assertJSInEventLoop(t, tb.vu, fmt.Sprintf(script, "false", "{ polling: 'blah' }", "null"))
+		err := runJSInEventLoop(t, vu, fmt.Sprintf(script, "false", "{ polling: 'blah' }", "null"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(),
 			`parsing waitForFunction options: wrong polling option value:`,
@@ -640,49 +630,48 @@ func TestPageWaitForFunction(t *testing.T) {
 	t.Run("ok_expr_poll_interval", func(t *testing.T) {
 		t.Parallel()
 
-		tb := newTestBrowser(t)
-		p := tb.NewPage(nil)
-		mp := browser.MapPage(tb.vu, p)
-		require.NoError(t, tb.runtime().Set("page", mp))
-		var log []string
-		require.NoError(t, tb.runtime().Set("log", func(s string) { log = append(log, s) }))
+		vu, rt, log, cleanUp := startIteration(t)
+		defer cleanUp()
 
-		p.Evaluate(tb.toGojaValue(`() => {
+		_, err := rt.RunString(`
+		const page = browser.newPage();
+		page.evaluate(() => {
 			setTimeout(() => {
 				const el = document.createElement('h1');
 				el.innerHTML = 'Hello';
 				document.body.appendChild(el);
 			}, 1000);
-		}`))
+		});`)
+		require.NoError(t, err)
 
 		script := `
+		const test = async function() {
 			let resp = await page.waitForFunction(%s, %s, %s);
 			if (resp) {
 				log('ok: '+resp.innerHTML());
 			} else {
 				log('err: '+err);
-			}`
+			}
+		}`
 
 		s := fmt.Sprintf(script, `"document.querySelector('h1')"`, "{ polling: 100, timeout: 2000, }", "null")
-		err := assertJSInEventLoop(t, tb.vu, s)
+		err = runJSInEventLoop(t, vu, s)
 		require.NoError(t, err)
-		assert.Contains(t, log, "ok: Hello")
+		assert.Contains(t, *log, "ok: Hello")
 	})
 
 	t.Run("ok_func_poll_mutation", func(t *testing.T) {
 		t.Parallel()
 
-		tb := newTestBrowser(t)
-		p := tb.NewPage(nil)
-		mp := browser.MapPage(tb.vu, p)
-		require.NoError(t, tb.runtime().Set("page", mp))
-		var log []string
-		require.NoError(t, tb.runtime().Set("log", func(s string) { log = append(log, s) }))
+		vu, rt, log, cleanUp := startIteration(t)
+		defer cleanUp()
 
-		_, err := tb.runJavaScript(`fn = () => document.querySelector('h1') !== null`)
+		_, err := rt.RunString(`fn = () => document.querySelector('h1') !== null`)
 		require.NoError(t, err)
 
-		p.Evaluate(tb.toGojaValue(`() => {
+		_, err = rt.RunString(`
+		const page = browser.newPage();
+		page.evaluate(() => {
 			console.log('calling setTimeout...');
 			setTimeout(() => {
 				console.log('creating element...');
@@ -690,12 +679,19 @@ func TestPageWaitForFunction(t *testing.T) {
 				el.innerHTML = 'Hello';
 				document.body.appendChild(el);
 			}, 1000);
-		}`))
+		})`)
+		require.NoError(t, err)
+
+		script := `
+		const test = async function() {
+			let resp = await page.waitForFunction(%s, %s, %s);
+			log('ok: '+resp);
+		}`
 
 		s := fmt.Sprintf(script, "fn", "{ polling: 'mutation', timeout: 2000, }", "null")
-		err = assertJSInEventLoop(t, tb.vu, s)
+		err = runJSInEventLoop(t, vu, s)
 		require.NoError(t, err)
-		assert.Contains(t, log, "ok: null")
+		assert.Contains(t, *log, "ok: null")
 	})
 }
 

--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -155,7 +155,9 @@ func TestTracing(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		assertJSInEventLoop(t, vu, tc.js)
+		err := assertJSInEventLoop(t, vu, tc.js)
+		require.NoError(t, err)
+
 		require.NoError(t, tracer.verifySpans(tc.spans...))
 	}
 }
@@ -176,7 +178,7 @@ func setupTestTracing(t *testing.T, rt *goja.Runtime) {
 	require.NoError(t, err)
 }
 
-func assertJSInEventLoop(t *testing.T, vu *k6test.VU, js string) {
+func assertJSInEventLoop(t *testing.T, vu *k6test.VU, js string) error {
 	t.Helper()
 
 	f := fmt.Sprintf(
@@ -194,7 +196,8 @@ func assertJSInEventLoop(t *testing.T, vu *k6test.VU, js string) {
 		_, err := test(goja.Undefined())
 		return err
 	})
-	require.NoError(t, err)
+
+	return err
 }
 
 type mockTracerProvider struct {

--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -155,8 +155,7 @@ func TestTracing(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err := assertJSInEventLoop(t, vu, tc.js)
-		require.NoError(t, err)
+		assertJSInEventLoop(t, vu, tc.js)
 
 		require.NoError(t, tracer.verifySpans(tc.spans...))
 	}
@@ -178,7 +177,7 @@ func setupTestTracing(t *testing.T, rt *goja.Runtime) {
 	require.NoError(t, err)
 }
 
-func assertJSInEventLoop(t *testing.T, vu *k6test.VU, js string) error {
+func assertJSInEventLoop(t *testing.T, vu *k6test.VU, js string) {
 	t.Helper()
 
 	f := fmt.Sprintf(
@@ -196,8 +195,7 @@ func assertJSInEventLoop(t *testing.T, vu *k6test.VU, js string) error {
 		_, err := test(goja.Undefined())
 		return err
 	})
-
-	return err
+	require.NoError(t, err)
 }
 
 type mockTracerProvider struct {


### PR DESCRIPTION
## What?

Refactor the parsing of the arguments of `waitForFunction` APIs so that they are done outside the promise and therefore on the main goja thread.

## Why?

This will help mitigate issues which can occur when trying to access the goja runtime from multiple goroutines, which can causes panics since the goja runtime is not thread safe.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/1180 & https://github.com/grafana/xk6-browser/issues/1181