### PR TITLE
Add sync to async example

### DIFF
--- a/browser/browser_context_mapping.go
+++ b/browser/browser_context_mapping.go
@@ -15,6 +15,12 @@ import (
 func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolint:funlen,gocognit,cyclop
 	rt := vu.Runtime()
 	return mapping{
+		"addCookiesAsync": func(cookies []*common.Cookie) *goja.Promise {
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				err := bc.AddCookies(cookies)
+				return nil, err //nolint:wrapcheck
+			})
+		},
 		"addCookies": bc.AddCookies,
 		"addInitScript": func(script goja.Value) error {
 			if !gojaValueExists(script) {

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -113,6 +113,9 @@ func TestMappings(t *testing.T) {
 			}
 			// to detect if a method is redundantly mapped.
 			tested[m] = true
+			// TODO: Remove this once we turn all our relevant methods
+			// from sync to async.
+			tested[m+"Async"] = true
 		}
 		// detect redundant mappings.
 		for m := range mapped {

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -35,8 +35,10 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 
 			return p.Close(opts) //nolint:wrapcheck
 		},
-		"content":  p.Content,
-		"context":  p.Context,
+		"content": p.Content,
+		"context": func() mapping {
+			return mapBrowserContext(vu, p.Context())
+		},
 		"dblclick": p.Dblclick,
 		"dispatchEvent": func(selector, typ string, eventInit, opts goja.Value) error {
 			popts := common.NewFrameDispatchEventOptions(p.Timeout())

--- a/examples/cookies.js
+++ b/examples/cookies.js
@@ -32,7 +32,7 @@ export default async function () {
     const day = 60*60*24;
     const dayAfter = unixTimeSinceEpoch+day;
     const dayBefore = unixTimeSinceEpoch-day;
-    context.addCookies([
+    await context.addCookiesAsync([
       // this cookie expires at the end of the session
       {
         name: 'testcookie',
@@ -82,25 +82,25 @@ export default async function () {
     });
 
     // let's add more cookies to filter by urls.
-    context.addCookies([
+    await context.addCookiesAsync([
       {
-        name: 'foo',
-        value: '42',
-        sameSite: 'Strict',
-        url: 'http://foo.com'
+        name: "foo",
+        value: "42",
+        sameSite: "Strict",
+        url: "http://foo.com",
       },
       {
-        name: 'bar',
-        value: '43',
-        sameSite: 'Lax',
-        url: 'https://bar.com'
+        name: "bar",
+        value: "43",
+        sameSite: "Lax",
+        url: "https://bar.com",
       },
       {
-        name: 'baz',
-        value: '44',
-        sameSite: 'Lax',
-        url: 'https://baz.com'
-      }
+        name: "baz",
+        value: "44",
+        sameSite: "Lax",
+        url: "https://baz.com",
+      },
     ]);
     cookies = context.cookies('http://foo.com', 'https://baz.com');
     check(cookies.length, {


### PR DESCRIPTION
## What?

This exemplifies a strategy for upgrading from sync methods to async without using a separate branch.

## Why?

Benefits:

* Reduces the possible merging conflicts if we can't deliver the sync-to-async migration (#428 ) in one cycle.
* No need to deal with keeping the `main-async` branch up-to-date.
* The work can span multiple cycles if it would be necessary.

## Strategy

How does it work?

1. Add an `Async` suffix to a sync method.
2. Turn the method into an async one.
3. The slightly modified mapping tests ensure that the method exists.

The strategy once we complete the migration:

1. Remove the sync methods.
2. Remove `Async` from the async methods.

We won't publish `Async` methods in TypeScripts or documentation until we complete the whole work.

## Example

As an example, I showcase the `addCookies` method.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas