### PR TITLE
Prepare `Keyboard` for Async migration

### DIFF
--- a/browser/keyboard_mapping.go
+++ b/browser/keyboard_mapping.go
@@ -1,0 +1,13 @@
+package browser
+
+import "github.com/grafana/xk6-browser/common"
+
+func mapKeyboard(_ moduleVU, kb *common.Keyboard) mapping {
+	return mapping{
+		"up":         kb.Up,
+		"down":       kb.Down,
+		"press":      kb.Press,
+		"type":       kb.Type,
+		"insertText": kb.InsertText,
+	}
+}

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -199,6 +199,12 @@ func TestMappings(t *testing.T) {
 				return mapTouchscreen(moduleVU{VU: vu}, &common.Touchscreen{})
 			},
 		},
+		"mapKeyboard": {
+			apiInterface: (*keyboardAPI)(nil),
+			mapp: func() mapping {
+				return mapKeyboard(moduleVU{VU: vu}, &common.Keyboard{})
+			},
+		},
 	} {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
@@ -514,15 +520,12 @@ type locatorAPI interface {
 }
 
 // keyboardAPI is the interface of a keyboard input device.
-// TODO: map this to page.GetKeyboard(). Currently, the common.Keyboard type
-// mapping is not tested using this interface. We use the concrete type
-// without testing its exported methods.
-type keyboardAPI interface { //nolint: unused
+type keyboardAPI interface {
 	Down(key string)
+	Up(key string)
 	InsertText(char string)
 	Press(key string, opts goja.Value)
 	Type(text string, opts goja.Value)
-	Up(key string)
 }
 
 // touchscreenAPI is the interface of a touchscreen.

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -525,7 +525,7 @@ type keyboardAPI interface {
 	Up(key string) error
 	InsertText(char string) error
 	Press(key string, opts goja.Value) error
-	Type(text string, opts goja.Value)
+	Type(text string, opts goja.Value) error
 }
 
 // touchscreenAPI is the interface of a touchscreen.

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -524,7 +524,7 @@ type keyboardAPI interface {
 	Down(key string) error
 	Up(key string) error
 	InsertText(char string)
-	Press(key string, opts goja.Value)
+	Press(key string, opts goja.Value) error
 	Type(text string, opts goja.Value)
 }
 

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -522,7 +522,7 @@ type locatorAPI interface {
 // keyboardAPI is the interface of a keyboard input device.
 type keyboardAPI interface {
 	Down(key string)
-	Up(key string)
+	Up(key string) error
 	InsertText(char string)
 	Press(key string, opts goja.Value)
 	Type(text string, opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -521,7 +521,7 @@ type locatorAPI interface {
 
 // keyboardAPI is the interface of a keyboard input device.
 type keyboardAPI interface {
-	Down(key string)
+	Down(key string) error
 	Up(key string) error
 	InsertText(char string)
 	Press(key string, opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -523,7 +523,7 @@ type locatorAPI interface {
 type keyboardAPI interface {
 	Down(key string) error
 	Up(key string) error
-	InsertText(char string)
+	InsertText(char string) error
 	Press(key string, opts goja.Value) error
 	Type(text string, opts goja.Value)
 }

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -98,7 +98,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 		"isEnabled":  p.IsEnabled,
 		"isHidden":   p.IsHidden,
 		"isVisible":  p.IsVisible,
-		"keyboard":   rt.ToValue(p.GetKeyboard()).ToObject(rt),
+		"keyboard":   mapKeyboard(vu, p.GetKeyboard()),
 		"locator": func(selector string, opts goja.Value) *goja.Object {
 			ml := mapLocator(vu, p.Locator(selector, opts))
 			return rt.ToValue(ml).ToObject(rt)

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -271,7 +271,9 @@ func (h *ElementHandle) fill(_ context.Context, value string) error {
 	}
 
 	if s == resultNeedsInput {
-		h.frame.page.Keyboard.InsertText(value)
+		if err := h.frame.page.Keyboard.InsertText(value); err != nil {
+			return fmt.Errorf("fill: %w", err)
+		}
 	} else if s != resultDone {
 		// Either we're done or an error happened (returned as "error:..." from JS)
 		return errorFromDOMError(s)

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/keyboardlayout"
 
 	"github.com/chromedp/cdproto/cdp"
@@ -89,14 +88,15 @@ func (k *Keyboard) InsertText(text string) error {
 //
 // It sends an insertText message if a character is not among
 // valid characters in the keyboard's layout.
-func (k *Keyboard) Type(text string, opts goja.Value) {
+func (k *Keyboard) Type(text string, opts goja.Value) error {
 	kbdOpts := NewKeyboardOptions()
 	if err := kbdOpts.Parse(k.ctx, opts); err != nil {
-		k6ext.Panic(k.ctx, "parsing keyboard options: %w", err)
+		return fmt.Errorf("parsing keyboard options: %w", err)
 	}
 	if err := k.typ(text, kbdOpts); err != nil {
-		k6ext.Panic(k.ctx, "typing text: %w", err)
+		return fmt.Errorf("typing text: %w", err)
 	}
+	return nil
 }
 
 func (k *Keyboard) down(key string) error {

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -45,10 +45,11 @@ func NewKeyboard(ctx context.Context, s session) *Keyboard {
 }
 
 // Down sends a key down message to a session target.
-func (k *Keyboard) Down(key string) {
+func (k *Keyboard) Down(key string) error {
 	if err := k.down(key); err != nil {
-		k6ext.Panic(k.ctx, "sending key down: %w", err)
+		return fmt.Errorf("sending key down: %w", err)
 	}
+	return nil
 }
 
 // Up sends a key up message to a session target.

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -63,15 +63,17 @@ func (k *Keyboard) Up(key string) error {
 // Press sends a key press message to a session target.
 // It delays the action if `Delay` option is specified.
 // A press message consists of successive key down and up messages.
-func (k *Keyboard) Press(key string, opts goja.Value) {
+func (k *Keyboard) Press(key string, opts goja.Value) error {
 	kbdOpts := NewKeyboardOptions()
 	if err := kbdOpts.Parse(k.ctx, opts); err != nil {
-		k6ext.Panic(k.ctx, "parsing keyboard options: %w", err)
+		return fmt.Errorf("parsing keyboard options: %w", err)
 	}
 
 	if err := k.comboPress(key, kbdOpts); err != nil {
-		k6ext.Panic(k.ctx, "pressing key: %w", err)
+		return fmt.Errorf("pressing key: %w", err)
 	}
+
+	return nil
 }
 
 // InsertText inserts a text without dispatching key events.

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -77,10 +77,11 @@ func (k *Keyboard) Press(key string, opts goja.Value) error {
 }
 
 // InsertText inserts a text without dispatching key events.
-func (k *Keyboard) InsertText(text string) {
+func (k *Keyboard) InsertText(text string) error {
 	if err := k.insertText(text); err != nil {
-		k6ext.Panic(k.ctx, "inserting text: %w", err)
+		return fmt.Errorf("inserting text: %w", err)
 	}
+	return nil
 }
 
 // Type sends a press message to a session target for each character in text.

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -52,10 +52,11 @@ func (k *Keyboard) Down(key string) {
 }
 
 // Up sends a key up message to a session target.
-func (k *Keyboard) Up(key string) {
+func (k *Keyboard) Up(key string) error {
 	if err := k.up(key); err != nil {
-		k6ext.Panic(k.ctx, "sending key up: %w", err)
+		return fmt.Errorf("sending key up: %w", err)
 	}
+	return nil
 }
 
 // Press sends a key press message to a session target.

--- a/common/keyboard_test.go
+++ b/common/keyboard_test.go
@@ -3,11 +3,11 @@ package common
 import (
 	"testing"
 
-	"github.com/grafana/xk6-browser/k6ext/k6test"
-	"github.com/grafana/xk6-browser/keyboardlayout"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/k6ext/k6test"
+	"github.com/grafana/xk6-browser/keyboardlayout"
 )
 
 func TestSplit(t *testing.T) {

--- a/common/keyboard_test.go
+++ b/common/keyboard_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/xk6-browser/keyboardlayout"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSplit(t *testing.T) {
@@ -82,7 +83,7 @@ func TestKeyboardPress(t *testing.T) {
 
 		vu := k6test.NewVU(t)
 		k := NewKeyboard(vu.Context(), nil)
-		assert.Panics(t, func() { k.Press("", nil) })
+		require.Error(t, k.Press("", nil))
 	})
 }
 

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -136,12 +136,12 @@ func TestKeyboardPress(t *testing.T) {
 
 		kb.Down("Shift")
 		kb.Down("f")
-		kb.Up("f")
+		require.NoError(t, kb.Up("f"))
 		kb.Down("G")
-		kb.Up("G")
+		require.NoError(t, kb.Up("G"))
 		kb.Down("KeyH")
-		kb.Up("KeyH")
-		kb.Up("Shift")
+		require.NoError(t, kb.Up("KeyH"))
+		require.NoError(t, kb.Up("Shift"))
 
 		assert.Equal(t, "CdefGH", el.InputValue(nil))
 	})
@@ -160,7 +160,7 @@ func TestKeyboardPress(t *testing.T) {
 
 		kb.Down("Shift")
 		kb.Type("oPqR", nil)
-		kb.Up("Shift")
+		require.NoError(t, kb.Up("Shift"))
 
 		assert.Equal(t, "oPqR", el.InputValue(nil))
 	})

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -41,7 +41,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		p.Focus("input", nil)
 
-		kb.Type("Hello World!", nil)
+		require.NoError(t, kb.Type("Hello World!", nil))
 		require.Equal(t, "Hello World!", el.InputValue(nil))
 
 		require.NoError(t, kb.Press("Backspace", nil))
@@ -114,7 +114,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		p.Focus("textarea", nil)
 
-		kb.Type("L+m+KeyN", nil)
+		require.NoError(t, kb.Type("L+m+KeyN", nil))
 		assert.Equal(t, "L+m+KeyN", el.InputValue(nil))
 	})
 
@@ -159,7 +159,7 @@ func TestKeyboardPress(t *testing.T) {
 		p.Focus("textarea", nil)
 
 		require.NoError(t, kb.Down("Shift"))
-		kb.Type("oPqR", nil)
+		require.NoError(t, kb.Type("oPqR", nil))
 		require.NoError(t, kb.Up("Shift"))
 
 		assert.Equal(t, "oPqR", el.InputValue(nil))
@@ -177,10 +177,10 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		p.Focus("textarea", nil)
 
-		kb.Type("Hello", nil)
+		require.NoError(t, kb.Type("Hello", nil))
 		require.NoError(t, kb.Press("Enter", nil))
 		require.NoError(t, kb.Press("Enter", nil))
-		kb.Type("World!", nil)
+		require.NoError(t, kb.Type("World!", nil))
 		assert.Equal(t, "Hello\n\nWorld!", el.InputValue(nil))
 	})
 
@@ -197,7 +197,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		p.Focus("input", nil)
 
-		kb.Type("Hello World!", nil)
+		require.NoError(t, kb.Type("Hello World!", nil))
 		require.Equal(t, "Hello World!", el.InputValue(nil))
 
 		require.NoError(t, kb.Press("ArrowLeft", nil))

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -24,7 +24,7 @@ func TestKeyboardPress(t *testing.T) {
 
 		assert.NotPanics(t, func() {
 			for k := range layout.Keys {
-				kb.Press(string(k), nil)
+				require.NoError(t, kb.Press(string(k), nil))
 			}
 		})
 	})
@@ -44,7 +44,7 @@ func TestKeyboardPress(t *testing.T) {
 		kb.Type("Hello World!", nil)
 		require.Equal(t, "Hello World!", el.InputValue(nil))
 
-		kb.Press("Backspace", nil)
+		require.NoError(t, kb.Press("Backspace", nil))
 		assert.Equal(t, "Hello World", el.InputValue(nil))
 	})
 
@@ -60,17 +60,17 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		p.Focus("input", nil)
 
-		kb.Press("Shift++", nil)
-		kb.Press("Shift+=", nil)
-		kb.Press("Shift+@", nil)
-		kb.Press("Shift+6", nil)
-		kb.Press("Shift+KeyA", nil)
-		kb.Press("Shift+b", nil)
-		kb.Press("Shift+C", nil)
+		require.NoError(t, kb.Press("Shift++", nil))
+		require.NoError(t, kb.Press("Shift+=", nil))
+		require.NoError(t, kb.Press("Shift+@", nil))
+		require.NoError(t, kb.Press("Shift+6", nil))
+		require.NoError(t, kb.Press("Shift+KeyA", nil))
+		require.NoError(t, kb.Press("Shift+b", nil))
+		require.NoError(t, kb.Press("Shift+C", nil))
 
-		kb.Press("Control+KeyI", nil)
-		kb.Press("Control+J", nil)
-		kb.Press("Control+k", nil)
+		require.NoError(t, kb.Press("Control+KeyI", nil))
+		require.NoError(t, kb.Press("Control+J", nil))
+		require.NoError(t, kb.Press("Control+k", nil))
 
 		require.Equal(t, "+=@6AbC", el.InputValue(nil))
 	})
@@ -87,9 +87,9 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		p.Focus("input", nil)
 
-		kb.Press("Shift+KeyA", nil)
-		kb.Press("Shift+b", nil)
-		kb.Press("Shift+C", nil)
+		require.NoError(t, kb.Press("Shift+KeyA", nil))
+		require.NoError(t, kb.Press("Shift+b", nil))
+		require.NoError(t, kb.Press("Shift+C", nil))
 
 		require.Equal(t, "AbC", el.InputValue(nil))
 
@@ -97,8 +97,8 @@ func TestKeyboardPress(t *testing.T) {
 		if runtime.GOOS == "darwin" {
 			metaKey = "Meta"
 		}
-		kb.Press(metaKey+"+A", nil)
-		kb.Press("Delete", nil)
+		require.NoError(t, kb.Press(metaKey+"+A", nil))
+		require.NoError(t, kb.Press("Delete", nil))
 		assert.Equal(t, "", el.InputValue(nil))
 	})
 
@@ -130,9 +130,9 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		p.Focus("textarea", nil)
 
-		kb.Press("C", nil)
-		kb.Press("d", nil)
-		kb.Press("KeyE", nil)
+		require.NoError(t, kb.Press("C", nil))
+		require.NoError(t, kb.Press("d", nil))
+		require.NoError(t, kb.Press("KeyE", nil))
 
 		require.NoError(t, kb.Down("Shift"))
 		require.NoError(t, kb.Down("f"))
@@ -178,8 +178,8 @@ func TestKeyboardPress(t *testing.T) {
 		p.Focus("textarea", nil)
 
 		kb.Type("Hello", nil)
-		kb.Press("Enter", nil)
-		kb.Press("Enter", nil)
+		require.NoError(t, kb.Press("Enter", nil))
+		require.NoError(t, kb.Press("Enter", nil))
 		kb.Type("World!", nil)
 		assert.Equal(t, "Hello\n\nWorld!", el.InputValue(nil))
 	})
@@ -200,16 +200,16 @@ func TestKeyboardPress(t *testing.T) {
 		kb.Type("Hello World!", nil)
 		require.Equal(t, "Hello World!", el.InputValue(nil))
 
-		kb.Press("ArrowLeft", nil)
+		require.NoError(t, kb.Press("ArrowLeft", nil))
 		// Should hold the key until Up() is called.
 		require.NoError(t, kb.Down("Shift"))
 		for i := 0; i < len(" World"); i++ {
-			kb.Press("ArrowLeft", nil)
+			require.NoError(t, kb.Press("ArrowLeft", nil))
 		}
 		// Should release the key but the selection should remain active.
 		kb.Up("Shift")
 		// Should delete the selection.
-		kb.Press("Backspace", nil)
+		require.NoError(t, kb.Press("Backspace", nil))
 
 		assert.Equal(t, "Hello!", el.InputValue(nil))
 	})

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -134,12 +134,12 @@ func TestKeyboardPress(t *testing.T) {
 		kb.Press("d", nil)
 		kb.Press("KeyE", nil)
 
-		kb.Down("Shift")
-		kb.Down("f")
+		require.NoError(t, kb.Down("Shift"))
+		require.NoError(t, kb.Down("f"))
 		require.NoError(t, kb.Up("f"))
-		kb.Down("G")
+		require.NoError(t, kb.Down("G"))
 		require.NoError(t, kb.Up("G"))
-		kb.Down("KeyH")
+		require.NoError(t, kb.Down("KeyH"))
 		require.NoError(t, kb.Up("KeyH"))
 		require.NoError(t, kb.Up("Shift"))
 
@@ -158,7 +158,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		p.Focus("textarea", nil)
 
-		kb.Down("Shift")
+		require.NoError(t, kb.Down("Shift"))
 		kb.Type("oPqR", nil)
 		require.NoError(t, kb.Up("Shift"))
 
@@ -202,7 +202,7 @@ func TestKeyboardPress(t *testing.T) {
 
 		kb.Press("ArrowLeft", nil)
 		// Should hold the key until Up() is called.
-		kb.Down("Shift")
+		require.NoError(t, kb.Down("Shift"))
 		for i := 0; i < len(" World"); i++ {
 			kb.Press("ArrowLeft", nil)
 		}


### PR DESCRIPTION
## What?

Maps the forgotten `Keyboard`, adds a test, and turns panics into errors.

## Why?

To make the async migration.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#1304