### PR TITLE
Prepare `Page.evaluate` for async migration

### DIFF
--- a/browser/frame_mapping.go
+++ b/browser/frame_mapping.go
@@ -46,8 +46,8 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping { //nolint:gocognit,cyclop
 			}
 			return f.DispatchEvent(selector, typ, exportArg(eventInit), popts) //nolint:wrapcheck
 		},
-		"evaluate": func(pageFunction goja.Value, gargs ...goja.Value) any {
-			return f.Evaluate(pageFunction.String(), exportArgs(gargs)...)
+		"evaluate": func(pageFunction goja.Value, gargs ...goja.Value) (any, error) {
+			return f.Evaluate(pageFunction.String(), exportArgs(gargs)...) //nolint:wrapcheck
 		},
 		"evaluateHandle": func(pageFunction goja.Value, gargs ...goja.Value) (mapping, error) {
 			jsh, err := f.EvaluateHandle(pageFunction.String(), exportArgs(gargs)...)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -347,7 +347,7 @@ type pageAPI interface {
 	Title() (string, error)
 	Type(selector string, text string, opts goja.Value)
 	Uncheck(selector string, opts goja.Value)
-	URL() string
+	URL() (string, error)
 	ViewportSize() map[string]float64
 	WaitForFunction(fn, opts goja.Value, args ...goja.Value) (any, error)
 	WaitForLoadState(state string, opts goja.Value)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -344,7 +344,7 @@ type pageAPI interface {
 	TextContent(selector string, opts goja.Value) string
 	ThrottleCPU(common.CPUProfile) error
 	ThrottleNetwork(common.NetworkProfile) error
-	Title() string
+	Title() (string, error)
 	Type(selector string, text string, opts goja.Value)
 	Uncheck(selector string, opts goja.Value)
 	URL() string

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -303,7 +303,7 @@ type pageAPI interface {
 	DispatchEvent(selector string, typ string, eventInit goja.Value, opts goja.Value)
 	EmulateMedia(opts goja.Value)
 	EmulateVisionDeficiency(typ string)
-	Evaluate(pageFunc goja.Value, arg ...goja.Value) any
+	Evaluate(pageFunc goja.Value, arg ...goja.Value) (any, error)
 	EvaluateHandle(pageFunc goja.Value, arg ...goja.Value) (common.JSHandleAPI, error)
 	Fill(selector string, value string, opts goja.Value)
 	Focus(selector string, opts goja.Value)
@@ -375,7 +375,7 @@ type frameAPI interface {
 	DispatchEvent(selector string, typ string, eventInit goja.Value, opts goja.Value)
 	// EvaluateWithContext for internal use only
 	EvaluateWithContext(ctx context.Context, pageFunc goja.Value, args ...goja.Value) (any, error)
-	Evaluate(pageFunc goja.Value, args ...goja.Value) any
+	Evaluate(pageFunc goja.Value, args ...goja.Value) (any, error)
 	EvaluateHandle(pageFunc goja.Value, args ...goja.Value) (common.JSHandleAPI, error)
 	Fill(selector string, value string, opts goja.Value)
 	Focus(selector string, opts goja.Value)

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -49,8 +49,8 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 		},
 		"emulateMedia":            p.EmulateMedia,
 		"emulateVisionDeficiency": p.EmulateVisionDeficiency,
-		"evaluate": func(pageFunction goja.Value, gargs ...goja.Value) any {
-			return p.Evaluate(pageFunction.String(), exportArgs(gargs)...)
+		"evaluate": func(pageFunction goja.Value, gargs ...goja.Value) (any, error) {
+			return p.Evaluate(pageFunction.String(), exportArgs(gargs)...) //nolint:wrapcheck
 		},
 		"evaluateHandle": func(pageFunc goja.Value, gargs ...goja.Value) (mapping, error) {
 			jsh, err := p.EvaluateHandle(pageFunc.String(), exportArgs(gargs)...)

--- a/common/frame.go
+++ b/common/frame.go
@@ -715,9 +715,11 @@ func (f *Frame) Content() string {
 		return content;
 	}`
 
+	v, _ := f.Evaluate(js)
+
 	// TODO: return error
 
-	return f.Evaluate(js).(string) //nolint:forcetypeassert
+	return v.(string) //nolint:forcetypeassert
 }
 
 // Dblclick double clicks an element matching provided selector.
@@ -806,15 +808,10 @@ func (f *Frame) EvaluateWithContext(ctx context.Context, pageFunc string, args .
 }
 
 // Evaluate will evaluate provided page function within an execution context.
-func (f *Frame) Evaluate(pageFunc string, args ...any) any {
+func (f *Frame) Evaluate(pageFunc string, args ...any) (any, error) {
 	f.log.Debugf("Frame:Evaluate", "fid:%s furl:%q", f.ID(), f.URL())
 
-	result, err := f.EvaluateWithContext(f.ctx, pageFunc, args...)
-	if err != nil {
-		k6ext.Panic(f.ctx, "%v", err)
-	}
-
-	return result
+	return f.EvaluateWithContext(f.ctx, pageFunc, args...)
 }
 
 // EvaluateGlobal will evaluate the given JS code in the global object.
@@ -1653,11 +1650,12 @@ func (f *Frame) Timeout() time.Duration {
 func (f *Frame) Title() string {
 	f.log.Debugf("Frame:Title", "fid:%s furl:%q", f.ID(), f.URL())
 
-	v := `() => document.title`
+	script := `() => document.title`
 
 	// TODO: return error
 
-	return f.Evaluate(v).(string) //nolint:forcetypeassert
+	v, _ := f.Evaluate(script)
+	return v.(string) //nolint:forcetypeassert
 }
 
 // Type text on the first element found matches the selector.

--- a/common/page.go
+++ b/common/page.go
@@ -770,7 +770,7 @@ func (p *Page) EmulateVisionDeficiency(typ string) {
 }
 
 // Evaluate runs JS code within the execution context of the main frame of the page.
-func (p *Page) Evaluate(pageFunc string, args ...any) any {
+func (p *Page) Evaluate(pageFunc string, args ...any) (any, error) {
 	p.logger.Debugf("Page:Evaluate", "sid:%v", p.sessionID())
 
 	return p.MainFrame().Evaluate(pageFunc, args...)
@@ -1179,7 +1179,9 @@ func (p *Page) Title() string {
 	// TODO: return error
 
 	v := `() => document.title`
-	return p.Evaluate(v).(string) //nolint:forcetypeassert
+	s, _ := p.Evaluate(v)
+
+	return s.(string) //nolint:forcetypeassert
 }
 
 // ThrottleCPU will slow the CPU down from chrome's perspective to simulate
@@ -1228,8 +1230,10 @@ func (p *Page) URL() string {
 
 	// TODO: return error
 
-	v := `() => document.location.toString()`
-	return p.Evaluate(v).(string) //nolint:forcetypeassert
+	script := `() => document.location.toString()`
+	v, _ := p.Evaluate(script)
+
+	return v.(string) //nolint:forcetypeassert
 }
 
 // ViewportSize will return information on the viewport width and height.

--- a/common/page.go
+++ b/common/page.go
@@ -1173,15 +1173,21 @@ func (p *Page) Timeout() time.Duration {
 	return p.defaultTimeout()
 }
 
-func (p *Page) Title() string {
+// Title returns the page title.
+func (p *Page) Title() (string, error) {
 	p.logger.Debugf("Page:Title", "sid:%v", p.sessionID())
 
-	// TODO: return error
+	js := `() => document.title`
+	v, err := p.Evaluate(js)
+	if err != nil {
+		return "", fmt.Errorf("getting page title: %w", err)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("getting page title: expected string, got %T", v)
+	}
 
-	v := `() => document.title`
-	s, _ := p.Evaluate(v)
-
-	return s.(string) //nolint:forcetypeassert
+	return s, nil
 }
 
 // ThrottleCPU will slow the CPU down from chrome's perspective to simulate

--- a/common/page.go
+++ b/common/page.go
@@ -1231,15 +1231,20 @@ func (p *Page) Type(selector string, text string, opts goja.Value) {
 }
 
 // URL returns the location of the page.
-func (p *Page) URL() string {
+func (p *Page) URL() (string, error) {
 	p.logger.Debugf("Page:URL", "sid:%v", p.sessionID())
 
-	// TODO: return error
+	js := `() => document.location.toString()`
+	v, err := p.Evaluate(js)
+	if err != nil {
+		return "", fmt.Errorf("getting page URL: %w", err)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("getting page URL: expected string, got %T", v)
+	}
 
-	script := `() => document.location.toString()`
-	v, _ := p.Evaluate(script)
-
-	return v.(string) //nolint:forcetypeassert
+	return s, nil
 }
 
 // ViewportSize will return information on the viewport width and height.

--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -565,7 +565,8 @@ func TestBrowserContextCookies(t *testing.T) {
 			)
 
 			// setting document.cookie into the page
-			cookie := p.Evaluate(tt.documentCookiesSnippet)
+			cookie, err := p.Evaluate(tt.documentCookiesSnippet)
+			require.NoError(t, err)
 			require.Equalf(t,
 				tt.wantDocumentCookies,
 				cookie,
@@ -934,7 +935,8 @@ func TestBrowserContextClearPermissions(t *testing.T) {
 				{ name: %q }
 			).then(result => result.state)
 		`, perm)
-		v := p.Evaluate(js)
+		v, err := p.Evaluate(js)
+		require.NoError(t, err)
 		s := asString(t, v)
 		return s == "granted"
 	}

--- a/tests/frame_manager_test.go
+++ b/tests/frame_manager_test.go
@@ -110,5 +110,7 @@ func TestWaitForFrameNavigation(t *testing.T) {
 	err = tb.run(ctx, waitForNav, click)
 	require.NoError(t, err)
 
-	assert.Equal(t, "Second page", p.Title())
+	title, err := p.Title()
+	require.NoError(t, err)
+	assert.Equal(t, "Second page", title)
 }

--- a/tests/launch_options_slowmo_test.go
+++ b/tests/launch_options_slowmo_test.go
@@ -64,7 +64,8 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
-				p.Evaluate(`() => void 0`)
+				_, err := p.Evaluate(`() => void 0`)
+				require.NoError(t, err)
 			})
 		})
 		t.Run("evaluateHandle", func(t *testing.T) {
@@ -202,7 +203,8 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f *common.Frame) {
-				f.Evaluate(`() => void 0`)
+				_, err := f.Evaluate(`() => void 0`)
+				require.NoError(t, err)
 			})
 		})
 		t.Run("evaluateHandle", func(t *testing.T) {

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -35,7 +35,8 @@ func TestLocator(t *testing.T) {
 			"Check", func(_ *testBrowser, p *common.Page) {
 				t.Run("check", func(t *testing.T) {
 					check := func() bool {
-						v := p.Evaluate(`() => window.check`)
+						v, err := p.Evaluate(`() => window.check`)
+						require.NoError(t, err)
 						return asBool(t, v)
 					}
 					l := p.Locator("#inputCheckbox", nil)
@@ -77,7 +78,8 @@ func TestLocator(t *testing.T) {
 				l := p.Locator("#link", nil)
 				err := l.Click(common.NewFrameClickOptions(l.Timeout()))
 				require.NoError(t, err)
-				v := p.Evaluate(`() => window.result`)
+				v, err := p.Evaluate(`() => window.result`)
+				require.NoError(t, err)
 				require.True(t, asBool(t, v), "cannot not click the link")
 			},
 		},
@@ -86,14 +88,16 @@ func TestLocator(t *testing.T) {
 				lo := p.Locator("#linkdbl", nil)
 				require.NoError(t, lo.Dblclick(nil))
 
-				v := p.Evaluate(`() => window.dblclick`)
+				v, err := p.Evaluate(`() => window.dblclick`)
+				require.NoError(t, err)
 				require.True(t, asBool(t, v), "cannot double click the link")
 			},
 		},
 		{
 			"DispatchEvent", func(_ *testBrowser, p *common.Page) {
 				result := func() bool {
-					v := p.Evaluate(`() => window.result`)
+					v, err := p.Evaluate(`() => window.result`)
+					require.NoError(t, err)
 					return asBool(t, v)
 				}
 				require.False(t, result(), "should not be clicked first")
@@ -133,9 +137,10 @@ func TestLocator(t *testing.T) {
 		{
 			"Focus", func(_ *testBrowser, p *common.Page) {
 				focused := func() bool {
-					v := p.Evaluate(
+					v, err := p.Evaluate(
 						`() => document.activeElement == document.getElementById('inputText')`,
 					)
+					require.NoError(t, err)
 					return asBool(t, v)
 				}
 				lo := p.Locator("#inputText", nil)
@@ -156,7 +161,8 @@ func TestLocator(t *testing.T) {
 		{
 			"Hover", func(_ *testBrowser, p *common.Page) {
 				result := func() bool {
-					v := p.Evaluate(`() => window.result`)
+					v, err := p.Evaluate(`() => window.result`)
+					require.NoError(t, err)
 					return asBool(t, v)
 				}
 				require.False(t, result(), "should not be hovered first")
@@ -217,7 +223,8 @@ func TestLocator(t *testing.T) {
 		{
 			"Tap", func(_ *testBrowser, p *common.Page) {
 				result := func() bool {
-					v := p.Evaluate(`() => window.result`)
+					v, err := p.Evaluate(`() => window.result`)
+					require.NoError(t, err)
 					return asBool(t, v)
 				}
 				require.False(t, result(), "should not be tapped first")
@@ -515,7 +522,8 @@ func TestLocatorElementState(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, result)
 
-			p.Evaluate(tt.eval)
+			_, err = p.Evaluate(tt.eval)
+			require.NoError(t, err)
 			result, err = tt.query(l)
 			require.NoError(t, err)
 			require.False(t, result)

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -869,7 +869,9 @@ func TestPageURL(t *testing.T) {
 	b := newTestBrowser(t, withHTTPServer())
 
 	p := b.NewPage(nil)
-	assert.Equal(t, common.BlankPage, p.URL())
+	uri, err := p.URL()
+	require.NoError(t, err)
+	assert.Equal(t, common.BlankPage, uri)
 
 	opts := &common.FrameGotoOptions{
 		Timeout: common.DefaultTimeout,
@@ -880,7 +882,9 @@ func TestPageURL(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Regexp(t, "http://.*/get", p.URL())
+	uri, err = p.URL()
+	require.NoError(t, err)
+	assert.Regexp(t, "http://.*/get", uri)
 }
 
 func TestPageClose(t *testing.T) {
@@ -932,7 +936,9 @@ func TestPageOn(t *testing.T) {
 				val, err := cm.Args[0].JSONValue()
 				assert.NoError(t, err)
 				assert.Equal(t, "this is a log message", val)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -945,7 +951,9 @@ func TestPageOn(t *testing.T) {
 				val, err := cm.Args[0].JSONValue()
 				assert.NoError(t, err)
 				assert.Equal(t, "this is a debug message", val)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -958,7 +966,9 @@ func TestPageOn(t *testing.T) {
 				val, err := cm.Args[0].JSONValue()
 				assert.NoError(t, err)
 				assert.Equal(t, "this is an info message", val)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -971,7 +981,9 @@ func TestPageOn(t *testing.T) {
 				val, err := cm.Args[0].JSONValue()
 				assert.NoError(t, err)
 				assert.Equal(t, "this is an error message", val)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -984,7 +996,9 @@ func TestPageOn(t *testing.T) {
 				val, err := cm.Args[0].JSONValue()
 				assert.NoError(t, err)
 				assert.Equal(t, "this is a warning message", val)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -994,7 +1008,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "dir", cm.Type)
 				assert.Equal(t, "Location", cm.Text)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -1004,7 +1020,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "dirxml", cm.Type)
 				assert.Equal(t, "Location", cm.Text)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -1017,7 +1035,9 @@ func TestPageOn(t *testing.T) {
 				val, err := cm.Args[0].JSONValue()
 				assert.NoError(t, err)
 				assert.Equal(t, `[["Grafana","k6"],["Grafana","Mimir"]]`, val)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -1030,7 +1050,9 @@ func TestPageOn(t *testing.T) {
 				val, err := cm.Args[0].JSONValue()
 				assert.NoError(t, err)
 				assert.Equal(t, "trace example", val)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -1039,7 +1061,9 @@ func TestPageOn(t *testing.T) {
 			assertFn: func(t *testing.T, cm *common.ConsoleMessage) {
 				t.Helper()
 				assert.Equal(t, "clear", cm.Type)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -1049,7 +1073,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "startGroup", cm.Type)
 				assert.Equal(t, "console.group", cm.Text)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -1059,7 +1085,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "startGroupCollapsed", cm.Type)
 				assert.Equal(t, "console.groupCollapsed", cm.Text)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -1069,7 +1097,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "endGroup", cm.Type)
 				assert.Equal(t, "console.groupEnd", cm.Text)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -1079,7 +1109,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "assert", cm.Type)
 				assert.Equal(t, "console.assert", cm.Text)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -1089,7 +1121,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "count", cm.Type)
 				assert.Equal(t, "default: 1", cm.Text)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -1099,7 +1133,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "count", cm.Type)
 				assert.Equal(t, "k6: 1", cm.Text)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 		{
@@ -1109,7 +1145,9 @@ func TestPageOn(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "timeEnd", cm.Type)
 				assert.Regexp(t, `^k6: [0-9]+\.[0-9]+`, cm.Text, `expected prefix "k6: <a float>" but got %q`, cm.Text)
-				assert.True(t, cm.Page.URL() == blankPage, "url is not %s", blankPage)
+				uri, err := cm.Page.URL()
+				require.NoError(t, err)
+				assert.True(t, uri == blankPage, "url is not %s", blankPage)
 			},
 		},
 	}

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -612,7 +612,9 @@ func TestPageTitle(t *testing.T) {
 
 	p := newTestBrowser(t).NewPage(nil)
 	p.SetContent(`<html><head><title>Some title</title></head></html>`, nil)
-	assert.Equal(t, "Some title", p.Title())
+	title, err := p.Title()
+	require.NoError(t, err)
+	assert.Equal(t, "Some title", title)
 }
 
 func TestPageSetExtraHTTPHeaders(t *testing.T) {

--- a/tests/remote_obj_test.go
+++ b/tests/remote_obj_test.go
@@ -93,10 +93,11 @@ func TestConsoleLogParse(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.log == "" {
-				p.Evaluate(`() => console.log("")`)
+				_, err = p.Evaluate(`() => console.log("")`)
 			} else {
-				p.Evaluate(fmt.Sprintf("() => console.log(%s)", tt.log))
+				_, err = p.Evaluate(fmt.Sprintf("() => console.log(%s)", tt.log))
 			}
+			require.NoError(t, err)
 
 			select {
 			case <-done:
@@ -178,13 +179,16 @@ func TestEvalRemoteObjectParse(t *testing.T) {
 			tb := newTestBrowser(t, withFileServer())
 			p := tb.NewPage(nil)
 
-			var got any
+			var (
+				got any
+				err error
+			)
 			if tt.eval == "" {
-				got = p.Evaluate(`() => ""`)
+				got, err = p.Evaluate(`() => ""`)
 			} else {
-				got = p.Evaluate(fmt.Sprintf("() => %s", tt.eval))
+				got, err = p.Evaluate(fmt.Sprintf("() => %s", tt.eval))
 			}
-
+			require.NoError(t, err)
 			assert.EqualValues(t, tt.want, got)
 		})
 	}

--- a/tests/setinputfiles_test.go
+++ b/tests/setinputfiles_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/xk6-browser/common"
 )
@@ -176,14 +177,19 @@ func TestSetInputFiles(t *testing.T) {
 				page.SetContent(pageContent, nil)
 
 				getFileCountFn := func() interface{} {
-					return page.Evaluate(`() => document.getElementById("upload").files.length`)
+					v, err := page.Evaluate(`() => document.getElementById("upload").files.length`)
+					require.NoError(t, err)
+
+					return v
 				}
 
 				getFilePropertyFn := func(idx int, propName string) interface{} {
-					return page.Evaluate(
+					v, err := page.Evaluate(
 						`(idx, propName) => document.getElementById("upload").files[idx][propName]`,
 						idx,
 						propName)
+					require.NoError(t, err)
+					return v
 				}
 
 				files, cleanup := tc.setup(tb)


### PR DESCRIPTION
## What?

Turns panics into errors only for `evaluate` as `Page` is big.

## Why?

To make the async migration more reliable.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#1307