### PR TITLE
Make `Tap` async

### DIFF
--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -746,7 +746,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 		"throttleCPU":     p.ThrottleCPU,
 		"throttleNetwork": p.ThrottleNetwork,
 		"title":           p.Title,
-		"touchscreen":     rt.ToValue(p.GetTouchscreen()).ToObject(rt),
+		"touchscreen":     mapTouchscreen(vu, p.GetTouchscreen()),
 		"type":            p.Type,
 		"uncheck":         p.Uncheck,
 		"unroute":         p.Unroute,
@@ -828,6 +828,13 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 	}
 
 	return maps
+}
+
+// mapTouchscreen to the JS module.
+func mapTouchscreen(_ moduleVU, ts *common.Touchscreen) mapping {
+	return mapping{
+		"tap": ts.Tap,
+	}
 }
 
 // mapWorker to the JS module.

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -82,12 +82,14 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping {
 		"press":        lo.Press,
 		"type":         lo.Type,
 		"hover":        lo.Hover,
-		"tap": func(opts goja.Value) error {
+		"tap": func(opts goja.Value) (*goja.Promise, error) {
 			copts := common.NewFrameTapOptions(lo.DefaultTimeout())
 			if err := copts.Parse(vu.Context(), opts); err != nil {
-				return fmt.Errorf("parsing locator tap options: %w", err)
+				return nil, fmt.Errorf("parsing locator tap options: %w", err)
 			}
-			return lo.Tap(copts) //nolint:wrapcheck
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				return nil, lo.Tap(copts) //nolint:wrapcheck
+			}), nil
 		},
 		"dispatchEvent": func(typ string, eventInit, opts goja.Value) error {
 			popts := common.NewFrameDispatchEventOptions(lo.DefaultTimeout())
@@ -304,12 +306,14 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping {
 		"selectOption":           eh.SelectOption,
 		"selectText":             eh.SelectText,
 		"setInputFiles":          eh.SetInputFiles,
-		"tap": func(opts goja.Value) error {
+		"tap": func(opts goja.Value) (*goja.Promise, error) {
 			popts := common.NewElementHandleTapOptions(eh.Timeout())
 			if err := popts.Parse(vu.Context(), opts); err != nil {
-				return fmt.Errorf("parsing element tap options: %w", err)
+				return nil, fmt.Errorf("parsing element tap options: %w", err)
 			}
-			return eh.Tap(popts) //nolint:wrapcheck
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				return nil, eh.Tap(popts) //nolint:wrapcheck
+			}), nil
 		},
 		"textContent":         eh.TextContent,
 		"type":                eh.Type,
@@ -462,12 +466,14 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 		"selectOption":  f.SelectOption,
 		"setContent":    f.SetContent,
 		"setInputFiles": f.SetInputFiles,
-		"tap": func(selector string, opts goja.Value) error {
+		"tap": func(selector string, opts goja.Value) (*goja.Promise, error) {
 			popts := common.NewFrameTapOptions(f.Timeout())
 			if err := popts.Parse(vu.Context(), opts); err != nil {
-				return fmt.Errorf("parsing frame tap options: %w", err)
+				return nil, fmt.Errorf("parsing frame tap options: %w", err)
 			}
-			return f.Tap(selector, popts) //nolint:wrapcheck
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				return nil, f.Tap(selector, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"textContent": f.TextContent,
 		"title":       f.Title,
@@ -727,12 +733,14 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 		"setExtraHTTPHeaders":         p.SetExtraHTTPHeaders,
 		"setInputFiles":               p.SetInputFiles,
 		"setViewportSize":             p.SetViewportSize,
-		"tap": func(selector string, opts goja.Value) error {
+		"tap": func(selector string, opts goja.Value) (*goja.Promise, error) {
 			popts := common.NewFrameTapOptions(p.Timeout())
 			if err := popts.Parse(vu.Context(), opts); err != nil {
-				return fmt.Errorf("parsing page tap options: %w", err)
+				return nil, fmt.Errorf("parsing page tap options: %w", err)
 			}
-			return p.Tap(selector, popts) //nolint:wrapcheck
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				return nil, p.Tap(selector, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"textContent":     p.TextContent,
 		"throttleCPU":     p.ThrottleCPU,

--- a/browser/mapping.go
+++ b/browser/mapping.go
@@ -831,9 +831,13 @@ func mapPage(vu moduleVU, p *common.Page) mapping {
 }
 
 // mapTouchscreen to the JS module.
-func mapTouchscreen(_ moduleVU, ts *common.Touchscreen) mapping {
+func mapTouchscreen(vu moduleVU, ts *common.Touchscreen) mapping {
 	return mapping{
-		"tap": ts.Tap,
+		"tap": func(x float64, y float64) *goja.Promise {
+			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
+				return nil, ts.Tap(x, y) //nolint:wrapcheck
+			})
+		},
 	}
 }
 

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -558,7 +558,7 @@ type keyboardAPI interface { //nolint: unused
 
 // touchscreenAPI is the interface of a touchscreen.
 type touchscreenAPI interface {
-	Tap(x float64, y float64) error
+	Tap(x float64, y float64) *goja.Promise
 }
 
 // mouseAPI is the interface of a mouse input device.

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -341,7 +341,7 @@ type pageAPI interface {
 	SetExtraHTTPHeaders(headers map[string]string)
 	SetInputFiles(selector string, files goja.Value, opts goja.Value)
 	SetViewportSize(viewportSize goja.Value)
-	Tap(selector string, opts goja.Value) error
+	Tap(selector string, opts goja.Value) (*goja.Promise, error)
 	TextContent(selector string, opts goja.Value) string
 	ThrottleCPU(common.CPUProfile) error
 	ThrottleNetwork(common.NetworkProfile) error
@@ -413,7 +413,7 @@ type frameAPI interface {
 	SelectOption(selector string, values goja.Value, opts goja.Value) []string
 	SetContent(html string, opts goja.Value)
 	SetInputFiles(selector string, files goja.Value, opts goja.Value)
-	Tap(selector string, opts goja.Value) error
+	Tap(selector string, opts goja.Value) (*goja.Promise, error)
 	TextContent(selector string, opts goja.Value) string
 	Title() string
 	Type(selector string, text string, opts goja.Value)
@@ -458,7 +458,7 @@ type elementHandleAPI interface {
 	SelectOption(values goja.Value, opts goja.Value) []string
 	SelectText(opts goja.Value)
 	SetInputFiles(files goja.Value, opts goja.Value)
-	Tap(opts goja.Value) error
+	Tap(opts goja.Value) (*goja.Promise, error)
 	TextContent() string
 	Type(text string, opts goja.Value)
 	Uncheck(opts goja.Value)
@@ -533,7 +533,7 @@ type locatorAPI interface {
 	Press(key string, opts goja.Value)
 	Type(text string, opts goja.Value)
 	Hover(opts goja.Value)
-	Tap(opts goja.Value) error
+	Tap(opts goja.Value) (*goja.Promise, error)
 	DispatchEvent(typ string, eventInit, opts goja.Value)
 	WaitFor(opts goja.Value)
 }

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -193,6 +193,12 @@ func TestMappings(t *testing.T) {
 				return mapConsoleMessage(moduleVU{VU: vu}, &common.ConsoleMessage{})
 			},
 		},
+		"mapTouchscreen": {
+			apiInterface: (*touchscreenAPI)(nil),
+			mapp: func() mapping {
+				return mapTouchscreen(moduleVU{VU: vu}, &common.Touchscreen{})
+			},
+		},
 	} {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
@@ -551,10 +557,7 @@ type keyboardAPI interface { //nolint: unused
 }
 
 // touchscreenAPI is the interface of a touchscreen.
-// TODO: map this to page.GetTouchscreen(). Currently, the common.TouchscreenAPI type
-// mapping is not tested using this interface. We use the concrete type
-// without testing its exported methods.
-type touchscreenAPI interface { //nolint: unused
+type touchscreenAPI interface {
 	Tap(x float64, y float64) error
 }
 

--- a/examples/touchscreen.js
+++ b/examples/touchscreen.js
@@ -21,7 +21,7 @@ export default async function () {
   // Obtain ElementHandle for news link and navigate to it
   // by tapping in the 'a' element's bounding box
   const newsLinkBox = page.$('a[href="/news.php"]').boundingBox();
-  page.touchscreen.tap(newsLinkBox.x + newsLinkBox.width / 2, newsLinkBox.y);
+  await page.touchscreen.tap(newsLinkBox.x + newsLinkBox.width / 2, newsLinkBox.y);
 
   // Wait until the navigation is done before closing the page.
   // Otherwise, there will be a race condition between the page closing


### PR DESCRIPTION
## What?

Makes `Tap` async.

**Note:** We'll merge this once we conclude on an approach to rollout the Async API.

## Why?

See #1251.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#1251