### PR TITLE
Fix DocumentFragment XPath evaluate

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -23,8 +23,10 @@ import (
 	"github.com/grafana/xk6-browser/k6ext"
 )
 
-const resultDone = "done"
-const resultNeedsInput = "needsinput"
+const (
+	resultDone       = "done"
+	resultNeedsInput = "needsinput"
+)
 
 type (
 	elementHandleActionFunc        func(context.Context, *ElementHandle) (any, error)

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -124,6 +124,11 @@ class XPathQueryEngine {
       selector = "." + selector;
     }
     const result = [];
+
+    if (root instanceof DocumentFragment) {
+      root = convertToDocument(root);
+    }
+
     const document = root instanceof Document ? root : root.ownerDocument;
     if (!document) {
       return result;

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -125,6 +125,13 @@ class XPathQueryEngine {
     }
     const result = [];
 
+    // DocumentFragments cannot be queried with XPath and they do not implement
+    // evaluate. It first needs to be converted to a Document before being able
+    // to run the evaluate against it.
+    //
+    // This avoids the following error:
+    // - Failed to execute 'evaluate' on 'Document': The node provided is
+    //   '#document-fragment', which is not a valid context node type.
     if (root instanceof DocumentFragment) {
       root = convertToDocument(root);
     }
@@ -148,9 +155,9 @@ class XPathQueryEngine {
   }
 }
 
-// DocumentFragments cannot be queried with XPath and they do not
-// implement evaluate. It first needs to be converted to a Document
-// before being able to run the evaluate against it.
+// convertToDocument will convert a DocumentFragment into a Document. It does
+// this by creating a new Document and copying the elements from the
+// DocumentFragment to the Document.
 function convertToDocument(fragment) {
   var newDoc = document.implementation.createHTMLDocument("Temporary Document");
 
@@ -159,8 +166,9 @@ function convertToDocument(fragment) {
   return newDoc;
 }
 
-// Function to manually copy nodes to a new document, excluding ShadowRoot
-// nodes. ShadowRoot are not cloneable so we need to manually clone them.
+// copyNodesToDocument manually copies nodes to a new document, excluding
+// ShadowRoot nodes -- ShadowRoot are not cloneable so we need to manually
+// clone them one element at a time.
 function copyNodesToDocument(sourceNode, targetNode) {
   sourceNode.childNodes.forEach((child) => {
       if (child.nodeType === Node.ELEMENT_NODE) {

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -844,13 +844,18 @@ class InjectedScript {
       return result;
 
       async function onTimeout() {
-        if (timedOut) {
-          reject(`timed out after ${timeout}ms`);
+        try{
+          if (timedOut) {
+            reject(`timed out after ${timeout}ms`);
+            return;
+          }
+          const success = predicate();
+          if (success !== continuePolling) resolve(success);
+          else setTimeout(onTimeout, pollInterval);
+        } catch(error) {
+          reject(error);
           return;
         }
-        const success = predicate();
-        if (success !== continuePolling) resolve(success);
-        else setTimeout(onTimeout, pollInterval);
       }
     }
   }

--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -815,13 +815,22 @@ class InjectedScript {
       return result;
 
       async function onRaf() {
-        if (timedOut) {
-          reject(`timed out after ${timeout}ms`);
+        try {
+          if (timedOut) {
+            reject(`timed out after ${timeout}ms`);
+            return;
+          }
+          const success = predicate();
+          if (success !== continuePolling) {
+            resolve(success);
+            return
+          } else {
+            requestAnimationFrame(onRaf);
+          }
+        } catch (error) {
+          reject(error);
           return;
         }
-        const success = predicate();
-        if (success !== continuePolling) resolve(success);
-        else requestAnimationFrame(onRaf);
       }
     }
 

--- a/tests/static/shadow_and_doc_frag.html
+++ b/tests/static/shadow_and_doc_frag.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DocumentFragment and ShadowRoot Test page</title>
+</head>
+<body>
+    <h2>DocumentFragment and ShadowRoot Test page</h2>
+    <div id="docFrag"></div>
+
+    <!-- Element that will host the Shadow DOM -->
+    <div id="shadowHost"></div>
+
+    <script>
+        function addDocFrag() {
+            const container = document.getElementById('docFrag');
+            const fragment = document.createDocumentFragment();
+
+            // Add some additional text in a paragraph
+            const paragraph = document.createElement('p');
+            paragraph.id = 'inDocFrag'; // Set the id of the div
+            paragraph.textContent = 'This text is added via a document fragment!';
+            fragment.appendChild(paragraph);
+
+            // Append the fragment to the container
+            container.appendChild(fragment);
+        }
+
+        function addShadowDom() {
+            const shadowHost = document.getElementById('shadowHost');
+            // When mode is set to closed, we cannot access internals with JS.
+            // We will need to create a custom element that exposes these
+            // internals with getters and setters.
+            const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+
+            // Create a DocumentFragment to add to the Shadow DOM
+            const fragment = document.createDocumentFragment();
+
+            // Add some styled content to the fragment
+            const styleElement = document.createElement('style');
+            styleElement.textContent = `
+                p {
+                    color: blue;
+                    font-weight: bold;
+                }
+            `;
+            fragment.appendChild(styleElement);
+
+            const paragraphElement = document.createElement('p');
+            paragraphElement.id = 'inShadowRootDocFrag';
+            paragraphElement.textContent = 'This is inside Shadow DOM, added via a DocumentFragment!';
+            fragment.appendChild(paragraphElement);
+
+            // Append the DocumentFragment to the Shadow DOM.
+            shadowRoot.appendChild(fragment);
+        }
+
+        function done() {
+            // Create a new div element which will reside in the original Document.
+            const doneDiv = document.createElement('div');
+            doneDiv.id = 'done';
+            doneDiv.textContent = "All additions to page completed (i'm in the original document)";
+
+            // Append it to the original Document.
+            document.body.appendChild(doneDiv);
+        }
+
+        addDocFrag();
+        addShadowDom();
+        done();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## What?

This adds javascript code to convert a `DocumentFragment` into a `Document`.

## Why?

`DocumentFragment`s do not implement `evaluate` and so do not work with `XPath` selectors. When a `DocumentFragment` is encountered it will convert that to a `Document` so that `evalaute` with `XPath` selectors can be performed.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/1243