### PR TITLE
Add operation field to file upload

### DIFF
--- a/storage/file_persister.go
+++ b/storage/file_persister.go
@@ -147,12 +147,14 @@ func (r *RemoteFilePersister) getPreSignedURL(ctx context.Context, path string) 
 
 func buildPresignedRequestBody(basePath, path string) ([]byte, error) {
 	b := struct {
-		Service string `json:"service"`
-		Files   []struct {
+		Service   string `json:"service"`
+		Operation string `json:"operation"`
+		Files     []struct {
 			Name string `json:"name"`
 		} `json:"files"`
 	}{
-		Service: "aws_s3",
+		Service:   "aws_s3",
+		Operation: "upload",
 		Files: []struct {
 			Name string `json:"name"`
 		}{

--- a/storage/file_persister_test.go
+++ b/storage/file_persister_test.go
@@ -103,6 +103,7 @@ func TestRemoteFilePersister(t *testing.T) {
 			dataToUpload: "here's some data",
 			wantPresignedURLBody: `{
 					"service":"aws_s3",
+					"operation": "upload",
 					"files":[{"name":"screenshots/some/path/file.png"}]
 				}`,
 			wantPresignedHeaders: map[string]string{
@@ -118,6 +119,7 @@ func TestRemoteFilePersister(t *testing.T) {
 			dataToUpload: "here's some data",
 			wantPresignedURLBody: `{
 					"service":"aws_s3",
+					"operation": "upload",
 					"files":[{"name":"screenshots/some/path/file.png"}]
 				}`,
 			wantPresignedHeaders: map[string]string{
@@ -133,6 +135,7 @@ func TestRemoteFilePersister(t *testing.T) {
 			dataToUpload: "here's some data",
 			wantPresignedURLBody: `{
 					"service":"aws_s3",
+					"operation": "upload",
 					"files":[{"name":"screenshots/some/path/file.png"}]
 				}`,
 			wantPresignedHeaders: map[string]string{
@@ -148,6 +151,7 @@ func TestRemoteFilePersister(t *testing.T) {
 			dataToUpload: "here's some data",
 			wantPresignedURLBody: `{
 					"service":"aws_s3",
+					"operation": "upload",
 					"files":[{"name":"screenshots/some/path/file.png"}]
 				}`,
 			wantPresignedHeaders: map[string]string{
@@ -164,6 +168,7 @@ func TestRemoteFilePersister(t *testing.T) {
 			dataToUpload: "here's some data",
 			wantPresignedURLBody: `{
 					"service":"aws_s3",
+					"operation": "upload",
 					"files":[{"name":"screenshots/some/path/file.png"}]
 				}`,
 			wantPresignedHeaders: map[string]string{


### PR DESCRIPTION
## What?

Add `"operation": "upload"` to the file upload payload.

## Why?

This is a new requirement when uploading files to a remote location.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
