### PR TITLE
Improve `GetAttribute` `null` attribute detection

### DIFF
--- a/browser/element_handle_mapping.go
+++ b/browser/element_handle_mapping.go
@@ -65,7 +65,14 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 		},
 		"getAttribute": func(name string) *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return eh.GetAttribute(name) //nolint:wrapcheck
+				s, ok, err := eh.GetAttribute(name)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				if !ok {
+					return nil, nil
+				}
+				return s, nil
 			})
 		},
 		"hover": func(opts goja.Value) *goja.Promise {

--- a/browser/frame_mapping.go
+++ b/browser/frame_mapping.go
@@ -94,7 +94,14 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping { //nolint:gocognit,cyclop
 		},
 		"getAttribute": func(selector, name string, opts goja.Value) *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return f.GetAttribute(selector, name, opts) //nolint:wrapcheck
+				s, ok, err := f.GetAttribute(selector, name, opts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				if !ok {
+					return nil, nil
+				}
+				return s, nil
 			})
 		},
 		"goto": func(url string, opts goja.Value) (*goja.Promise, error) {

--- a/browser/locator_mapping.go
+++ b/browser/locator_mapping.go
@@ -88,7 +88,14 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
 		},
 		"getAttribute": func(name string, opts goja.Value) *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return lo.GetAttribute(name, opts) //nolint:wrapcheck
