### PR TITLE
Improve `TextContent` `null` element detection

### DIFF
--- a/browser/element_handle_mapping.go
+++ b/browser/element_handle_mapping.go
@@ -187,7 +187,14 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 		},
 		"textContent": func() *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return eh.TextContent() //nolint:wrapcheck
+				s, ok, err := eh.TextContent()
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				if !ok {
+					return nil, nil
+				}
+				return s, nil
 			})
 		},
 		"type": func(text string, opts goja.Value) *goja.Promise {

--- a/browser/frame_mapping.go
+++ b/browser/frame_mapping.go
@@ -213,7 +213,14 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping { //nolint:gocognit,cyclop
 		},
 		"textContent": func(selector string, opts goja.Value) *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return f.TextContent(selector, opts) //nolint:wrapcheck
+				s, ok, err := f.TextContent(selector, opts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				if !ok {
+					return nil, nil
+				}
+				return s, nil
 			})
 		},
 		"title": func() *goja.Promise {

--- a/browser/locator_mapping.go
+++ b/browser/locator_mapping.go
@@ -110,7 +110,14 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
 		},
 		"textContent": func(opts goja.Value) *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return lo.TextContent(opts) //nolint:wrapcheck
+				s, ok, err := lo.TextContent(opts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				if !ok {
+					return nil, nil
+				}
+				return s, nil
 			})
 		},
 		"inputValue": func(opts goja.Value) *goja.Promise {

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -341,7 +341,7 @@ type pageAPI interface {
 	SetInputFiles(selector string, files goja.Value, opts goja.Value) error
 	SetViewportSize(viewportSize goja.Value) error
 	Tap(selector string, opts goja.Value) error
-	TextContent(selector string, opts goja.Value) (string, error)
+	TextContent(selector string, opts goja.Value) (string, bool, error)
 	ThrottleCPU(common.CPUProfile) error
 	ThrottleNetwork(common.NetworkProfile) error
 	Title() (string, error)
@@ -406,7 +406,7 @@ type frameAPI interface {
 	SetContent(html string, opts goja.Value) error
 	SetInputFiles(selector string, files goja.Value, opts goja.Value)
 	Tap(selector string, opts goja.Value) error
-	TextContent(selector string, opts goja.Value) (string, error)
+	TextContent(selector string, opts goja.Value) (string, bool, error)
 	Title() string
 	Type(selector string, text string, opts goja.Value) error
 	Uncheck(selector string, opts goja.Value) error
@@ -515,7 +515,7 @@ type locatorAPI interface {
 	GetAttribute(name string, opts goja.Value) (string, bool, error)
 	InnerHTML(opts goja.Value) (string, error)
 	InnerText(opts goja.Value) (string, error)
-	TextContent(opts goja.Value) (string, error)
+	TextContent(opts goja.Value) (string, bool, error)
 	InputValue(opts goja.Value) (string, error)
 	SelectOption(values goja.Value, opts goja.Value) ([]string, error)
 	Press(key string, opts goja.Value) error

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -451,7 +451,7 @@ type elementHandleAPI interface {
 	SelectText(opts goja.Value) error
 	SetInputFiles(files goja.Value, opts goja.Value) error
 	Tap(opts goja.Value) error
-	TextContent() (string, error)
+	TextContent() (string, bool, error)
 	Type(text string, opts goja.Value) error
 	Uncheck(opts goja.Value) error
 	WaitForElementState(state string, opts goja.Value) error

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -296,7 +296,14 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 		},
 		"textContent": func(selector string, opts goja.Value) *goja.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return p.TextContent(selector, opts) //nolint:wrapcheck
+				s, ok, err := p.TextContent(selector, opts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				if !ok {
+					return nil, nil
+				}
+				return s, nil
 			})
 		},
 		"throttleCPU": func(cpuProfile common.CPUProfile) *goja.Promise {

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1416,7 +1416,8 @@ func (h *ElementHandle) tap(_ context.Context, p *Position) error {
 }
 
 // TextContent returns the text content of the element.
-func (h *ElementHandle) TextContent() (string, error) {
+// The second return value is true if the text content exists, and false otherwise.
+func (h *ElementHandle) TextContent() (string, bool, error) {
 	textContent := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.textContent(apiCtx)
 	}
@@ -1426,17 +1427,20 @@ func (h *ElementHandle) TextContent() (string, error) {
 	)
 	v, err := call(h.ctx, textContentAction, opts.Timeout)
 	if err != nil {
-		return "", fmt.Errorf("getting text content of element: %w", err)
+		return "", false, fmt.Errorf("getting text content of element: %w", err)
 	}
-
-	applySlowMo(h.ctx)
-
+	if v == nil {
+		return "", false, nil
+	}
 	s, ok := v.(string)
 	if !ok {
-		return "", fmt.Errorf("unexpected type %T (expecting string)", v)
+		return "", false, fmt.Errorf(
+			"getting text content of element: unexpected type %T (expecting string)",
+			v,
+		)
 	}
 
-	return s, nil
+	return s, true, nil
 }
 
 // Timeout will return the default timeout or the one set by the user.

--- a/common/locator.go
+++ b/common/locator.go
@@ -391,23 +391,25 @@ func (l *Locator) innerText(opts *FrameInnerTextOptions) (string, error) {
 }
 
 // TextContent returns the element's text content that matches
-// the locator's selector with strict mode on.
-func (l *Locator) TextContent(opts goja.Value) (string, error) {
+// the locator's selector with strict mode on. The second return
+// value is true if the returned text content is not null or empty,
+// and false otherwise.
+func (l *Locator) TextContent(opts goja.Value) (string, bool, error) {
 	l.log.Debugf("Locator:TextContent", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)
 
 	copts := NewFrameTextContentOptions(l.frame.defaultTimeout())
 	if err := copts.Parse(l.ctx, opts); err != nil {
-		return "", fmt.Errorf("parsing text context options: %w", err)
+		return "", false, fmt.Errorf("parsing text context options: %w", err)
 	}
-	s, err := l.textContent(copts)
+	s, ok, err := l.textContent(copts)
 	if err != nil {
-		return "", fmt.Errorf("getting text content of %q: %w", l.selector, err)
+		return "", false, fmt.Errorf("getting text content of %q: %w", l.selector, err)
 	}
 
-	return s, nil
+	return s, ok, nil
 }
 
-func (l *Locator) textContent(opts *FrameTextContentOptions) (string, error) {
+func (l *Locator) textContent(opts *FrameTextContentOptions) (string, bool, error) {
 	opts.Strict = true
 	return l.frame.textContent(l.selector, opts)
 }

--- a/common/page.go
+++ b/common/page.go
@@ -1203,8 +1203,9 @@ func (p *Page) Tap(selector string, opts *FrameTapOptions) error {
 }
 
 // TextContent returns the textContent attribute of the first element found
-// that matches the selector.
-func (p *Page) TextContent(selector string, opts goja.Value) (string, error) {
+// that matches the selector. The second return value is true if the returned
+// text content is not null or empty, and false otherwise.
+func (p *Page) TextContent(selector string, opts goja.Value) (string, bool, error) {
 	p.logger.Debugf("Page:TextContent", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().TextContent(selector, opts)

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -529,3 +529,49 @@ func TestElementHandleQuery(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, element)
 }
+
+func TestElementHandleTextContent(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBrowser(t).NewPage(nil)
+	err := p.SetContent(`<div id="el">Something</div>`, nil)
+	require.NoError(t, err)
+
+	el, err := p.Query("#el")
+	require.NoError(t, err)
+
+	got, ok, err := el.TextContent()
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "Something", got)
+}
+
+func TestElementHandleTextContentMissing(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t)
+	p := tb.NewPage(nil)
+
+	// document never has text content.
+	js, err := p.EvaluateHandle(`() => document`)
+	require.NoError(t, err)
+	_, ok, err := js.AsElement().TextContent()
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestElementHandleTextContentEmpty(t *testing.T) {
+	t.Parallel()
+
+	p := newTestBrowser(t).NewPage(nil)
+	err := p.SetContent(`<div id="el"/>`, nil)
+	require.NoError(t, err)
+
+	el, err := p.Query("#el")
+	require.NoError(t, err)
+
+	got, ok, err := el.TextContent()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, got)
+}

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -64,8 +64,9 @@ func TestFrameDismissDialogBox(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			result, err := p.TextContent("#textField", nil)
+			result, ok, err := p.TextContent("#textField", nil)
 			require.NoError(t, err)
+			require.True(t, ok)
 			assert.EqualValues(t, tt+" dismissed", result)
 		})
 	}
@@ -98,8 +99,9 @@ func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 	_, err := p.Goto(tb.staticURL("embedded_iframe.html"), opts)
 	require.NoError(t, err)
 
-	result, err := p.TextContent("#doneDiv", nil)
+	result, ok, err := p.TextContent("#doneDiv", nil)
 	require.NoError(t, err)
+	require.True(t, ok)
 	assert.EqualValues(t, "Done!", result)
 }
 
@@ -151,8 +153,9 @@ func TestFrameNoPanicNavigateAndClickOnPageWithIFrames(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	result, err := p.TextContent("#doneDiv", nil)
+	result, ok, err := p.TextContent("#doneDiv", nil)
 	require.NoError(t, err)
+	require.True(t, ok)
 	assert.EqualValues(t, "Sign In Page", result)
 }
 

--- a/tests/lifecycle_wait_test.go
+++ b/tests/lifecycle_wait_test.go
@@ -125,7 +125,7 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 			pingJSSlow:   false,
 			waitUntil:    common.LifecycleEventNetworkIdle,
 			assertFunc: func(tb *testBrowser, p *common.Page) error {
-				result, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", nil)
 				if err != nil {
 					return err
 				}
@@ -163,13 +163,13 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 			}
 
 			assertHome(t, tb, p, tt.waitUntil, func() error {
-				result, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", nil)
 				if err != nil {
 					return err
 				}
 				tt.pingRequestTextAssert(result, 10)
 
-				result, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", nil)
 				if err != nil {
 					return err
 				}
@@ -192,11 +192,11 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 
 				return tb.run(ctx, waitForNav, click)
 			}, func() {
-				result, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", nil)
 				require.NoError(t, err)
 				tt.pingRequestTextAssert(result, 20)
 
-				result, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", nil)
 				require.NoError(t, err)
 				tt.pingJSTextAssert(result)
 			}, "")
@@ -281,11 +281,11 @@ func TestLifecycleWaitForLoadState(t *testing.T) {
 				err := p.WaitForLoadState(common.LifecycleEventNetworkIdle.String(), nil)
 				require.NoError(t, err)
 
-				result, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", nil)
 				require.NoError(t, err)
 				assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
-				result, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", nil)
 				require.NoError(t, err)
 				assert.EqualValues(t, "ping.js loaded from server", result)
 			},
@@ -313,11 +313,11 @@ func TestLifecycleWaitForLoadState(t *testing.T) {
 			}
 
 			assertHome(t, tb, p, tt.waitUntil, func() error {
-				result, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", nil)
 				require.NoError(t, err)
 				tt.pingRequestTextAssert(result)
 
-				result, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", nil)
 				require.NoError(t, err)
 				tt.pingJSTextAssert(result)
 
@@ -400,13 +400,13 @@ func TestLifecycleReload(t *testing.T) {
 			withPingJSHandler(t, tb, tt.pingJSSlow, nil, false)
 
 			assertHome(t, tb, p, tt.waitUntil, func() error {
-				result, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", nil)
 				if err != nil {
 					return err
 				}
 				tt.pingRequestTextAssert(result, 10)
 
-				result, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", nil)
 				if err != nil {
 					return err
 				}
@@ -419,13 +419,13 @@ func TestLifecycleReload(t *testing.T) {
 				_, err = p.Reload(opts)
 				require.NoError(t, err)
 
-				result, err = p.TextContent("#pingRequestText", nil)
+				result, _, err = p.TextContent("#pingRequestText", nil)
 				if err != nil {
 					return err
 				}
 				tt.pingRequestTextAssert(result, 20)
 
-				result, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", nil)
 				if err != nil {
 					return err
 				}
@@ -510,13 +510,13 @@ func TestLifecycleGotoWithSubFrame(t *testing.T) {
 			withPingJSHandler(t, tb, tt.pingJSSlow, nil, true)
 
 			assertHome(t, tb, p, tt.waitUntil, func() error {
-				result, err := p.TextContent("#subFramePingRequestText", nil)
+				result, _, err := p.TextContent("#subFramePingRequestText", nil)
 				if err != nil {
 					return err
 				}
 				tt.pingRequestTextAssert(result)
 
-				result, err = p.TextContent("#subFramePingJSText", nil)
+				result, _, err = p.TextContent("#subFramePingJSText", nil)
 				if err != nil {
 					return err
 				}
@@ -587,13 +587,13 @@ func TestLifecycleGoto(t *testing.T) {
 			withPingJSHandler(t, tb, tt.pingJSSlow, nil, false)
 
 			assertHome(t, tb, p, tt.waitUntil, func() error {
-				result, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", nil)
 				if err != nil {
 					return err
 				}
 				tt.pingRequestTextAssert(result)
 
-				result, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", nil)
 				if err != nil {
 					return err
 				}
@@ -628,7 +628,7 @@ func TestLifecycleGotoNetworkIdle(t *testing.T) {
 		withPingJSHandler(t, tb, false, nil, false)
 
 		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() error {
-			result, err := p.TextContent("#pingJSText", nil)
+			result, _, err := p.TextContent("#pingJSText", nil)
 			if err != nil {
 				return err
 			}
@@ -650,13 +650,13 @@ func TestLifecycleGotoNetworkIdle(t *testing.T) {
 		withPingJSHandler(t, tb, false, ch, false)
 
 		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() error {
-			result, err := p.TextContent("#pingRequestText", nil)
+			result, _, err := p.TextContent("#pingRequestText", nil)
 			if err != nil {
 				return err
 			}
 			assert.EqualValues(t, "Waiting... pong 4 - for loop complete", result)
 
-			result, err = p.TextContent("#pingJSText", nil)
+			result, _, err = p.TextContent("#pingJSText", nil)
 			if err != nil {
 				return err
 			}
@@ -676,7 +676,7 @@ func TestLifecycleGotoNetworkIdle(t *testing.T) {
 		withPingHandler(t, tb, 50*time.Millisecond, nil)
 
 		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() error {
-			result, err := p.TextContent("#pingRequestText", nil)
+			result, _, err := p.TextContent("#pingRequestText", nil)
 			if err != nil {
 				return err
 			}

--- a/tests/locator_test.go
+++ b/tests/locator_test.go
@@ -137,8 +137,9 @@ func TestLocator(t *testing.T) {
 				const value = "fill me up"
 				lo := p.Locator("#firstParagraph", nil)
 				require.NoError(t, lo.Fill(value, nil))
-				textContent, err := p.TextContent("#firstParagraph", nil)
+				textContent, ok, err := p.TextContent("#firstParagraph", nil)
 				require.NoError(t, err)
+				require.True(t, ok)
 				require.Equal(t, value, textContent)
 				lo = p.Locator("#secondParagraph", nil)
 				require.Error(t, lo.Fill(value, nil))
@@ -249,8 +250,9 @@ func TestLocator(t *testing.T) {
 		},
 		{
 			"TextContent", func(_ *testBrowser, p *common.Page) {
-				text, err := p.Locator("#divHello", nil).TextContent(nil)
+				text, ok, err := p.Locator("#divHello", nil).TextContent(nil)
 				require.NoError(t, err)
+				require.True(t, ok)
 				require.Equal(t, `hello`, text)
 			},
 		},
@@ -418,7 +420,7 @@ func TestLocator(t *testing.T) {
 		},
 		{
 			"TextContent", func(l *common.Locator, tb *testBrowser) error {
-				_, err := l.TextContent(timeout(tb))
+				_, _, err := l.TextContent(timeout(tb))
 				return err
 			},
 		},

--- a/tests/mouse_test.go
+++ b/tests/mouse_test.go
@@ -31,8 +31,9 @@ func TestMouseActions(t *testing.T) {
 		require.NoError(t, m.Click(box.X, box.Y, nil))
 
 		// Verify the button's text changed
-		text, err := button.TextContent()
+		text, ok, err := button.TextContent()
 		require.NoError(t, err)
+		require.True(t, ok)
 		assert.Equal(t, "Clicked!", text)
 	})
 
@@ -63,15 +64,17 @@ func TestMouseActions(t *testing.T) {
 		require.NoError(t, m.DblClick(box.X, box.Y, nil))
 
 		// Verify the button's text changed
-		text, err := button.TextContent()
+		text, ok, err := button.TextContent()
 		require.NoError(t, err)
+		require.True(t, ok)
 		assert.Equal(t, "Double Clicked!", text)
 
 		// Also verify that the element was clicked twice
 		clickCountDiv, err := p.Query("div#clicks")
 		require.NoError(t, err)
-		text, err = clickCountDiv.TextContent()
+		text, ok, err = clickCountDiv.TextContent()
 		require.NoError(t, err)
+		require.True(t, ok)
 		assert.Equal(t, "2", text)
 	})
 
@@ -97,8 +100,9 @@ func TestMouseActions(t *testing.T) {
 		// Simulate mouse move within the div
 		box := area.BoundingBox()
 		require.NoError(t, m.Move(box.X+50, box.Y+50, nil)) // Move to the center of the div
-		text, err := area.TextContent()
+		text, ok, err := area.TextContent()
 		require.NoError(t, err)
+		require.True(t, ok)
 		assert.Equal(t, "Mouse Moved", text)
 	})
 
@@ -124,12 +128,14 @@ func TestMouseActions(t *testing.T) {
 		box := button.BoundingBox()
 		require.NoError(t, m.Move(box.X, box.Y, nil))
 		require.NoError(t, m.Down(nil))
-		text, err := button.TextContent()
+		text, ok, err := button.TextContent()
 		require.NoError(t, err)
+		require.True(t, ok)
 		assert.Equal(t, "Mouse Down", text)
 		require.NoError(t, m.Up(nil))
-		text, err = button.TextContent()
+		text, ok, err = button.TextContent()
 		require.NoError(t, err)
+		require.True(t, ok)
 		assert.Equal(t, "Mouse Up", text)
 	})
 }

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -452,8 +452,9 @@ func TestPageTextContent(t *testing.T) {
 		p := newTestBrowser(t).NewPage(nil)
 		err := p.SetContent(sampleHTML, nil)
 		require.NoError(t, err)
-		textContent, err := p.TextContent("div", nil)
+		textContent, ok, err := p.TextContent("div", nil)
 		require.NoError(t, err)
+		require.True(t, ok)
 		assert.Equal(t, "TestOne", textContent)
 	})
 
@@ -462,7 +463,7 @@ func TestPageTextContent(t *testing.T) {
 
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
-		_, err := p.TextContent("", nil)
+		_, _, err := p.TextContent("", nil)
 		require.ErrorContains(t, err, "The provided selector is empty")
 	})
 
@@ -473,7 +474,20 @@ func TestPageTextContent(t *testing.T) {
 		p := tb.NewPage(nil)
 		err := p.SetContent(sampleHTML, nil)
 		require.NoError(t, err)
-		_, err = p.TextContent("p", tb.toGojaValue(jsFrameBaseOpts{
+		_, _, err = p.TextContent("p", tb.toGojaValue(jsFrameBaseOpts{
+			Timeout: "100",
+		}))
+		require.Error(t, err)
+	})
+
+	t.Run("err_wrong_selector", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t)
+		p := tb.NewPage(nil)
+		err := p.SetContent(sampleHTML, nil)
+		require.NoError(t, err)
+		_, _, err = p.TextContent("p", tb.toGojaValue(jsFrameBaseOpts{
 			Timeout: "100",
 		}))
 		require.Error(t, err)


### PR DESCRIPTION
## What?

The `TextContent` methods now return `false` when the element's text content cannot be grabbed (like a JS `document`). I've added tests only for `ElementHandle` as the other types have their `TextContent` tests.

## Why?

Previously, these methods returned an empty string (`""`). That approach makes it impossible to distinguish between whether the text content is missing or empty.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#428 