### PR TITLE
Fix web vital trace test

### DIFF
--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -108,13 +108,6 @@ func TestTracing(t *testing.T) {
 			},
 		},
 		{
-			name: "web_vital",
-			js:   "sleep(100);", // Wait for async WebVitals processing
-			spans: []string{
-				"web_vital",
-			},
-		},
-		{
 			name: "page.screenshot",
 			js:   "page.screenshot();",
 			spans: []string{
@@ -147,14 +140,17 @@ func TestTracing(t *testing.T) {
 			},
 		},
 		{
-			name: "page.close",
-			js:   "page.close()",
+			name: "web_vital",
+			js:   "page.close();", // on page.close, web vitals are collected and fired/received.
 			spans: []string{
+				"web_vital",
 				"page.close",
 			},
 		},
 	}
 
+	// Each sub test depends on the previous sub test, so they cannot be ran
+	// in parallel.
 	for _, tc := range testCases {
 		assertJSInEventLoop(t, vu, tc.js)
 


### PR DESCRIPTION
## What?

Catch the web vital spans after the `page.close` API call is made. This should definitely cause the web vitals to emit and be received in time before the sub-test completes.

## Why?

Instead of a sleep to wait for a web vital, which is problematic on slower machines that can cause the sub test to fail, catch the web vital spans that are emitted/received when the page.close() API is called.

I've ran the integration tests 10 times and there were no failures with the tracing tests, whereas usually I would get 2-3 failures.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
https://github.com/grafana/xk6-browser/issues/1150