### PR TITLE
Revert request.headers and request.size to sync

### DIFF
--- a/browser/request_mapping.go
+++ b/browser/request_mapping.go
@@ -57,11 +57,7 @@ func mapRequest(vu moduleVU, r *common.Request) mapping {
 				return mapResponse(vu, resp), nil
 			})
 		},
-		"size": func() *goja.Promise {
-			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return r.Size(), nil
-			})
-		},
+		"size":   r.Size,
 		"timing": r.Timing,
 		"url":    r.URL,
 	}

--- a/browser/request_mapping.go
+++ b/browser/request_mapping.go
@@ -25,11 +25,7 @@ func mapRequest(vu moduleVU, r *common.Request) mapping {
 				return r.HeaderValue(name), nil
 			})
 		},
-		"headers": func() *goja.Promise {
-			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return r.Headers(), nil
-			})
-		},
+		"headers": r.Headers,
 		"headersArray": func() *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				return r.HeadersArray(), nil


### PR DESCRIPTION
## What?

Revert `request.headers` and `request.size` to sync.

## Why?

Both these APIs are safe to stay as sync because:
1. In Playwright they are sync APIs.
2. They don't make any long running IO calls or long running processes.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
