### PR TITLE
Refactor parsing of options for waitForEvent

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -741,16 +741,16 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 		"unroute":            bc.Unroute,
 		"waitForEvent": func(event string, optsOrPredicate goja.Value) (*goja.Promise, error) {
 			ctx := vu.Context()
-			parsedOpts := common.NewWaitForEventOptions(
+			popts := common.NewWaitForEventOptions(
 				bc.Timeout(),
 			)
-			if err := parsedOpts.Parse(ctx, optsOrPredicate); err != nil {
+			if err := popts.Parse(ctx, optsOrPredicate); err != nil {
 				return nil, fmt.Errorf("parsing waitForEvent options: %w", err)
 			}
 
 			return k6ext.Promise(ctx, func() (result any, reason error) {
 				var runInTaskQueue func(p *common.Page) (bool, error)
-				if parsedOpts.PredicateFn != nil {
+				if popts.PredicateFn != nil {
 					runInTaskQueue = func(p *common.Page) (bool, error) {
 						tq := vu.taskQueueRegistry.get(p.TargetID())
 
@@ -762,7 +762,7 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 						c := make(chan bool)
 						tq.Queue(func() error {
 							var resp goja.Value
-							resp, err = parsedOpts.PredicateFn(vu.Runtime().ToValue(p))
+							resp, err = popts.PredicateFn(vu.Runtime().ToValue(p))
 							rtn = resp.ToBoolean()
 							close(c)
 							return nil
@@ -773,7 +773,7 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 					}
 				}
 
-				resp, err := bc.WaitForEvent(event, runInTaskQueue, parsedOpts.Timeout)
+				resp, err := bc.WaitForEvent(event, runInTaskQueue, popts.Timeout)
 				panicIfFatalError(ctx, err)
 				if err != nil {
 					return nil, err //nolint:wrapcheck

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -739,16 +739,16 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 		"setOffline":         bc.SetOffline,
 		"storageState":       bc.StorageState,
 		"unroute":            bc.Unroute,
-		"waitForEvent": func(event string, optsOrPredicate goja.Value) *goja.Promise {
+		"waitForEvent": func(event string, optsOrPredicate goja.Value) (*goja.Promise, error) {
 			ctx := vu.Context()
-			return k6ext.Promise(ctx, func() (result any, reason error) {
-				parsedOpts := common.NewWaitForEventOptions(
-					bc.Timeout(),
-				)
-				if err := parsedOpts.Parse(ctx, optsOrPredicate); err != nil {
-					return nil, fmt.Errorf("parsing waitForEvent options: %w", err)
-				}
+			parsedOpts := common.NewWaitForEventOptions(
+				bc.Timeout(),
+			)
+			if err := parsedOpts.Parse(ctx, optsOrPredicate); err != nil {
+				return nil, fmt.Errorf("parsing waitForEvent options: %w", err)
+			}
 
+			return k6ext.Promise(ctx, func() (result any, reason error) {
 				var runInTaskQueue func(p *common.Page) (bool, error)
 				if parsedOpts.PredicateFn != nil {
 					runInTaskQueue = func(p *common.Page) (bool, error) {
@@ -784,7 +784,7 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 				}
 
 				return mapPage(vu, p), nil
-			})
+			}), nil
 		},
 		"pages": func() *goja.Object {
 			var (


### PR DESCRIPTION
## What?

Refactor the parsing of the options for the `browserContext.waitForEvent` API so that it is done outside the promise and therefore on the main goja thread.

## Why?

This will help mitigate issues which can occur when trying to access the goja runtime from multiple goroutines, which can causes panics since the goja runtime is not thread safe.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/1187