### PR TITLE
Precalculate `browser.version` and `browser.userAgent` to prevent the I/O call

### DIFF
--- a/browser/browser_mapping.go
+++ b/browser/browser_mapping.go
@@ -56,7 +56,7 @@ func mapBrowser(vu moduleVU) mapping { //nolint:funlen,cyclop
 			if err != nil {
 				return "", err
 			}
-			return b.UserAgent() //nolint:wrapcheck
+			return b.UserAgent(), nil
 		},
 		"version": func() (string, error) {
 			b, err := vu.browser()

--- a/browser/browser_mapping.go
+++ b/browser/browser_mapping.go
@@ -63,7 +63,7 @@ func mapBrowser(vu moduleVU) mapping { //nolint:funlen,cyclop
 			if err != nil {
 				return "", err
 			}
-			return b.Version() //nolint:wrapcheck
+			return b.Version(), nil
 		},
 		"newPage": func(opts goja.Value) (mapping, error) {
 			b, err := vu.browser()

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -255,7 +255,7 @@ type browserAPI interface {
 	NewContext(opts goja.Value) (*common.BrowserContext, error)
 	NewPage(opts goja.Value) (*common.Page, error)
 	On(string) (bool, error)
-	UserAgent() (string, error)
+	UserAgent() string
 	Version() string
 }
 

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -256,7 +256,7 @@ type browserAPI interface {
 	NewPage(opts goja.Value) (*common.Page, error)
 	On(string) (bool, error)
 	UserAgent() (string, error)
-	Version() (string, error)
+	Version() string
 }
 
 // browserContextAPI is the public interface of a CDP browser context.

--- a/common/browser.go
+++ b/common/browser.go
@@ -68,6 +68,9 @@ type Browser struct {
 	// Used to display a warning when the browser is reclosed.
 	closed bool
 
+	// version caches the browser version information.
+	version browserVersion
+
 	vu k6modules.VU
 
 	logger *log.Logger

--- a/common/browser.go
+++ b/common/browser.go
@@ -657,17 +657,13 @@ func (b *Browser) UserAgent() (string, error) {
 }
 
 // Version returns the controlled browser's version.
-func (b *Browser) Version() (string, error) {
-	action := cdpbrowser.GetVersion()
-	_, product, _, _, _, err := action.Do(cdp.WithExecutor(b.ctx, b.conn)) //nolint:dogsled
-	if err != nil {
-		return "", fmt.Errorf("getting browser version: %w", err)
-	}
+func (b *Browser) Version() string {
+	product := b.version.product
 	i := strings.Index(product, "/")
 	if i == -1 {
-		return product, nil
+		return product
 	}
-	return product[i+1:], nil
+	return product[i+1:]
 }
 
 // fetchVersion returns the browser version information.

--- a/common/browser.go
+++ b/common/browser.go
@@ -73,6 +73,15 @@ type Browser struct {
 	logger *log.Logger
 }
 
+// browserVersion is a struct to hold the browser version information.
+type browserVersion struct {
+	protocolVersion string
+	product         string
+	revision        string
+	userAgent       string
+	jsVersion       string
+}
+
 // NewBrowser creates a new browser, connects to it, then returns it.
 func NewBrowser(
 	ctx context.Context,

--- a/common/browser.go
+++ b/common/browser.go
@@ -660,6 +660,22 @@ func (b *Browser) Version() (string, error) {
 	return product[i+1:], nil
 }
 
+// fetchVersion returns the browser version information.
+func (b *Browser) fetchVersion() (browserVersion, error) {
+	var (
+		bv  browserVersion
+		err error
+	)
+	bv.protocolVersion, bv.product, bv.revision, bv.userAgent, bv.jsVersion, err = cdpbrowser.
+		GetVersion().
+		Do(cdp.WithExecutor(b.ctx, b.conn))
+	if err != nil {
+		return browserVersion{}, fmt.Errorf("getting browser version information: %w", err)
+	}
+
+	return bv, nil
+}
+
 // WsURL returns the Websocket URL that the browser is listening on for CDP clients.
 func (b *Browser) WsURL() string {
 	return b.browserProc.WsURL()

--- a/common/browser.go
+++ b/common/browser.go
@@ -97,6 +97,13 @@ func NewBrowser(
 	if err := b.connect(); err != nil {
 		return nil, err
 	}
+
+	// cache the browser version information.
+	var err error
+	if b.version, err = b.fetchVersion(); err != nil {
+		return nil, err
+	}
+
 	return b, nil
 }
 

--- a/common/browser.go
+++ b/common/browser.go
@@ -647,13 +647,8 @@ func (b *Browser) On(event string) (bool, error) {
 }
 
 // UserAgent returns the controlled browser's user agent string.
-func (b *Browser) UserAgent() (string, error) {
-	action := cdpbrowser.GetVersion()
-	_, _, _, ua, _, err := action.Do(cdp.WithExecutor(b.ctx, b.conn)) //nolint:dogsled
-	if err != nil {
-		return "", fmt.Errorf("getting browser user agent: %w", err)
-	}
-	return ua, nil
+func (b *Browser) UserAgent() string {
+	return b.version.userAgent
 }
 
 // Version returns the controlled browser's version.

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -211,8 +211,7 @@ func TestBrowserUserAgent(t *testing.T) {
 
 	// testBrowserVersion() tests the version already
 	// just look for "Headless" in UserAgent
-	ua, err := b.UserAgent()
-	require.NoError(t, err)
+	ua := b.UserAgent()
 	if prefix := "Mozilla/5.0"; !strings.HasPrefix(ua, prefix) {
 		t.Errorf("UserAgent should start with %q, but got: %q", prefix, ua)
 	}

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -197,8 +197,7 @@ func TestBrowserVersion(t *testing.T) {
 	const re = `^\d+\.\d+\.\d+\.\d+$`
 	r, err := regexp.Compile(re) //nolint:gocritic
 	require.NoError(t, err)
-	ver, err := newTestBrowser(t).Version()
-	require.NoError(t, err)
+	ver := newTestBrowser(t).Version()
 	assert.Regexp(t, r, ver, "expected browser version to match regex %q, but found %q", re, ver)
 }
 


### PR DESCRIPTION
## What?

* Precalculates the browser version information after connecting to the browser.
* Removes `error` from the `Version` and `UserAgent` methods as the version information is cached.
* Downside: The browser version information is always fetched to cache it.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#1359