### PR TITLE
Prepare `ElementHandle` for async migration

### DIFF
--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -434,7 +434,7 @@ type elementHandleAPI interface {
 	Hover(opts goja.Value) error
 	InnerHTML() (string, error)
 	InnerText() (string, error)
-	InputValue(opts goja.Value) string
+	InputValue(opts goja.Value) (string, error)
 	IsChecked() bool
 	IsDisabled() bool
 	IsEditable() bool

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -454,7 +454,7 @@ type elementHandleAPI interface {
 	TextContent() (string, error)
 	Type(text string, opts goja.Value) error
 	Uncheck(opts goja.Value) error
-	WaitForElementState(state string, opts goja.Value)
+	WaitForElementState(state string, opts goja.Value) error
 	WaitForSelector(selector string, opts goja.Value) (*common.ElementHandle, error)
 }
 

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -440,7 +440,7 @@ type elementHandleAPI interface {
 	IsEditable() (bool, error)
 	IsEnabled() (bool, error)
 	IsHidden() (bool, error)
-	IsVisible() bool
+	IsVisible() (bool, error)
 	OwnerFrame() (*common.Frame, error)
 	Press(key string, opts goja.Value)
 	Query(selector string) (*common.ElementHandle, error)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -431,7 +431,7 @@ type elementHandleAPI interface {
 	Fill(value string, opts goja.Value) error
 	Focus() error
 	GetAttribute(name string) (any, error)
-	Hover(opts goja.Value)
+	Hover(opts goja.Value) error
 	InnerHTML() string
 	InnerText() string
 	InputValue(opts goja.Value) string

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -427,7 +427,7 @@ type elementHandleAPI interface {
 	Click(opts goja.Value) error
 	ContentFrame() (*common.Frame, error)
 	Dblclick(opts goja.Value) error
-	DispatchEvent(typ string, props goja.Value)
+	DispatchEvent(typ string, props goja.Value) error
 	Fill(value string, opts goja.Value) error
 	Focus()
 	GetAttribute(name string) goja.Value

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -437,7 +437,7 @@ type elementHandleAPI interface {
 	InputValue(opts goja.Value) (string, error)
 	IsChecked() (bool, error)
 	IsDisabled() (bool, error)
-	IsEditable() bool
+	IsEditable() (bool, error)
 	IsEnabled() bool
 	IsHidden() bool
 	IsVisible() bool

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -442,7 +442,7 @@ type elementHandleAPI interface {
 	IsHidden() (bool, error)
 	IsVisible() (bool, error)
 	OwnerFrame() (*common.Frame, error)
-	Press(key string, opts goja.Value)
+	Press(key string, opts goja.Value) error
 	Query(selector string) (*common.ElementHandle, error)
 	QueryAll(selector string) ([]*common.ElementHandle, error)
 	Screenshot(opts goja.Value) goja.ArrayBuffer

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -453,7 +453,7 @@ type elementHandleAPI interface {
 	Tap(opts goja.Value) error
 	TextContent() string
 	Type(text string, opts goja.Value)
-	Uncheck(opts goja.Value)
+	Uncheck(opts goja.Value) error
 	WaitForElementState(state string, opts goja.Value)
 	WaitForSelector(selector string, opts goja.Value) (*common.ElementHandle, error)
 }

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -428,7 +428,7 @@ type elementHandleAPI interface {
 	ContentFrame() (*common.Frame, error)
 	Dblclick(opts goja.Value) error
 	DispatchEvent(typ string, props goja.Value)
-	Fill(value string, opts goja.Value)
+	Fill(value string, opts goja.Value) error
 	Focus()
 	GetAttribute(name string) goja.Value
 	Hover(opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -436,7 +436,7 @@ type elementHandleAPI interface {
 	InnerText() (string, error)
 	InputValue(opts goja.Value) (string, error)
 	IsChecked() (bool, error)
-	IsDisabled() bool
+	IsDisabled() (bool, error)
 	IsEditable() bool
 	IsEnabled() bool
 	IsHidden() bool

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -433,7 +433,7 @@ type elementHandleAPI interface {
 	GetAttribute(name string) (any, error)
 	Hover(opts goja.Value) error
 	InnerHTML() (string, error)
-	InnerText() string
+	InnerText() (string, error)
 	InputValue(opts goja.Value) string
 	IsChecked() bool
 	IsDisabled() bool

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -448,7 +448,7 @@ type elementHandleAPI interface {
 	Screenshot(opts goja.Value) (goja.ArrayBuffer, error)
 	ScrollIntoViewIfNeeded(opts goja.Value) error
 	SelectOption(values goja.Value, opts goja.Value) ([]string, error)
-	SelectText(opts goja.Value)
+	SelectText(opts goja.Value) error
 	SetInputFiles(files goja.Value, opts goja.Value)
 	Tap(opts goja.Value) error
 	TextContent() string

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -430,7 +430,7 @@ type elementHandleAPI interface {
 	DispatchEvent(typ string, props goja.Value) error
 	Fill(value string, opts goja.Value) error
 	Focus() error
-	GetAttribute(name string) goja.Value
+	GetAttribute(name string) (any, error)
 	Hover(opts goja.Value)
 	InnerHTML() string
 	InnerText() string

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -422,7 +422,7 @@ type frameAPI interface {
 type elementHandleAPI interface {
 	common.JSHandleAPI
 
-	BoundingBox() *common.Rect
+	BoundingBox() (*common.Rect, error)
 	Check(opts goja.Value)
 	Click(opts goja.Value) error
 	ContentFrame() (*common.Frame, error)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -426,7 +426,7 @@ type elementHandleAPI interface {
 	Check(opts goja.Value) error
 	Click(opts goja.Value) error
 	ContentFrame() (*common.Frame, error)
-	Dblclick(opts goja.Value)
+	Dblclick(opts goja.Value) error
 	DispatchEvent(typ string, props goja.Value)
 	Fill(value string, opts goja.Value)
 	Focus()

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -449,7 +449,7 @@ type elementHandleAPI interface {
 	ScrollIntoViewIfNeeded(opts goja.Value) error
 	SelectOption(values goja.Value, opts goja.Value) ([]string, error)
 	SelectText(opts goja.Value) error
-	SetInputFiles(files goja.Value, opts goja.Value)
+	SetInputFiles(files goja.Value, opts goja.Value) error
 	Tap(opts goja.Value) error
 	TextContent() string
 	Type(text string, opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -452,7 +452,7 @@ type elementHandleAPI interface {
 	SetInputFiles(files goja.Value, opts goja.Value) error
 	Tap(opts goja.Value) error
 	TextContent() (string, error)
-	Type(text string, opts goja.Value)
+	Type(text string, opts goja.Value) error
 	Uncheck(opts goja.Value) error
 	WaitForElementState(state string, opts goja.Value)
 	WaitForSelector(selector string, opts goja.Value) (*common.ElementHandle, error)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -432,7 +432,7 @@ type elementHandleAPI interface {
 	Focus() error
 	GetAttribute(name string) (any, error)
 	Hover(opts goja.Value) error
-	InnerHTML() string
+	InnerHTML() (string, error)
 	InnerText() string
 	InputValue(opts goja.Value) string
 	IsChecked() bool

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -423,7 +423,7 @@ type elementHandleAPI interface {
 	common.JSHandleAPI
 
 	BoundingBox() (*common.Rect, error)
-	Check(opts goja.Value)
+	Check(opts goja.Value) error
 	Click(opts goja.Value) error
 	ContentFrame() (*common.Frame, error)
 	Dblclick(opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -445,7 +445,7 @@ type elementHandleAPI interface {
 	Press(key string, opts goja.Value) error
 	Query(selector string) (*common.ElementHandle, error)
 	QueryAll(selector string) ([]*common.ElementHandle, error)
-	Screenshot(opts goja.Value) goja.ArrayBuffer
+	Screenshot(opts goja.Value) (goja.ArrayBuffer, error)
 	ScrollIntoViewIfNeeded(opts goja.Value)
 	SelectOption(values goja.Value, opts goja.Value) []string
 	SelectText(opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -438,7 +438,7 @@ type elementHandleAPI interface {
 	IsChecked() (bool, error)
 	IsDisabled() (bool, error)
 	IsEditable() (bool, error)
-	IsEnabled() bool
+	IsEnabled() (bool, error)
 	IsHidden() bool
 	IsVisible() bool
 	OwnerFrame() (*common.Frame, error)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -446,7 +446,7 @@ type elementHandleAPI interface {
 	Query(selector string) (*common.ElementHandle, error)
 	QueryAll(selector string) ([]*common.ElementHandle, error)
 	Screenshot(opts goja.Value) (goja.ArrayBuffer, error)
-	ScrollIntoViewIfNeeded(opts goja.Value)
+	ScrollIntoViewIfNeeded(opts goja.Value) error
 	SelectOption(values goja.Value, opts goja.Value) []string
 	SelectText(opts goja.Value)
 	SetInputFiles(files goja.Value, opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -451,7 +451,7 @@ type elementHandleAPI interface {
 	SelectText(opts goja.Value) error
 	SetInputFiles(files goja.Value, opts goja.Value) error
 	Tap(opts goja.Value) error
-	TextContent() string
+	TextContent() (string, error)
 	Type(text string, opts goja.Value)
 	Uncheck(opts goja.Value) error
 	WaitForElementState(state string, opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -439,7 +439,7 @@ type elementHandleAPI interface {
 	IsDisabled() (bool, error)
 	IsEditable() (bool, error)
 	IsEnabled() (bool, error)
-	IsHidden() bool
+	IsHidden() (bool, error)
 	IsVisible() bool
 	OwnerFrame() (*common.Frame, error)
 	Press(key string, opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -447,7 +447,7 @@ type elementHandleAPI interface {
 	QueryAll(selector string) ([]*common.ElementHandle, error)
 	Screenshot(opts goja.Value) (goja.ArrayBuffer, error)
 	ScrollIntoViewIfNeeded(opts goja.Value) error
-	SelectOption(values goja.Value, opts goja.Value) []string
+	SelectOption(values goja.Value, opts goja.Value) ([]string, error)
 	SelectText(opts goja.Value)
 	SetInputFiles(files goja.Value, opts goja.Value)
 	Tap(opts goja.Value) error

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -429,7 +429,7 @@ type elementHandleAPI interface {
 	Dblclick(opts goja.Value) error
 	DispatchEvent(typ string, props goja.Value) error
 	Fill(value string, opts goja.Value) error
-	Focus()
+	Focus() error
 	GetAttribute(name string) goja.Value
 	Hover(opts goja.Value)
 	InnerHTML() string

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -435,7 +435,7 @@ type elementHandleAPI interface {
 	InnerHTML() (string, error)
 	InnerText() (string, error)
 	InputValue(opts goja.Value) (string, error)
-	IsChecked() bool
+	IsChecked() (bool, error)
 	IsDisabled() bool
 	IsEditable() bool
 	IsEnabled() bool

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1650,11 +1650,11 @@ func errorFromDOMError(v any) error {
 		serr = e
 	case error:
 		if e == nil {
-			panic("DOM error is nil")
+			return errors.New("DOM error is nil")
 		}
 		err, serr = e, e.Error()
 	default:
-		panic(fmt.Errorf("unexpected DOM error type %T", v))
+		return fmt.Errorf("unexpected DOM error type %T", v)
 	}
 	var uerr *k6ext.UserFriendlyError
 	if errors.As(err, &uerr) {

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1082,9 +1082,9 @@ func (h *ElementHandle) Press(key string, opts goja.Value) error {
 func (h *ElementHandle) Query(selector string, strict bool) (*ElementHandle, error) {
 	parsedSelector, err := NewSelector(selector)
 	if err != nil {
-		k6ext.Panic(h.ctx, "parsing selector %q: %w", selector, err)
+		return nil, fmt.Errorf("parsing selector %q: %w", selector, err)
 	}
-	fn := `
+	querySelector := `
 		(node, injected, selector, strict) => {
 			return injected.querySelector(selector, strict, node || document);
 		}
@@ -1093,7 +1093,7 @@ func (h *ElementHandle) Query(selector string, strict bool) (*ElementHandle, err
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.evalWithScript(h.ctx, opts, fn, parsedSelector, strict)
+	result, err := h.evalWithScript(h.ctx, opts, querySelector, parsedSelector, strict)
 	if err != nil {
 		return nil, fmt.Errorf("querying selector %q: %w", selector, err)
 	}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1134,8 +1134,8 @@ func (h *ElementHandle) SetChecked(checked bool, opts goja.Value) error {
 
 // Uncheck scrolls element into view, and if it's an input element of type
 // checkbox that is already checked, clicks on it to mark it as unchecked.
-func (h *ElementHandle) Uncheck(opts goja.Value) {
-	h.SetChecked(false, opts)
+func (h *ElementHandle) Uncheck(opts goja.Value) error {
+	return h.SetChecked(false, opts)
 }
 
 // Check scrolls element into view, and if it's an input element of type

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1435,16 +1435,18 @@ func (h *ElementHandle) Type(text string, opts goja.Value) error {
 	return nil
 }
 
-func (h *ElementHandle) WaitForElementState(state string, opts goja.Value) {
-	parsedOpts := NewElementHandleWaitForElementStateOptions(h.defaultTimeout())
-	err := parsedOpts.Parse(h.ctx, opts)
-	if err != nil {
-		k6ext.Panic(h.ctx, "parsing waitForElementState options: %w", err)
+// WaitForElementState waits for the element to reach the given state.
+func (h *ElementHandle) WaitForElementState(state string, opts goja.Value) error {
+	popts := NewElementHandleWaitForElementStateOptions(h.defaultTimeout())
+	if err := popts.Parse(h.ctx, opts); err != nil {
+		return fmt.Errorf("parsing waitForElementState options: %w", err)
 	}
-	_, err = h.waitForElementState(h.ctx, []string{state}, parsedOpts.Timeout)
+	_, err := h.waitForElementState(h.ctx, []string{state}, popts.Timeout)
 	if err != nil {
-		k6ext.Panic(h.ctx, "waiting for element state %q: %w", state, err)
+		return fmt.Errorf("waiting for element state %q: %w", state, err)
 	}
+
+	return nil
 }
 
 // WaitForSelector waits for the selector to appear in the DOM.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -953,12 +953,14 @@ func (h *ElementHandle) IsChecked() (bool, error) {
 }
 
 // IsDisabled checks if the element is disabled.
-func (h *ElementHandle) IsDisabled() bool {
-	result, err := h.isDisabled(h.ctx, 0)
-	if err != nil && !errors.Is(err, ErrTimedOut) { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "checking element is disabled: %w", err)
+func (h *ElementHandle) IsDisabled() (bool, error) {
+	ok, err := h.isDisabled(h.ctx, 0)
+	// We don't care anout timeout errors here!
+	if err != nil && !errors.Is(err, ErrTimedOut) {
+		return false, fmt.Errorf("checking element is disabled: %w", err)
 	}
-	return result
+
+	return ok, nil
 }
 
 // IsEditable checks if the element is editable.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1293,20 +1293,25 @@ func (h *ElementHandle) SelectOption(values goja.Value, opts goja.Value) ([]stri
 	return returnVal, nil
 }
 
-func (h *ElementHandle) SelectText(opts goja.Value) {
-	actionOpts := NewElementHandleBaseOptions(h.defaultTimeout())
-	if err := actionOpts.Parse(h.ctx, opts); err != nil {
-		k6ext.Panic(h.ctx, "parsing selectText options: %w", err)
+// SelectText selects the text of the element.
+func (h *ElementHandle) SelectText(opts goja.Value) error {
+	aopts := NewElementHandleBaseOptions(h.defaultTimeout())
+	if err := aopts.Parse(h.ctx, opts); err != nil {
+		return fmt.Errorf("parsing selectText options: %w", err)
 	}
-	fn := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
+	selectText := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return nil, handle.selectText(apiCtx)
 	}
-	actFn := h.newAction([]string{}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
-	_, err := call(h.ctx, actFn, actionOpts.Timeout)
-	if err != nil {
-		k6ext.Panic(h.ctx, "selecting text: %w", err)
+	selectTextAction := h.newAction(
+		[]string{}, selectText, aopts.Force, aopts.NoWaitAfter, aopts.Timeout,
+	)
+	if _, err := call(h.ctx, selectTextAction, aopts.Timeout); err != nil {
+		return fmt.Errorf("selecting text: %w", err)
 	}
+
 	applySlowMo(h.ctx)
+
+	return nil
 }
 
 // SetInputFiles sets the given files into the input file element.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -975,12 +975,14 @@ func (h *ElementHandle) IsEditable() (bool, error) {
 }
 
 // IsEnabled checks if the element is enabled.
-func (h *ElementHandle) IsEnabled() bool {
-	result, err := h.isEnabled(h.ctx, 0)
-	if err != nil && !errors.Is(err, ErrTimedOut) { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "checking element is enabled: %w", err)
+func (h *ElementHandle) IsEnabled() (bool, error) {
+	ok, err := h.isEnabled(h.ctx, 0)
+	// We don't care anout timeout errors here!
+	if err != nil && !errors.Is(err, ErrTimedOut) {
+		return false, fmt.Errorf("checking element is enabled: %w", err)
 	}
-	return result
+
+	return ok, nil
 }
 
 // IsHidden checks if the element is hidden.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1113,8 +1113,6 @@ func (h *ElementHandle) Query(selector string, strict bool) (*ElementHandle, err
 // QueryAll queries element subtree for matching elements.
 // If no element matches the selector, the return value resolves to "null".
 func (h *ElementHandle) QueryAll(selector string) ([]*ElementHandle, error) {
-	defer applySlowMo(h.ctx)
-
 	handles, err := h.queryAll(selector, h.evalWithScript)
 	if err != nil {
 		return nil, fmt.Errorf("querying all selector %q: %w", selector, err)

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -986,12 +986,14 @@ func (h *ElementHandle) IsEnabled() (bool, error) {
 }
 
 // IsHidden checks if the element is hidden.
-func (h *ElementHandle) IsHidden() bool {
-	result, err := h.isHidden(h.ctx)
-	if err != nil && !errors.Is(err, ErrTimedOut) { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "checking element is hidden: %w", err)
+func (h *ElementHandle) IsHidden() (bool, error) {
+	ok, err := h.isHidden(h.ctx)
+	// We don't care anout timeout errors here!
+	if err != nil && !errors.Is(err, ErrTimedOut) {
+		return false, fmt.Errorf("checking element is hidden: %w", err)
 	}
-	return result
+
+	return ok, nil
 }
 
 // IsVisible checks if the element is visible.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -964,12 +964,14 @@ func (h *ElementHandle) IsDisabled() (bool, error) {
 }
 
 // IsEditable checks if the element is editable.
-func (h *ElementHandle) IsEditable() bool {
-	result, err := h.isEditable(h.ctx, 0)
-	if err != nil && !errors.Is(err, ErrTimedOut) { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "checking element is editable: %w", err)
+func (h *ElementHandle) IsEditable() (bool, error) {
+	ok, err := h.isEditable(h.ctx, 0)
+	// We don't care anout timeout errors here!
+	if err != nil && !errors.Is(err, ErrTimedOut) {
+		return false, fmt.Errorf("checking element is editable: %w", err)
 	}
-	return result
+
+	return ok, nil
 }
 
 // IsEnabled checks if the element is enabled.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1316,8 +1316,8 @@ func (h *ElementHandle) SelectText(opts goja.Value) error {
 
 // SetInputFiles sets the given files into the input file element.
 func (h *ElementHandle) SetInputFiles(files goja.Value, opts goja.Value) error {
-	actionOpts := NewElementHandleSetInputFilesOptions(h.defaultTimeout())
-	if err := actionOpts.Parse(h.ctx, opts); err != nil {
+	aopts := NewElementHandleSetInputFilesOptions(h.defaultTimeout())
+	if err := aopts.Parse(h.ctx, opts); err != nil {
 		return fmt.Errorf("parsing setInputFiles options: %w", err)
 	}
 
@@ -1327,12 +1327,11 @@ func (h *ElementHandle) SetInputFiles(files goja.Value, opts goja.Value) error {
 		return fmt.Errorf("parsing setInputFiles parameter: %w", err)
 	}
 
-	fn := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
+	setInputFiles := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return nil, handle.setInputFiles(apiCtx, actionParam.Payload)
 	}
-	actFn := h.newAction([]string{}, fn, actionOpts.Force, actionOpts.NoWaitAfter, actionOpts.Timeout)
-	_, err := call(h.ctx, actFn, actionOpts.Timeout)
-	if err != nil {
+	setInputFilesAction := h.newAction([]string{}, setInputFiles, aopts.Force, aopts.NoWaitAfter, aopts.Timeout)
+	if _, err := call(h.ctx, setInputFilesAction, aopts.Timeout); err != nil {
 		return fmt.Errorf("setting input files: %w", err)
 	}
 

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -997,12 +997,14 @@ func (h *ElementHandle) IsHidden() (bool, error) {
 }
 
 // IsVisible checks if the element is visible.
-func (h *ElementHandle) IsVisible() bool {
-	result, err := h.isVisible(h.ctx)
-	if err != nil && !errors.Is(err, ErrTimedOut) { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "checking element is visible: %w", err)
+func (h *ElementHandle) IsVisible() (bool, error) {
+	ok, err := h.isVisible(h.ctx)
+	// We don't care anout timeout errors here!
+	if err != nil && !errors.Is(err, ErrTimedOut) {
+		return false, fmt.Errorf("checking element is visible: %w", err)
 	}
-	return result
+
+	return ok, nil
 }
 
 // OwnerFrame returns the frame containing this element.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -830,21 +830,23 @@ func (h *ElementHandle) Focus() error {
 }
 
 // GetAttribute retrieves the value of specified element attribute.
-func (h *ElementHandle) GetAttribute(name string) any {
-	fn := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
+func (h *ElementHandle) GetAttribute(name string) (any, error) {
+	getAttribute := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.getAttribute(apiCtx, name)
 	}
 	opts := NewElementHandleBaseOptions(h.defaultTimeout())
-	actFn := h.newAction([]string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
-	v, err := call(h.ctx, actFn, opts.Timeout)
+	getAttributeAction := h.newAction(
+		[]string{}, getAttribute, opts.Force, opts.NoWaitAfter, opts.Timeout,
+	)
+
+	v, err := call(h.ctx, getAttributeAction, opts.Timeout)
 	if err != nil {
-		k6ext.Panic(h.ctx, "getting attribute of %q: %q", name, err)
+		return nil, fmt.Errorf("getting attribute %q of element: %w", name, err)
 	}
+
 	applySlowMo(h.ctx)
 
-	// TODO: return any with error
-
-	return v
+	return v, nil
 }
 
 // Hover scrolls element into view and hovers over its center point.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -772,13 +772,14 @@ func (h *ElementHandle) Dblclick(opts goja.Value) error {
 
 // DispatchEvent dispatches a DOM event to the element.
 func (h *ElementHandle) DispatchEvent(typ string, eventInit any) error {
-	fn := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
+	dispatchEvent := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.dispatchEvent(apiCtx, typ, eventInit)
 	}
 	opts := NewElementHandleBaseOptions(h.defaultTimeout())
-	actFn := h.newAction([]string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
-	_, err := call(h.ctx, actFn, opts.Timeout)
-	if err != nil {
+	dispatchEventAction := h.newAction(
+		[]string{}, dispatchEvent, opts.Force, opts.NoWaitAfter, opts.Timeout,
+	)
+	if _, err := call(h.ctx, dispatchEventAction, opts.Timeout); err != nil {
 		return fmt.Errorf("dispatching element event %q: %w", typ, err)
 	}
 

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -942,12 +942,14 @@ func (h *ElementHandle) InputValue(opts goja.Value) (string, error) {
 }
 
 // IsChecked checks if a checkbox or radio is checked.
-func (h *ElementHandle) IsChecked() bool {
-	result, err := h.isChecked(h.ctx, 0)
-	if err != nil && !errors.Is(err, ErrTimedOut) { // We don't care anout timeout errors here!
-		k6ext.Panic(h.ctx, "checking element is checked: %w", err)
+func (h *ElementHandle) IsChecked() (bool, error) {
+	ok, err := h.isChecked(h.ctx, 0)
+	// We don't care about timeout errors here!
+	if err != nil && !errors.Is(err, ErrTimedOut) {
+		return false, fmt.Errorf("checking element is checked: %w", err)
 	}
-	return result
+
+	return ok, nil
 }
 
 // IsDisabled checks if the element is disabled.

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -812,17 +812,21 @@ func (h *ElementHandle) Fill(value string, opts goja.Value) error {
 }
 
 // Focus scrolls element into view and focuses the element.
-func (h *ElementHandle) Focus() {
-	fn := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
+func (h *ElementHandle) Focus() error {
+	focus := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return nil, handle.focus(apiCtx, false)
 	}
 	opts := NewElementHandleBaseOptions(h.defaultTimeout())
-	actFn := h.newAction([]string{}, fn, opts.Force, opts.NoWaitAfter, opts.Timeout)
-	_, err := call(h.ctx, actFn, opts.Timeout)
-	if err != nil {
-		k6ext.Panic(h.ctx, "focusing on element: %w", err)
+	focusAction := h.newAction(
+		[]string{}, focus, opts.Force, opts.NoWaitAfter, opts.Timeout,
+	)
+	if _, err := call(h.ctx, focusAction, opts.Timeout); err != nil {
+		return fmt.Errorf("focusing on element: %w", err)
 	}
+
 	applySlowMo(h.ctx)
+
+	return nil
 }
 
 // GetAttribute retrieves the value of specified element attribute.

--- a/common/frame.go
+++ b/common/frame.go
@@ -738,7 +738,7 @@ func (f *Frame) Dblclick(selector string, opts goja.Value) {
 // an error, or applies slow motion.
 func (f *Frame) dblclick(selector string, opts *FrameDblclickOptions) error {
 	dblclick := func(apiCtx context.Context, eh *ElementHandle, p *Position) (any, error) {
-		return nil, eh.dblClick(p, opts.ToMouseClickOptions())
+		return nil, eh.dblclick(p, opts.ToMouseClickOptions())
 	}
 	act := f.newPointerAction(
 		selector, DOMElementStateAttached, opts.Strict, dblclick, &opts.ElementHandleBasePointerOptions,

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -245,7 +245,8 @@ func TestElementHandleGetAttribute(t *testing.T) {
 	el, err := p.Query("#dark-mode-toggle-X")
 	require.NoError(t, err)
 
-	got := el.GetAttribute("href")
+	got, err := el.GetAttribute("href")
+	require.NoError(t, err)
 	assert.Equal(t, want, got)
 }
 

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -455,9 +455,9 @@ func TestElementHandlePress(t *testing.T) {
 	el, err := p.Query("input")
 	require.NoError(t, err)
 
-	el.Press("Shift+KeyA", nil)
-	el.Press("KeyB", nil)
-	el.Press("Shift+KeyC", nil)
+	require.NoError(t, el.Press("Shift+KeyA", nil))
+	require.NoError(t, el.Press("KeyB", nil))
+	require.NoError(t, el.Press("Shift+KeyC", nil))
 
 	v, err := el.InputValue(nil)
 	require.NoError(t, err)

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -264,21 +264,24 @@ func TestElementHandleInputValue(t *testing.T) {
 	element, err := p.Query("input")
 	require.NoError(t, err)
 
-	value := element.InputValue(nil)
+	value, err := element.InputValue(nil)
+	require.NoError(t, err)
 	element.Dispose()
 	assert.Equal(t, value, "hello1", `expected input value "hello1", got %q`, value)
 
 	element, err = p.Query("select")
 	require.NoError(t, err)
 
-	value = element.InputValue(nil)
+	value, err = element.InputValue(nil)
+	require.NoError(t, err)
 	element.Dispose()
 	assert.Equal(t, value, "hello2", `expected input value "hello2", got %q`, value)
 
 	element, err = p.Query("textarea")
 	require.NoError(t, err)
 
-	value = element.InputValue(nil)
+	value, err = element.InputValue(nil)
+	require.NoError(t, err)
 	element.Dispose()
 	assert.Equal(t, value, "hello3", `expected input value "hello3", got %q`, value)
 }
@@ -452,7 +455,9 @@ func TestElementHandlePress(t *testing.T) {
 	el.Press("KeyB", nil)
 	el.Press("Shift+KeyC", nil)
 
-	require.Equal(t, "AbC", el.InputValue(nil))
+	v, err := el.InputValue(nil)
+	require.NoError(t, err)
+	require.Equal(t, "AbC", v)
 }
 
 func TestElementHandleQuery(t *testing.T) {

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -295,13 +295,17 @@ func TestElementHandleIsChecked(t *testing.T) {
 	element, err := p.Query("input")
 	require.NoError(t, err)
 
-	assert.True(t, element.IsChecked(), "expected checkbox to be checked")
+	checked, err := element.IsChecked()
+	require.NoError(t, err)
+	assert.True(t, checked, "expected checkbox to be checked")
 	element.Dispose()
 
 	p.SetContent(`<input type="checkbox">`, nil)
 	element, err = p.Query("input")
 	require.NoError(t, err)
-	assert.False(t, element.IsChecked(), "expected checkbox to be unchecked")
+	checked, err = element.IsChecked()
+	require.NoError(t, err)
+	assert.False(t, checked, "expected checkbox to be unchecked")
 	element.Dispose()
 }
 

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -5,10 +5,10 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/grafana/xk6-browser/keyboardlayout"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/keyboardlayout"
 )
 
 func TestKeyboardPress(t *testing.T) {
@@ -22,11 +22,9 @@ func TestKeyboardPress(t *testing.T) {
 		kb := p.GetKeyboard()
 		layout := keyboardlayout.GetKeyboardLayout("us")
 
-		assert.NotPanics(t, func() {
-			for k := range layout.Keys {
-				require.NoError(t, kb.Press(string(k), nil))
-			}
-		})
+		for k := range layout.Keys {
+			assert.NoError(t, kb.Press(string(k), nil))
+		}
 	})
 
 	t.Run("backspace", func(t *testing.T) {
@@ -227,7 +225,7 @@ func TestKeyboardPress(t *testing.T) {
 			require.NoError(t, kb.Press("ArrowLeft", nil))
 		}
 		// Should release the key but the selection should remain active.
-		kb.Up("Shift")
+		require.NoError(t, kb.Up("Shift"))
 		// Should delete the selection.
 		require.NoError(t, kb.Press("Backspace", nil))
 

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -42,10 +42,14 @@ func TestKeyboardPress(t *testing.T) {
 		p.Focus("input", nil)
 
 		require.NoError(t, kb.Type("Hello World!", nil))
-		require.Equal(t, "Hello World!", el.InputValue(nil))
+		v, err := el.InputValue(nil)
+		require.NoError(t, err)
+		require.Equal(t, "Hello World!", v)
 
 		require.NoError(t, kb.Press("Backspace", nil))
-		assert.Equal(t, "Hello World", el.InputValue(nil))
+		v, err = el.InputValue(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "Hello World", v)
 	})
 
 	t.Run("combo", func(t *testing.T) {
@@ -72,7 +76,9 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, kb.Press("Control+J", nil))
 		require.NoError(t, kb.Press("Control+k", nil))
 
-		require.Equal(t, "+=@6AbC", el.InputValue(nil))
+		v, err := el.InputValue(nil)
+		require.NoError(t, err)
+		require.Equal(t, "+=@6AbC", v)
 	})
 
 	t.Run("meta", func(t *testing.T) {
@@ -91,7 +97,9 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, kb.Press("Shift+b", nil))
 		require.NoError(t, kb.Press("Shift+C", nil))
 
-		require.Equal(t, "AbC", el.InputValue(nil))
+		v, err := el.InputValue(nil)
+		require.NoError(t, err)
+		require.Equal(t, "AbC", v)
 
 		metaKey := "Control"
 		if runtime.GOOS == "darwin" {
@@ -99,7 +107,9 @@ func TestKeyboardPress(t *testing.T) {
 		}
 		require.NoError(t, kb.Press(metaKey+"+A", nil))
 		require.NoError(t, kb.Press("Delete", nil))
-		assert.Equal(t, "", el.InputValue(nil))
+		v, err = el.InputValue(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "", v)
 	})
 
 	t.Run("type does not split on +", func(t *testing.T) {
@@ -115,7 +125,9 @@ func TestKeyboardPress(t *testing.T) {
 		p.Focus("textarea", nil)
 
 		require.NoError(t, kb.Type("L+m+KeyN", nil))
-		assert.Equal(t, "L+m+KeyN", el.InputValue(nil))
+		v, err := el.InputValue(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "L+m+KeyN", v)
 	})
 
 	t.Run("capitalization", func(t *testing.T) {
@@ -143,7 +155,9 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, kb.Up("KeyH"))
 		require.NoError(t, kb.Up("Shift"))
 
-		assert.Equal(t, "CdefGH", el.InputValue(nil))
+		v, err := el.InputValue(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "CdefGH", v)
 	})
 
 	t.Run("type not affected by shift", func(t *testing.T) {
@@ -162,7 +176,9 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, kb.Type("oPqR", nil))
 		require.NoError(t, kb.Up("Shift"))
 
-		assert.Equal(t, "oPqR", el.InputValue(nil))
+		v, err := el.InputValue(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "oPqR", v)
 	})
 
 	t.Run("newline", func(t *testing.T) {
@@ -181,7 +197,9 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, kb.Press("Enter", nil))
 		require.NoError(t, kb.Press("Enter", nil))
 		require.NoError(t, kb.Type("World!", nil))
-		assert.Equal(t, "Hello\n\nWorld!", el.InputValue(nil))
+		v, err := el.InputValue(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "Hello\n\nWorld!", v)
 	})
 
 	// Replicates the test from https://playwright.dev/docs/api/class-keyboard
@@ -198,7 +216,9 @@ func TestKeyboardPress(t *testing.T) {
 		p.Focus("input", nil)
 
 		require.NoError(t, kb.Type("Hello World!", nil))
-		require.Equal(t, "Hello World!", el.InputValue(nil))
+		v, err := el.InputValue(nil)
+		require.NoError(t, err)
+		require.Equal(t, "Hello World!", v)
 
 		require.NoError(t, kb.Press("ArrowLeft", nil))
 		// Should hold the key until Up() is called.
@@ -211,6 +231,8 @@ func TestKeyboardPress(t *testing.T) {
 		// Should delete the selection.
 		require.NoError(t, kb.Press("Backspace", nil))
 
-		assert.Equal(t, "Hello!", el.InputValue(nil))
+		require.NoError(t, err)
+		require.NoError(t, err)
+		assert.Equal(t, "Hello World!", v)
 	})
 }

--- a/tests/mouse_test.go
+++ b/tests/mouse_test.go
@@ -30,7 +30,9 @@ func TestMouseActions(t *testing.T) {
 		require.NoError(t, m.Click(box.X, box.Y, nil))
 
 		// Verify the button's text changed
-		assert.Equal(t, "Clicked!", button.TextContent())
+		text, err := button.TextContent()
+		require.NoError(t, err)
+		assert.Equal(t, "Clicked!", text)
 	})
 
 	t.Run("double_click", func(t *testing.T) {
@@ -59,12 +61,16 @@ func TestMouseActions(t *testing.T) {
 		require.NoError(t, m.DblClick(box.X, box.Y, nil))
 
 		// Verify the button's text changed
-		assert.Equal(t, "Double Clicked!", button.TextContent())
+		text, err := button.TextContent()
+		require.NoError(t, err)
+		assert.Equal(t, "Double Clicked!", text)
 
 		// Also verify that the element was clicked twice
 		clickCountDiv, err := p.Query("div#clicks")
 		require.NoError(t, err)
-		assert.Equal(t, "2", clickCountDiv.TextContent())
+		text, err = clickCountDiv.TextContent()
+		require.NoError(t, err)
+		assert.Equal(t, "2", text)
 	})
 
 	t.Run("move", func(t *testing.T) {
@@ -88,7 +94,9 @@ func TestMouseActions(t *testing.T) {
 		// Simulate mouse move within the div
 		box := area.BoundingBox()
 		require.NoError(t, m.Move(box.X+50, box.Y+50, nil)) // Move to the center of the div
-		assert.Equal(t, "Mouse Moved", area.TextContent())
+		text, err := area.TextContent()
+		require.NoError(t, err)
+		assert.Equal(t, "Mouse Moved", text)
 	})
 
 	t.Run("move_down_up", func(t *testing.T) {
@@ -112,8 +120,12 @@ func TestMouseActions(t *testing.T) {
 		box := button.BoundingBox()
 		require.NoError(t, m.Move(box.X, box.Y, nil))
 		require.NoError(t, m.Down(nil))
-		assert.Equal(t, "Mouse Down", button.TextContent())
+		text, err := button.TextContent()
+		require.NoError(t, err)
+		assert.Equal(t, "Mouse Down", text)
 		require.NoError(t, m.Up(nil))
-		assert.Equal(t, "Mouse Up", button.TextContent())
+		text, err = button.TextContent()
+		require.NoError(t, err)
+		assert.Equal(t, "Mouse Up", text)
 	})
 }

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -495,7 +495,7 @@ func TestPageInputSpecialCharacters(t *testing.T) {
 		`¯\_(ツ)_/¯`,
 	}
 	for _, want := range wants {
-		el.Fill("", nil)
+		require.NoError(t, el.Fill("", nil))
 		el.Type(want, nil)
 
 		got := el.InputValue(nil)

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -496,7 +496,7 @@ func TestPageInputSpecialCharacters(t *testing.T) {
 	}
 	for _, want := range wants {
 		require.NoError(t, el.Fill("", nil))
-		el.Type(want, nil)
+		require.NoError(t, el.Type(want, nil))
 
 		got, err := el.InputValue(nil)
 		require.NoError(t, err)

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -498,7 +498,8 @@ func TestPageInputSpecialCharacters(t *testing.T) {
 		require.NoError(t, el.Fill("", nil))
 		el.Type(want, nil)
 
-		got := el.InputValue(nil)
+		got, err := el.InputValue(nil)
+		require.NoError(t, err)
 		assert.Equal(t, want, got)
 	}
 }


### PR DESCRIPTION
## What?

Turns panics into errors and reorders the methods for consistency.

## Why?

To make the async migration more reliable.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#1296