### PR TITLE
Fix Multi VU deadlock by isolating browser contexts

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -229,10 +229,6 @@ func (b *Browser) initEvents() error {
 // connectionOnAttachedToTarget is called when Connection receives an attachedToTarget
 // event. Returning false will stop the event from being processed by the connection.
 func (b *Browser) connectionOnAttachedToTarget(eva *target.EventAttachedToTarget) bool {
-	// Allow connection to attach to target as the browser context is not set
-	// (hence it's the first one we have—the default), or the target is in the
-	// same browser context as the current one.
-	//
 	// This allows to attach targets to the same browser context as the current
 	// one, and to the default browser context.
 	//
@@ -338,7 +334,6 @@ func (b *Browser) isAttachedPageValid(ev *target.EventAttachedToTarget, browserC
 		return false
 	}
 	// If the target is not in the same browser context as the current one, ignore it.
-	// We're not adding a log to prevent overhead.
 	if browserCtx.id != targetPage.BrowserContextID {
 		b.logger.Warnf(
 			"Browser:isAttachedPageValid", "incorrect browser context sid:%v tid:%v bctxid:%v target bctxid:%v",

--- a/common/browser.go
+++ b/common/browser.go
@@ -123,6 +123,9 @@ func (b *Browser) connect() error {
 
 	b.conn = conn
 
+	// Start the connection to listen for CDP events.
+	conn.start()
+
 	// We don't need to lock this because `connect()` is called only in NewBrowser
 	b.defaultContext, err = NewBrowserContext(b.ctx, b, "", NewBrowserContextOptions(), b.logger)
 	if err != nil {

--- a/common/browser.go
+++ b/common/browser.go
@@ -335,7 +335,7 @@ func (b *Browser) isAttachedPageValid(ev *target.EventAttachedToTarget, browserC
 	}
 	// If the target is not in the same browser context as the current one, ignore it.
 	if browserCtx.id != targetPage.BrowserContextID {
-		b.logger.Warnf(
+		b.logger.Debugf(
 			"Browser:isAttachedPageValid", "incorrect browser context sid:%v tid:%v bctxid:%v target bctxid:%v",
 			ev.SessionID, targetPage.TargetID, targetPage.BrowserContextID, browserCtx.id,
 		)

--- a/common/browser.go
+++ b/common/browser.go
@@ -217,6 +217,12 @@ func (b *Browser) initEvents() error {
 	return nil
 }
 
+// connectionOnAttachedToTarget is called when Connection receives an attachedToTarget
+// event. Returning false will stop the event from being processed by the connection.
+func (b *Browser) connectionOnAttachedToTarget(_ *target.EventAttachedToTarget) bool {
+	return true
+}
+
 // onAttachedToTarget is called when a new page is attached to the browser.
 func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) {
 	b.logger.Debugf("Browser:onAttachedToTarget", "sid:%v tid:%v bctxid:%v",

--- a/common/browser.go
+++ b/common/browser.go
@@ -116,6 +116,11 @@ func (b *Browser) connect() error {
 		return fmt.Errorf("connecting to browser DevTools URL: %w", err)
 	}
 
+	// hook into the connection to listen for target attachment events.
+	// this way, browser can manage the decision of target attachments.
+	// so that we can stop connection from doing unnecessary work.
+	conn.onTargetAttachedToTarget = b.connectionOnAttachedToTarget
+
 	b.conn = conn
 
 	// We don't need to lock this because `connect()` is called only in NewBrowser

--- a/common/browser.go
+++ b/common/browser.go
@@ -334,6 +334,15 @@ func (b *Browser) isAttachedPageValid(ev *target.EventAttachedToTarget, browserC
 			ev.SessionID, targetPage.TargetID, targetPage.BrowserContextID, browserCtx == nil, targetPage.Type)
 		return false
 	}
+	// If the target is not in the same browser context as the current one, ignore it.
+	// We're not adding a log to prevent overhead.
+	if browserCtx.id != targetPage.BrowserContextID {
+		b.logger.Warnf(
+			"Browser:isAttachedPageValid", "incorrect browser context sid:%v tid:%v bctxid:%v target bctxid:%v",
+			ev.SessionID, targetPage.TargetID, targetPage.BrowserContextID, browserCtx.id,
+		)
+		return false
+	}
 
 	return true
 }

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -289,11 +289,7 @@ func (b *BrowserContext) NewPage() (*Page, error) {
 
 // Pages returns a list of pages inside this browser context.
 func (b *BrowserContext) Pages() []*Page {
-	pages := make([]*Page, 1)
-	for _, p := range b.browser.getPages() {
-		pages = append(pages, p)
-	}
-	return pages
+	return append([]*Page{}, b.browser.getPages()...)
 }
 
 // Route is not implemented.

--- a/common/connection.go
+++ b/common/connection.go
@@ -136,10 +136,6 @@ type Connection struct {
 	// onTargetAttachedToTarget is called when a new target is attached to the browser.
 	// Returning false will prevent the session from being created.
 	// If onTargetAttachedToTarget is nil, the session will be created.
-	//
-	// Register this only once, before the connection is used.
-	// It's not a constructor parameter to prevent polluting the constructor
-	// signature. Also, tests don't need to set this (or some other future code).
 	onTargetAttachedToTarget func(*target.EventAttachedToTarget) bool
 }
 

--- a/common/connection.go
+++ b/common/connection.go
@@ -171,10 +171,18 @@ func NewConnection(ctx context.Context, wsURL string, logger *log.Logger) (*Conn
 		sessions:         make(map[target.SessionID]*Session),
 	}
 
-	go c.recvLoop()
-	go c.sendLoop()
+	// starts the main control loop
+	// where the connection reads and writes messages
+	// in gorooutines.
+	c.start()
 
 	return &c, nil
+}
+
+// start starts the connection's main control loop.
+func (c *Connection) start() {
+	go c.recvLoop()
+	go c.sendLoop()
 }
 
 func (c *Connection) close(code int) error {

--- a/common/connection.go
+++ b/common/connection.go
@@ -345,6 +345,7 @@ func (c *Connection) recvLoop() {
 				// if a session should be created for the target.
 				ok := c.onTargetAttachedToTarget(eva)
 				if !ok {
+					c.stopWaitingForDebugger(sid)
 					continue
 				}
 			}

--- a/common/connection.go
+++ b/common/connection.go
@@ -203,14 +203,22 @@ func (c *Connection) close(code int) error {
 	return err
 }
 
-func (c *Connection) closeSession(sid target.SessionID, tid target.ID) {
+// closeSession closes the session with the given session ID.
+// It returns true if the session was found and closed, false otherwise.
+func (c *Connection) closeSession(sid target.SessionID, tid target.ID) bool {
 	c.logger.Debugf("Connection:closeSession", "sid:%v tid:%v wsURL:%v", sid, tid, c.wsURL)
+
 	c.sessionsMu.Lock()
-	if session, ok := c.sessions[sid]; ok {
-		session.close()
+	defer c.sessionsMu.Unlock()
+
+	session, ok := c.sessions[sid]
+	if !ok {
+		return false
 	}
+	session.close()
 	delete(c.sessions, sid)
-	c.sessionsMu.Unlock()
+
+	return true
 }
 
 func (c *Connection) closeAllSessions() {

--- a/common/connection.go
+++ b/common/connection.go
@@ -429,8 +429,14 @@ func (c *Connection) recvLoop() {
 }
 
 // stopWaitingForDebugger tells the browser to stop waiting for the
-// debugger. Otherwise, the browser will wait for the debugger to
-// attach indefinitely.
+// debugger to attach to the page's session.
+//
+// Whether we're not sharing pages among browser contexts, Chromium
+// still does so (since we're auto-attaching all browser targets).
+// This means that if we don't stop waiting for the debugger, the
+// browser will wait for the debugger to attach to the new page
+// indefinitely, even if the page is not part of the browser context
+// we're using.
 //
 // We don't return an error because the browser might have already
 // closed the connection. In that case, handling the error would

--- a/common/connection.go
+++ b/common/connection.go
@@ -348,7 +348,16 @@ func (c *Connection) recvLoop() {
 			evt := ev.(*target.EventDetachedFromTarget)
 			sid := evt.SessionID
 			tid := c.findTargetIDForLog(sid)
-			c.closeSession(sid, tid)
+			ok := c.closeSession(sid, tid)
+			if !ok {
+				c.logger.Debugf(
+					"Connection:recvLoop:EventDetachedFromTarget",
+					"sid:%v tid:%v wsURL:%q, session not found",
+					sid, tid, c.wsURL,
+				)
+
+				continue
+			}
 		}
 
 		switch {

--- a/common/connection_test.go
+++ b/common/connection_test.go
@@ -29,8 +29,7 @@ func TestConnection(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/echo", url.Host)
-		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
-		conn.start()
+		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger(), nil)
 		conn.Close()
 
 		require.NoError(t, err)
@@ -48,8 +47,7 @@ func TestConnectionClosureAbnormal(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/closure-abnormal", url.Host)
-		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
-		conn.start()
+		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger(), nil)
 
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
@@ -70,8 +68,7 @@ func TestConnectionSendRecv(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
-		conn.start()
+		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger(), nil)
 
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
@@ -138,8 +135,7 @@ func TestConnectionCreateSession(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
-		conn.start()
+		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger(), nil)
 
 		if assert.NoError(t, err) {
 			session, err := conn.createSession(&target.Info{

--- a/common/connection_test.go
+++ b/common/connection_test.go
@@ -30,6 +30,7 @@ func TestConnection(t *testing.T) {
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/echo", url.Host)
 		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
+		conn.start()
 		conn.Close()
 
 		require.NoError(t, err)
@@ -48,6 +49,7 @@ func TestConnectionClosureAbnormal(t *testing.T) {
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/closure-abnormal", url.Host)
 		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
+		conn.start()
 
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
@@ -69,6 +71,7 @@ func TestConnectionSendRecv(t *testing.T) {
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
 		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
+		conn.start()
 
 		if assert.NoError(t, err) {
 			action := target.SetDiscoverTargets(true)
@@ -136,6 +139,7 @@ func TestConnectionCreateSession(t *testing.T) {
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
 		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
+		conn.start()
 
 		if assert.NoError(t, err) {
 			session, err := conn.createSession(&target.Info{

--- a/common/session_test.go
+++ b/common/session_test.go
@@ -88,10 +88,9 @@ func TestSessionCreateSession(t *testing.T) {
 		ctx := context.Background()
 		url, _ := url.Parse(server.ServerHTTP.URL)
 		wsURL := fmt.Sprintf("ws://%s/cdp", url.Host)
-		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
+		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger(), nil)
 
 		if assert.NoError(t, err) {
-			conn.start()
 			session, err := conn.createSession(&target.Info{
 				Type:             "page",
 				TargetID:         cdpTargetID,

--- a/common/session_test.go
+++ b/common/session_test.go
@@ -91,6 +91,7 @@ func TestSessionCreateSession(t *testing.T) {
 		conn, err := NewConnection(ctx, wsURL, log.NewNullLogger())
 
 		if assert.NoError(t, err) {
+			conn.start()
 			session, err := conn.createSession(&target.Info{
 				Type:             "page",
 				TargetID:         cdpTargetID,


### PR DESCRIPTION
## What?

With this fix, the browser module can now work with an **unlimited** number of VUs and iterations (_limited by the machine power and the browser, of course_). As explained in #1112, this PR separates browser contexts to make each iteration focus solely on its pages rather than those created by other iterations. This brings:

- Efficiency (at least 10X depending on the number of VUs)
- Better debugging (less log noise)
- Possibly fewer deadlocks (none seen so far in our tests)

Tested with the script in #971 and saw no deadlocks.

Note: This PR aims to apply this fix with minimum code changes to avoid disrupting the module's working.

## Why?

Please take a look at #1112 and #971 for more details.

We're adding a separate `onAttachedToTarget` hook to act precisely even before the module's event system is used to carry on the `onAttachedToTarget` event. This way, we can _precisely_ control `Connection`'s attachment decisions at the moment that happens. This also prevents other related concurrency issues between `Browser` and `Connection` event management.

In an ideal world, the session management should be outside of `Connection`, and `Browser` would be managing sessions itself. Currently, this is the cleanest way (IMO) to do this.

## The effects of this PR on other open issues

#971: Deadlock: Multi-VU many iterations

There are no longer deadlocks, even with 1000 VUs. See test run ID: 167467.

#966: Creating new page in browser context sometimes times out

```
Uncaught (in promise) GoError: creating new page in browser context: timed out after 30s
	at github.com/grafana/xk6-browser/browser.mapBrowserContext.func4 (native)
	at file:///tmp/TgCEDu/script.js:24:15(8)
 executor=shared-iterations scenario=ui
```

We no longer see these errors. See test run ID: 167467. However, there were plenty in test run ID 167336 (before this fix was applied).

#970: Uncaught (in promise) when navigating due to time out

```
Uncaught (in promise) navigating frame to "https://test.k6.io/": navigating to "https://test.k6.io/": timed out after 30s executor=shared-iterations scenario=ui
```

This still occurs. But this is about the server(s) under the test unable to keep up with the load. When I manually loaded the page on my browser, it gave me 503/502 many times. Here's the test run ID 167467's log:

```
2024-02-20 17:58:07.832 Failed to load resource: the server responded with a status of 502 (Bad Gateway) browser_source=network line_number=0 stacktrace=<nil> url=https://test.k6.io/ 
2024-02-20 17:58:07.835 Failed to load resource: the server responded with a status of 502 (Bad Gateway) browser_source=network line_number=0 stacktrace=<nil> url=https://test.k6.io/
2024-02-20 17:58:07.841 Failed to load resource: the server responded with a status of 502 (Bad Gateway) browser_source=network line_number=0 stacktrace=<nil> url=https://test.k6.io/static/css/site.css
2024-02-20 17:58:07.853 Failed to load resource: the server responded with a status of 502 (Bad Gateway) browser_source=network line_number=0 stacktrace=<nil> url=https://test.k6.io/static/js/prisms.js
2024-02-20 17:58:07.856 Failed to load resource: the server responded with a status of 502 (Bad Gateway) browser_source=network line_number=0 stacktrace=<nil> url=https://test.k6.io/static/css/site.css
2024-02-20 17:58:39.547 Uncaught (in promise) clicking on "a[href=\"/my_messages.php\"]": timed out after 30s executor=per-vu-iterations scenario=browser
2024-02-20 17:58:39.600 Uncaught (in promise) clicking on "a[href=\"/my_messages.php\"]": timed out after 30s executor=per-vu-iterations scenario=browser
2024-02-20 17:58:40.597 Uncaught (in promise) navigating frame to "https://test.k6.io/": navigating to "https://test.k6.io/": timed out after 30s executor=per-vu-iterations scenario=browser
```

Failing here looks normal to me.


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates #1112, #971, and #966 (even maybe #970).