### PR TITLE
Fix log warn in execution context

### DIFF
--- a/common/execution_context.go
+++ b/common/execution_context.go
@@ -215,7 +215,7 @@ func (e *ExecutionContext) eval(
 			return nil, errors.New(cdpe.Message)
 		}
 
-		e.logger.Warn("ExecutionContext:eval", "Unexpected DevTools server error: %v", err)
+		e.logger.Warnf("ExecutionContext:eval", "Unexpected DevTools server error: %v", err)
 		return nil, err
 	}
 	if exceptionDetails != nil {


### PR DESCRIPTION
## What?

Replace `Warn` with `Warnf`.

## Why?

We used `Warn` incorrectly.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas
