### PR TITLE
Add test run id to RootModule

### DIFF
--- a/browser/module.go
+++ b/browser/module.go
@@ -38,6 +38,7 @@ type (
 		initOnce       *sync.Once
 		tracesMetadata map[string]string
 		filePersister  filePersister
+		testRunID      string
 	}
 
 	// JSModule exposes the properties available to the JS script.
@@ -91,6 +92,7 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 				),
 				taskQueueRegistry: newTaskQueueRegistry(vu),
 				filePersister:     m.filePersister,
+				testRunID:         m.testRunID,
 			}),
 			Devices:         common.GetDevices(),
 			NetworkProfiles: common.GetNetworkProfiles(),
@@ -125,6 +127,9 @@ func (m *RootModule) initialize(vu k6modules.VU) {
 	m.filePersister, err = newScreenshotPersister(initEnv.LookupEnv)
 	if err != nil {
 		k6ext.Abort(vu.Context(), "failed to create file persister: %v", err)
+	}
+	if e, ok := initEnv.LookupEnv(env.K6TestRunID); ok && e != "" {
+		m.testRunID = e
 	}
 }
 

--- a/browser/modulevu.go
+++ b/browser/modulevu.go
@@ -22,6 +22,8 @@ type moduleVU struct {
 	*taskQueueRegistry
 
 	filePersister
+
+	testRunID string
 }
 
 // browser returns the VU browser instance for the current iteration.

--- a/env/env.go
+++ b/env/env.go
@@ -81,6 +81,12 @@ const (
 	ScreenshotsOutput = "K6_BROWSER_SCREENSHOTS_OUTPUT"
 )
 
+const (
+	// K6TestRunID represents the test run id. Note: this was taken from
+	// k6.
+	K6TestRunID = "K6_CLOUD_PUSH_REF_ID"
+)
+
 // LookupFunc defines a function to look up a key from the environment.
 type LookupFunc func(key string) (string, bool)
 

--- a/env/env.go
+++ b/env/env.go
@@ -81,6 +81,7 @@ const (
 	ScreenshotsOutput = "K6_BROWSER_SCREENSHOTS_OUTPUT"
 )
 
+// Infrastructural.
 const (
 	// K6TestRunID represents the test run id. Note: this was taken from
 	// k6.


### PR DESCRIPTION
## What?

This adds the test run ID to the `RootModule` allowing any browser component to work with the test run ID.

## Why?

This is a requirement to allow better integration with external tools (such as faro)to be used to label sessions with a test run ID. The test run id will eventually be populated in the `window.k6` object which is injected into each and every `browserContext` and `page`.

The change localises the retrieval of the test run id in one place instead of having every component need to do a lookup for an env var.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/k6-cloud/issues/2066