### PR TITLE
Fix fill functionality for textarea

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -270,7 +270,10 @@ func (h *ElementHandle) fill(_ context.Context, value string) error {
 	if !ok {
 		return fmt.Errorf("unexpected type %T", result)
 	}
-	if ok && s != resultDone {
+
+	if s == "needsinput" {
+		h.frame.page.Keyboard.InsertText(value)
+	} else if s != resultDone {
 		// Either we're done or an error happened (returned as "error:..." from JS)
 		return errorFromDOMError(s)
 	}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -24,6 +24,7 @@ import (
 )
 
 const resultDone = "done"
+const resultNeedsInput = "needsinput"
 
 type (
 	elementHandleActionFunc        func(context.Context, *ElementHandle) (any, error)
@@ -271,7 +272,7 @@ func (h *ElementHandle) fill(_ context.Context, value string) error {
 		return fmt.Errorf("unexpected type %T", result)
 	}
 
-	if s == "needsinput" {
+	if s == resultNeedsInput {
 		h.frame.page.Keyboard.InsertText(value)
 	} else if s != resultDone {
 		// Either we're done or an error happened (returned as "error:..." from JS)

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -104,6 +104,22 @@ func TestLocator(t *testing.T) {
 			},
 		},
 		{
+			"FillTextarea", func(tb *testBrowser, p *common.Page) {
+				const value = "fill me up"
+				p.Locator("textarea", nil).Fill(value, nil)
+				require.Equal(t, value, p.InputValue("textarea", nil))
+			},
+		},
+		{
+			"FillParagraph", func(tb *testBrowser, p *common.Page) {
+				const value = "fill me up"
+				p.Locator("#firstParagraph", nil).Fill(value, nil)
+				require.Equal(t, value, p.TextContent("#firstParagraph", nil))
+				l := p.Locator("#secondParagraph", nil)
+				assert.Panics(t, func() { l.Fill(value, nil) }, "should panic")
+			},
+		},
+		{
 			"Focus", func(tb *testBrowser, p *common.Page) {
 				focused := func() bool {
 					v := p.Evaluate(

--- a/tests/static/locators.html
+++ b/tests/static/locators.html
@@ -16,6 +16,8 @@
     <div id="divHello"><span>hello</span></div>
     <div><span>bye</span></div>
     <textarea>text area</textarea>
+    <p id="firstParagraph" contenteditable="true">original text</p>
+    <p id="secondParagraph">original text</p>
     <select id="selectElement"><option value="option text"></option><option value="option text 2"></option></select>
     <select></select>
     <script>


### PR DESCRIPTION
## What?

Fixes a bug, where calling fill() on textarea throws error. #1225 

## Why?

fill() should work for any contenteditable node. Currently it works only for ```<input>```

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#1225 

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
