### PR TITLE
WiP: Video capture

### DIFF
--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -18,7 +18,17 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 	rt := vu.Runtime()
 	maps := mapping{
 		"bringToFront": p.BringToFront,
-		"check":        p.Check,
+		"captureVideo": func(opts goja.Value) error {
+			ctx := vu.Context()
+
+			popts := common.NewVidepCaptureOptions()
+			if err := popts.Parse(ctx, opts); err != nil {
+				return fmt.Errorf("parsing page screencast options: %w", err)
+			}
+
+			return p.CaptureVideo(popts, vu.filePersister)
+		},
+		"check": p.Check,
 		"click": func(selector string, opts goja.Value) (*goja.Promise, error) {
 			popts, err := parseFrameClickOptions(vu.Context(), opts, p.Timeout())
 			if err != nil {
@@ -163,6 +173,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 		"setExtraHTTPHeaders":         p.SetExtraHTTPHeaders,
 		"setInputFiles":               p.SetInputFiles,
 		"setViewportSize":             p.SetViewportSize,
+		"stopVideoCapture":            p.StopVideCapture,
 		"tap": func(selector string, opts goja.Value) (*goja.Promise, error) {
 			popts := common.NewFrameTapOptions(p.Timeout())
 			if err := popts.Parse(vu.Context(), opts); err != nil {

--- a/common/page.go
+++ b/common/page.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -229,6 +230,9 @@ type Page struct {
 	closedMu sync.RWMutex
 	closed   bool
 
+	videoCaptureMu sync.RWMutex
+	videoCapture   *videocapture
+
 	// TODO: setter change these fields (mutex?)
 	emulatedSize     *EmulatedSize
 	mediaType        MediaType
@@ -334,6 +338,7 @@ func (p *Page) initEvents() {
 
 	events := []string{
 		cdproto.EventRuntimeConsoleAPICalled,
+		cdproto.EventPageScreencastFrame,
 	}
 	p.session.on(p.ctx, events, p.eventCh)
 
@@ -356,8 +361,17 @@ func (p *Page) initEvents() {
 					"sid:%v tid:%v", p.session.ID(), p.targetID)
 				return
 			case event := <-p.eventCh:
-				if ev, ok := event.data.(*cdpruntime.EventConsoleAPICalled); ok {
-					p.onConsoleAPICalled(ev)
+				p.logger.Debugf("Page:initEvents:event",
+					"sid:%v tid:%v event:%s eventDataType:%T", p.session.ID(), p.targetID, event.typ, event.data)
+				switch event.typ {
+				case cdproto.EventPageScreencastFrame:
+					if ev, ok := event.data.(*page.EventScreencastFrame); ok {
+						p.onScreencastFrame(ev)
+					}
+				case cdproto.EventRuntimeConsoleAPICalled:
+					if ev, ok := event.data.(*cdpruntime.EventConsoleAPICalled); ok {
+						p.onConsoleAPICalled(ev)
+					}
 				}
 			}
 		}
@@ -1091,6 +1105,67 @@ func (p *Page) Screenshot(opts *PageScreenshotOptions, sp ScreenshotPersister) (
 	return buf, err
 }
 
+// CaptureVideo will start a screen cast of the current page and save it to specified file.
+func (p *Page) CaptureVideo(opts *VideoCaptureOptions, scp VideoCapturePersister) error {
+	p.videoCaptureMu.RLock()
+	defer p.videoCaptureMu.RUnlock()
+
+	if p.videoCapture != nil {
+		return fmt.Errorf("ongoing video capture")
+	}
+
+	vc, err := newVideoCapture(p.ctx, p.logger, *opts, scp)
+	if err != nil {
+		return fmt.Errorf("creating video capture: %w", err)
+	}
+	p.videoCapture = vc
+
+	err = p.session.ExecuteWithoutExpectationOnReply(
+		p.ctx,
+		cdppage.CommandStartScreencast,
+		cdppage.StartScreencastParams{
+			Format:        "png",
+			Quality:       opts.Quality,
+			MaxWidth:      opts.MaxWidth,
+			MaxHeight:     opts.MaxHeight,
+			EveryNthFrame: opts.EveryNthFrame,
+		},
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("starting screen cast %w", err)
+	}
+
+	return nil
+}
+
+// StopVideCapture stops any ongoing screen capture. In none is ongoing, is nop
+func (p *Page) StopVideCapture() error {
+	p.videoCaptureMu.RLock()
+	defer p.videoCaptureMu.RUnlock()
+
+	if p.videoCapture == nil {
+		return nil
+	}
+
+	err := p.session.ExecuteWithoutExpectationOnReply(
+		p.ctx,
+		cdppage.CommandStopScreencast,
+		nil,
+		nil,
+	)
+	// don't return error to allow video to be recorded
+	if err != nil {
+		p.logger.Errorf("Page:StopVideoCapture", "sid:%v error:%v", p.sessionID(), err)
+	}
+
+	// prevent any pending frame to be sent to video capture while closing it
+	vc := p.videoCapture
+	p.videoCapture = nil
+
+	return vc.Close(p.ctx)
+}
+
 func (p *Page) SelectOption(selector string, values goja.Value, opts goja.Value) []string {
 	p.logger.Debugf("Page:SelectOption", "sid:%v selector:%s", p.sessionID(), selector)
 
@@ -1292,6 +1367,41 @@ func (p *Page) Workers() []*Worker {
 // For internal use only.
 func (p *Page) TargetID() string {
 	return p.targetID.String()
+}
+
+func (p *Page) onScreencastFrame(event *page.EventScreencastFrame) {
+	p.videoCaptureMu.RLock()
+	defer p.videoCaptureMu.RUnlock()
+
+	if p.videoCapture != nil {
+		err := p.session.ExecuteWithoutExpectationOnReply(
+			p.ctx,
+			cdppage.CommandScreencastFrameAck,
+			cdppage.ScreencastFrameAckParams{SessionID: event.SessionID},
+			nil,
+		)
+		if err != nil {
+			p.logger.Debugf("Page:onScreenCastFrame", "frame ack:%v", err)
+			return
+		}
+
+		frameData := make([]byte, base64.StdEncoding.DecodedLen(len(event.Data)))
+		_, err = base64.StdEncoding.Decode(frameData, []byte(event.Data))
+		if err != nil {
+			p.logger.Debugf("Page:onScreenCastFrame", "decoding frame :%v", err)
+		}
+		//content := base64.NewDecoder(base64.StdEncoding, bytes.NewBuffer([]byte(event.Data)))
+		err = p.videoCapture.handleFrame(
+			p.ctx,
+			&VideoFrame{
+				Content:   frameData,
+				Timestamp: event.Metadata.Timestamp.Time().UnixMilli(),
+			},
+		)
+		if err != nil {
+			p.logger.Debugf("Page:onScreenCastFrame", "handling frame :%v", err)
+		}
+	}
 }
 
 func (p *Page) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICalled) {

--- a/common/page_options.go
+++ b/common/page_options.go
@@ -32,6 +32,16 @@ type PageScreenshotOptions struct {
 	Quality        int64          `json:"quality"`
 }
 
+type VideoCaptureOptions struct {
+	Path          string      `json:"path"`
+	Format        VideoFormat `json:"format"`
+	FrameRate     int64       `json:"frameRate"`
+	Quality       int64       `json:"quality"`
+	EveryNthFrame int64       `json:"everyNthFrame"`
+	MaxWidth      int64       `json:"maxWidth"`
+	MaxHeight     int64       `json:"maxHeight"`
+}
+
 func NewPageEmulateMediaOptions(defaultMedia MediaType, defaultColorScheme ColorScheme, defaultReducedMotion ReducedMotion) *PageEmulateMediaOptions {
 	return &PageEmulateMediaOptions{
 		ColorScheme:   defaultColorScheme,
@@ -131,7 +141,7 @@ func (o *PageScreenshotOptions) Parse(ctx context.Context, opts goja.Value) erro
 			}
 		}
 
-		// Infer file format by path if format not explicitly specified (default is PNG)
+		// Infer file format by path if format not explicitly specified (default is jpg)
 		if o.Path != "" && !formatSpecified {
 			if strings.HasSuffix(o.Path, ".jpg") || strings.HasSuffix(o.Path, ".jpeg") {
 				o.Format = ImageFormatJPEG
@@ -140,4 +150,53 @@ func (o *PageScreenshotOptions) Parse(ctx context.Context, opts goja.Value) erro
 	}
 
 	return nil
+}
+
+func (o *VideoCaptureOptions) Parse(ctx context.Context, opts goja.Value) error {
+	rt := k6ext.Runtime(ctx)
+	if opts != nil && !goja.IsUndefined(opts) && !goja.IsNull(opts) {
+		formatSpecified := false
+		opts := opts.ToObject(rt)
+		for _, k := range opts.Keys() {
+			switch k {
+			case "everyNthFrame":
+				o.EveryNthFrame = opts.Get(k).ToInteger()
+			case "frameRate":
+				o.FrameRate = opts.Get(k).ToInteger()
+			case "maxHeigth":
+				o.MaxHeight = opts.Get(k).ToInteger()
+			case "maxWidth":
+				o.MaxWidth = opts.Get(k).ToInteger()
+			case "path":
+				o.Path = opts.Get(k).String()
+			case "quality":
+				o.Quality = opts.Get(k).ToInteger()
+			case "format":
+				if f, ok := videoFormatToID[opts.Get(k).String()]; ok {
+					o.Format = f
+					formatSpecified = true
+				}
+			}
+		}
+
+		// Infer file format by path if format not explicitly specified (default is webm)
+		// TODO: throw error if format is not defined
+		if o.Path != "" && !formatSpecified {
+			if strings.HasSuffix(o.Path, ".webm") {
+				o.Format = VideoFormatWebM
+			}
+		}
+	}
+
+	return nil
+}
+
+func NewVidepCaptureOptions() *VideoCaptureOptions {
+	return &VideoCaptureOptions{
+		Path:          "",
+		Format:        VideoFormatWebM,
+		Quality:       100,
+		FrameRate:     25,
+		EveryNthFrame: 1,
+	}
 }

--- a/common/videocapture.go
+++ b/common/videocapture.go
@@ -1,0 +1,150 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/grafana/xk6-browser/log"
+)
+
+// VideoCapturePersister defines the interface for persisting a video capture
+type VideoCapturePersister interface {
+	Persist(ctx context.Context, path string, data io.Reader) (err error)
+}
+
+type VideoFrame struct {
+	Content   []byte
+	Timestamp int64
+}
+
+// VideoFormat represents a video file format.
+type VideoFormat string
+
+// Valid video format options.
+const (
+	// VideoFormatWebM stores video as a series of jpeg files
+	VideoFormatWebM VideoFormat = "webm"
+)
+
+// String returns the video format as a string
+func (f VideoFormat) String() string {
+	return f.String()
+}
+
+var videoFormatToID = map[string]VideoFormat{ //nolint:gochecknoglobals
+	"webm": VideoFormatWebM,
+}
+
+type videocapture struct {
+	ctx       context.Context
+	logger    *log.Logger
+	opts      VideoCaptureOptions
+	persister VideoCapturePersister
+	ffmpegCmd exec.Cmd
+	ffmpegIn  io.WriteCloser
+	ffmpegOut io.ReadCloser
+	lastFrame VideoFrame
+}
+
+// creates a new videocapture for a session
+func newVideoCapture(
+	ctx context.Context,
+	logger *log.Logger,
+	opts VideoCaptureOptions,
+	persister VideoCapturePersister,
+) (*videocapture, error) {
+
+	// construct command to start ffmpeg to convert series of images into a video
+	// heavily inspired by puppeteer's screen recorder
+	// https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/node/ScreenRecorder.ts
+	ffmpegCmd := exec.Command(
+		"ffmpeg",
+		// create video from sequence of images
+		"-f", "image2pipe",
+		// copy stream without conversion
+		"-c:v", "png",
+		// set frame rate
+		"-framerate", fmt.Sprintf("%d", opts.FrameRate),
+		// read from stdin
+		"-i", "pipe:0",
+		// set output format
+		"-f", "webm",
+		// set quality
+		//"-crf", fmt.Sprintf("%d", opts.Quality),
+		// optimize for speed
+		"-deadline", "realtime", "-cpu-used", "8",
+		// write to sdtout
+		//"pipe:1",
+		"-y",
+		opts.Path, // FIXME: send to stdout
+	)
+	ffmpegCmd.Stderr = os.Stderr // FIXME: for debugging
+
+	ffmpegIn, err := ffmpegCmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("creating ffmpeg stdin pipe: %w", err)
+	}
+
+	// ffmpegOut, err := ffmpegCmd.StdoutPipe()
+	// if err != nil {
+	// 	return nil, fmt.Errorf("creating ffmpeg stdout pipe: %w", err)
+	// }
+
+	err = ffmpegCmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("starting ffmpeg: %w", err)
+	}
+
+	return &videocapture{
+		ctx:       ctx,
+		logger:    logger,
+		opts:      opts,
+		persister: persister,
+		ffmpegCmd: *ffmpegCmd,
+		ffmpegIn:  ffmpegIn,
+		//		ffmpegOut: ffmpegOut,
+	}, nil
+}
+
+// HandleFrame sends the frame to the video stream
+func (v *videocapture) handleFrame(ctx context.Context, frame *VideoFrame) error {
+	// time between frames (in milliseconds)
+	step := 1000 / v.opts.FrameRate
+
+	//normalize frame timestamp to a multiple of the step
+	timestamp := frame.Timestamp
+	if timestamp%step != 0 {
+		timestamp = ((timestamp + step) / step) * step
+	}
+
+	// repeat last frame to fill video until the current frame
+	if v.lastFrame.Timestamp > 0 {
+		for ts := v.lastFrame.Timestamp + step; ts < timestamp; ts += step {
+			if _, err := v.ffmpegIn.Write(v.lastFrame.Content); err != nil {
+				return fmt.Errorf("writing frame: %w", err)
+			}
+		}
+	}
+
+	if _, err := v.ffmpegIn.Write(frame.Content); err != nil {
+		return fmt.Errorf("writing frame: %w", err)
+	}
+
+	v.lastFrame = VideoFrame{Timestamp: timestamp, Content: frame.Content}
+
+	return nil
+}
+
+// Close stops the recording of the video capture
+func (v *videocapture) Close(ctx context.Context) error {
+	_ = v.ffmpegIn.Close()
+
+	// if err := v.persister.Persist(ctx, v.opts.Path, v.ffmpegOut); err != nil {
+	// 	return fmt.Errorf("creating video file: %w", err)
+	// }
+
+	return nil
+}


### PR DESCRIPTION
## What?

Implements a video recording API for the browser using the screencast API to capture screens and ffmpeg for converting them into a video (similar approach used by puppeteer's [screen recorder](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/node/ScreenRecorder.ts))

The functionality to start recording a video is added to the page interface. As it is not possible to have more than one active recording at a time, it was decided not to return a `screenrecorder` object as in the [puppeter's API ](ScreenRecorder), but leave the functionality to control the active recording (basically, stop the recording) in the page object itself. Addopting pupperter's model would be relatively simple. 

## Why?

- [ ] Capture what the end-user experience is like
- [ ] Help debug flaky tests that fail due to unforeseen changes in the page under test

Todo
- [ ] Fix: output directed from ffmpef to the file persister is truncated
- [ ] Ensure video is recorded if the page is closed
- [ ] Review API (method names, etc)
- [ ] Add tests 
- [ ] [ ] Review style
- [ ] Document
- [ ] Add Examples


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

Closes grafana/k6#4487 
