### PR TITLE
Refactor parsing of options for waitForNavigation

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -423,14 +423,19 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 			})
 		},
 		"waitForLoadState": f.WaitForLoadState,
-		"waitForNavigation": func(opts goja.Value) *goja.Promise {
+		"waitForNavigation": func(opts goja.Value) (*goja.Promise, error) {
+			popts := common.NewFrameWaitForNavigationOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing frame wait for navigation options: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
-				resp, err := f.WaitForNavigation(opts)
+				resp, err := f.WaitForNavigation(popts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
 				return mapResponse(vu, resp), nil
-			})
+			}), nil
 		},
 		"waitForSelector": func(selector string, opts goja.Value) (mapping, error) {
 			eh, err := f.WaitForSelector(selector, opts)

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -634,14 +634,19 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 			})
 		},
 		"waitForLoadState": p.WaitForLoadState,
-		"waitForNavigation": func(opts goja.Value) *goja.Promise {
+		"waitForNavigation": func(opts goja.Value) (*goja.Promise, error) {
+			popts := common.NewFrameWaitForNavigationOptions(p.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing page wait for navigation options: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
-				resp, err := p.WaitForNavigation(opts)
+				resp, err := p.WaitForNavigation(popts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
 				return mapResponse(vu, resp), nil
-			})
+			}), nil
 		},
 		"waitForRequest":  p.WaitForRequest,
 		"waitForResponse": p.WaitForResponse,

--- a/common/page.go
+++ b/common/page.go
@@ -1307,17 +1307,12 @@ func (p *Page) WaitForLoadState(state string, opts goja.Value) {
 }
 
 // WaitForNavigation waits for the given navigation lifecycle event to happen.
-func (p *Page) WaitForNavigation(opts goja.Value) (*Response, error) {
+func (p *Page) WaitForNavigation(opts *FrameWaitForNavigationOptions) (*Response, error) {
 	p.logger.Debugf("Page:WaitForNavigation", "sid:%v", p.sessionID())
 	_, span := TraceAPICall(p.ctx, p.targetID.String(), "page.waitForNavigation")
 	defer span.End()
 
-	popts := NewFrameWaitForNavigationOptions(p.frameManager.timeoutSettings.timeout())
-	if err := popts.Parse(p.ctx, opts); err != nil {
-		return nil, fmt.Errorf("parsing page wait for navigation options: %w", err)
-	}
-
-	return p.frameManager.MainFrame().WaitForNavigation(popts)
+	return p.frameManager.MainFrame().WaitForNavigation(opts)
 }
 
 // WaitForRequest is not implemented.

--- a/common/page.go
+++ b/common/page.go
@@ -1312,7 +1312,12 @@ func (p *Page) WaitForNavigation(opts goja.Value) (*Response, error) {
 	_, span := TraceAPICall(p.ctx, p.targetID.String(), "page.waitForNavigation")
 	defer span.End()
 
-	return p.frameManager.MainFrame().WaitForNavigation(opts)
+	popts := NewFrameWaitForNavigationOptions(p.frameManager.timeoutSettings.timeout())
+	if err := popts.Parse(p.ctx, opts); err != nil {
+		return nil, fmt.Errorf("parsing page wait for navigation options: %w", err)
+	}
+
+	return p.frameManager.MainFrame().WaitForNavigation(popts)
 }
 
 // WaitForRequest is not implemented.

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -42,9 +42,7 @@ func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 			require.NotNil(t, resp)
 
 			waitForNav := func() error {
-				opts := tb.toGojaValue(&common.FrameWaitForNavigationOptions{
-					Timeout: time.Duration(timeout.Milliseconds()), // interpreted as ms
-				})
+				opts := &common.FrameWaitForNavigationOptions{Timeout: timeout}
 				_, err := p.WaitForNavigation(opts)
 				return err
 			}
@@ -98,9 +96,9 @@ func TestWaitForFrameNavigation(t *testing.T) {
 	require.NoError(t, err)
 
 	waitForNav := func() error {
-		opts := tb.toGojaValue(&common.FrameWaitForNavigationOptions{
-			Timeout: 5000, // interpreted as ms
-		})
+		opts := &common.FrameWaitForNavigationOptions{
+			Timeout: 5000 * time.Millisecond,
+		}
 		_, err := p.WaitForNavigation(opts)
 		return err
 	}

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -137,7 +137,12 @@ func TestFrameNoPanicNavigateAndClickOnPageWithIFrames(t *testing.T) {
 	err = tb.run(
 		ctx,
 		func() error { return p.Click(`a[href="/iframeSignIn"]`, common.NewFrameClickOptions(p.Timeout())) },
-		func() error { _, err := p.WaitForNavigation(nil); return err },
+		func() error {
+			_, err := p.WaitForNavigation(
+				common.NewFrameWaitForNavigationOptions(p.Timeout()),
+			)
+			return err
+		},
 	)
 	require.NoError(t, err)
 

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -128,10 +128,10 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 				result := p.TextContent("#pingRequestText", nil)
 				assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
-				opts := tb.toGojaValue(&common.FrameWaitForNavigationOptions{
-					Timeout:   1000,
+				opts := &common.FrameWaitForNavigationOptions{
+					Timeout:   1000 * time.Millisecond,
 					WaitUntil: common.LifecycleEventNetworkIdle,
-				})
+				}
 				_, err := p.WaitForNavigation(opts)
 
 				return err
@@ -167,10 +167,10 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 				tt.pingJSTextAssert(result)
 
 				waitForNav := func() error {
-					opts := tb.toGojaValue(&common.FrameWaitForNavigationOptions{
-						Timeout:   30000,
+					opts := &common.FrameWaitForNavigationOptions{
+						Timeout:   30000 * time.Millisecond,
 						WaitUntil: tt.waitUntil,
-					})
+					}
 					_, err := p.WaitForNavigation(opts)
 					return err
 				}

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -737,7 +737,9 @@ func TestPageWaitForNavigationErrOnCtxDone(t *testing.T) {
 	p := b.NewPage(nil)
 	go b.cancelContext()
 	<-b.context().Done()
-	_, err := p.WaitForNavigation(nil)
+	_, err := p.WaitForNavigation(
+		common.NewFrameWaitForNavigationOptions(p.Timeout()),
+	)
 	require.ErrorContains(t, err, "canceled")
 }
 

--- a/tests/webvital_test.go
+++ b/tests/webvital_test.go
@@ -70,7 +70,12 @@ func TestWebVitalMetric(t *testing.T) {
 	err = browser.run(
 		ctx,
 		func() error { return page.Click("#clickMe", common.NewFrameClickOptions(page.Timeout())) },
-		func() error { _, err := page.WaitForNavigation(nil); return err },
+		func() error {
+			_, err := page.WaitForNavigation(
+				common.NewFrameWaitForNavigationOptions(page.Timeout()),
+			)
+			return err
+		},
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## What?

Refactor the parsing of the options of `waitForNavigation` APIs so that they are done outside the promise and therefore on the main goja thread.

## Why?

This will help mitigate issues which can occur when trying to access the goja runtime from multiple goroutines, which can causes panics since the goja runtime is not thread safe.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/1184 & https://github.com/grafana/xk6-browser/issues/1185