### PR TITLE
Add a shadow DOM example

### DIFF
--- a/examples/shadowdom.js
+++ b/examples/shadowdom.js
@@ -1,0 +1,36 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const page = browser.newPage();
+  page.setContent("<html><head><style></style></head><body>hello!</body></html>")
+  await page.evaluate(() => {
+    const shadowRoot = document.createElement('div');
+    shadowRoot.id = 'shadow-root';
+    shadowRoot.attachShadow({mode: 'open'});
+    shadowRoot.shadowRoot.innerHTML = '<p id="find">Shadow DOM</p>';
+    document.body.appendChild(shadowRoot);
+  });
+  const shadowEl = page.locator("#find");
+  check(shadowEl, {
+    "shadow element exists": (e) => e !== null,
+    "shadow element text is correct": (e) => e.innerText() === "Shadow DOM",
+  });
+  page.close();
+}


### PR DESCRIPTION
## What?

Adds a shadow DOM E2E example test script.

## Why?

To verify the behavior and redirect users to the example.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

Updates: https://github.com/grafana/xk6-browser/issues/1210
