### PR TITLE
Remove unused name field from request mapping

### DIFF
--- a/browser/request_mapping.go
+++ b/browser/request_mapping.go
@@ -25,12 +25,12 @@ func mapRequest(vu moduleVU, r *common.Request) mapping {
 				return r.HeaderValue(name), nil
 			})
 		},
-		"headers": func(name string) *goja.Promise {
+		"headers": func() *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				return r.Headers(), nil
 			})
 		},
-		"headersArray": func(name string) *goja.Promise {
+		"headersArray": func() *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				return r.HeadersArray(), nil
 			})
@@ -52,7 +52,7 @@ func mapRequest(vu moduleVU, r *common.Request) mapping {
 			return rt.NewArrayBuffer(p)
 		},
 		"resourceType": r.ResourceType,
-		"response": func(name string) *goja.Promise {
+		"response": func() *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				resp := r.Response()
 				if resp == nil {
@@ -61,7 +61,7 @@ func mapRequest(vu moduleVU, r *common.Request) mapping {
 				return mapResponse(vu, resp), nil
 			})
 		},
-		"size": func(name string) *goja.Promise {
+		"size": func() *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				return r.Size(), nil
 			})


### PR DESCRIPTION
## What?

Remove unused name field from request mapping.

## Why?

Linter error.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
https://github.com/grafana/xk6-browser/issues/1308