### PR TITLE
Fix error for `evaluate` APIs

### DIFF
--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -206,7 +206,9 @@ func (e *ExecutionContext) eval(
 	)
 	if remoteObject, exceptionDetails, err = action.Do(cdp.WithExecutor(apiCtx, e.session)); err != nil {
 		var cdpe *cdproto.Error
-		if errors.As(err, &cdpe) && cdpe.Code == -32000 {
+		if errors.As(err, &cdpe) && cdpe.Message == "Given expression does not evaluate to a function" {
+			err = errors.New("given expression does not evaluate to a function")
+		} else if errors.As(err, &cdpe) && cdpe.Code == -32000 {
 			err = errors.New("execution context changed; most likely because of a navigation")
 		}
 		return nil, err

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -246,12 +246,12 @@ func TestPageEvaluateMappingError(t *testing.T) {
 		{
 			name:    "invalid",
 			script:  "5",
-			wantErr: "given expression does not evaluate to a function",
+			wantErr: "Given expression does not evaluate to a function",
 		},
 		{
 			name:    "invalid_with_brackets",
 			script:  "(6)",
-			wantErr: "given expression does not evaluate to a function",
+			wantErr: "Given expression does not evaluate to a function",
 		},
 	}
 


### PR DESCRIPTION
## What?

This fixes the error that is returned when a user works with the `evaluate` APIs when a navigation isn't occurring:

```js
  const page = browser.newPage();

  const blah = page.evaluate("1+1");
  console.log(blah);
  
  page.close();
```

This used to return `GoError: evaluating JS: execution context changed; most likely because of a navigation`, but now it returns `given expression does not evaluate to a function`.

## Why?

The new error better represents what the user can do to fix the problem instead of being left confused when no navigation has occurred. In the example above and with the new error, they should be able to work out that `evaluate` only works with callable functions.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
https://github.com/grafana/k6-cloud/issues/2066