+				s, ok, err := lo.GetAttribute(name, opts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				if !ok {
+					return nil, nil
+				}
+				return s, nil
 			})
 		},
 		"innerHTML": func(opts goja.Value) *goja.Promise {

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -308,7 +308,7 @@ type pageAPI interface {
 	Fill(selector string, value string, opts goja.Value) error
 	Focus(selector string, opts goja.Value) error
 	Frames() []*common.Frame
-	GetAttribute(selector string, name string, opts goja.Value) (any, error)
+	GetAttribute(selector string, name string, opts goja.Value) (string, bool, error)
 	GetKeyboard() *common.Keyboard
 	GetMouse() *common.Mouse
 	GetTouchscreen() *common.Touchscreen
@@ -380,7 +380,7 @@ type frameAPI interface {
 	Fill(selector string, value string, opts goja.Value) error
 	Focus(selector string, opts goja.Value) error
 	FrameElement() (*common.ElementHandle, error)
-	GetAttribute(selector string, name string, opts goja.Value) (any, error)
+	GetAttribute(selector string, name string, opts goja.Value) (string, bool, error)
 	Goto(url string, opts goja.Value) (*common.Response, error)
 	Hover(selector string, opts goja.Value) error
 	InnerHTML(selector string, opts goja.Value) (string, error)
@@ -430,7 +430,7 @@ type elementHandleAPI interface {
 	DispatchEvent(typ string, props goja.Value) error
 	Fill(value string, opts goja.Value) error
 	Focus() error
-	GetAttribute(name string) (any, error)
+	GetAttribute(name string) (string, bool, error)
 	Hover(opts goja.Value) error
 	InnerHTML() (string, error)
 	InnerText() (string, error)
@@ -512,7 +512,7 @@ type locatorAPI interface {
 	IsHidden(opts goja.Value) (bool, error)
 	Fill(value string, opts goja.Value) error
 	Focus(opts goja.Value) error
-	GetAttribute(name string, opts goja.Value) (any, error)
+	GetAttribute(name string, opts goja.Value) (string, bool, error)
 	InnerHTML(opts goja.Value) (string, error)
 	InnerText(opts goja.Value) (string, error)
 	TextContent(opts goja.Value) (string, error)

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -112,7 +112,14 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 		},
 		"getAttribute": func(selector string, name string, opts goja.Value) *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return p.GetAttribute(selector, name, opts) //nolint:wrapcheck
+				s, ok, err := p.GetAttribute(selector, name, opts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				if !ok {
+					return nil, nil
+				}
+				return s, nil
 			})
 		},
 		"goto": func(url string, opts goja.Value) (*goja.Promise, error) {

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -840,7 +840,8 @@ func (h *ElementHandle) Focus() error {
 }
 
 // GetAttribute retrieves the value of specified element attribute.
-func (h *ElementHandle) GetAttribute(name string) (any, error) {
+// The second return value is true if the attribute exists, and false otherwise.
+func (h *ElementHandle) GetAttribute(name string) (string, bool, error) {
 	getAttribute := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.getAttribute(apiCtx, name)
 	}
@@ -851,12 +852,20 @@ func (h *ElementHandle) GetAttribute(name string) (any, error) {
 
 	v, err := call(h.ctx, getAttributeAction, opts.Timeout)
 	if err != nil {
-		return nil, fmt.Errorf("getting attribute %q of element: %w", name, err)
+		return "", false, fmt.Errorf("getting attribute %q of element: %w", name, err)
+	}
+	if v == nil {
+		return "", false, nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false, fmt.Errorf(
+			"getting attribute %q of element: unexpected type %T (expecting string)",
+			name, v,
+		)
 	}
 
-	applySlowMo(h.ctx)
-
-	return v, nil
+	return s, true, nil
 }
 
 // Hover scrolls element into view and hovers over its center point.

--- a/common/locator.go
+++ b/common/locator.go
@@ -322,7 +322,8 @@ func (l *Locator) focus(opts *FrameBaseOptions) error {
 }
 
 // GetAttribute of the element using locator's selector with strict mode on.
-func (l *Locator) GetAttribute(name string, opts goja.Value) (any, error) {
+// The second return value is true if the attribute exists, and false otherwise.
+func (l *Locator) GetAttribute(name string, opts goja.Value) (string, bool, error) {
 	l.log.Debugf(
 		"Locator:GetAttribute", "fid:%s furl:%q sel:%q name:%q opts:%+v",
 		l.frame.ID(), l.frame.URL(), l.selector, name, opts,
@@ -330,17 +331,17 @@ func (l *Locator) GetAttribute(name string, opts goja.Value) (any, error) {
 
 	copts := NewFrameBaseOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		return nil, fmt.Errorf("parsing get attribute options: %w", err)
+		return "", false, fmt.Errorf("parsing get attribute options: %w", err)
 	}
-	v, err := l.getAttribute(name, copts)
+	s, ok, err := l.getAttribute(name, copts)
 	if err != nil {
-		return nil, fmt.Errorf("getting attribute %q of %q: %w", name, l.selector, err)
+		return "", false, fmt.Errorf("getting attribute %q of %q: %w", name, l.selector, err)
 	}
 
-	return v, nil
+	return s, ok, nil
 }
 
-func (l *Locator) getAttribute(name string, opts *FrameBaseOptions) (any, error) {
+func (l *Locator) getAttribute(name string, opts *FrameBaseOptions) (string, bool, error) {
 	opts.Strict = true
 	return l.frame.getAttribute(l.selector, name, opts)
 }

--- a/common/page.go
+++ b/common/page.go
@@ -821,7 +821,8 @@ func (p *Page) Frames() []*Frame {
 }
 
 // GetAttribute returns the attribute value of the element matching the provided selector.
-func (p *Page) GetAttribute(selector string, name string, opts goja.Value) (any, error) {
+// The second return value is true if the attribute exists, and false otherwise.
+func (p *Page) GetAttribute(selector string, name string, opts goja.Value) (string, bool, error) {
 	p.logger.Debugf("Page:GetAttribute", "sid:%v selector:%s name:%s",
 		p.sessionID(), selector, name)
 

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -259,8 +259,9 @@ func TestElementHandleGetAttribute(t *testing.T) {
 	el, err := p.Query("#dark-mode-toggle-X")
 	require.NoError(t, err)
 
-	got, err := el.GetAttribute("href")
+	got, ok, err := el.GetAttribute("href")
 	require.NoError(t, err)
+	require.True(t, ok)
 	assert.Equal(t, want, got)
 }
 

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -248,21 +248,49 @@ func TestElementHandleNonClickable(t *testing.T) {
 func TestElementHandleGetAttribute(t *testing.T) {
 	t.Parallel()
 
-	const want = "https://somewhere"
-
 	p := newTestBrowser(t).NewPage(nil)
-	err := p.SetContent(`
-		<a id="dark-mode-toggle-X" href="https://somewhere">Dark</a>
-	`, nil)
+	err := p.SetContent(`<a id="el" href="null">Something</a>`, nil)
 	require.NoError(t, err)
 
-	el, err := p.Query("#dark-mode-toggle-X")
+	el, err := p.Query("#el")
 	require.NoError(t, err)
 
 	got, ok, err := el.GetAttribute("href")
 	require.NoError(t, err)
 	require.True(t, ok)
-	assert.Equal(t, want, got)
+	assert.Equal(t, "null", got)
+}
+
+func TestElementHandleGetAttributeMissing(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBrowser(t).NewPage(nil)
+	err := p.SetContent(`<a id="el">Something</a>`, nil)
+	require.NoError(t, err)
+
+	el, err := p.Query("#el")
+	require.NoError(t, err)
+
+	got, ok, err := el.GetAttribute("missing")
+	require.NoError(t, err)
+	require.False(t, ok)
+	assert.Equal(t, "", got)
+}
+
+func TestElementHandleGetAttributeEmpty(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBrowser(t).NewPage(nil)
+	err := p.SetContent(`<a id="el" empty>Something</a>`, nil)
+	require.NoError(t, err)
+
+	el, err := p.Query("#el")
+	require.NoError(t, err)
+
+	got, ok, err := el.GetAttribute("empty")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "", got)
 }
 
 func TestElementHandleInputValue(t *testing.T) {

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -167,3 +167,42 @@ func TestFrameTitle(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Some title", p.MainFrame().Title())
 }
+
+func TestFrameGetAttribute(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBrowser(t).NewPage(nil)
+	err := p.SetContent(`<a id="el" href="null">Something</a>`, nil)
+	require.NoError(t, err)
+
+	got, ok, err := p.Frames()[0].GetAttribute("#el", "href", nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "null", got)
+}
+
+func TestFrameGetAttributeMissing(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBrowser(t).NewPage(nil)
+	err := p.SetContent(`<a id="el">Something</a>`, nil)
+	require.NoError(t, err)
+
+	got, ok, err := p.Frames()[0].GetAttribute("#el", "missing", nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+	assert.Equal(t, "", got)
+}
+
+func TestFrameGetAttributeEmpty(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBrowser(t).NewPage(nil)
+	err := p.SetContent(`<a id="el" empty>Something</a>`, nil)
+	require.NoError(t, err)
+
+	got, ok, err := p.Frames()[0].GetAttribute("#el", "empty", nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "", got)
+}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -162,9 +162,10 @@ func TestLocator(t *testing.T) {
 		{
 			"GetAttribute", func(_ *testBrowser, p *common.Page) {
 				l := p.Locator("#inputText", nil)
-				v, err := l.GetAttribute("value", nil)
+				v, ok, err := l.GetAttribute("value", nil)
 				require.NoError(t, err)
 				require.NotNil(t, v)
+				require.True(t, ok)
 				require.Equal(t, "something", v)
 			},
 		},
@@ -366,7 +367,7 @@ func TestLocator(t *testing.T) {
 		},
 		{
 			"GetAttribute", func(l *common.Locator, tb *testBrowser) error {
-				_, err := l.GetAttribute("value", timeout(tb))
+				_, _, err := l.GetAttribute("value", timeout(tb))
 				return err
 			},
 		},

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1806,3 +1806,42 @@ func TestPageTargetBlank(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "you clicked!", got)
 }
+
+func TestPageGetAttribute(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBrowser(t).NewPage(nil)
+	err := p.SetContent(`<a id="el" href="null">Something</a>`, nil)
+	require.NoError(t, err)
+
+	got, ok, err := p.GetAttribute("#el", "href", nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "null", got)
+}
+
+func TestPageGetAttributeMissing(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBrowser(t).NewPage(nil)
+	err := p.SetContent(`<a id="el">Something</a>`, nil)
+	require.NoError(t, err)
+
+	got, ok, err := p.GetAttribute("#el", "missing", nil)
+	require.NoError(t, err)
+	require.False(t, ok)
+	assert.Equal(t, "", got)
+}
+
+func TestPageGetAttributeEmpty(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBrowser(t).NewPage(nil)
+	err := p.SetContent(`<a id="el" empty>Something</a>`, nil)
+	require.NoError(t, err)
+
+	got, ok, err := p.GetAttribute("#el", "empty", nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "", got)
+}


### PR DESCRIPTION
## What?

The `GetAttribute` methods now return `false` when the attribute is missing.

## Why?

Previously, these methods returned an empty string (`""`). That approach makes it impossible to distinguish between whether the attribute is missing or empty.

## Note

I'm happy to convert the tests into table tests if desired.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#428 