### PR TITLE
Refactor JSONValue to use parseConsoleRemoteObject

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -1455,7 +1455,11 @@ func (f *Frame) selectOption(selector string, values goja.Value, opts *FrameSele
 	}
 	vals := make([]string, 0, len(optHandles))
 	for _, oh := range optHandles {
-		vals = append(vals, oh.JSONValue())
+		val, err := oh.JSONValue()
+		if err != nil {
+			return nil, fmt.Errorf("reading value: %w", err)
+		}
+		vals = append(vals, val)
 		if err := oh.dispose(); err != nil {
 			return nil, fmt.Errorf("optionHandle.dispose: %w", err)
 		}

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -642,6 +642,8 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 	case "error":
 		l.Error()
 	default:
+		// this is where debug & other console.* apis will default to (such as
+		// console.table).
 		l.Debug()
 	}
 }

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -165,16 +165,14 @@ func (h *BaseJSHandle) GetProperty(_ string) JSHandleAPI {
 func (h *BaseJSHandle) JSONValue() (string, error) {
 	remoteObject := h.remoteObject
 	if remoteObject.ObjectID != "" {
-		var result *runtime.RemoteObject
 		var err error
 		action := runtime.CallFunctionOn("function() { return this; }").
 			WithReturnByValue(true).
 			WithAwaitPromise(true).
 			WithObjectID(h.remoteObject.ObjectID)
-		if result, _, err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
+		if remoteObject, _, err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
 			return "", fmt.Errorf("retrieving json value: %w", err)
 		}
-		remoteObject = result
 	}
 
 	res, err := parseConsoleRemoteObject(h.logger, remoteObject)

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -177,7 +177,7 @@ func (h *BaseJSHandle) JSONValue() (string, error) {
 
 	res, err := parseConsoleRemoteObject(h.logger, remoteObject)
 	if err != nil {
-		return "", fmt.Errorf("extracting json value: %w", err)
+		return "", fmt.Errorf("extracting json value (remote object id: %v): %w", remoteObject.ObjectID, err)
 	}
 
 	return res, nil

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -24,7 +24,7 @@ type JSHandleAPI interface {
 	EvaluateHandle(pageFunc string, args ...any) (JSHandleAPI, error)
 	GetProperties() (map[string]JSHandleAPI, error)
 	GetProperty(propertyName string) JSHandleAPI
-	JSONValue() string
+	JSONValue() (string, error)
 	ObjectID() cdpruntime.RemoteObjectID
 }
 
@@ -162,7 +162,7 @@ func (h *BaseJSHandle) GetProperty(_ string) JSHandleAPI {
 }
 
 // JSONValue returns a JSON version of this JS handle.
-func (h *BaseJSHandle) JSONValue() string {
+func (h *BaseJSHandle) JSONValue() (string, error) {
 	if h.remoteObject.ObjectID != "" {
 		var result *runtime.RemoteObject
 		var err error
@@ -175,15 +175,17 @@ func (h *BaseJSHandle) JSONValue() string {
 		}
 		res, err := parseConsoleRemoteObject(h.logger, result)
 		if err != nil {
-			k6ext.Panic(h.ctx, "extracting value from remote object: %w", err)
+			return "", fmt.Errorf("extracting value from result: %w", err)
 		}
-		return res
+
+		return res, nil
 	}
 	res, err := parseConsoleRemoteObject(h.logger, h.remoteObject)
 	if err != nil {
-		k6ext.Panic(h.ctx, "extracting value from remote object: %w", err)
+		return "", fmt.Errorf("extracting value from remote object: %w", err)
 	}
-	return res
+
+	return res, nil
 }
 
 // ObjectID returns the remote object ID.

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -163,7 +163,8 @@ func (h *BaseJSHandle) GetProperty(_ string) JSHandleAPI {
 
 // JSONValue returns a JSON version of this JS handle.
 func (h *BaseJSHandle) JSONValue() (string, error) {
-	if h.remoteObject.ObjectID != "" {
+	remoteObject := h.remoteObject
+	if remoteObject.ObjectID != "" {
 		var result *runtime.RemoteObject
 		var err error
 		action := runtime.CallFunctionOn("function() { return this; }").
@@ -173,16 +174,12 @@ func (h *BaseJSHandle) JSONValue() (string, error) {
 		if result, _, err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
 			return "", fmt.Errorf("retrieving json value: %w", err)
 		}
-		res, err := parseConsoleRemoteObject(h.logger, result)
-		if err != nil {
-			return "", fmt.Errorf("extracting value from result: %w", err)
-		}
-
-		return res, nil
+		remoteObject = result
 	}
-	res, err := parseConsoleRemoteObject(h.logger, h.remoteObject)
+
+	res, err := parseConsoleRemoteObject(h.logger, remoteObject)
 	if err != nil {
-		return "", fmt.Errorf("extracting value from remote object: %w", err)
+		return "", fmt.Errorf("extracting json value: %w", err)
 	}
 
 	return res, nil

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -171,7 +171,7 @@ func (h *BaseJSHandle) JSONValue() (string, error) {
 			WithAwaitPromise(true).
 			WithObjectID(h.remoteObject.ObjectID)
 		if result, _, err = action.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-			k6ext.Panic(h.ctx, "getting properties for JS handle: %w", err)
+			return "", fmt.Errorf("retrieving json value: %w", err)
 		}
 		res, err := parseConsoleRemoteObject(h.logger, result)
 		if err != nil {

--- a/tests/js_handle_get_properties_test.go
+++ b/tests/js_handle_get_properties_test.go
@@ -28,6 +28,7 @@ func TestJSHandleGetProperties(t *testing.T) {
 	props, err := handle.GetProperties()
 	require.NoError(t, err, "expected no error when getting properties")
 
-	value := props["prop1"].JSONValue()
+	value, err := props["prop1"].JSONValue()
+	assert.NoError(t, err, "expected no error when getting JSONValue")
 	assert.Equal(t, value, "one", `expected property value of "one", got %q`, value)
 }

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -852,7 +852,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "log", cm.Type)
 				assert.Equal(t, "this is a log message", cm.Text)
-				assert.Equal(t, "this is a log message", cm.Args[0].JSONValue())
+				val, err := cm.Args[0].JSONValue()
+				assert.NoError(t, err)
+				assert.Equal(t, "this is a log message", val)
 				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
 			},
 		},
@@ -863,7 +865,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "debug", cm.Type)
 				assert.Equal(t, "this is a debug message", cm.Text)
-				assert.Equal(t, "this is a debug message", cm.Args[0].JSONValue())
+				val, err := cm.Args[0].JSONValue()
+				assert.NoError(t, err)
+				assert.Equal(t, "this is a debug message", val)
 				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
 			},
 		},
@@ -874,7 +878,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "info", cm.Type)
 				assert.Equal(t, "this is an info message", cm.Text)
