### PR TITLE
Improve `valueFromRemoteObject` `null` detection

### DIFF
--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/xk6-browser/log"
 
+	"github.com/chromedp/cdproto/runtime"
 	cdpruntime "github.com/chromedp/cdproto/runtime"
 )
 
@@ -105,8 +106,8 @@ func parseRemoteObjectValue(
 		if val == "Object" {
 			return val, nil
 		}
-		if st == "null" {
-			return "null", nil
+		if st == runtime.SubtypeNull {
+			return nil, nil //nolint:nilnil
 		}
 	case cdpruntime.TypeUndefined:
 		return "undefined", nil

--- a/common/remote_object_test.go
+++ b/common/remote_object_test.go
@@ -104,6 +104,20 @@ func TestValueFromRemoteObject(t *testing.T) {
 		require.Nil(t, arg)
 	})
 
+	t.Run("null", func(t *testing.T) {
+		t.Parallel()
+
+		vu := k6test.NewVU(t)
+		remoteObject := &runtime.RemoteObject{
+			Type:    cdpruntime.TypeObject,
+			Subtype: cdpruntime.SubtypeNull,
+		}
+
+		arg, err := valueFromRemoteObject(vu.Context(), remoteObject)
+		require.NoError(t, err)
+		require.Nil(t, arg)
+	})
+
 	t.Run("primitive types", func(t *testing.T) {
 		t.Parallel()
 
@@ -236,7 +250,7 @@ func TestParseRemoteObject(t *testing.T) {
 			name:     "null",
 			subtype:  "null",
 			value:    nil,
-			expected: "null",
+			expected: nil,
 		},
 	}
 

--- a/tests/remote_obj_test.go
+++ b/tests/remote_obj_test.go
@@ -144,7 +144,7 @@ func TestEvalRemoteObjectParse(t *testing.T) {
 			name: "empty", eval: "", want: "",
 		},
 		{
-			name: "null", eval: "null", want: "null",
+			name: "null", eval: "null", want: nil,
 		},
 		{
 			name: "undefined", eval: "undefined", want: nil,


### PR DESCRIPTION
## What?

Improve `valueFromRemoteObject` `null` detection by returning a Go `nil` instead of `"null"` as a string.

## Why?

Previously, we couldn't detect a null value:

```go
v, _ := page.GetAttribute("#el", "missing", nil)
assert.Nil(t, nil, v) // v is not nil. it's "null"
```

After this PR, `v` will be `nil` instead of `"null"` as a string. This enables us to detect `nil` in methods like `GetAttribute`, `TextNode`, etc., to tell the user that what they're looking for does not exist instead of returning `"null"` or an empty string.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas