### PR TITLE
Degojaify the `Tap` methods and remove `panic`s

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -304,11 +304,17 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping {
 		"selectOption":           eh.SelectOption,
 		"selectText":             eh.SelectText,
 		"setInputFiles":          eh.SetInputFiles,
-		"tap":                    eh.Tap,
-		"textContent":            eh.TextContent,
-		"type":                   eh.Type,
-		"uncheck":                eh.Uncheck,
-		"waitForElementState":    eh.WaitForElementState,
+		"tap": func(opts goja.Value) error {
+			popts := common.NewElementHandleTapOptions(eh.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return fmt.Errorf("parsing element tap options: %w", err)
+			}
+			return eh.Tap(popts) //nolint:wrapcheck
+		},
+		"textContent":         eh.TextContent,
+		"type":                eh.Type,
+		"uncheck":             eh.Uncheck,
+		"waitForElementState": eh.WaitForElementState,
 		"waitForSelector": func(selector string, opts goja.Value) (mapping, error) {
 			eh, err := eh.WaitForSelector(selector, opts)
 			if err != nil {

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -82,7 +82,13 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping {
 		"press":        lo.Press,
 		"type":         lo.Type,
 		"hover":        lo.Hover,
-		"tap":          lo.Tap,
+		"tap": func(opts goja.Value) error {
+			copts := common.NewFrameTapOptions(lo.DefaultTimeout())
+			if err := copts.Parse(vu.Context(), opts); err != nil {
+				return fmt.Errorf("parsing locator tap options: %w", err)
+			}
+			return lo.Tap(copts) //nolint:wrapcheck
+		},
 		"dispatchEvent": func(typ string, eventInit, opts goja.Value) error {
 			popts := common.NewFrameDispatchEventOptions(lo.DefaultTimeout())
 			if err := popts.Parse(vu.Context(), opts); err != nil {

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -456,12 +456,18 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 		"selectOption":  f.SelectOption,
 		"setContent":    f.SetContent,
 		"setInputFiles": f.SetInputFiles,
-		"tap":           f.Tap,
-		"textContent":   f.TextContent,
-		"title":         f.Title,
-		"type":          f.Type,
-		"uncheck":       f.Uncheck,
-		"url":           f.URL,
+		"tap": func(selector string, opts goja.Value) error {
+			popts := common.NewFrameTapOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return fmt.Errorf("parsing frame tap options: %w", err)
+			}
+			return f.Tap(selector, popts) //nolint:wrapcheck
+		},
+		"textContent": f.TextContent,
+		"title":       f.Title,
+		"type":        f.Type,
+		"uncheck":     f.Uncheck,
+		"url":         f.URL,
 		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) (*goja.Promise, error) {
 			js, popts, pargs, err := parseWaitForFunctionArgs(
 				vu.Context(), f.Timeout(), pageFunc, opts, args...,
@@ -709,19 +715,25 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 		"setExtraHTTPHeaders":         p.SetExtraHTTPHeaders,
 		"setInputFiles":               p.SetInputFiles,
 		"setViewportSize":             p.SetViewportSize,
-		"tap":                         p.Tap,
-		"textContent":                 p.TextContent,
-		"throttleCPU":                 p.ThrottleCPU,
-		"throttleNetwork":             p.ThrottleNetwork,
-		"title":                       p.Title,
-		"touchscreen":                 rt.ToValue(p.GetTouchscreen()).ToObject(rt),
-		"type":                        p.Type,
-		"uncheck":                     p.Uncheck,
-		"unroute":                     p.Unroute,
-		"url":                         p.URL,
-		"video":                       p.Video,
-		"viewportSize":                p.ViewportSize,
-		"waitForEvent":                p.WaitForEvent,
+		"tap": func(selector string, opts goja.Value) error {
+			popts := common.NewFrameTapOptions(p.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return fmt.Errorf("parsing page tap options: %w", err)
+			}
+			return p.Tap(selector, popts) //nolint:wrapcheck
+		},
+		"textContent":     p.TextContent,
+		"throttleCPU":     p.ThrottleCPU,
+		"throttleNetwork": p.ThrottleNetwork,
+		"title":           p.Title,
+		"touchscreen":     rt.ToValue(p.GetTouchscreen()).ToObject(rt),
+		"type":            p.Type,
+		"uncheck":         p.Uncheck,
+		"unroute":         p.Unroute,
+		"url":             p.URL,
+		"video":           p.Video,
+		"viewportSize":    p.ViewportSize,
+		"waitForEvent":    p.WaitForEvent,
 		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) (*goja.Promise, error) {
 			js, popts, pargs, err := parseWaitForFunctionArgs(
 				vu.Context(), p.Timeout(), pageFunc, opts, args...,

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -555,7 +555,7 @@ type keyboardAPI interface { //nolint: unused
 // mapping is not tested using this interface. We use the concrete type
 // without testing its exported methods.
 type touchscreenAPI interface { //nolint: unused
-	Tap(x float64, y float64)
+	Tap(x float64, y float64) error
 }
 
 // mouseAPI is the interface of a mouse input device.

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -458,7 +458,7 @@ type elementHandleAPI interface {
 	SelectOption(values goja.Value, opts goja.Value) []string
 	SelectText(opts goja.Value)
 	SetInputFiles(files goja.Value, opts goja.Value)
-	Tap(opts goja.Value)
+	Tap(opts goja.Value) error
 	TextContent() string
 	Type(text string, opts goja.Value)
 	Uncheck(opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -341,7 +341,7 @@ type pageAPI interface {
 	SetExtraHTTPHeaders(headers map[string]string)
 	SetInputFiles(selector string, files goja.Value, opts goja.Value)
 	SetViewportSize(viewportSize goja.Value)
-	Tap(selector string, opts goja.Value)
+	Tap(selector string, opts goja.Value) error
 	TextContent(selector string, opts goja.Value) string
 	ThrottleCPU(common.CPUProfile) error
 	ThrottleNetwork(common.NetworkProfile) error
@@ -413,7 +413,7 @@ type frameAPI interface {
 	SelectOption(selector string, values goja.Value, opts goja.Value) []string
 	SetContent(html string, opts goja.Value)
 	SetInputFiles(selector string, files goja.Value, opts goja.Value)
-	Tap(selector string, opts goja.Value)
+	Tap(selector string, opts goja.Value) error
 	TextContent(selector string, opts goja.Value) string
 	Title() string
 	Type(selector string, text string, opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -533,7 +533,7 @@ type locatorAPI interface {
 	Press(key string, opts goja.Value)
 	Type(text string, opts goja.Value)
 	Hover(opts goja.Value)
-	Tap(opts goja.Value)
+	Tap(opts goja.Value) error
 	DispatchEvent(typ string, eventInit, opts goja.Value)
 	WaitFor(opts goja.Value)
 }

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1292,12 +1292,12 @@ func (h *ElementHandle) setInputFiles(apiCtx context.Context, payload []*File) e
 
 // Tap scrolls element into view and taps in the center of the element.
 func (h *ElementHandle) Tap(opts *ElementHandleTapOptions) error {
-	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (any, error) {
+	tap := func(apiCtx context.Context, handle *ElementHandle, p *Position) (any, error) {
 		return nil, handle.tap(apiCtx, p)
 	}
-	pointerFn := h.newPointerAction(fn, &opts.ElementHandleBasePointerOptions)
-	_, err := call(h.ctx, pointerFn, opts.Timeout)
-	if err != nil {
+	tapAction := h.newPointerAction(tap, &opts.ElementHandleBasePointerOptions)
+
+	if _, err := call(h.ctx, tapAction, opts.Timeout); err != nil {
 		return fmt.Errorf("tapping element: %w", err)
 	}
 

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1290,6 +1290,7 @@ func (h *ElementHandle) setInputFiles(apiCtx context.Context, payload []*File) e
 	return nil
 }
 
+// Tap scrolls element into view and taps in the center of the element.
 func (h *ElementHandle) Tap(opts goja.Value) {
 	parsedOpts := NewElementHandleTapOptions(h.defaultTimeout())
 	err := parsedOpts.Parse(h.ctx, opts)
@@ -1308,7 +1309,7 @@ func (h *ElementHandle) Tap(opts goja.Value) {
 	applySlowMo(h.ctx)
 }
 
-func (h *ElementHandle) tap(apiCtx context.Context, p *Position) error {
+func (h *ElementHandle) tap(_ context.Context, p *Position) error {
 	return h.frame.page.Touchscreen.tap(p.X, p.Y)
 }
 

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1291,11 +1291,11 @@ func (h *ElementHandle) setInputFiles(apiCtx context.Context, payload []*File) e
 }
 
 // Tap scrolls element into view and taps in the center of the element.
-func (h *ElementHandle) Tap(opts goja.Value) {
+func (h *ElementHandle) Tap(opts goja.Value) error {
 	parsedOpts := NewElementHandleTapOptions(h.defaultTimeout())
 	err := parsedOpts.Parse(h.ctx, opts)
 	if err != nil {
-		k6ext.Panic(h.ctx, "parsing tap options: %w", err)
+		return fmt.Errorf("parsing tap options: %w", err)
 	}
 
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (any, error) {
@@ -1304,9 +1304,12 @@ func (h *ElementHandle) Tap(opts goja.Value) {
 	pointerFn := h.newPointerAction(fn, &parsedOpts.ElementHandleBasePointerOptions)
 	_, err = call(h.ctx, pointerFn, parsedOpts.Timeout)
 	if err != nil {
-		k6ext.Panic(h.ctx, "tapping element: %w", err)
+		return fmt.Errorf("tapping element: %w", err)
 	}
+
 	applySlowMo(h.ctx)
+
+	return nil
 }
 
 func (h *ElementHandle) tap(_ context.Context, p *Position) error {

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -589,10 +589,6 @@ func (h *ElementHandle) selectText(apiCtx context.Context) error {
 	return nil
 }
 
-func (h *ElementHandle) tap(apiCtx context.Context, p *Position) error {
-	return h.frame.page.Touchscreen.tap(p.X, p.Y)
-}
-
 func (h *ElementHandle) textContent(apiCtx context.Context) (any, error) {
 	js := `
 		(element) => {
@@ -1310,6 +1306,10 @@ func (h *ElementHandle) Tap(opts goja.Value) {
 		k6ext.Panic(h.ctx, "tapping element: %w", err)
 	}
 	applySlowMo(h.ctx)
+}
+
+func (h *ElementHandle) tap(apiCtx context.Context, p *Position) error {
+	return h.frame.page.Touchscreen.tap(p.X, p.Y)
 }
 
 func (h *ElementHandle) TextContent() string {

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1291,18 +1291,12 @@ func (h *ElementHandle) setInputFiles(apiCtx context.Context, payload []*File) e
 }
 
 // Tap scrolls element into view and taps in the center of the element.
-func (h *ElementHandle) Tap(opts goja.Value) error {
-	parsedOpts := NewElementHandleTapOptions(h.defaultTimeout())
-	err := parsedOpts.Parse(h.ctx, opts)
-	if err != nil {
-		return fmt.Errorf("parsing tap options: %w", err)
-	}
-
+func (h *ElementHandle) Tap(opts *ElementHandleTapOptions) error {
 	fn := func(apiCtx context.Context, handle *ElementHandle, p *Position) (any, error) {
 		return nil, handle.tap(apiCtx, p)
 	}
-	pointerFn := h.newPointerAction(fn, &parsedOpts.ElementHandleBasePointerOptions)
-	_, err = call(h.ctx, pointerFn, parsedOpts.Timeout)
+	pointerFn := h.newPointerAction(fn, &opts.ElementHandleBasePointerOptions)
+	_, err := call(h.ctx, pointerFn, opts.Timeout)
 	if err != nil {
 		return fmt.Errorf("tapping element: %w", err)
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -1565,6 +1565,20 @@ func (f *Frame) Tap(selector string, opts goja.Value) error {
 	return nil
 }
 
+func (f *Frame) tap(selector string, opts *FrameTapOptions) error {
+	tap := func(apiCtx context.Context, handle *ElementHandle, p *Position) (any, error) {
+		return nil, handle.tap(apiCtx, p)
+	}
+	act := f.newPointerAction(
+		selector, DOMElementStateAttached, opts.Strict, tap, &opts.ElementHandleBasePointerOptions,
+	)
+	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
+		return errorFromDOMError(err)
+	}
+
+	return nil
+}
+
 func (f *Frame) setInputFiles(selector string, files *Files, opts *FrameSetInputFilesOptions) error {
 	setInputFiles := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return nil, handle.setInputFiles(apiCtx, files.Payload)
@@ -1575,20 +1589,6 @@ func (f *Frame) setInputFiles(selector string, files *Files, opts *FrameSetInput
 		opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
 
-	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
-		return errorFromDOMError(err)
-	}
-
-	return nil
-}
-
-func (f *Frame) tap(selector string, opts *FrameTapOptions) error {
-	tap := func(apiCtx context.Context, handle *ElementHandle, p *Position) (any, error) {
-		return nil, handle.tap(apiCtx, p)
-	}
-	act := f.newPointerAction(
-		selector, DOMElementStateAttached, opts.Strict, tap, &opts.ElementHandleBasePointerOptions,
-	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err)
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -1549,18 +1549,20 @@ func (f *Frame) SetInputFiles(selector string, files goja.Value, opts goja.Value
 }
 
 // Tap the first element that matches the selector.
-func (f *Frame) Tap(selector string, opts goja.Value) {
+func (f *Frame) Tap(selector string, opts goja.Value) error {
 	f.log.Debugf("Frame:Tap", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
 	popts := NewFrameTapOptions(f.defaultTimeout())
 	if err := popts.Parse(f.ctx, opts); err != nil {
-		k6ext.Panic(f.ctx, "parsing tap options: %w", err)
+		return fmt.Errorf("parsing tap options: %w", err)
 	}
 	if err := f.tap(selector, popts); err != nil {
-		k6ext.Panic(f.ctx, "tapping on %q: %w", selector, err)
+		return fmt.Errorf("tapping on %q: %w", selector, err)
 	}
 
 	applySlowMo(f.ctx)
+
+	return nil
 }
 
 func (f *Frame) setInputFiles(selector string, files *Files, opts *FrameSetInputFilesOptions) error {

--- a/common/frame.go
+++ b/common/frame.go
@@ -1549,14 +1549,10 @@ func (f *Frame) SetInputFiles(selector string, files goja.Value, opts goja.Value
 }
 
 // Tap the first element that matches the selector.
-func (f *Frame) Tap(selector string, opts goja.Value) error {
+func (f *Frame) Tap(selector string, opts *FrameTapOptions) error {
 	f.log.Debugf("Frame:Tap", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	popts := NewFrameTapOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return fmt.Errorf("parsing tap options: %w", err)
-	}
-	if err := f.tap(selector, popts); err != nil {
+	if err := f.tap(selector, opts); err != nil {
 		return fmt.Errorf("tapping on %q: %w", selector, err)
 	}
 

--- a/common/locator.go
+++ b/common/locator.go
@@ -561,15 +561,11 @@ func (l *Locator) hover(opts *FrameHoverOptions) error {
 }
 
 // Tap the element found that matches the locator's selector with strict mode on.
-func (l *Locator) Tap(opts goja.Value) error {
+func (l *Locator) Tap(opts *FrameTapOptions) error {
 	l.log.Debugf("Locator:Tap", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
 
-	copts := NewFrameTapOptions(l.frame.defaultTimeout())
-	if err := copts.Parse(l.ctx, opts); err != nil {
-		return fmt.Errorf("parsing tap options: %w", err)
-	}
-	copts.Strict = true
-	if err := l.frame.tap(l.selector, copts); err != nil {
+	opts.Strict = true
+	if err := l.frame.tap(l.selector, opts); err != nil {
 		return fmt.Errorf("tapping on %q: %w", l.selector, err)
 	}
 

--- a/common/locator.go
+++ b/common/locator.go
@@ -568,18 +568,14 @@ func (l *Locator) Tap(opts goja.Value) error {
 	if err := copts.Parse(l.ctx, opts); err != nil {
 		return fmt.Errorf("parsing tap options: %w", err)
 	}
-	if err := l.tap(copts); err != nil {
+	copts.Strict = true
+	if err := l.frame.tap(l.selector, copts); err != nil {
 		return fmt.Errorf("tapping on %q: %w", l.selector, err)
 	}
 
 	applySlowMo(l.ctx)
 
 	return nil
-}
-
-func (l *Locator) tap(opts *FrameTapOptions) error {
-	opts.Strict = true
-	return l.frame.tap(l.selector, opts)
 }
 
 // DispatchEvent dispatches an event for the element matching the

--- a/common/locator.go
+++ b/common/locator.go
@@ -561,21 +561,20 @@ func (l *Locator) hover(opts *FrameHoverOptions) error {
 }
 
 // Tap the element found that matches the locator's selector with strict mode on.
-func (l *Locator) Tap(opts goja.Value) {
+func (l *Locator) Tap(opts goja.Value) error {
 	l.log.Debugf("Locator:Tap", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
 
-	var err error
-	defer func() { panicOrSlowMo(l.ctx, err) }()
-
 	copts := NewFrameTapOptions(l.frame.defaultTimeout())
-	if err = copts.Parse(l.ctx, opts); err != nil {
-		err = fmt.Errorf("parsing tap options: %w", err)
-		return
+	if err := copts.Parse(l.ctx, opts); err != nil {
+		return fmt.Errorf("parsing tap options: %w", err)
 	}
-	if err = l.tap(copts); err != nil {
-		err = fmt.Errorf("tapping on %q: %w", l.selector, err)
-		return
+	if err := l.tap(copts); err != nil {
+		return fmt.Errorf("tapping on %q: %w", l.selector, err)
 	}
+
+	applySlowMo(l.ctx)
+
+	return nil
 }
 
 func (l *Locator) tap(opts *FrameTapOptions) error {

--- a/common/page.go
+++ b/common/page.go
@@ -1191,7 +1191,7 @@ func (p *Page) SetViewportSize(viewportSize goja.Value) {
 }
 
 // Tap will tap the element matching the provided selector.
-func (p *Page) Tap(selector string, opts goja.Value) error {
+func (p *Page) Tap(selector string, opts *FrameTapOptions) error {
 	p.logger.Debugf("Page:SetViewportSize", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().Tap(selector, opts)

--- a/common/page.go
+++ b/common/page.go
@@ -1190,10 +1190,10 @@ func (p *Page) SetViewportSize(viewportSize goja.Value) {
 	applySlowMo(p.ctx)
 }
 
-func (p *Page) Tap(selector string, opts goja.Value) {
+func (p *Page) Tap(selector string, opts goja.Value) error {
 	p.logger.Debugf("Page:SetViewportSize", "sid:%v selector:%s", p.sessionID(), selector)
 
-	p.MainFrame().Tap(selector, opts)
+	return p.MainFrame().Tap(selector, opts)
 }
 
 func (p *Page) TextContent(selector string, opts goja.Value) string {

--- a/common/page.go
+++ b/common/page.go
@@ -1190,6 +1190,7 @@ func (p *Page) SetViewportSize(viewportSize goja.Value) {
 	applySlowMo(p.ctx)
 }
 
+// Tap will tap the element matching the provided selector.
 func (p *Page) Tap(selector string, opts goja.Value) error {
 	p.logger.Debugf("Page:SetViewportSize", "sid:%v selector:%s", p.sessionID(), selector)
 

--- a/common/touchscreen.go
+++ b/common/touchscreen.go
@@ -26,26 +26,34 @@ func NewTouchscreen(ctx context.Context, s session, k *Keyboard) *Touchscreen {
 	}
 }
 
-func (t *Touchscreen) tap(x float64, y float64) error {
-	action := input.DispatchTouchEvent(input.TouchStart, []*input.TouchPoint{{X: x, Y: y}}).
-		WithModifiers(input.Modifier(t.keyboard.modifiers))
-	if err := action.Do(cdp.WithExecutor(t.ctx, t.session)); err != nil {
-		return fmt.Errorf("touch start: %w", err)
-	}
-
-	action = input.DispatchTouchEvent(input.TouchEnd, []*input.TouchPoint{}).
-		WithModifiers(input.Modifier(t.keyboard.modifiers))
-	if err := action.Do(cdp.WithExecutor(t.ctx, t.session)); err != nil {
-		return fmt.Errorf("touch end: %w", err)
-	}
-
-	return nil
-}
-
 // Tap dispatches a tap start and tap end event.
 func (t *Touchscreen) Tap(x float64, y float64) error {
 	if err := t.tap(x, y); err != nil {
 		return fmt.Errorf("tapping: %w", err)
 	}
+	return nil
+}
+
+func (t *Touchscreen) tap(x float64, y float64) error {
+	touchStart := input.DispatchTouchEvent(
+		input.TouchStart,
+		[]*input.TouchPoint{{X: x, Y: y}},
+	).WithModifiers(
+		input.Modifier(t.keyboard.modifiers),
+	)
+	if err := touchStart.Do(cdp.WithExecutor(t.ctx, t.session)); err != nil {
+		return fmt.Errorf("touch start: %w", err)
+	}
+
+	touchEnd := input.DispatchTouchEvent(
+		input.TouchEnd,
+		[]*input.TouchPoint{},
+	).WithModifiers(
+		input.Modifier(t.keyboard.modifiers),
+	)
+	if err := touchEnd.Do(cdp.WithExecutor(t.ctx, t.session)); err != nil {
+		return fmt.Errorf("touch end: %w", err)
+	}
+
 	return nil
 }

--- a/common/touchscreen.go
+++ b/common/touchscreen.go
@@ -2,8 +2,7 @@ package common
 
 import (
 	"context"
-
-	"github.com/grafana/xk6-browser/k6ext"
+	"fmt"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/input"
@@ -31,19 +30,22 @@ func (t *Touchscreen) tap(x float64, y float64) error {
 	action := input.DispatchTouchEvent(input.TouchStart, []*input.TouchPoint{{X: x, Y: y}}).
 		WithModifiers(input.Modifier(t.keyboard.modifiers))
 	if err := action.Do(cdp.WithExecutor(t.ctx, t.session)); err != nil {
-		return err
+		return fmt.Errorf("touch start: %w", err)
 	}
+
 	action = input.DispatchTouchEvent(input.TouchEnd, []*input.TouchPoint{}).
 		WithModifiers(input.Modifier(t.keyboard.modifiers))
 	if err := action.Do(cdp.WithExecutor(t.ctx, t.session)); err != nil {
-		return err
+		return fmt.Errorf("touch end: %w", err)
 	}
+
 	return nil
 }
 
 // Tap dispatches a tap start and tap end event.
-func (t *Touchscreen) Tap(x float64, y float64) {
+func (t *Touchscreen) Tap(x float64, y float64) error {
 	if err := t.tap(x, y); err != nil {
-		k6ext.Panic(t.ctx, "tapping: %w", err)
+		return fmt.Errorf("tapping: %w", err)
 	}
+	return nil
 }

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -190,13 +190,14 @@ func TestLocator(t *testing.T) {
 			},
 		},
 		{
-			"Tap", func(tb *testBrowser, p *common.Page) {
+			"Tap", func(_ *testBrowser, p *common.Page) {
 				result := func() bool {
 					v := p.Evaluate(`() => window.result`)
 					return asBool(t, v)
 				}
 				require.False(t, result(), "should not be tapped first")
-				p.Locator("#inputText", nil).Tap(nil)
+				err := p.Locator("#inputText", nil).Tap(nil)
+				require.NoError(t, err)
 				require.True(t, result(), "should be tapped")
 			},
 		},
@@ -332,7 +333,12 @@ func TestLocator(t *testing.T) {
 			"SelectOption", func(l *common.Locator, tb *testBrowser) { l.SelectOption(tb.toGojaValue(""), timeout(tb)) },
 		},
 		{
-			"Tap", func(l *common.Locator, tb *testBrowser) { l.Tap(timeout(tb)) },
+			"Tap", func(l *common.Locator, tb *testBrowser) {
+				if err := l.Tap(timeout(tb)); err != nil {
+					// TODO: remove panic and update tests when all locator methods return error.
+					panic(err)
+				}
+			},
 		},
 		{
 			"Type", func(l *common.Locator, tb *testBrowser) { l.Type("a", timeout(tb)) },

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -196,7 +196,8 @@ func TestLocator(t *testing.T) {
 					return asBool(t, v)
 				}
 				require.False(t, result(), "should not be tapped first")
-				err := p.Locator("#inputText", nil).Tap(nil)
+				opts := common.NewFrameTapOptions(common.DefaultTimeout)
+				err := p.Locator("#inputText", nil).Tap(opts)
 				require.NoError(t, err)
 				require.True(t, result(), "should be tapped")
 			},
@@ -333,8 +334,8 @@ func TestLocator(t *testing.T) {
 			"SelectOption", func(l *common.Locator, tb *testBrowser) { l.SelectOption(tb.toGojaValue(""), timeout(tb)) },
 		},
 		{
-			"Tap", func(l *common.Locator, tb *testBrowser) {
-				if err := l.Tap(timeout(tb)); err != nil {
+			"Tap", func(l *common.Locator, _ *testBrowser) {
+				if err := l.Tap(common.NewFrameTapOptions(100 * time.Millisecond)); err != nil {
 					// TODO: remove panic and update tests when all locator methods return error.
 					panic(err)
 				}


### PR DESCRIPTION
## What?

Degojaifies the `Tap` methods.

## Why?

See: #1064 and #1251.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates #1251 and #1064.