### PR TITLE
Remove the setInputFiles os.read support

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -2,13 +2,9 @@ package common
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"math"
-	"mime"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -1273,22 +1269,6 @@ func (h *ElementHandle) SetInputFiles(files goja.Value, opts goja.Value) error {
 	return nil
 }
 
-func (h *ElementHandle) resolveFiles(payload []*File) error {
-	for _, file := range payload {
-		if strings.TrimSpace(file.Path) != "" {
-			buffer, err := os.ReadFile(file.Path)
-			if err != nil {
-				return fmt.Errorf("reading file: %w", err)
-			}
-			file.Buffer = base64.StdEncoding.EncodeToString(buffer)
-			file.Name = filepath.Base(file.Path)
-			file.Mimetype = mime.TypeByExtension(filepath.Ext(file.Path))
-		}
-	}
-
-	return nil
-}
-
 func (h *ElementHandle) setInputFiles(apiCtx context.Context, payload []*File) error {
 	fn := `
 		(node, injected, payload) => {
@@ -1298,10 +1278,6 @@ func (h *ElementHandle) setInputFiles(apiCtx context.Context, payload []*File) e
 	evalOpts := evalOptions{
 		forceCallable: true,
 		returnByValue: true,
-	}
-	err := h.resolveFiles(payload)
-	if err != nil {
-		return err
 	}
 	result, err := h.evalWithScript(apiCtx, evalOpts, fn, payload)
 	if err != nil {

--- a/common/element_handle_options.go
+++ b/common/element_handle_options.go
@@ -78,7 +78,6 @@ type ElementHandleHoverOptions struct {
 
 // File is the descriptor of a single file.
 type File struct {
-	Path     string `json:"-"`
 	Name     string `json:"name"`
 	Mimetype string `json:"mimeType"`
 	Buffer   string `json:"buffer"`
@@ -204,7 +203,7 @@ func NewElementHandleSetInputFilesOptions(defaultTimeout time.Duration) *Element
 	}
 }
 
-// addFile to the struct. Input value can be a path, or a file descriptor object.
+// addFile to the struct. Input value can only be a file descriptor object.
 func (f *Files) addFile(ctx context.Context, file goja.Value) error {
 	if !gojaValueExists(file) {
 		return nil
@@ -218,10 +217,6 @@ func (f *Files) addFile(ctx context.Context, file goja.Value) error {
 			return fmt.Errorf("parsing file descriptor: %w", err)
 		}
 		f.Payload = append(f.Payload, &parsedFile)
-	case reflect.String: // file path
-		if v, ok := file.Export().(string); ok {
-			f.Payload = append(f.Payload, &File{Path: v})
-		}
 	default:
 		return fmt.Errorf("invalid parameter type : %s", fileType.Kind().String())
 	}

--- a/tests/setinputfiles_test.go
+++ b/tests/setinputfiles_test.go
@@ -1,8 +1,6 @@
 package tests
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/dop251/goja"
@@ -93,76 +91,6 @@ func TestSetInputFiles(t *testing.T) {
 			},
 		},
 		{
-			name: "set_one_file_with_path",
-			setup: func(tb *testBrowser) (goja.Value, func()) {
-				tempFile, err := os.CreateTemp("", "*.json")
-				assert.NoError(t, err)
-				n, err := tempFile.Write([]byte("0123456789"))
-				assert.Equal(t, 10, n)
-				assert.NoError(t, err)
-				cleanupFunc := func() {
-					err := os.Remove(tempFile.Name())
-					assert.NoError(t, err)
-				}
-				return tb.toGojaValue(tempFile.Name()), cleanupFunc
-			},
-			tests: []testFn{defaultTestPage, defaultTestElementHandle},
-			check: func(t *testing.T, getFileCountFn func() interface{}, getFilePropFn indexedFn, err error) {
-				t.Helper()
-				assert.NoError(t, err)
-				// check if input has 1 file
-				assert.Equal(t, float64(1), getFileCountFn())
-				// check added file is correct
-				filename, ok := getFilePropFn(0, propName).(string)
-				assert.True(t, ok)
-				assert.Equal(t, ".json", filepath.Ext(filename))
-				assert.Equal(t, float64(10), getFilePropFn(0, propSize))
-				assert.Equal(t, "application/json", getFilePropFn(0, propType))
-			},
-		},
-		{
-			name: "set_two_files_with_path",
-			setup: func(tb *testBrowser) (goja.Value, func()) {
-				tempFile1, err := os.CreateTemp("", "*.json")
-				assert.NoError(t, err)
-				n, err := tempFile1.Write([]byte("0123456789"))
-				assert.Equal(t, 10, n)
-				assert.NoError(t, err)
-
-				tempFile2, err := os.CreateTemp("", "*.xml")
-				assert.NoError(t, err)
-				n, err = tempFile2.Write([]byte("012345678901234"))
-				assert.Equal(t, 15, n)
-				assert.NoError(t, err)
-				cleanupFunc := func() {
-					err := os.Remove(tempFile1.Name())
-					assert.NoError(t, err)
-					err = os.Remove(tempFile2.Name())
-					assert.NoError(t, err)
-				}
-
-				return tb.toGojaValue([]string{tempFile1.Name(), tempFile2.Name()}), cleanupFunc
-			},
-			tests: []testFn{defaultTestPage, defaultTestElementHandle},
-			check: func(t *testing.T, getFileCountFn func() interface{}, getFilePropFn indexedFn, err error) {
-				t.Helper()
-				assert.NoError(t, err)
-				// check if input has 2 files
-				assert.Equal(t, float64(2), getFileCountFn())
-				// check added files are correct
-				filename1, ok := getFilePropFn(0, propName).(string)
-				assert.True(t, ok)
-				assert.Equal(t, ".json", filepath.Ext(filename1))
-				assert.Equal(t, float64(10), getFilePropFn(0, propSize))
-				assert.Equal(t, "application/json", getFilePropFn(0, propType))
-				filename2, ok := getFilePropFn(1, propName).(string)
-				assert.True(t, ok)
-				assert.Equal(t, ".xml", filepath.Ext(filename2))
-				assert.Equal(t, float64(15), getFilePropFn(1, propSize))
-				assert.Equal(t, "text/xml; charset=utf-8", getFilePropFn(1, propType))
-			},
-		},
-		{
 			name: "set_nil",
 			setup: func(tb *testBrowser) (goja.Value, func()) {
 				return tb.toGojaValue(nil), nil
@@ -184,24 +112,6 @@ func TestSetInputFiles(t *testing.T) {
 			check: func(t *testing.T, getFileCountFn func() interface{}, getFilePropFn indexedFn, err error) {
 				t.Helper()
 				assert.ErrorContains(t, err, "invalid parameter type : int64")
-				// check if input has 0 file
-				assert.Equal(t, float64(0), getFileCountFn())
-			},
-		},
-		{
-			name: "set_file_not_exists",
-			setup: func(tb *testBrowser) (goja.Value, func()) {
-				tempFile, err := os.CreateTemp("", "*.json")
-				assert.NoError(t, err)
-				err = os.Remove(tempFile.Name())
-				assert.NoError(t, err)
-				return tb.toGojaValue(tempFile.Name()), nil
-			},
-			tests: []testFn{defaultTestPage, defaultTestElementHandle},
-			check: func(t *testing.T, getFileCountFn func() interface{}, getFilePropFn indexedFn, err error) {
-				t.Helper()
-				assert.ErrorContains(t, err, "reading file:")
-				assert.ErrorContains(t, err, "setting input files")
 				// check if input has 0 file
 				assert.Equal(t, float64(0), getFileCountFn())
 			},


### PR DESCRIPTION
## What?

Removing the support for `setInputFiles` to read off of the filesystem with the os package.

## Why?

We do not want k6 to be able to read anything off of a filesystem that it shouldn't be reading. Instead anyone wishing to work with files on the filesystem should look to use the built in [experimental fs module](https://grafana.com/docs/k6/latest/javascript-api/k6-experimental/fs/). The fs module abstracts away the detail of how it loads the required file for when working in a remote environment. It also reduces the risk of OOMs. A simple example can be found below:

<details>

<summary>Example working with `setInputFiles` and the fs module</summary>

```js
import { browser } from 'k6/experimental/browser';
import encoding from 'k6/encoding';
import { open } from 'k6/experimental/fs';

export const options = {
  scenarios: {
    ui: {
      executor: 'shared-iterations',
      iterations: 1,
      vus: 1,
      options: {
        browser: {
          type: 'chromium'
        },
      },
    },
  },
}

let file;
(async function () {
  file = await open('/abs/path/to/file.txt');
})();

export default async function () {
  const page = browser.newPage();

  await page.goto(url)

  const buffer = await readAll(file);

  page.setInputFiles('input[id="upload"]', { name: 'file.txt', mimetype: 'text/plain', buffer: encoding.b64encode(buffer) })
  
  const submitButton = page.locator('input[type="submit"]')
  await Promise.all([page.waitForNavigation(), submitButton.click()])

  page.close();
}

async function readAll(file) {
  const fileInfo = await file.stat();
  const buffer = new Uint8Array(fileInfo.size);

  const bytesRead = await file.read(buffer);
  if (bytesRead !== fileInfo.size) {
    throw new Error(
      'unexpected number of bytes read; expected ' +
      fileInfo.size +
      ' but got ' +
      bytesRead +
      ' bytes'
    );
  }

  return buffer;
}

```

</details>

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
