### PR TITLE
Fix navigate to link in new page

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -105,6 +105,10 @@ func NewFrameSession(
 		logger:               l,
 	}
 
+	if err := cdpruntime.RunIfWaitingForDebugger().Do(cdp.WithExecutor(fs.ctx, fs.session)); err != nil {
+		return nil, fmt.Errorf("run if waiting for debugger to attach: %w", err)
+	}
+
 	var parentNM *NetworkManager
 	if fs.parent != nil {
 		parentNM = fs.parent.networkManager
@@ -531,8 +535,6 @@ func (fs *FrameSession) initOptions() error {
 	      promises.push(this._evaluateOnNewDocument(source, 'main'));
 	  for (const source of this._crPage._page._evaluateOnNewDocumentSources)
 	      promises.push(this._evaluateOnNewDocument(source, 'main'));*/
-
-	optActions = append(optActions, cdpruntime.RunIfWaitingForDebugger())
 
 	for _, action := range optActions {
 		if err := action.Do(cdp.WithExecutor(fs.ctx, fs.session)); err != nil {


### PR DESCRIPTION
## What?

Move the CDP request `RunIfWaitingForDebugger` to be called first when creating a `FrameSession`.

## Why?

We have identified that the call to `RunIfWaitingForDebugger` wasn't being performed at the correct time when a new page was created after a link was clicked on that opened the page.

This is currently the simplest and safest solution. I tried to place some of the CDP actions that are in `NewFrameSession` within their own goroutines but there were data races.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/827