### PR TITLE
Refactor goja out of browserContext.addinitscript

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -814,25 +814,27 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 	return mapping{
 		"addCookies": bc.AddCookies,
 		"addInitScript": func(script goja.Value) error {
+			if !gojaValueExists(script) {
+				return nil
+			}
+
 			source := ""
-			if gojaValueExists(script) {
-				switch script.ExportType() {
-				case reflect.TypeOf(string("")):
-					source = script.String()
-				case reflect.TypeOf(goja.Object{}):
-					opts := script.ToObject(rt)
-					for _, k := range opts.Keys() {
-						if k == "content" {
-							source = opts.Get(k).String()
-						}
+			switch script.ExportType() {
+			case reflect.TypeOf(string("")):
+				source = script.String()
+			case reflect.TypeOf(goja.Object{}):
+				opts := script.ToObject(rt)
+				for _, k := range opts.Keys() {
+					if k == "content" {
+						source = opts.Get(k).String()
 					}
-				default:
-					_, isCallable := goja.AssertFunction(script)
-					if !isCallable {
-						source = fmt.Sprintf("(%s);", script.ToString().String())
-					} else {
-						source = fmt.Sprintf("(%s)(...args);", script.ToString().String())
-					}
+				}
+			default:
+				_, isCallable := goja.AssertFunction(script)
+				if !isCallable {
+					source = fmt.Sprintf("(%s);", script.ToString().String())
+				} else {
+					source = fmt.Sprintf("(%s)(...args);", script.ToString().String())
 				}
 			}
 

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -822,8 +822,7 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 				case reflect.TypeOf(goja.Object{}):
 					opts := script.ToObject(rt)
 					for _, k := range opts.Keys() {
-						switch k {
-						case "content":
+						if k == "content" {
 							source = opts.Get(k).String()
 						}
 					}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -114,13 +114,13 @@ func NewBrowserContext(
 	wv := rt.ToValue(js.WebVitalIIFEScript)
 	wvi := rt.ToValue(js.WebVitalInitScript)
 
-	if err := b.AddInitScript(k6Obj, nil); err != nil {
+	if err := b.AddInitScript(k6Obj); err != nil {
 		return nil, fmt.Errorf("adding k6 object to new browser context: %w", err)
 	}
-	if err := b.AddInitScript(wv, nil); err != nil {
+	if err := b.AddInitScript(wv); err != nil {
 		return nil, fmt.Errorf("adding web vital script to new browser context: %w", err)
 	}
-	if err := b.AddInitScript(wvi, nil); err != nil {
+	if err := b.AddInitScript(wvi); err != nil {
 		return nil, fmt.Errorf("adding web vital init script to new browser context: %w", err)
 	}
 
@@ -128,7 +128,7 @@ func NewBrowserContext(
 }
 
 // AddInitScript adds a script that will be initialized on all new pages.
-func (b *BrowserContext) AddInitScript(script goja.Value, arg goja.Value) error {
+func (b *BrowserContext) AddInitScript(script goja.Value) error {
 	b.logger.Debugf("BrowserContext:AddInitScript", "bctxid:%v", b.id)
 
 	rt := b.vu.Runtime()

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"reflect"
 	"strings"
 	"time"
 
@@ -109,18 +108,13 @@ func NewBrowserContext(
 		}
 	}
 
-	rt := b.vu.Runtime()
-	k6Obj := rt.ToValue(js.K6ObjectScript)
-	wv := rt.ToValue(js.WebVitalIIFEScript)
-	wvi := rt.ToValue(js.WebVitalInitScript)
-
-	if err := b.AddInitScript(k6Obj); err != nil {
+	if err := b.AddInitScript(js.K6ObjectScript); err != nil {
 		return nil, fmt.Errorf("adding k6 object to new browser context: %w", err)
 	}
-	if err := b.AddInitScript(wv); err != nil {
+	if err := b.AddInitScript(js.WebVitalIIFEScript); err != nil {
 		return nil, fmt.Errorf("adding web vital script to new browser context: %w", err)
 	}
-	if err := b.AddInitScript(wvi); err != nil {
+	if err := b.AddInitScript(js.WebVitalInitScript); err != nil {
 		return nil, fmt.Errorf("adding web vital init script to new browser context: %w", err)
 	}
 
@@ -128,38 +122,13 @@ func NewBrowserContext(
 }
 
 // AddInitScript adds a script that will be initialized on all new pages.
-func (b *BrowserContext) AddInitScript(script goja.Value) error {
+func (b *BrowserContext) AddInitScript(script string) error {
 	b.logger.Debugf("BrowserContext:AddInitScript", "bctxid:%v", b.id)
 
-	rt := b.vu.Runtime()
-
-	source := ""
-	if gojaValueExists(script) {
-		switch script.ExportType() {
-		case reflect.TypeOf(string("")):
-			source = script.String()
-		case reflect.TypeOf(goja.Object{}):
-			opts := script.ToObject(rt)
-			for _, k := range opts.Keys() {
-				switch k {
-				case "content":
-					source = opts.Get(k).String()
-				}
-			}
-		default:
-			_, isCallable := goja.AssertFunction(script)
-			if !isCallable {
-				source = fmt.Sprintf("(%s);", script.ToString().String())
-			} else {
-				source = fmt.Sprintf("(%s)(...args);", script.ToString().String())
-			}
-		}
-	}
-
-	b.evaluateOnNewDocumentSources = append(b.evaluateOnNewDocumentSources, source)
+	b.evaluateOnNewDocumentSources = append(b.evaluateOnNewDocumentSources, script)
 
 	for _, p := range b.browser.getPages() {
-		if err := p.evaluateOnNewDocument(source); err != nil {
+		if err := p.evaluateOnNewDocument(script); err != nil {
 			return fmt.Errorf("adding init script to browser context: %w", err)
 		}
 	}


### PR DESCRIPTION
## What?

Refactor browserContext.addinitscript to move the goja code into the mapping layer.

## Why?

This will help isolate goja specific code in the mapping layer.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
https://github.com/grafana/xk6-browser/issues/1064
https://github.com/grafana/k6-cloud/issues/2066