### PR TITLE
Fix Async examples

### DIFF
--- a/examples/elementstate.js
+++ b/examples/elementstate.js
@@ -33,26 +33,13 @@ export default async function() {
   `);
 
   // Check state
-  let el = await page.$('.visible');
-  const isVisible = await el.isVisible();
-
-  el = await page.$('.hidden');
-  const isHidden = await el.isHidden();
-
-  el = await page.$('.editable');
-  const isEditable = await el.isEditable();
-
-  el = await page.$('.enabled');
-  const isEnabled = await el.isEnabled();
-
-  el = await page.$('.disabled');
-  const isDisabled = await el.isDisabled();
-
-  el = await page.$('.checked');
-  const isChecked = await el.isChecked();
-
-  el = await page.$('.unchecked');
-  const isUnchecked = await el.isChecked() === false;
+  let isVisible = await page.$('.visible').then(e => e.isVisible());
+  let isHidden = await page.$('.hidden').then(e => e.isHidden());
+  let isEditable = await page.$('.editable').then(e => e.isEditable());
+  let isEnabled = await page.$('.enabled').then(e => e.isEnabled());
+  let isDisabled = await page.$('.disabled').then(e => e.isDisabled());
+  let isChecked = await page.$('.checked').then(e => e.isChecked());
+  let isUnchecked = !await page.$('.unchecked').then(e => e.isChecked());
 
   check(page, {
     'visible': isVisible,

--- a/examples/mouse.js
+++ b/examples/mouse.js
@@ -20,7 +20,7 @@ export default async function () {
 
   // Obtain ElementHandle for news link and navigate to it
   // by clicking in the 'a' element's bounding box
-  const newsLinkBox = await page.$('a[href="/news.php"]').boundingBox();
+  const newsLinkBox = await page.$('a[href="/news.php"]').then(e => e.boundingBox());
 
   await Promise.all([
     page.waitForNavigation(),

--- a/examples/querying.js
+++ b/examples/querying.js
@@ -24,8 +24,8 @@ export default async function() {
   try {
     await page.goto('https://test.k6.io/');
 
-    const titleWithCSS = await page.$('header h1.title').textContent();
-    const titleWithXPath = await page.$(`//header//h1[@class="title"]`).textContent();
+    const titleWithCSS = await page.$('header h1.title').then(e => e.textContent());
+    const titleWithXPath = await page.$(`//header//h1[@class="title"]`).then(e => e.textContent());
 
     check(page, {
       'Title with CSS selector': titleWithCSS == 'test.k6.io',

--- a/examples/touchscreen.js
+++ b/examples/touchscreen.js
@@ -20,7 +20,7 @@ export default async function () {
 
   // Obtain ElementHandle for news link and navigate to it
   // by tapping in the 'a' element's bounding box
-  const newsLinkBox = await page.$('a[href="/news.php"]').boundingBox();
+  const newsLinkBox = await page.$('a[href="/news.php"]').then((e) => e.boundingBox());
 
   // Wait until the navigation is done before closing the page.
   // Otherwise, there will be a race condition between the page closing


### PR DESCRIPTION
## What?

Fixes `await` usage.

## Why?

The examples were incorrectly using `await`, leading to [incorrect results](https://github.com/grafana/xk6-browser/actions/runs/9364831439).

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
