### PR TITLE
Fix the touchscreen example

### DIFF
--- a/examples/touchscreen.js
+++ b/examples/touchscreen.js
@@ -17,11 +17,16 @@ export default async function () {
   const page = browser.newPage();
 
   await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
-  
+
   // Obtain ElementHandle for news link and navigate to it
   // by tapping in the 'a' element's bounding box
   const newsLinkBox = page.$('a[href="/news.php"]').boundingBox();
   page.touchscreen.tap(newsLinkBox.x + newsLinkBox.width / 2, newsLinkBox.y);
-    
-  await page.close();
+
+  // Wait until the navigation is done before closing the page.
+  // Otherwise, there will be a race condition between the page closing
+  // and the navigation.
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  page.close();
 }


### PR DESCRIPTION
## What?

Fixes the race condition in the example.

## Why?

The touchscreen example was printing out the warning (before the fix):

```
WARN[0002] failed to hide page: evaluating JS: Cannot find context with specified id  category="Page:Close" elapsed="0 ms" source=browser
```

The reason is "tapping" causes a page navigation, and we try to close the page while the navigation is in progress.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas