### PR TITLE
Add local file persister

### DIFF
--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/k6ext"
+	"github.com/grafana/xk6-browser/storage"
 
 	k6modules "go.k6.io/k6/js/modules"
 )
@@ -20,6 +21,8 @@ type moduleVU struct {
 	*browserRegistry
 
 	*taskQueueRegistry
+
+	FilePersister storage.FilePersister
 }
 
 // browser returns the VU browser instance for the current iteration.

--- a/storage/file_persister.go
+++ b/storage/file_persister.go
@@ -2,11 +2,60 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 )
 
 // FilePersister will persist files. It abstracts away the where and how of
 // writing files to the source destination.
 type FilePersister interface {
 	Persist(ctx context.Context, path string, data io.Reader) error
+}
+
+// LocalFilePersister will persist files to the local disk.
+type LocalFilePersister struct{}
+
+// Persist will write the contents of data to the local disk on the specified path.
+// TODO: we should not write to disk here but put it on some queue for async disk writes.
+func (l *LocalFilePersister) Persist(_ context.Context, path string, data io.Reader) error {
+	cp := filepath.Clean(path)
+
+	dir := filepath.Dir(cp)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating a local directory %q: %w", dir, err)
+	}
+
+	f, err := os.OpenFile(cp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("creating a local file %q: %w", cp, err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			logger.Errorf("LocalFilePersister:Persist", "closing the local file %q: %v", cp, err)
+		}
+	}()
+
+	return write(f, data)
+}
+
+func write(w io.Writer, r io.Reader) error {
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
+				return fmt.Errorf("writing to the local writer: %w", writeErr)
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading from the reader: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/storage/file_persister.go
+++ b/storage/file_persister.go
@@ -1,0 +1,14 @@
+package storage
+
+import (
+	"context"
+	"io"
+
+	"github.com/grafana/xk6-browser/log"
+)
+
+// FilePersister will persist files. It abstracts away the where and how of
+// writing files to the source destination.
+type FilePersister interface {
+	Persist(ctx context.Context, logger *log.Logger, path string, data io.Reader) error
+}

--- a/storage/file_persister.go
+++ b/storage/file_persister.go
@@ -3,12 +3,10 @@ package storage
 import (
 	"context"
 	"io"
-
-	"github.com/grafana/xk6-browser/log"
 )
 
 // FilePersister will persist files. It abstracts away the where and how of
 // writing files to the source destination.
 type FilePersister interface {
-	Persist(ctx context.Context, logger *log.Logger, path string, data io.Reader) error
+	Persist(ctx context.Context, path string, data io.Reader) error
 }

--- a/storage/file_persister.go
+++ b/storage/file_persister.go
@@ -37,25 +37,7 @@ func (l *LocalFilePersister) Persist(_ context.Context, path string, data io.Rea
 		}
 	}()
 
-	return write(f, data)
-}
+	_, err = io.Copy(f, data)
 
-func write(w io.Writer, r io.Reader) error {
-	buf := make([]byte, 4096)
-	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
-				return fmt.Errorf("writing to the local writer: %w", writeErr)
-			}
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("reading from the reader: %w", err)
-		}
-	}
-
-	return nil
+	return err
 }

--- a/storage/file_persister_test.go
+++ b/storage/file_persister_test.go
@@ -1,0 +1,87 @@
+package storage
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalFilePersister(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		path         string
+		existingData string
+		data         string
+		truncates    bool
+	}{
+		{
+			name: "just_file",
+			path: "test.txt",
+			data: "some data",
+		},
+		{
+			name: "with_dir",
+			path: "path/test.txt",
+			data: "some data",
+		},
+		{
+			name:         "truncates",
+			path:         "test.txt",
+			data:         "some data",
+			truncates:    true,
+			existingData: "existing data",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir, err := os.MkdirTemp("", "*")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.RemoveAll(dir) })
+			p := filepath.Join(dir, tt.path)
+
+			// We want to make sure that the persister truncates the existing
+			// data and therefore overwrites existing data. This sets up a file
+			// with some existing data that should be overwritten.
+			if tt.truncates {
+				err = os.WriteFile(p, []byte(tt.existingData), 0o600)
+				require.NoError(t, err)
+			}
+
+			l := &LocalFilePersister{}
+			err = l.Persist(context.Background(), p, strings.NewReader(tt.data))
+			assert.NoError(t, err)
+
+			i, err := os.Stat(p)
+			require.NoError(t, err)
+			assert.False(t, i.IsDir())
+
+			f, err := os.Open(filepath.Clean(p))
+			require.NoError(t, err)
+			defer func() {
+				err = f.Close()
+				require.NoError(t, err)
+			}()
+
+			bb, err := io.ReadAll(f)
+			require.NoError(t, err)
+
+			if tt.truncates {
+				assert.NotEqual(t, tt.existingData, string(bb))
+			}
+
+			assert.Equal(t, tt.data, string(bb))
+		})
+	}
+}


### PR DESCRIPTION
## What?

This adds a local file persister which will save files to the local disk. It implements the interface defined in https://github.com/grafana/xk6-browser/issues/1155.

## Why?

So that we can replace how we're currently writing screenshots to disk. This will help hide the details of where and how the files are saved, allowing us to easily work with different file persisters.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1156