### PR TITLE
Fix NPD when using goto on a second page

### DIFF
--- a/browser/browser_mapping.go
+++ b/browser/browser_mapping.go
@@ -12,12 +12,12 @@ import (
 func mapBrowser(vu moduleVU) mapping { //nolint:funlen,cyclop
 	rt := vu.Runtime()
 	return mapping{
-		"context": func() (*common.BrowserContext, error) {
+		"context": func() (mapping, error) {
 			b, err := vu.browser()
 			if err != nil {
 				return nil, err
 			}
-			return b.Context(), nil
+			return mapBrowserContext(vu, b.Context()), nil
 		},
 		"closeContext": func() error {
 			b, err := vu.browser()


### PR DESCRIPTION
## What?

This fixes an issue when working with a second tab (i.e. opening a new page in the same existing browserContext), and navigating to a url.

You can also test with the following test script to see what happens without the fix and with the fix:

```js
import { browser } from "k6/x/browser";

export const options = {
  scenarios: {
    ui: {
      executor: "shared-iterations",
      options: {
        browser: {
          type: "chromium",
        },
      },
    },
  }
};

export default async function () {
  const page = browser.newPage();
  await page.goto("https://k6.io", { waitUntil: "networkidle" });

  const context = browser.context();
  const page2 = context.newPage();
  await page2.goto("https://k6.io", { waitUntil: "networkidle" });

  page.close();
}
```

## Why?

This issue would arise as soon as any API is used from the new page instance. This was occurring due to the unmapped `browserContext` when getting it from the `browser`.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [X] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
