### PR TITLE
Refactor APIs that are traced

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -692,9 +692,15 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 		"pause":  p.Pause,
 		"pdf":    p.Pdf,
 		"press":  p.Press,
-		"reload": func(opts goja.Value) *goja.Object {
-			r := mapResponse(vu, p.Reload(opts))
-			return rt.ToValue(r).ToObject(rt)
+		"reload": func(opts goja.Value) (*goja.Object, error) {
+			resp, err := p.Reload(opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+
+			r := mapResponse(vu, resp)
+
+			return rt.ToValue(r).ToObject(rt), nil
 		},
 		"route": p.Route,
 		"screenshot": func(opts goja.Value) (*goja.ArrayBuffer, error) {

--- a/common/browser.go
+++ b/common/browser.go
@@ -557,12 +557,12 @@ func (b *Browser) NewContext(opts goja.Value) (*BrowserContext, error) {
 	browserContextID, err := action.Do(cdp.WithExecutor(b.ctx, b.conn))
 	b.logger.Debugf("Browser:NewContext", "bctxid:%v", browserContextID)
 	if err != nil {
-		k6ext.Panic(b.ctx, "creating browser context ID %s: %w", browserContextID, err)
+		return nil, fmt.Errorf("creating browser context ID %s: %w", browserContextID, err)
 	}
 
 	browserCtxOpts := NewBrowserContextOptions()
 	if err := browserCtxOpts.Parse(b.ctx, opts); err != nil {
-		k6ext.Panic(b.ctx, "parsing newContext options: %w", err)
+		return nil, fmt.Errorf("parsing newContext options: %w", err)
 	}
 
 	browserCtx, err := NewBrowserContext(b.ctx, b, browserContextID, browserCtxOpts, b.logger)

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -342,7 +342,13 @@ func TestLocator(t *testing.T) {
 			},
 		},
 		{
-			"Type", func(l *common.Locator, tb *testBrowser) { l.Type("a", timeout(tb)) },
+			"Type", func(l *common.Locator, tb *testBrowser) {
+				err := l.Type("a", timeout(tb))
+				if err != nil {
+					// TODO: remove panic and update tests when all locator methods return error.
+					panic(err)
+				}
+			},
 		},
 		{
 			"TextContent", func(l *common.Locator, tb *testBrowser) { l.TextContent(timeout(tb)) },


### PR DESCRIPTION
## What?

Refactor the APIs that are currently traced so that they return an error instead of panicking.

## Why?

This refactor is to enable to the work for https://github.com/grafana/xk6-browser/issues/1249. We need access to the error itself so that it can be added to the span.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
https://github.com/grafana/xk6-browser/issues/1249