-				assert.Equal(t, "this is an info message", cm.Args[0].JSONValue())
+				val, err := cm.Args[0].JSONValue()
+				assert.NoError(t, err)
+				assert.Equal(t, "this is an info message", val)
 				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
 			},
 		},
@@ -885,7 +891,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "error", cm.Type)
 				assert.Equal(t, "this is an error message", cm.Text)
-				assert.Equal(t, "this is an error message", cm.Args[0].JSONValue())
+				val, err := cm.Args[0].JSONValue()
+				assert.NoError(t, err)
+				assert.Equal(t, "this is an error message", val)
 				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
 			},
 		},
@@ -896,7 +904,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "warning", cm.Type)
 				assert.Equal(t, "this is a warning message", cm.Text)
-				assert.Equal(t, "this is a warning message", cm.Args[0].JSONValue())
+				val, err := cm.Args[0].JSONValue()
+				assert.NoError(t, err)
+				assert.Equal(t, "this is a warning message", val)
 				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
 			},
 		},
@@ -927,7 +937,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "table", cm.Type)
 				assert.Equal(t, "Array(2)", cm.Text)
-				assert.Equal(t, `[["Grafana","k6"],["Grafana","Mimir"]]`, cm.Args[0].JSONValue())
+				val, err := cm.Args[0].JSONValue()
+				assert.NoError(t, err)
+				assert.Equal(t, `[["Grafana","k6"],["Grafana","Mimir"]]`, val)
 				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
 			},
 		},
@@ -938,7 +950,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "trace", cm.Type)
 				assert.Equal(t, "trace example", cm.Text)
-				assert.Equal(t, "trace example", cm.Args[0].JSONValue())
+				val, err := cm.Args[0].JSONValue()
+				assert.NoError(t, err)
+				assert.Equal(t, "trace example", val)
 				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
 			},
 		},


### PR DESCRIPTION
## What?

Refactor `JSONValue` to use `parseConsoleRemoteObject`.

## Why?

This will help avoid working with the goja runtime outside of the mapping layer and therefore avoid possible race conditions with the unsafe goja runtime. `JSONValue` wasn't ever working with the goja values and so it made sense to always work with string values.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/1168