### PR TITLE
Add file persister interface

### DIFF
--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/k6ext"
+	"github.com/grafana/xk6-browser/storage"
 
 	k6modules "go.k6.io/k6/js/modules"
 )
@@ -20,6 +21,8 @@ type moduleVU struct {
 	*browserRegistry
 
 	*taskQueueRegistry
+
+	FilePersister storage.FilePersister
 }
 
 // browser returns the VU browser instance for the current iteration.

--- a/storage/file_persister.go
+++ b/storage/file_persister.go
@@ -1,0 +1,12 @@
+package storage
+
+import (
+	"context"
+	"io"
+)
+
+// FilePersister will persist files. It abstracts away the where and how of
+// writing files to the source destination.
+type FilePersister interface {
+	Persist(ctx context.Context, path string, data io.Reader) error
+}


### PR DESCRIPTION
## What?

This adds a file persister interface.

## Why?

It is a way to hide the details of where and how the files that the browser module saves to disk (and soon remotely).

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1155