### PR TITLE
Prepare `BrowserContext` for async migration

### DIFF
--- a/browser/browser_context_mapping.go
+++ b/browser/browser_context_mapping.go
@@ -43,7 +43,10 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 
 			return bc.AddInitScript(source) //nolint:wrapcheck
 		},
-		"browser":          bc.Browser,
+		"browser": func() mapping {
+			// the browser is grabbed from VU.
+			return mapBrowser(vu)
+		},
 		"clearCookies":     bc.ClearCookies,
 		"clearPermissions": bc.ClearPermissions,
 		"close":            bc.Close,

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -285,7 +285,7 @@ type browserContextAPI interface {
 	Pages() []*common.Page
 	SetDefaultNavigationTimeout(timeout int64)
 	SetDefaultTimeout(timeout int64)
-	SetGeolocation(geolocation goja.Value)
+	SetGeolocation(geolocation goja.Value) error
 	SetHTTPCredentials(httpCredentials goja.Value)
 	SetOffline(offline bool)
 	WaitForEvent(event string, optsOrPredicate goja.Value) (any, error)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -286,7 +286,7 @@ type browserContextAPI interface {
 	SetDefaultNavigationTimeout(timeout int64)
 	SetDefaultTimeout(timeout int64)
 	SetGeolocation(geolocation goja.Value) error
-	SetHTTPCredentials(httpCredentials goja.Value)
+	SetHTTPCredentials(httpCredentials goja.Value) error
 	SetOffline(offline bool)
 	WaitForEvent(event string, optsOrPredicate goja.Value) (any, error)
 }

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -277,7 +277,7 @@ type browserContextAPI interface {
 	AddInitScript(script goja.Value, arg goja.Value) error
 	Browser() *common.Browser
 	ClearCookies() error
-	ClearPermissions()
+	ClearPermissions() error
 	Close() error
 	Cookies(urls ...string) ([]*common.Cookie, error)
 	GrantPermissions(permissions []string, opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -287,7 +287,7 @@ type browserContextAPI interface {
 	SetDefaultTimeout(timeout int64)
 	SetGeolocation(geolocation goja.Value) error
 	SetHTTPCredentials(httpCredentials goja.Value) error
-	SetOffline(offline bool)
+	SetOffline(offline bool) error
 	WaitForEvent(event string, optsOrPredicate goja.Value) (any, error)
 }
 

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -280,7 +280,7 @@ type browserContextAPI interface {
 	ClearPermissions() error
 	Close() error
 	Cookies(urls ...string) ([]*common.Cookie, error)
-	GrantPermissions(permissions []string, opts goja.Value)
+	GrantPermissions(permissions []string, opts goja.Value) error
 	NewPage() (*common.Page, error)
 	Pages() []*common.Page
 	SetDefaultNavigationTimeout(timeout int64)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -278,7 +278,7 @@ type browserContextAPI interface {
 	Browser() *common.Browser
 	ClearCookies() error
 	ClearPermissions()
-	Close()
+	Close() error
 	Cookies(urls ...string) ([]*common.Cookie, error)
 	GrantPermissions(permissions []string, opts goja.Value)
 	NewPage() (*common.Page, error)

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -35,8 +35,10 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 
 			return p.Close(opts) //nolint:wrapcheck
 		},
-		"content":  p.Content,
-		"context":  p.Context,
+		"content": p.Content,
+		"context": func() mapping {
+			return mapBrowserContext(vu, p.Context())
+		},
 		"dblclick": p.Dblclick,
 		"dispatchEvent": func(selector, typ string, eventInit, opts goja.Value) error {
 			popts := common.NewFrameDispatchEventOptions(p.Timeout())

--- a/common/browser.go
+++ b/common/browser.go
@@ -529,8 +529,7 @@ func (b *Browser) CloseContext() error {
 	if b.context == nil {
 		return errors.New("cannot close context as none is active in browser")
 	}
-	b.context.Close()
-	return nil
+	return b.context.Close()
 }
 
 // Context returns the current browser context or nil.

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -305,13 +305,20 @@ func (b *BrowserContext) SetHTTPCredentials(httpCredentials goja.Value) error {
 }
 
 // SetOffline toggles the browser's connectivity on/off.
-func (b *BrowserContext) SetOffline(offline bool) {
+func (b *BrowserContext) SetOffline(offline bool) error {
 	b.logger.Debugf("BrowserContext:SetOffline", "bctxid:%v offline:%t", b.id, offline)
 
 	b.opts.Offline = offline
 	for _, p := range b.browser.getPages() {
-		p.updateOffline()
+		if err := p.updateOffline(); err != nil {
+			return fmt.Errorf(
+				"setting offline status to %t for the browser context ID %s: %w",
+				offline, b.id, err,
+			)
+		}
 	}
+
+	return nil
 }
 
 // Timeout will return the default timeout or the one set by the user.

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -260,20 +260,22 @@ func (b *BrowserContext) SetDefaultTimeout(timeout int64) {
 }
 
 // SetGeolocation overrides the geo location of the user.
-func (b *BrowserContext) SetGeolocation(geolocation goja.Value) {
+func (b *BrowserContext) SetGeolocation(geolocation goja.Value) error {
 	b.logger.Debugf("BrowserContext:SetGeolocation", "bctxid:%v", b.id)
 
 	g := NewGeolocation()
 	if err := g.Parse(b.ctx, geolocation); err != nil {
-		k6ext.Panic(b.ctx, "parsing geo location: %v", err)
+		return fmt.Errorf("parsing geo location: %w", err)
 	}
 
 	b.opts.Geolocation = g
 	for _, p := range b.browser.getPages() {
 		if err := p.updateGeolocation(); err != nil {
-			k6ext.Panic(b.ctx, "updating geo location in target ID %s: %w", p.targetID, err)
+			return fmt.Errorf("updating geo location in target ID %s: %w", p.targetID, err)
 		}
 	}
+
+	return nil
 }
 
 // SetHTTPCredentials sets username/password credentials to use for HTTP authentication.

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -161,15 +161,16 @@ func (b *BrowserContext) ClearPermissions() error {
 }
 
 // Close shuts down the browser context.
-func (b *BrowserContext) Close() {
+func (b *BrowserContext) Close() error {
 	b.logger.Debugf("BrowserContext:Close", "bctxid:%v", b.id)
 
 	if b.id == "" {
-		k6ext.Panic(b.ctx, "default browser context can't be closed")
+		return fmt.Errorf("default browser context can't be closed")
 	}
 	if err := b.browser.disposeContext(b.id); err != nil {
-		k6ext.Panic(b.ctx, "disposing browser context: %w", err)
+		return fmt.Errorf("disposing browser context: %w", err)
 	}
+	return nil
 }
 
 // GrantPermissions enables the specified permissions, all others will be disabled.

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -519,7 +519,9 @@ func (fs *FrameSession) initOptions() error {
 	}
 
 	fs.updateOffline(true)
-	fs.updateHTTPCredentials(true)
+	if err := fs.updateHTTPCredentials(true); err != nil {
+		return err
+	}
 	if err := fs.updateEmulateMedia(true); err != nil {
 		return err
 	}
@@ -1083,16 +1085,19 @@ func (fs *FrameSession) updateGeolocation(initial bool) error {
 			return fmt.Errorf("%w", err)
 		}
 	}
+
 	return nil
 }
 
-func (fs *FrameSession) updateHTTPCredentials(initial bool) {
+func (fs *FrameSession) updateHTTPCredentials(initial bool) error {
 	fs.logger.Debugf("NewFrameSession:updateHttpCredentials", "sid:%v tid:%v", fs.session.ID(), fs.targetID)
 
 	credentials := fs.page.browserCtx.opts.HttpCredentials
 	if !initial || credentials != nil {
-		fs.networkManager.Authenticate(credentials)
+		return fs.networkManager.Authenticate(credentials)
 	}
+
+	return nil
 }
 
 func (fs *FrameSession) updateOffline(initial bool) {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -518,7 +518,9 @@ func (fs *FrameSession) initOptions() error {
 		return err
 	}
 
-	fs.updateOffline(true)
+	if err := fs.updateOffline(true); err != nil {
+		return err
+	}
 	if err := fs.updateHTTPCredentials(true); err != nil {
 		return err
 	}
@@ -1100,13 +1102,17 @@ func (fs *FrameSession) updateHTTPCredentials(initial bool) error {
 	return nil
 }
 
-func (fs *FrameSession) updateOffline(initial bool) {
+func (fs *FrameSession) updateOffline(initial bool) error {
 	fs.logger.Debugf("NewFrameSession:updateOffline", "sid:%v tid:%v", fs.session.ID(), fs.targetID)
 
 	offline := fs.page.browserCtx.opts.Offline
 	if !initial || offline {
-		fs.networkManager.SetOfflineMode(offline)
+		if err := fs.networkManager.SetOfflineMode(offline); err != nil {
+			return fmt.Errorf("updating offline mode for frame %v: %w", fs.targetID, err)
+		}
 	}
+
+	return nil
 }
 
 func (fs *FrameSession) throttleNetwork(networkProfile NetworkProfile) error {

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -732,9 +732,9 @@ func (m *NetworkManager) SetExtraHTTPHeaders(headers network.Headers) {
 }
 
 // SetOfflineMode toggles offline mode on/off.
-func (m *NetworkManager) SetOfflineMode(offline bool) {
+func (m *NetworkManager) SetOfflineMode(offline bool) error {
 	if m.offline == offline {
-		return
+		return nil
 	}
 	m.offline = offline
 
@@ -745,8 +745,10 @@ func (m *NetworkManager) SetOfflineMode(offline bool) {
 		m.networkProfile.Upload,
 	)
 	if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
-		k6ext.Panic(m.ctx, "setting offline mode: %w", err)
+		return fmt.Errorf("emulating network conditions: %w", err)
 	}
+
+	return nil
 }
 
 // ThrottleNetwork changes the network attributes in chrome to simulate slower

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -705,14 +705,16 @@ func (m *NetworkManager) updateProtocolRequestInterception() error {
 }
 
 // Authenticate sets HTTP authentication credentials to use.
-func (m *NetworkManager) Authenticate(credentials *Credentials) {
+func (m *NetworkManager) Authenticate(credentials *Credentials) error {
 	m.credentials = credentials
 	if credentials != nil {
 		m.userReqInterceptionEnabled = true
 	}
 	if err := m.updateProtocolRequestInterception(); err != nil {
-		k6ext.Panic(m.ctx, "setting authentication credentials: %w", err)
+		return fmt.Errorf("setting authentication credentials: %w", err)
 	}
+
+	return nil
 }
 
 // ExtraHTTPHeaders returns the currently set extra HTTP request headers.

--- a/common/page.go
+++ b/common/page.go
@@ -583,15 +583,19 @@ func (p *Page) updateOffline() {
 	}
 }
 
-func (p *Page) updateHttpCredentials() {
+func (p *Page) updateHTTPCredentials() error {
 	p.logger.Debugf("Page:updateHttpCredentials", "sid:%v", p.sessionID())
 
 	p.frameSessionsMu.RLock()
 	defer p.frameSessionsMu.RUnlock()
 
 	for _, fs := range p.frameSessions {
-		fs.updateHTTPCredentials(false)
+		if err := fs.updateHTTPCredentials(false); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
 func (p *Page) viewportSize() Size {

--- a/common/page.go
+++ b/common/page.go
@@ -572,15 +572,19 @@ func (p *Page) updateGeolocation() error {
 	return nil
 }
 
-func (p *Page) updateOffline() {
+func (p *Page) updateOffline() error {
 	p.logger.Debugf("Page:updateOffline", "sid:%v", p.sessionID())
 
 	p.frameSessionsMu.RLock()
 	defer p.frameSessionsMu.RUnlock()
 
 	for _, fs := range p.frameSessions {
-		fs.updateOffline(false)
+		if err := fs.updateOffline(false); err != nil {
+			return fmt.Errorf("updating page frame sessions to offline: %w", err)
+		}
 	}
+
+	return nil
 }
 
 func (p *Page) updateHTTPCredentials() error {

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -60,7 +60,11 @@ func TestBrowserContextOptionsSetViewport(t *testing.T) {
 		},
 	}))
 	require.NoError(t, err)
-	t.Cleanup(bctx.Close)
+	t.Cleanup(func() {
+		if err := bctx.Close(); err != nil {
+			t.Log("closing browser context:", err)
+		}
+	})
 	p, err := bctx.NewPage()
 	require.NoError(t, err)
 
@@ -81,7 +85,11 @@ func TestBrowserContextOptionsExtraHTTPHeaders(t *testing.T) {
 		},
 	}))
 	require.NoError(t, err)
-	t.Cleanup(bctx.Close)
+	t.Cleanup(func() {
+		if err := bctx.Close(); err != nil {
+			t.Log("closing browser context:", err)
+		}
+	})
 	p, err := bctx.NewPage()
 	require.NoError(t, err)
 

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -41,7 +41,7 @@ func TestBrowserNewPage(t *testing.T) {
 	_, err = b.Browser.NewPage(nil)
 	assert.EqualError(t, err, "new page: existing browser context must be closed before creating a new one")
 
-	b.Context().Close()
+	require.NoError(t, b.Context().Close())
 	c = b.Context()
 	assert.Nil(t, c)
 
@@ -62,7 +62,7 @@ func TestBrowserNewContext(t *testing.T) {
 	_, err = b.NewContext(nil)
 	assert.EqualError(t, err, "existing browser context must be closed before creating a new one")
 
-	bc1.Close()
+	require.NoError(t, bc1.Close())
 	c = b.Context()
 	assert.Nil(t, c)
 
@@ -339,7 +339,7 @@ func TestMultiConnectToSingleBrowser(t *testing.T) {
 
 	err = p1.Close(nil)
 	require.NoError(t, err, "failed to close page #1")
-	bctx1.Close()
+	require.NoError(t, bctx1.Close())
 
 	p2, err := bctx2.NewPage()
 	require.NoError(t, err, "failed to create page #2")


### PR DESCRIPTION
## What?

Turns panics into errors.

## Why?

To make the async migration more reliable.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#1295