### PR TITLE
Remove logging in-flight requests

### DIFF
--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -447,24 +447,6 @@ func (m *FrameManager) requestFailed(req *Request, canceled bool) {
 	}
 	frame.deleteRequest(req.getID())
 
-	ifr := frame.cloneInflightRequests()
-	switch rc := len(ifr); {
-	case rc <= 10:
-		for reqID := range ifr {
-			req, ok := frame.requestByID(reqID)
-			if !ok {
-				m.logger.Debugf("FrameManager:requestFailed:rc<=10 request is nil",
-					"reqID:%s frameID:%s",
-					reqID, frame.ID())
-				continue
-			}
-
-			m.logger.Debugf("FrameManager:requestFailed:rc<=10",
-				"reqID:%s inflightURL:%s frameID:%s",
-				reqID, req.URL(), frame.ID())
-		}
-	}
-
 	frame.pendingDocumentMu.RLock()
 	if frame.pendingDocument == nil || frame.pendingDocument.request != req {
 		m.logger.Debugf("FrameManager:requestFailed:return", "fmid:%d pdoc:nil", m.ID())


### PR DESCRIPTION
## What?

Remove logging in-flight requests when a request is failed.

## Why?

We noticed we shouldn't find an internally failed request, as it can cause race condition issues within the module's internal components. Also, we've decided that logging in-flight requests only adds noise without bringing any tangential value.

We keep logging the failed request, though.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updated #986