### PR TITLE
Fix iframe panic on navigation

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -406,8 +406,9 @@ func (fs *FrameSession) initFrameTree() error {
 		return fmt.Errorf("got a nil page frame tree")
 	}
 
+	fs.handleFrameTree(frameTree)
+
 	if fs.isMainFrame() {
-		fs.handleFrameTree(frameTree)
 		fs.initRendererEvents()
 	}
 	return nil

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -406,7 +406,8 @@ func (fs *FrameSession) initFrameTree() error {
 		return fmt.Errorf("got a nil page frame tree")
 	}
 
-	fs.handleFrameTree(frameTree)
+	// Any new frame may have a child frame, not just mainframes.
+	fs.handleFrameTree(frameTree, fs.isMainFrame())
 
 	if fs.isMainFrame() {
 		fs.initRendererEvents()
@@ -578,19 +579,19 @@ func (fs *FrameSession) isMainFrame() bool {
 	return fs.targetID == fs.page.targetID
 }
 
-func (fs *FrameSession) handleFrameTree(frameTree *cdppage.FrameTree) {
+func (fs *FrameSession) handleFrameTree(frameTree *cdppage.FrameTree, initialFrame bool) {
 	fs.logger.Debugf("FrameSession:handleFrameTree",
-		"sid:%v tid:%v", fs.session.ID(), fs.targetID)
+		"fid:%v sid:%v tid:%v", frameTree.Frame.ID, fs.session.ID(), fs.targetID)
 
 	if frameTree.Frame.ParentID != "" {
 		fs.onFrameAttached(frameTree.Frame.ID, frameTree.Frame.ParentID)
 	}
-	fs.onFrameNavigated(frameTree.Frame, true)
+	fs.onFrameNavigated(frameTree.Frame, initialFrame)
 	if frameTree.ChildFrames == nil {
 		return
 	}
 	for _, child := range frameTree.ChildFrames {
-		fs.handleFrameTree(child)
+		fs.handleFrameTree(child, initialFrame)
 	}
 }
 


### PR DESCRIPTION
## What?

This fixes an issue where a page with an iframe panics during a navigation.

## Why?

The reason are two fold:

1. Firstly we didn't have a reference to the iframes child frame. This was resolved by adding handling the frame tree of the iframe. It's not a mainframe but it still needs to be handled correctly so that we have a reference to the iframe and its children.
2. Now that we have the child frame, we don't want it to be removed during a detach (of type swap). We protect against this by checking the session of the incoming detach event and the frame that it is trying to detach. If they don't match we ignore the request.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1341