### PR TITLE
Fix testServer close operation

### DIFF
--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -67,6 +67,7 @@ func TestTracing(t *testing.T) {
 			fmt.Fprint(w, html)
 		},
 	))
+	defer ts.Close()
 
 	// Initialize VU and browser module
 	vu := k6test.NewVU(t, k6test.WithTracerProvider(tp))


### PR DESCRIPTION
## What?

The close wasn't being called on testServer which is a requirement when using it.

## Why?

To avoid leaks or unknown consequences.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
