### PR TITLE
Refactor goja out of screenshots and byte pointer changes

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -704,8 +704,22 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 			return rt.ToValue(r).ToObject(rt)
 		},
 		"route": p.Route,
-		"screenshot": func(opts goja.Value) goja.ArrayBuffer {
-			return p.Screenshot(opts, vu.LocalFilePersister)
+		"screenshot": func(opts goja.Value) (*goja.ArrayBuffer, error) {
+			ctx := vu.Context()
+
+			popts := common.NewPageScreenshotOptions()
+			if err := popts.Parse(ctx, opts); err != nil {
+				return nil, fmt.Errorf("parsing page screenshot options: %w", err)
+			}
+
+			bb, err := p.Screenshot(popts, vu.LocalFilePersister)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+
+			ab := rt.NewArrayBuffer(bb)
+
+			return &ab, nil
 		},
 		"selectOption":                p.SelectOption,
 		"setContent":                  p.SetContent,

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1181,7 +1181,7 @@ func (h *ElementHandle) setChecked(apiCtx context.Context, checked bool, p *Posi
 func (h *ElementHandle) Screenshot(
 	opts *ElementHandleScreenshotOptions,
 	fp *storage.LocalFilePersister,
-) (*[]byte, error) {
+) ([]byte, error) {
 	spanCtx, span := TraceAPICall(
 		h.ctx,
 		h.frame.page.targetID.String(),

--- a/common/page.go
+++ b/common/page.go
@@ -1121,7 +1121,7 @@ func (p *Page) Route(url goja.Value, handler goja.Callable) {
 }
 
 // Screenshot will instruct Chrome to save a screenshot of the current page and save it to specified file.
-func (p *Page) Screenshot(opts *PageScreenshotOptions, fp *storage.LocalFilePersister) (*[]byte, error) {
+func (p *Page) Screenshot(opts *PageScreenshotOptions, fp *storage.LocalFilePersister) ([]byte, error) {
 	spanCtx, span := TraceAPICall(p.ctx, p.targetID.String(), "page.screenshot")
 	defer span.End()
 

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -300,7 +300,7 @@ func (s *screenshotter) screenshotElement(h *ElementHandle, opts *ElementHandleS
 	return buf, nil
 }
 
-//nolint:funlen,cyclop
+//nolint:funlen,cyclop,gocognit
 func (s *screenshotter) screenshotPage(p *Page, opts *PageScreenshotOptions) ([]byte, error) {
 	format := opts.Format
 

--- a/common/screenshotter.go
+++ b/common/screenshotter.go
@@ -141,7 +141,7 @@ func (s *screenshotter) restoreViewport(p *Page, originalViewport *Size) error {
 //nolint:funlen,cyclop
 func (s *screenshotter) screenshot(
 	sess session, doc, viewport *Rect, format ImageFormat, omitBackground bool, quality int64, path string,
-) (*[]byte, error) {
+) ([]byte, error) {
 	var (
 		buf  []byte
 		clip *cdppage.Viewport
@@ -222,10 +222,11 @@ func (s *screenshotter) screenshot(
 		}
 	}
 
-	return &buf, nil
+	return buf, nil
 }
 
-func (s *screenshotter) screenshotElement(h *ElementHandle, opts *ElementHandleScreenshotOptions) (*[]byte, error) {
+//nolint:funlen,cyclop
+func (s *screenshotter) screenshotElement(h *ElementHandle, opts *ElementHandleScreenshotOptions) ([]byte, error) {
 	format := opts.Format
 	viewportSize, originalViewportSize, err := s.originalViewportSize(h.frame.page)
 	if err != nil {
@@ -296,7 +297,8 @@ func (s *screenshotter) screenshotElement(h *ElementHandle, opts *ElementHandleS
 	return buf, nil
 }
 
-func (s *screenshotter) screenshotPage(p *Page, opts *PageScreenshotOptions) (*[]byte, error) {
+//nolint:funlen,cyclop
+func (s *screenshotter) screenshotPage(p *Page, opts *PageScreenshotOptions) ([]byte, error) {
 	format := opts.Format
 
 	// Infer file format by path

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -381,7 +381,7 @@ func TestElementHandleScreenshot(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	reader := bytes.NewReader(*buf)
+	reader := bytes.NewReader(buf)
 	img, err := png.Decode(reader)
 	assert.Nil(t, err)
 

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -375,9 +375,13 @@ func TestElementHandleScreenshot(t *testing.T) {
 	elem, err := p.Query("div")
 	require.NoError(t, err)
 
-	buf := elem.Screenshot(nil, &storage.LocalFilePersister{})
+	buf, err := elem.Screenshot(
+		common.NewElementHandleScreenshotOptions(elem.Timeout()),
+		&storage.LocalFilePersister{},
+	)
+	require.NoError(t, err)
 
-	reader := bytes.NewReader(buf.Bytes())
+	reader := bytes.NewReader(*buf)
 	img, err := png.Decode(reader)
 	assert.Nil(t, err)
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -474,13 +474,12 @@ func TestPageScreenshotFullpage(t *testing.T) {
 	}
     `)
 
-	buf := p.Screenshot(tb.toGojaValue(struct {
-		FullPage bool `js:"fullPage"`
-	}{
-		FullPage: true,
-	}), &storage.LocalFilePersister{})
+	opts := common.NewPageScreenshotOptions()
+	opts.FullPage = true
+	buf, err := p.Screenshot(opts, &storage.LocalFilePersister{})
+	require.NoError(t, err)
 
-	reader := bytes.NewReader(buf.Bytes())
+	reader := bytes.NewReader(*buf)
 	img, err := png.Decode(reader)
 	assert.Nil(t, err)
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -479,7 +479,7 @@ func TestPageScreenshotFullpage(t *testing.T) {
 	buf, err := p.Screenshot(opts, &storage.LocalFilePersister{})
 	require.NoError(t, err)
 
-	reader := bytes.NewReader(*buf)
+	reader := bytes.NewReader(buf)
 	img, err := png.Decode(reader)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
## What?

This refactors the parsing of the goja options for `frame.screenshot` and `page.screenshot` to the mapping layer, as well as moving goja out of screenshotter. This means that the screenshot business logic is free of goja.

It also changes the `screenshotter` to return a `[]byte` instead of a pointer to it (`*[]byte`).

## Why?

The options should be parsed out of the `goja.Value` representation in the mapping layer to avoid goja escaping into the business logic which makes the business logic more complex and this will also help if we convert this method into async.

There's no reason to return a `*[]byte` as far as i can tell.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1064