### PR TITLE
Bump linter and test Github action Go versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19.x
+          go-version: 1.21.x
           check-latest: true
       - name: Check dependencies
         run: |
@@ -42,7 +42,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19.x
+          go-version: 1.21.x
           check-latest: true
       - name: Retrieve golangci-lint version
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.50.0
+# v1.55.2
 # Please don't remove the first line. It's used in CI to determine the
 # golangci-lint version. See the lint step in .github/workflows/all.yaml
 run:


### PR DESCRIPTION
## What?

Fixes and bumps the Go versions for the linter and test Github actions.

## Why?

- The current linter Go version 1.19 won't work for the linter action after #850 change. See the error [here](https://github.com/grafana/xk6-browser/actions/runs/7897531005/job/21553265573?pr=850).
- Test runners are upgraded to Go 1.21 as per k6-core.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#850, #1214, #1212