### PR TITLE
Add errors to spans

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -559,21 +559,21 @@ func (b *Browser) NewContext(opts goja.Value) (*BrowserContext, error) {
 	browserContextID, err := action.Do(cdp.WithExecutor(b.ctx, b.conn))
 	b.logger.Debugf("Browser:NewContext", "bctxid:%v", browserContextID)
 	if err != nil {
-		err = fmt.Errorf("creating browser context ID %s: %w", browserContextID, err)
+		err := fmt.Errorf("creating browser context ID %s: %w", browserContextID, err)
 		SpanRecordError(span, "browserContext creation in Chrome failed", err)
 		return nil, err
 	}
 
 	browserCtxOpts := NewBrowserContextOptions()
 	if err := browserCtxOpts.Parse(b.ctx, opts); err != nil {
-		err = fmt.Errorf("parsing newContext options: %w", err)
+		err := fmt.Errorf("parsing newContext options: %w", err)
 		SpanRecordError(span, "new browserContext options parsing failed", err)
 		return nil, err
 	}
 
 	browserCtx, err := NewBrowserContext(b.ctx, b, browserContextID, browserCtxOpts, b.logger)
 	if err != nil {
-		err = fmt.Errorf("new context: %w", err)
+		err := fmt.Errorf("new context: %w", err)
 		SpanRecordError(span, "new browserContext creation failed", err)
 		return nil, err
 	}
@@ -592,7 +592,7 @@ func (b *Browser) NewPage(opts goja.Value) (*Page, error) {
 
 	browserCtx, err := b.NewContext(opts)
 	if err != nil {
-		err = fmt.Errorf("new page: %w", err)
+		err := fmt.Errorf("new page: %w", err)
 		SpanRecordError(span, "new browserContext creation failed", err)
 		return nil, err
 	}

--- a/common/browser.go
+++ b/common/browser.go
@@ -551,7 +551,7 @@ func (b *Browser) NewContext(opts goja.Value) (*BrowserContext, error) {
 
 	if b.context != nil {
 		err := errors.New("existing browser context must be closed before creating a new one")
-		spanRecordError(span, "browserContext already exists", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 
@@ -560,21 +560,21 @@ func (b *Browser) NewContext(opts goja.Value) (*BrowserContext, error) {
 	b.logger.Debugf("Browser:NewContext", "bctxid:%v", browserContextID)
 	if err != nil {
 		err := fmt.Errorf("creating browser context ID %s: %w", browserContextID, err)
-		spanRecordError(span, "browserContext creation in Chrome failed", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 
 	browserCtxOpts := NewBrowserContextOptions()
 	if err := browserCtxOpts.Parse(b.ctx, opts); err != nil {
 		err := fmt.Errorf("parsing newContext options: %w", err)
-		spanRecordError(span, "new browserContext options parsing failed", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 
 	browserCtx, err := NewBrowserContext(b.ctx, b, browserContextID, browserCtxOpts, b.logger)
 	if err != nil {
 		err := fmt.Errorf("new context: %w", err)
-		spanRecordError(span, "new browserContext creation failed", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 
@@ -593,13 +593,13 @@ func (b *Browser) NewPage(opts goja.Value) (*Page, error) {
 	browserCtx, err := b.NewContext(opts)
 	if err != nil {
 		err := fmt.Errorf("new page: %w", err)
-		spanRecordError(span, "new browserContext creation failed", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 
 	page, err := browserCtx.NewPage()
 	if err != nil {
-		spanRecordError(span, "new page creation failed", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 

--- a/common/browser.go
+++ b/common/browser.go
@@ -584,10 +584,18 @@ func (b *Browser) NewPage(opts goja.Value) (*Page, error) {
 
 	browserCtx, err := b.NewContext(opts)
 	if err != nil {
-		return nil, fmt.Errorf("new page: %w", err)
+		err = fmt.Errorf("new page: %w", err)
+		SpanRecordError(span, "new browserContext creation failed", err)
+		return nil, err
 	}
 
-	return browserCtx.NewPage()
+	page, err := browserCtx.NewPage()
+	if err != nil {
+		SpanRecordError(span, "new page creation failed", err)
+		return nil, err
+	}
+
+	return page, nil
 }
 
 // On returns a Promise that is resolved when the browser process is disconnected.

--- a/common/browser.go
+++ b/common/browser.go
@@ -550,24 +550,32 @@ func (b *Browser) NewContext(opts goja.Value) (*BrowserContext, error) {
 	defer span.End()
 
 	if b.context != nil {
-		return nil, errors.New("existing browser context must be closed before creating a new one")
+		err := errors.New("existing browser context must be closed before creating a new one")
+		SpanRecordError(span, "browserContext already exists", err)
+		return nil, err
 	}
 
 	action := target.CreateBrowserContext().WithDisposeOnDetach(true)
 	browserContextID, err := action.Do(cdp.WithExecutor(b.ctx, b.conn))
 	b.logger.Debugf("Browser:NewContext", "bctxid:%v", browserContextID)
 	if err != nil {
-		return nil, fmt.Errorf("creating browser context ID %s: %w", browserContextID, err)
+		err = fmt.Errorf("creating browser context ID %s: %w", browserContextID, err)
+		SpanRecordError(span, "browserContext creation in Chrome failed", err)
+		return nil, err
 	}
 
 	browserCtxOpts := NewBrowserContextOptions()
 	if err := browserCtxOpts.Parse(b.ctx, opts); err != nil {
-		return nil, fmt.Errorf("parsing newContext options: %w", err)
+		err = fmt.Errorf("parsing newContext options: %w", err)
+		SpanRecordError(span, "new browserContext options parsing failed", err)
+		return nil, err
 	}
 
 	browserCtx, err := NewBrowserContext(b.ctx, b, browserContextID, browserCtxOpts, b.logger)
 	if err != nil {
-		return nil, fmt.Errorf("new context: %w", err)
+		err = fmt.Errorf("new context: %w", err)
+		SpanRecordError(span, "new browserContext creation failed", err)
+		return nil, err
 	}
 
 	b.contextMu.Lock()

--- a/common/browser.go
+++ b/common/browser.go
@@ -551,7 +551,7 @@ func (b *Browser) NewContext(opts goja.Value) (*BrowserContext, error) {
 
 	if b.context != nil {
 		err := errors.New("existing browser context must be closed before creating a new one")
-		SpanRecordError(span, "browserContext already exists", err)
+		spanRecordError(span, "browserContext already exists", err)
 		return nil, err
 	}
 
@@ -560,21 +560,21 @@ func (b *Browser) NewContext(opts goja.Value) (*BrowserContext, error) {
 	b.logger.Debugf("Browser:NewContext", "bctxid:%v", browserContextID)
 	if err != nil {
 		err := fmt.Errorf("creating browser context ID %s: %w", browserContextID, err)
-		SpanRecordError(span, "browserContext creation in Chrome failed", err)
+		spanRecordError(span, "browserContext creation in Chrome failed", err)
 		return nil, err
 	}
 
 	browserCtxOpts := NewBrowserContextOptions()
 	if err := browserCtxOpts.Parse(b.ctx, opts); err != nil {
 		err := fmt.Errorf("parsing newContext options: %w", err)
-		SpanRecordError(span, "new browserContext options parsing failed", err)
+		spanRecordError(span, "new browserContext options parsing failed", err)
 		return nil, err
 	}
 
 	browserCtx, err := NewBrowserContext(b.ctx, b, browserContextID, browserCtxOpts, b.logger)
 	if err != nil {
 		err := fmt.Errorf("new context: %w", err)
-		SpanRecordError(span, "new browserContext creation failed", err)
+		spanRecordError(span, "new browserContext creation failed", err)
 		return nil, err
 	}
 
@@ -593,13 +593,13 @@ func (b *Browser) NewPage(opts goja.Value) (*Page, error) {
 	browserCtx, err := b.NewContext(opts)
 	if err != nil {
 		err := fmt.Errorf("new page: %w", err)
-		SpanRecordError(span, "new browserContext creation failed", err)
+		spanRecordError(span, "new browserContext creation failed", err)
 		return nil, err
 	}
 
 	page, err := browserCtx.NewPage()
 	if err != nil {
-		SpanRecordError(span, "new page creation failed", err)
+		spanRecordError(span, "new page creation failed", err)
 		return nil, err
 	}
 

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -219,7 +219,9 @@ func (b *BrowserContext) NewPage() (*Page, error) {
 
 	p, err := b.browser.newPageInContext(b.id)
 	if err != nil {
-		return nil, fmt.Errorf("creating new page in browser context: %w", err)
+		err = fmt.Errorf("creating new page in browser context: %w", err)
+		SpanRecordError(span, "failed to create a new page", err)
+		return nil, err
 	}
 
 	var (

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -219,7 +219,7 @@ func (b *BrowserContext) NewPage() (*Page, error) {
 
 	p, err := b.browser.newPageInContext(b.id)
 	if err != nil {
-		err = fmt.Errorf("creating new page in browser context: %w", err)
+		err := fmt.Errorf("creating new page in browser context: %w", err)
 		SpanRecordError(span, "failed to create a new page", err)
 		return nil, err
 	}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -220,7 +220,7 @@ func (b *BrowserContext) NewPage() (*Page, error) {
 	p, err := b.browser.newPageInContext(b.id)
 	if err != nil {
 		err := fmt.Errorf("creating new page in browser context: %w", err)
-		spanRecordError(span, "failed to create a new page", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -220,7 +220,7 @@ func (b *BrowserContext) NewPage() (*Page, error) {
 	p, err := b.browser.newPageInContext(b.id)
 	if err != nil {
 		err := fmt.Errorf("creating new page in browser context: %w", err)
-		SpanRecordError(span, "failed to create a new page", err)
+		spanRecordError(span, "failed to create a new page", err)
 		return nil, err
 	}
 

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1184,7 +1184,7 @@ func (h *ElementHandle) Screenshot(
 	buf, err := s.screenshotElement(h, opts)
 	if err != nil {
 		err := fmt.Errorf("taking screenshot of elementHandle: %w", err)
-		spanRecordError(span, "failed to take screenshot", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1183,7 +1183,9 @@ func (h *ElementHandle) Screenshot(
 	s := newScreenshotter(spanCtx, sp)
 	buf, err := s.screenshotElement(h, opts)
 	if err != nil {
-		return nil, fmt.Errorf("taking screenshot of elementHandle: %w", err)
+		err = fmt.Errorf("taking screenshot of elementHandle: %w", err)
+		SpanRecordError(span, "failed to take screenshot", err)
+		return nil, err
 	}
 
 	return buf, err

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1184,7 +1184,7 @@ func (h *ElementHandle) Screenshot(
 	buf, err := s.screenshotElement(h, opts)
 	if err != nil {
 		err := fmt.Errorf("taking screenshot of elementHandle: %w", err)
-		SpanRecordError(span, "failed to take screenshot", err)
+		spanRecordError(span, "failed to take screenshot", err)
 		return nil, err
 	}
 

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1183,7 +1183,7 @@ func (h *ElementHandle) Screenshot(
 	s := newScreenshotter(spanCtx, sp)
 	buf, err := s.screenshotElement(h, opts)
 	if err != nil {
-		err = fmt.Errorf("taking screenshot of elementHandle: %w", err)
+		err := fmt.Errorf("taking screenshot of elementHandle: %w", err)
 		SpanRecordError(span, "failed to take screenshot", err)
 		return nil, err
 	}

--- a/common/locator.go
+++ b/common/locator.go
@@ -521,10 +521,14 @@ func (l *Locator) Type(text string, opts goja.Value) error {
 
 	copts := NewFrameTypeOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		return fmt.Errorf("parsing type options: %w", err)
+		err = fmt.Errorf("parsing type options: %w", err)
+		SpanRecordError(span, "type option parsing failed", err)
+		return err
 	}
 	if err := l.typ(text, copts); err != nil {
-		return fmt.Errorf("typing %q in %q: %w", text, l.selector, err)
+		err = fmt.Errorf("typing %q in %q: %w", text, l.selector, err)
+		SpanRecordError(span, "type failed", err)
+		return err
 	}
 
 	applySlowMo(l.ctx)

--- a/common/locator.go
+++ b/common/locator.go
@@ -65,7 +65,7 @@ func (l *Locator) Click(opts *FrameClickOptions) error {
 
 	if err := l.click(opts); err != nil {
 		err := fmt.Errorf("clicking on %q: %w", l.selector, err)
-		SpanRecordError(span, "click failed", err)
+		spanRecordError(span, "click failed", err)
 		return err
 	}
 
@@ -522,12 +522,12 @@ func (l *Locator) Type(text string, opts goja.Value) error {
 	copts := NewFrameTypeOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
 		err := fmt.Errorf("parsing type options: %w", err)
-		SpanRecordError(span, "type option parsing failed", err)
+		spanRecordError(span, "type option parsing failed", err)
 		return err
 	}
 	if err := l.typ(text, copts); err != nil {
 		err := fmt.Errorf("typing %q in %q: %w", text, l.selector, err)
-		SpanRecordError(span, "type failed", err)
+		spanRecordError(span, "type failed", err)
 		return err
 	}
 

--- a/common/locator.go
+++ b/common/locator.go
@@ -64,7 +64,9 @@ func (l *Locator) Click(opts *FrameClickOptions) error {
 	defer span.End()
 
 	if err := l.click(opts); err != nil {
-		return fmt.Errorf("clicking on %q: %w", l.selector, err)
+		err = fmt.Errorf("clicking on %q: %w", l.selector, err)
+		SpanRecordError(span, "click failed", err)
+		return err
 	}
 
 	applySlowMo(l.ctx)

--- a/common/locator.go
+++ b/common/locator.go
@@ -64,7 +64,7 @@ func (l *Locator) Click(opts *FrameClickOptions) error {
 	defer span.End()
 
 	if err := l.click(opts); err != nil {
-		err = fmt.Errorf("clicking on %q: %w", l.selector, err)
+		err := fmt.Errorf("clicking on %q: %w", l.selector, err)
 		SpanRecordError(span, "click failed", err)
 		return err
 	}
@@ -521,12 +521,12 @@ func (l *Locator) Type(text string, opts goja.Value) error {
 
 	copts := NewFrameTypeOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parsing type options: %w", err)
+		err := fmt.Errorf("parsing type options: %w", err)
 		SpanRecordError(span, "type option parsing failed", err)
 		return err
 	}
 	if err := l.typ(text, copts); err != nil {
-		err = fmt.Errorf("typing %q in %q: %w", text, l.selector, err)
+		err := fmt.Errorf("typing %q in %q: %w", text, l.selector, err)
 		SpanRecordError(span, "type failed", err)
 		return err
 	}

--- a/common/locator.go
+++ b/common/locator.go
@@ -65,7 +65,7 @@ func (l *Locator) Click(opts *FrameClickOptions) error {
 
 	if err := l.click(opts); err != nil {
 		err := fmt.Errorf("clicking on %q: %w", l.selector, err)
-		spanRecordError(span, "click failed", err)
+		spanRecordError(span, err)
 		return err
 	}
 
@@ -522,12 +522,12 @@ func (l *Locator) Type(text string, opts goja.Value) error {
 	copts := NewFrameTypeOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
 		err := fmt.Errorf("parsing type options: %w", err)
-		spanRecordError(span, "type option parsing failed", err)
+		spanRecordError(span, err)
 		return err
 	}
 	if err := l.typ(text, copts); err != nil {
 		err := fmt.Errorf("typing %q in %q: %w", text, l.selector, err)
-		spanRecordError(span, "type failed", err)
+		spanRecordError(span, err)
 		return err
 	}
 

--- a/common/page.go
+++ b/common/page.go
@@ -658,7 +658,7 @@ func (p *Page) Close(_ goja.Value) error {
 	add := runtime.RemoveBinding(webVitalBinding)
 	if err := add.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
 		err := fmt.Errorf("internal error while removing binding from page: %w", err)
-		spanRecordError(span, "close failed due to internal error", err)
+		spanRecordError(span, err)
 		return err
 	}
 
@@ -679,7 +679,7 @@ func (p *Page) Close(_ goja.Value) error {
 		}
 
 		err := fmt.Errorf("closing a page: %w", err)
-		spanRecordError(span, "close failed", err)
+		spanRecordError(span, err)
 		return err
 	}
 
@@ -832,7 +832,7 @@ func (p *Page) Goto(url string, opts *FrameGotoOptions) (*Response, error) {
 
 	resp, err := p.MainFrame().Goto(url, opts)
 	if err != nil {
-		spanRecordError(span, "goto failed", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 
@@ -996,7 +996,7 @@ func (p *Page) Reload(opts goja.Value) (*Response, error) { //nolint:funlen,cycl
 	)
 	if err := parsedOpts.Parse(p.ctx, opts); err != nil {
 		err := fmt.Errorf("parsing reload options: %w", err)
-		spanRecordError(span, "reload option parsing failed", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 
@@ -1024,7 +1024,7 @@ func (p *Page) Reload(opts goja.Value) (*Response, error) { //nolint:funlen,cycl
 	action := cdppage.Reload()
 	if err := action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
 		err := fmt.Errorf("reloading page: %w", err)
-		spanRecordError(span, "reload failed", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 
@@ -1046,7 +1046,7 @@ func (p *Page) Reload(opts goja.Value) (*Response, error) { //nolint:funlen,cycl
 	case <-p.ctx.Done():
 	case <-timeoutCtx.Done():
 		err := wrapTimeoutError(timeoutCtx.Err())
-		spanRecordError(span, "reload navigation timed out", err)
+		spanRecordError(span, err)
 		return nil, err
 	case data := <-ch:
 		event = data.(*NavigationEvent)
@@ -1064,7 +1064,7 @@ func (p *Page) Reload(opts goja.Value) (*Response, error) { //nolint:funlen,cycl
 	case <-lifecycleEvtCh:
 	case <-timeoutCtx.Done():
 		err := wrapTimeoutError(timeoutCtx.Err())
-		spanRecordError(span, "reload lifecycle timed out", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 
@@ -1084,7 +1084,7 @@ func (p *Page) Screenshot(opts *PageScreenshotOptions, sp ScreenshotPersister) (
 	buf, err := s.screenshotPage(p, opts)
 	if err != nil {
 		err := fmt.Errorf("taking screenshot of page: %w", err)
-		spanRecordError(span, "screenshot failed", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 
@@ -1256,7 +1256,7 @@ func (p *Page) WaitForNavigation(opts *FrameWaitForNavigationOptions) (*Response
 
 	resp, err := p.frameManager.MainFrame().WaitForNavigation(opts)
 	if err != nil {
-		spanRecordError(span, "waiting for navigation failed", err)
+		spanRecordError(span, err)
 		return nil, err
 	}
 

--- a/common/page.go
+++ b/common/page.go
@@ -658,7 +658,7 @@ func (p *Page) Close(_ goja.Value) error {
 	add := runtime.RemoveBinding(webVitalBinding)
 	if err := add.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
 		err := fmt.Errorf("internal error while removing binding from page: %w", err)
-		SpanRecordError(span, "close failed due to internal error", err)
+		spanRecordError(span, "close failed due to internal error", err)
 		return err
 	}
 
@@ -679,7 +679,7 @@ func (p *Page) Close(_ goja.Value) error {
 		}
 
 		err := fmt.Errorf("closing a page: %w", err)
-		SpanRecordError(span, "close failed", err)
+		spanRecordError(span, "close failed", err)
 		return err
 	}
 
@@ -832,7 +832,7 @@ func (p *Page) Goto(url string, opts *FrameGotoOptions) (*Response, error) {
 
 	resp, err := p.MainFrame().Goto(url, opts)
 	if err != nil {
-		SpanRecordError(span, "goto failed", err)
+		spanRecordError(span, "goto failed", err)
 		return nil, err
 	}
 
@@ -996,7 +996,7 @@ func (p *Page) Reload(opts goja.Value) (*Response, error) { //nolint:funlen,cycl
 	)
 	if err := parsedOpts.Parse(p.ctx, opts); err != nil {
 		err := fmt.Errorf("parsing reload options: %w", err)
-		SpanRecordError(span, "reload option parsing failed", err)
+		spanRecordError(span, "reload option parsing failed", err)
 		return nil, err
 	}
 
@@ -1024,7 +1024,7 @@ func (p *Page) Reload(opts goja.Value) (*Response, error) { //nolint:funlen,cycl
 	action := cdppage.Reload()
 	if err := action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
 		err := fmt.Errorf("reloading page: %w", err)
-		SpanRecordError(span, "reload failed", err)
+		spanRecordError(span, "reload failed", err)
 		return nil, err
 	}
 
@@ -1046,7 +1046,7 @@ func (p *Page) Reload(opts goja.Value) (*Response, error) { //nolint:funlen,cycl
 	case <-p.ctx.Done():
 	case <-timeoutCtx.Done():
 		err := wrapTimeoutError(timeoutCtx.Err())
-		SpanRecordError(span, "reload navigation timed out", err)
+		spanRecordError(span, "reload navigation timed out", err)
 		return nil, err
 	case data := <-ch:
 		event = data.(*NavigationEvent)
@@ -1064,7 +1064,7 @@ func (p *Page) Reload(opts goja.Value) (*Response, error) { //nolint:funlen,cycl
 	case <-lifecycleEvtCh:
 	case <-timeoutCtx.Done():
 		err := wrapTimeoutError(timeoutCtx.Err())
-		SpanRecordError(span, "reload lifecycle timed out", err)
+		spanRecordError(span, "reload lifecycle timed out", err)
 		return nil, err
 	}
 
@@ -1084,7 +1084,7 @@ func (p *Page) Screenshot(opts *PageScreenshotOptions, sp ScreenshotPersister) (
 	buf, err := s.screenshotPage(p, opts)
 	if err != nil {
 		err := fmt.Errorf("taking screenshot of page: %w", err)
-		SpanRecordError(span, "screenshot failed", err)
+		spanRecordError(span, "screenshot failed", err)
 		return nil, err
 	}
 
@@ -1256,7 +1256,7 @@ func (p *Page) WaitForNavigation(opts *FrameWaitForNavigationOptions) (*Response
 
 	resp, err := p.frameManager.MainFrame().WaitForNavigation(opts)
 	if err != nil {
-		SpanRecordError(span, "waiting for navigation failed", err)
+		spanRecordError(span, "waiting for navigation failed", err)
 		return nil, err
 	}
 

--- a/common/page.go
+++ b/common/page.go
@@ -1254,7 +1254,13 @@ func (p *Page) WaitForNavigation(opts *FrameWaitForNavigationOptions) (*Response
 	_, span := TraceAPICall(p.ctx, p.targetID.String(), "page.waitForNavigation")
 	defer span.End()
 
-	return p.frameManager.MainFrame().WaitForNavigation(opts)
+	resp, err := p.frameManager.MainFrame().WaitForNavigation(opts)
+	if err != nil {
+		SpanRecordError(span, "waiting for navigation failed", err)
+		return nil, err
+	}
+
+	return resp, err
 }
 
 // WaitForSelector waits for the given selector to match the waiting criteria.

--- a/common/page.go
+++ b/common/page.go
@@ -1083,7 +1083,9 @@ func (p *Page) Screenshot(opts *PageScreenshotOptions, sp ScreenshotPersister) (
 	s := newScreenshotter(spanCtx, sp)
 	buf, err := s.screenshotPage(p, opts)
 	if err != nil {
-		return nil, fmt.Errorf("taking screenshot of page: %w", err)
+		err = fmt.Errorf("taking screenshot of page: %w", err)
+		SpanRecordError(span, "screenshot failed", err)
+		return nil, err
 	}
 
 	return buf, err

--- a/common/page.go
+++ b/common/page.go
@@ -830,7 +830,13 @@ func (p *Page) Goto(url string, opts *FrameGotoOptions) (*Response, error) {
 	)
 	defer span.End()
 
-	return p.MainFrame().Goto(url, opts)
+	resp, err := p.MainFrame().Goto(url, opts)
+	if err != nil {
+		SpanRecordError(span, "goto failed", err)
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 func (p *Page) Hover(selector string, opts goja.Value) {

--- a/common/page.go
+++ b/common/page.go
@@ -657,7 +657,7 @@ func (p *Page) Close(_ goja.Value) error {
 
 	add := runtime.RemoveBinding(webVitalBinding)
 	if err := add.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
-		err = fmt.Errorf("internal error while removing binding from page: %w", err)
+		err := fmt.Errorf("internal error while removing binding from page: %w", err)
 		SpanRecordError(span, "close failed due to internal error", err)
 		return err
 	}
@@ -678,7 +678,7 @@ func (p *Page) Close(_ goja.Value) error {
 			return nil
 		}
 
-		err = fmt.Errorf("closing a page: %w", err)
+		err := fmt.Errorf("closing a page: %w", err)
 		SpanRecordError(span, "close failed", err)
 		return err
 	}
@@ -995,7 +995,7 @@ func (p *Page) Reload(opts goja.Value) (*Response, error) { //nolint:funlen,cycl
 		p.timeoutSettings.navigationTimeout(),
 	)
 	if err := parsedOpts.Parse(p.ctx, opts); err != nil {
-		err = fmt.Errorf("parsing reload options: %w", err)
+		err := fmt.Errorf("parsing reload options: %w", err)
 		SpanRecordError(span, "reload option parsing failed", err)
 		return nil, err
 	}
@@ -1023,7 +1023,7 @@ func (p *Page) Reload(opts goja.Value) (*Response, error) { //nolint:funlen,cycl
 
 	action := cdppage.Reload()
 	if err := action.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
-		err = fmt.Errorf("reloading page: %w", err)
+		err := fmt.Errorf("reloading page: %w", err)
 		SpanRecordError(span, "reload failed", err)
 		return nil, err
 	}
@@ -1083,7 +1083,7 @@ func (p *Page) Screenshot(opts *PageScreenshotOptions, sp ScreenshotPersister) (
 	s := newScreenshotter(spanCtx, sp)
 	buf, err := s.screenshotPage(p, opts)
 	if err != nil {
-		err = fmt.Errorf("taking screenshot of page: %w", err)
+		err := fmt.Errorf("taking screenshot of page: %w", err)
 		SpanRecordError(span, "screenshot failed", err)
 		return nil, err
 	}

--- a/common/page.go
+++ b/common/page.go
@@ -657,7 +657,9 @@ func (p *Page) Close(_ goja.Value) error {
 
 	add := runtime.RemoveBinding(webVitalBinding)
 	if err := add.Do(cdp.WithExecutor(p.ctx, p.session)); err != nil {
-		return fmt.Errorf("internal error while removing binding from page: %w", err)
+		err = fmt.Errorf("internal error while removing binding from page: %w", err)
+		SpanRecordError(span, "close failed due to internal error", err)
+		return err
 	}
 
 	action := target.CloseTarget(p.targetID)
@@ -676,7 +678,9 @@ func (p *Page) Close(_ goja.Value) error {
 			return nil
 		}
 
-		return fmt.Errorf("closing a page: %w", err)
+		err = fmt.Errorf("closing a page: %w", err)
+		SpanRecordError(span, "close failed", err)
+		return err
 	}
 
 	return nil

--- a/common/trace.go
+++ b/common/trace.go
@@ -61,7 +61,7 @@ func TraceEvent(
 // spanRecordError will set the status of the span to error and record the
 // error on the span. Check the documentation for trace.SetStatus and
 // trace.RecordError for more details.
-func spanRecordError(span trace.Span, description string, err error) {
-	span.SetStatus(codes.Error, description)
+func spanRecordError(span trace.Span, err error) {
+	span.SetStatus(codes.Error, err.Error())
 	span.RecordError(err)
 }

--- a/common/trace.go
+++ b/common/trace.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	browsertrace "github.com/grafana/xk6-browser/trace"
@@ -55,4 +56,12 @@ func TraceEvent(
 		return tracer.TraceEvent(ctx, targetID, eventName, spanID, options...)
 	}
 	return ctx, browsertrace.NoopSpan{}
+}
+
+// SpanRecordError will set the status of the span to error and record the
+// error on the span. Check the documentation for trace.SetStatus and
+// trace.RecordError for more details.
+func SpanRecordError(span trace.Span, description string, err error) {
+	span.SetStatus(codes.Error, description)
+	span.RecordError(err)
 }

--- a/common/trace.go
+++ b/common/trace.go
@@ -58,10 +58,10 @@ func TraceEvent(
 	return ctx, browsertrace.NoopSpan{}
 }
 
-// SpanRecordError will set the status of the span to error and record the
+// spanRecordError will set the status of the span to error and record the
 // error on the span. Check the documentation for trace.SetStatus and
 // trace.RecordError for more details.
-func SpanRecordError(span trace.Span, description string, err error) {
+func spanRecordError(span trace.Span, description string, err error) {
 	span.SetStatus(codes.Error, description)
 	span.RecordError(err)
 }


### PR DESCRIPTION
## What?

Adding errors to the API spans that currently exist.

## Why?

When a user views the traces for the test, it's useful to see whether an error occurred and in which API call. This will help highlight spans where errors occurred and therefore caused the test iteration to fail.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
https://github.com/grafana/xk6-browser/issues/1249