### PR TITLE
Provide both Sync and Async JS APIs

### DIFF
--- a/.github/workflows/sync_e2e.yml
+++ b/.github/workflows/sync_e2e.yml
@@ -1,0 +1,73 @@
+name: sync_E2E
+on:
+  # Enable manually triggering this workflow via the API or web UI
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # At 06:00 AM UTC from Monday through Friday
+    - cron:  '0 6 * * 1-5'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go: [stable, tip]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout code
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
+        uses: actions/checkout@v4
+      - name: Install Go
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.x
+      - name: Install Go tip
+        if: matrix.go == 'tip' && matrix.platform != 'windows-latest'
+        run: |
+          go install golang.org/dl/gotip@latest
+          gotip download
+          echo "GOROOT=$HOME/sdk/gotip" >> "$GITHUB_ENV"
+          echo "GOPATH=$HOME/go" >> "$GITHUB_ENV"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "$HOME/sdk/gotip/bin" >> "$GITHUB_PATH"
+      - name: Install xk6
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
+        run: go install go.k6.io/xk6/cmd/xk6@master
+      - name: Build extension
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
+        run: |
+          which go
+          go version
+
+          GOPRIVATE="go.k6.io/k6" xk6 build \
+            --output ./k6extension \
+            --with github.com/grafana/xk6-browser=.
+          ./k6extension version
+      - name: Run E2E tests
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
+        run: |
+          set -x
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
+          fi
+          export K6_BROWSER_HEADLESS=true
+          for f in sync-examples/*.js; do
+            if [ "$f" == "sync-examples/sync_hosts.js" ] && [ "$RUNNER_OS" == "Windows" ]; then
+              echo "skipping $f on Windows"
+              continue
+            fi
+            ./k6extension run -q "$f"
+          done
+      - name: Check screenshot
+        if: matrix.go != 'tip' || matrix.platform != 'windows-latest'
+        # TODO: Do something more sophisticated?
+        run: test -s screenshot.png

--- a/browser/module.go
+++ b/browser/module.go
@@ -39,6 +39,7 @@ type (
 		tracesMetadata map[string]string
 		filePersister  filePersister
 		testRunID      string
+		isSync         bool // remove later
 	}
 
 	// JSModule exposes the properties available to the JS script.
@@ -64,6 +65,17 @@ func New() *RootModule {
 	return &RootModule{
 		PidRegistry: &pidRegistry{},
 		initOnce:    &sync.Once{},
+	}
+}
+
+// NewSync returns a pointer to a new RootModule instance that maps the
+// browser's business logic to the synchronous version of the module's
+// JS API.
+func NewSync() *RootModule {
+	return &RootModule{
+		PidRegistry: &pidRegistry{},
+		initOnce:    &sync.Once{},
+		isSync:      true,
 	}
 }
 

--- a/browser/module.go
+++ b/browser/module.go
@@ -90,9 +90,17 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 	m.initOnce.Do(func() {
 		m.initialize(vu)
 	})
+
+	// decide whether to map the browser module to the async JS API or
+	// the sync one.
+	mapper := mapBrowserToGoja
+	if m.isSync {
+		mapper = syncMapBrowserToGoja
+	}
+
 	return &ModuleInstance{
 		mod: &JSModule{
-			Browser: mapBrowserToGoja(moduleVU{
+			Browser: mapper(moduleVU{
 				VU:          vu,
 				pidRegistry: m.PidRegistry,
 				browserRegistry: newBrowserRegistry(

--- a/browser/sync_browser_context_mapping.go
+++ b/browser/sync_browser_context_mapping.go
@@ -1,10 +1,132 @@
 package browser
 
 import (
+	"fmt"
+	"reflect"
+
+	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/k6error"
+	"github.com/grafana/xk6-browser/k6ext"
 )
 
 // syncMapBrowserContext is like mapBrowserContext but returns synchronous functions.
-func syncMapBrowserContext(_ moduleVU, _ *common.BrowserContext) mapping {
-	return nil
+func syncMapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolint:funlen,gocognit,cyclop
+	rt := vu.Runtime()
+	return mapping{
+		"addCookies": bc.AddCookies,
+		"addInitScript": func(script goja.Value) error {
+			if !gojaValueExists(script) {
+				return nil
+			}
+
+			source := ""
+			switch script.ExportType() {
+			case reflect.TypeOf(string("")):
+				source = script.String()
+			case reflect.TypeOf(goja.Object{}):
+				opts := script.ToObject(rt)
+				for _, k := range opts.Keys() {
+					if k == "content" {
+						source = opts.Get(k).String()
+					}
+				}
+			default:
+				_, isCallable := goja.AssertFunction(script)
+				if !isCallable {
+					source = fmt.Sprintf("(%s);", script.ToString().String())
+				} else {
+					source = fmt.Sprintf("(%s)(...args);", script.ToString().String())
+				}
+			}
+
+			return bc.AddInitScript(source) //nolint:wrapcheck
+		},
+		"browser":          bc.Browser,
+		"clearCookies":     bc.ClearCookies,
+		"clearPermissions": bc.ClearPermissions,
+		"close":            bc.Close,
+		"cookies":          bc.Cookies,
+		"grantPermissions": func(permissions []string, opts goja.Value) error {
+			pOpts := common.NewGrantPermissionsOptions()
+			pOpts.Parse(vu.Context(), opts)
+
+			return bc.GrantPermissions(permissions, pOpts) //nolint:wrapcheck
+		},
+		"setDefaultNavigationTimeout": bc.SetDefaultNavigationTimeout,
+		"setDefaultTimeout":           bc.SetDefaultTimeout,
+		"setGeolocation":              bc.SetGeolocation,
+		"setHTTPCredentials":          bc.SetHTTPCredentials, //nolint:staticcheck
+		"setOffline":                  bc.SetOffline,
+		"waitForEvent": func(event string, optsOrPredicate goja.Value) (*goja.Promise, error) {
+			ctx := vu.Context()
+			popts := common.NewWaitForEventOptions(
+				bc.Timeout(),
+			)
+			if err := popts.Parse(ctx, optsOrPredicate); err != nil {
+				return nil, fmt.Errorf("parsing waitForEvent options: %w", err)
+			}
+
+			return k6ext.Promise(ctx, func() (result any, reason error) {
+				var runInTaskQueue func(p *common.Page) (bool, error)
+				if popts.PredicateFn != nil {
+					runInTaskQueue = func(p *common.Page) (bool, error) {
+						tq := vu.taskQueueRegistry.get(p.TargetID())
+
+						var rtn bool
+						var err error
+						// The function on the taskqueue runs in its own goroutine
+						// so we need to use a channel to wait for it to complete
+						// before returning the result to the caller.
+						c := make(chan bool)
+						tq.Queue(func() error {
+							var resp goja.Value
+							resp, err = popts.PredicateFn(vu.Runtime().ToValue(p))
+							rtn = resp.ToBoolean()
+							close(c)
+							return nil
+						})
+						<-c
+
+						return rtn, err //nolint:wrapcheck
+					}
+				}
+
+				resp, err := bc.WaitForEvent(event, runInTaskQueue, popts.Timeout)
+				panicIfFatalError(ctx, err)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				p, ok := resp.(*common.Page)
+				if !ok {
+					panicIfFatalError(ctx, fmt.Errorf("response object is not a page: %w", k6error.ErrFatal))
+				}
+
+				return syncMapPage(vu, p), nil
+			}), nil
+		},
+		"pages": func() *goja.Object {
+			var (
+				mpages []mapping
+				pages  = bc.Pages()
+			)
+			for _, page := range pages {
+				if page == nil {
+					continue
+				}
+				m := syncMapPage(vu, page)
+				mpages = append(mpages, m)
+			}
+
+			return rt.ToValue(mpages).ToObject(rt)
+		},
+		"newPage": func() (mapping, error) {
+			page, err := bc.NewPage()
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return syncMapPage(vu, page), nil
+		},
+	}
 }

--- a/browser/sync_browser_context_mapping.go
+++ b/browser/sync_browser_context_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// syncMapBrowserContext is like mapBrowserContext but returns synchronous functions.
+func syncMapBrowserContext(_ moduleVU, _ *common.BrowserContext) mapping {
+	return nil
+}

--- a/browser/sync_browser_mapping.go
+++ b/browser/sync_browser_mapping.go
@@ -1,0 +1,81 @@
+package browser
+
+import (
+	"github.com/dop251/goja"
+)
+
+// syncMapBrowser is like mapBrowser but returns synchronous functions.
+func syncMapBrowser(vu moduleVU) mapping { //nolint:funlen,cyclop
+	rt := vu.Runtime()
+	return mapping{
+		"context": func() (mapping, error) {
+			b, err := vu.browser()
+			if err != nil {
+				return nil, err
+			}
+			return syncMapBrowserContext(vu, b.Context()), nil
+		},
+		"closeContext": func() error {
+			b, err := vu.browser()
+			if err != nil {
+				return err
+			}
+			return b.CloseContext() //nolint:wrapcheck
+		},
+		"isConnected": func() (bool, error) {
+			b, err := vu.browser()
+			if err != nil {
+				return false, err
+			}
+			return b.IsConnected(), nil
+		},
+		"newContext": func(opts goja.Value) (*goja.Object, error) {
+			b, err := vu.browser()
+			if err != nil {
+				return nil, err
+			}
+			bctx, err := b.NewContext(opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+
+			if err := initBrowserContext(bctx, vu.testRunID); err != nil {
+				return nil, err
+			}
+
+			m := syncMapBrowserContext(vu, bctx)
+
+			return rt.ToValue(m).ToObject(rt), nil
+		},
+		"userAgent": func() (string, error) {
+			b, err := vu.browser()
+			if err != nil {
+				return "", err
+			}
+			return b.UserAgent(), nil
+		},
+		"version": func() (string, error) {
+			b, err := vu.browser()
+			if err != nil {
+				return "", err
+			}
+			return b.Version(), nil
+		},
+		"newPage": func(opts goja.Value) (mapping, error) {
+			b, err := vu.browser()
+			if err != nil {
+				return nil, err
+			}
+			page, err := b.NewPage(opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+
+			if err := initBrowserContext(b.Context(), vu.testRunID); err != nil {
+				return nil, err
+			}
+
+			return syncMapPage(vu, page), nil
+		},
+	}
+}

--- a/browser/sync_console_message_mapping.go
+++ b/browser/sync_console_message_mapping.go
@@ -1,10 +1,31 @@
 package browser
 
 import (
+	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/common"
 )
 
 // syncMapConsoleMessage is like mapConsoleMessage but returns synchronous functions.
-func syncMapConsoleMessage(_ moduleVU, _ *common.ConsoleMessage) mapping {
-	return nil
+func syncMapConsoleMessage(vu moduleVU, cm *common.ConsoleMessage) mapping {
+	rt := vu.Runtime()
+	return mapping{
+		"args": func() *goja.Object {
+			var (
+				margs []mapping
+				args  = cm.Args
+			)
+			for _, arg := range args {
+				a := syncMapJSHandle(vu, arg)
+				margs = append(margs, a)
+			}
+
+			return rt.ToValue(margs).ToObject(rt)
+		},
+		// page(), text() and type() are defined as
+		// functions in order to match Playwright's API
+		"page": func() mapping { return syncMapPage(vu, cm.Page) },
+		"text": func() string { return cm.Text },
+		"type": func() string { return cm.Type },
+	}
 }

--- a/browser/sync_console_message_mapping.go
+++ b/browser/sync_console_message_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// syncMapConsoleMessage is like mapConsoleMessage but returns synchronous functions.
+func syncMapConsoleMessage(_ moduleVU, _ *common.ConsoleMessage) mapping {
+	return nil
+}

--- a/browser/sync_element_handle_mapping.go
+++ b/browser/sync_element_handle_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// syncMapElementHandle is like mapElementHandle but returns synchronous functions.
+func syncMapElementHandle(_ moduleVU, _ *common.ElementHandle) mapping {
+	return nil
+}

--- a/browser/sync_element_handle_mapping.go
+++ b/browser/sync_element_handle_mapping.go
@@ -1,10 +1,139 @@
 package browser
 
 import (
+	"fmt"
+
+	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/k6ext"
 )
 
 // syncMapElementHandle is like mapElementHandle but returns synchronous functions.
-func syncMapElementHandle(_ moduleVU, _ *common.ElementHandle) mapping {
-	return nil
+func syncMapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:cyclop,funlen
+	rt := vu.Runtime()
+	maps := mapping{
+		"boundingBox": eh.BoundingBox,
+		"check":       eh.Check,
+		"click": func(opts goja.Value) (*goja.Promise, error) {
+			ctx := vu.Context()
+
+			popts := common.NewElementHandleClickOptions(eh.Timeout())
+			if err := popts.Parse(ctx, opts); err != nil {
+				return nil, fmt.Errorf("parsing element click options: %w", err)
+			}
+
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				err := eh.Click(popts)
+				return nil, err //nolint:wrapcheck
+			}), nil
+		},
+		"contentFrame": func() (mapping, error) {
+			f, err := eh.ContentFrame()
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return syncMapFrame(vu, f), nil
+		},
+		"dblclick": eh.Dblclick,
+		"dispatchEvent": func(typ string, eventInit goja.Value) error {
+			return eh.DispatchEvent(typ, exportArg(eventInit)) //nolint:wrapcheck
+		},
+		"fill":         eh.Fill,
+		"focus":        eh.Focus,
+		"getAttribute": eh.GetAttribute,
+		"hover":        eh.Hover,
+		"innerHTML":    eh.InnerHTML,
+		"innerText":    eh.InnerText,
+		"inputValue":   eh.InputValue,
+		"isChecked":    eh.IsChecked,
+		"isDisabled":   eh.IsDisabled,
+		"isEditable":   eh.IsEditable,
+		"isEnabled":    eh.IsEnabled,
+		"isHidden":     eh.IsHidden,
+		"isVisible":    eh.IsVisible,
+		"ownerFrame": func() (mapping, error) {
+			f, err := eh.OwnerFrame()
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return syncMapFrame(vu, f), nil
+		},
+		"press": eh.Press,
+		"screenshot": func(opts goja.Value) (*goja.ArrayBuffer, error) {
+			ctx := vu.Context()
+
+			popts := common.NewElementHandleScreenshotOptions(eh.Timeout())
+			if err := popts.Parse(ctx, opts); err != nil {
+				return nil, fmt.Errorf("parsing frame screenshot options: %w", err)
+			}
+
+			bb, err := eh.Screenshot(popts, vu.filePersister)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+
+			ab := rt.NewArrayBuffer(bb)
+
+			return &ab, nil
+		},
+		"scrollIntoViewIfNeeded": eh.ScrollIntoViewIfNeeded,
+		"selectOption":           eh.SelectOption,
+		"selectText":             eh.SelectText,
+		"setInputFiles":          eh.SetInputFiles,
+		"tap": func(opts goja.Value) (*goja.Promise, error) {
+			popts := common.NewElementHandleTapOptions(eh.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing element tap options: %w", err)
+			}
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				return nil, eh.Tap(popts) //nolint:wrapcheck
+			}), nil
+		},
+		"textContent":         eh.TextContent,
+		"type":                eh.Type,
+		"uncheck":             eh.Uncheck,
+		"waitForElementState": eh.WaitForElementState,
+		"waitForSelector": func(selector string, opts goja.Value) (mapping, error) {
+			eh, err := eh.WaitForSelector(selector, opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return syncMapElementHandle(vu, eh), nil
+		},
+	}
+	maps["$"] = func(selector string) (mapping, error) {
+		eh, err := eh.Query(selector, common.StrictModeOff)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+		// ElementHandle can be null when the selector does not match any elements.
+		// We do not want to map nil elementHandles since the expectation is a
+		// null result in the test script for this case.
+		if eh == nil {
+			return nil, nil //nolint:nilnil
+		}
+		ehm := syncMapElementHandle(vu, eh)
+
+		return ehm, nil
+	}
+	maps["$$"] = func(selector string) ([]mapping, error) {
+		ehs, err := eh.QueryAll(selector)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+		var mehs []mapping
+		for _, eh := range ehs {
+			ehm := syncMapElementHandle(vu, eh)
+			mehs = append(mehs, ehm)
+		}
+		return mehs, nil
+	}
+
+	jsHandleMap := syncMapJSHandle(vu, eh)
+	for k, v := range jsHandleMap {
+		maps[k] = v
+	}
+
+	return maps
 }

--- a/browser/sync_element_handle_mapping.go
+++ b/browser/sync_element_handle_mapping.go
@@ -10,7 +10,7 @@ import (
 )
 
 // syncMapElementHandle is like mapElementHandle but returns synchronous functions.
-func syncMapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:cyclop,funlen
+func syncMapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:gocognit,cyclop,funlen
 	rt := vu.Runtime()
 	maps := mapping{
 		"boundingBox": eh.BoundingBox,
@@ -39,19 +39,28 @@ func syncMapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nol
 		"dispatchEvent": func(typ string, eventInit goja.Value) error {
 			return eh.DispatchEvent(typ, exportArg(eventInit)) //nolint:wrapcheck
 		},
-		"fill":         eh.Fill,
-		"focus":        eh.Focus,
-		"getAttribute": eh.GetAttribute,
-		"hover":        eh.Hover,
-		"innerHTML":    eh.InnerHTML,
-		"innerText":    eh.InnerText,
-		"inputValue":   eh.InputValue,
-		"isChecked":    eh.IsChecked,
-		"isDisabled":   eh.IsDisabled,
-		"isEditable":   eh.IsEditable,
-		"isEnabled":    eh.IsEnabled,
-		"isHidden":     eh.IsHidden,
-		"isVisible":    eh.IsVisible,
+		"fill":  eh.Fill,
+		"focus": eh.Focus,
+		"getAttribute": func(name string) (any, error) {
+			v, ok, err := eh.GetAttribute(name)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			if !ok {
+				return nil, nil //nolint:nilnil
+			}
+			return v, nil
+		},
+		"hover":      eh.Hover,
+		"innerHTML":  eh.InnerHTML,
+		"innerText":  eh.InnerText,
+		"inputValue": eh.InputValue,
+		"isChecked":  eh.IsChecked,
+		"isDisabled": eh.IsDisabled,
+		"isEditable": eh.IsEditable,
+		"isEnabled":  eh.IsEnabled,
+		"isHidden":   eh.IsHidden,
+		"isVisible":  eh.IsVisible,
 		"ownerFrame": func() (mapping, error) {
 			f, err := eh.OwnerFrame()
 			if err != nil {

--- a/browser/sync_element_handle_mapping.go
+++ b/browser/sync_element_handle_mapping.go
@@ -90,7 +90,16 @@ func syncMapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nol
 				return nil, eh.Tap(popts) //nolint:wrapcheck
 			}), nil
 		},
-		"textContent":         eh.TextContent,
+		"textContent": func() (any, error) {
+			v, ok, err := eh.TextContent()
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			if !ok {
+				return nil, nil //nolint:nilnil
+			}
+			return v, nil
+		},
 		"type":                eh.Type,
 		"uncheck":             eh.Uncheck,
 		"waitForElementState": eh.WaitForElementState,

--- a/browser/sync_frame_mapping.go
+++ b/browser/sync_frame_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// syncMapFrame is like mapFrame but returns synchronous functions.
+func syncMapFrame(_ moduleVU, _ *common.Frame) mapping {
+	return nil
+}

--- a/browser/sync_frame_mapping.go
+++ b/browser/sync_frame_mapping.go
@@ -1,10 +1,191 @@
 package browser
 
 import (
+	"fmt"
+
+	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/k6ext"
 )
 
 // syncMapFrame is like mapFrame but returns synchronous functions.
-func syncMapFrame(_ moduleVU, _ *common.Frame) mapping {
-	return nil
+func syncMapFrame(vu moduleVU, f *common.Frame) mapping { //nolint:gocognit,cyclop,funlen
+	rt := vu.Runtime()
+	maps := mapping{
+		"check": f.Check,
+		"childFrames": func() *goja.Object {
+			var (
+				mcfs []mapping
+				cfs  = f.ChildFrames()
+			)
+			for _, fr := range cfs {
+				mcfs = append(mcfs, syncMapFrame(vu, fr))
+			}
+			return rt.ToValue(mcfs).ToObject(rt)
+		},
+		"click": func(selector string, opts goja.Value) (*goja.Promise, error) {
+			popts, err := parseFrameClickOptions(vu.Context(), opts, f.Timeout())
+			if err != nil {
+				return nil, err
+			}
+
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				err := f.Click(selector, popts)
+				return nil, err //nolint:wrapcheck
+			}), nil
+		},
+		"content":  f.Content,
+		"dblclick": f.Dblclick,
+		"dispatchEvent": func(selector, typ string, eventInit, opts goja.Value) error {
+			popts := common.NewFrameDispatchEventOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return fmt.Errorf("parsing frame dispatch event options: %w", err)
+			}
+			return f.DispatchEvent(selector, typ, exportArg(eventInit), popts) //nolint:wrapcheck
+		},
+		"evaluate": func(pageFunction goja.Value, gargs ...goja.Value) (any, error) {
+			return f.Evaluate(pageFunction.String(), exportArgs(gargs)...) //nolint:wrapcheck
+		},
+		"evaluateHandle": func(pageFunction goja.Value, gargs ...goja.Value) (mapping, error) {
+			jsh, err := f.EvaluateHandle(pageFunction.String(), exportArgs(gargs)...)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return syncMapJSHandle(vu, jsh), nil
+		},
+		"fill":  f.Fill,
+		"focus": f.Focus,
+		"frameElement": func() (mapping, error) {
+			fe, err := f.FrameElement()
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return syncMapElementHandle(vu, fe), nil
+		},
+		"getAttribute": f.GetAttribute,
+		"goto": func(url string, opts goja.Value) (*goja.Promise, error) {
+			gopts := common.NewFrameGotoOptions(
+				f.Referrer(),
+				f.NavigationTimeout(),
+			)
+			if err := gopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing frame navigation options to %q: %w", url, err)
+			}
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				resp, err := f.Goto(url, gopts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+
+				return syncMapResponse(vu, resp), nil
+			}), nil
+		},
+		"hover":      f.Hover,
+		"innerHTML":  f.InnerHTML,
+		"innerText":  f.InnerText,
+		"inputValue": f.InputValue,
+		"isChecked":  f.IsChecked,
+		"isDetached": f.IsDetached,
+		"isDisabled": f.IsDisabled,
+		"isEditable": f.IsEditable,
+		"isEnabled":  f.IsEnabled,
+		"isHidden":   f.IsHidden,
+		"isVisible":  f.IsVisible,
+		"locator": func(selector string, opts goja.Value) *goja.Object {
+			ml := syncMapLocator(vu, f.Locator(selector, opts))
+			return rt.ToValue(ml).ToObject(rt)
+		},
+		"name": f.Name,
+		"page": func() *goja.Object {
+			mp := syncMapPage(vu, f.Page())
+			return rt.ToValue(mp).ToObject(rt)
+		},
+		"parentFrame": func() *goja.Object {
+			mf := syncMapFrame(vu, f.ParentFrame())
+			return rt.ToValue(mf).ToObject(rt)
+		},
+		"press":         f.Press,
+		"selectOption":  f.SelectOption,
+		"setContent":    f.SetContent,
+		"setInputFiles": f.SetInputFiles,
+		"tap": func(selector string, opts goja.Value) (*goja.Promise, error) {
+			popts := common.NewFrameTapOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing frame tap options: %w", err)
+			}
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				return nil, f.Tap(selector, popts) //nolint:wrapcheck
+			}), nil
+		},
+		"textContent": f.TextContent,
+		"title":       f.Title,
+		"type":        f.Type,
+		"uncheck":     f.Uncheck,
+		"url":         f.URL,
+		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) (*goja.Promise, error) {
+			js, popts, pargs, err := parseWaitForFunctionArgs(
+				vu.Context(), f.Timeout(), pageFunc, opts, args...,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("frame waitForFunction: %w", err)
+			}
+
+			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
+				return f.WaitForFunction(js, popts, pargs...) //nolint:wrapcheck
+			}), nil
+		},
+		"waitForLoadState": f.WaitForLoadState,
+		"waitForNavigation": func(opts goja.Value) (*goja.Promise, error) {
+			popts := common.NewFrameWaitForNavigationOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing frame wait for navigation options: %w", err)
+			}
+
+			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
+				resp, err := f.WaitForNavigation(popts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				return syncMapResponse(vu, resp), nil
+			}), nil
+		},
+		"waitForSelector": func(selector string, opts goja.Value) (mapping, error) {
+			eh, err := f.WaitForSelector(selector, opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return syncMapElementHandle(vu, eh), nil
+		},
+		"waitForTimeout": f.WaitForTimeout,
+	}
+	maps["$"] = func(selector string) (mapping, error) {
+		eh, err := f.Query(selector, common.StrictModeOff)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+		// ElementHandle can be null when the selector does not match any elements.
+		// We do not want to map nil elementHandles since the expectation is a
+		// null result in the test script for this case.
+		if eh == nil {
+			return nil, nil //nolint:nilnil
+		}
+		ehm := syncMapElementHandle(vu, eh)
+
+		return ehm, nil
+	}
+	maps["$$"] = func(selector string) ([]mapping, error) {
+		ehs, err := f.QueryAll(selector)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+		var mehs []mapping
+		for _, eh := range ehs {
+			ehm := syncMapElementHandle(vu, eh)
+			mehs = append(mehs, ehm)
+		}
+		return mehs, nil
+	}
+
+	return maps
 }

--- a/browser/sync_frame_mapping.go
+++ b/browser/sync_frame_mapping.go
@@ -118,11 +118,20 @@ func syncMapFrame(vu moduleVU, f *common.Frame) mapping { //nolint:gocognit,cycl
 				return nil, f.Tap(selector, popts) //nolint:wrapcheck
 			}), nil
 		},
-		"textContent": f.TextContent,
-		"title":       f.Title,
-		"type":        f.Type,
-		"uncheck":     f.Uncheck,
-		"url":         f.URL,
+		"textContent": func(selector string, opts goja.Value) (any, error) {
+			v, ok, err := f.TextContent(selector, opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			if !ok {
+				return nil, nil //nolint:nilnil
+			}
+			return v, nil
+		},
+		"title":   f.Title,
+		"type":    f.Type,
+		"uncheck": f.Uncheck,
+		"url":     f.URL,
 		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) (*goja.Promise, error) {
 			js, popts, pargs, err := parseWaitForFunctionArgs(
 				vu.Context(), f.Timeout(), pageFunc, opts, args...,

--- a/browser/sync_frame_mapping.go
+++ b/browser/sync_frame_mapping.go
@@ -63,7 +63,16 @@ func syncMapFrame(vu moduleVU, f *common.Frame) mapping { //nolint:gocognit,cycl
 			}
 			return syncMapElementHandle(vu, fe), nil
 		},
-		"getAttribute": f.GetAttribute,
+		"getAttribute": func(selector, name string, opts goja.Value) (any, error) {
+			v, ok, err := f.GetAttribute(selector, name, opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			if !ok {
+				return nil, nil //nolint:nilnil
+			}
+			return v, nil
+		},
 		"goto": func(url string, opts goja.Value) (*goja.Promise, error) {
 			gopts := common.NewFrameGotoOptions(
 				f.Referrer(),

--- a/browser/sync_js_handle_mapping.go
+++ b/browser/sync_js_handle_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// syncMapJSHandle is like mapJSHandle but returns synchronous functions.
+func syncMapJSHandle(_ moduleVU, _ common.JSHandleAPI) mapping {
+	return nil
+}

--- a/browser/sync_js_handle_mapping.go
+++ b/browser/sync_js_handle_mapping.go
@@ -1,10 +1,46 @@
 package browser
 
 import (
+	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/common"
 )
 
 // syncMapJSHandle is like mapJSHandle but returns synchronous functions.
-func syncMapJSHandle(_ moduleVU, _ common.JSHandleAPI) mapping {
-	return nil
+func syncMapJSHandle(vu moduleVU, jsh common.JSHandleAPI) mapping {
+	rt := vu.Runtime()
+	return mapping{
+		"asElement": func() *goja.Object {
+			m := syncMapElementHandle(vu, jsh.AsElement())
+			return rt.ToValue(m).ToObject(rt)
+		},
+		"dispose": jsh.Dispose,
+		"evaluate": func(pageFunc goja.Value, gargs ...goja.Value) (any, error) {
+			args := make([]any, 0, len(gargs))
+			for _, a := range gargs {
+				args = append(args, exportArg(a))
+			}
+			return jsh.Evaluate(pageFunc.String(), args...) //nolint:wrapcheck
+		},
+		"evaluateHandle": func(pageFunc goja.Value, gargs ...goja.Value) (mapping, error) {
+			h, err := jsh.EvaluateHandle(pageFunc.String(), exportArgs(gargs)...)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return syncMapJSHandle(vu, h), nil
+		},
+		"getProperties": func() (mapping, error) {
+			props, err := jsh.GetProperties()
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+
+			dst := make(map[string]any)
+			for k, v := range props {
+				dst[k] = syncMapJSHandle(vu, v)
+			}
+			return dst, nil
+		},
+		"jsonValue": jsh.JSONValue,
+	}
 }

--- a/browser/sync_locator_mapping.go
+++ b/browser/sync_locator_mapping.go
@@ -10,7 +10,7 @@ import (
 )
 
 // syncMapLocator is like mapLocator but returns synchronous functions.
-func syncMapLocator(vu moduleVU, lo *common.Locator) mapping {
+func syncMapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
 	return mapping{
 		"clear": func(opts goja.Value) error {
 			ctx := vu.Context()
@@ -46,7 +46,16 @@ func syncMapLocator(vu moduleVU, lo *common.Locator) mapping {
 		"getAttribute": lo.GetAttribute,
 		"innerHTML":    lo.InnerHTML,
 		"innerText":    lo.InnerText,
-		"textContent":  lo.TextContent,
+		"textContent": func(opts goja.Value) (any, error) {
+			v, ok, err := lo.TextContent(opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			if !ok {
+				return nil, nil
+			}
+			return v, nil
+		},
 		"inputValue":   lo.InputValue,
 		"selectOption": lo.SelectOption,
 		"press":        lo.Press,

--- a/browser/sync_locator_mapping.go
+++ b/browser/sync_locator_mapping.go
@@ -1,10 +1,73 @@
 package browser
 
 import (
+	"fmt"
+
+	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/k6ext"
 )
 
 // syncMapLocator is like mapLocator but returns synchronous functions.
-func syncMapLocator(_ moduleVU, _ *common.Locator) mapping {
-	return nil
+func syncMapLocator(vu moduleVU, lo *common.Locator) mapping {
+	return mapping{
+		"clear": func(opts goja.Value) error {
+			ctx := vu.Context()
+
+			copts := common.NewFrameFillOptions(lo.Timeout())
+			if err := copts.Parse(ctx, opts); err != nil {
+				return fmt.Errorf("parsing clear options: %w", err)
+			}
+
+			return lo.Clear(copts) //nolint:wrapcheck
+		},
+		"click": func(opts goja.Value) (*goja.Promise, error) {
+			popts, err := parseFrameClickOptions(vu.Context(), opts, lo.Timeout())
+			if err != nil {
+				return nil, err
+			}
+
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				return nil, lo.Click(popts) //nolint:wrapcheck
+			}), nil
+		},
+		"dblclick":     lo.Dblclick,
+		"check":        lo.Check,
+		"uncheck":      lo.Uncheck,
+		"isChecked":    lo.IsChecked,
+		"isEditable":   lo.IsEditable,
+		"isEnabled":    lo.IsEnabled,
+		"isDisabled":   lo.IsDisabled,
+		"isVisible":    lo.IsVisible,
+		"isHidden":     lo.IsHidden,
+		"fill":         lo.Fill,
+		"focus":        lo.Focus,
+		"getAttribute": lo.GetAttribute,
+		"innerHTML":    lo.InnerHTML,
+		"innerText":    lo.InnerText,
+		"textContent":  lo.TextContent,
+		"inputValue":   lo.InputValue,
+		"selectOption": lo.SelectOption,
+		"press":        lo.Press,
+		"type":         lo.Type,
+		"hover":        lo.Hover,
+		"tap": func(opts goja.Value) (*goja.Promise, error) {
+			copts := common.NewFrameTapOptions(lo.DefaultTimeout())
+			if err := copts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing locator tap options: %w", err)
+			}
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				return nil, lo.Tap(copts) //nolint:wrapcheck
+			}), nil
+		},
+		"dispatchEvent": func(typ string, eventInit, opts goja.Value) error {
+			popts := common.NewFrameDispatchEventOptions(lo.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return fmt.Errorf("parsing locator dispatch event options: %w", err)
+			}
+			return lo.DispatchEvent(typ, exportArg(eventInit), popts) //nolint:wrapcheck
+		},
+		"waitFor": lo.WaitFor,
+	}
 }

--- a/browser/sync_locator_mapping.go
+++ b/browser/sync_locator_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// syncMapLocator is like mapLocator but returns synchronous functions.
+func syncMapLocator(_ moduleVU, _ *common.Locator) mapping {
+	return nil
+}

--- a/browser/sync_locator_mapping.go
+++ b/browser/sync_locator_mapping.go
@@ -32,20 +32,29 @@ func syncMapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
 				return nil, lo.Click(popts) //nolint:wrapcheck
 			}), nil
 		},
-		"dblclick":     lo.Dblclick,
-		"check":        lo.Check,
-		"uncheck":      lo.Uncheck,
-		"isChecked":    lo.IsChecked,
-		"isEditable":   lo.IsEditable,
-		"isEnabled":    lo.IsEnabled,
-		"isDisabled":   lo.IsDisabled,
-		"isVisible":    lo.IsVisible,
-		"isHidden":     lo.IsHidden,
-		"fill":         lo.Fill,
-		"focus":        lo.Focus,
-		"getAttribute": lo.GetAttribute,
-		"innerHTML":    lo.InnerHTML,
-		"innerText":    lo.InnerText,
+		"dblclick":   lo.Dblclick,
+		"check":      lo.Check,
+		"uncheck":    lo.Uncheck,
+		"isChecked":  lo.IsChecked,
+		"isEditable": lo.IsEditable,
+		"isEnabled":  lo.IsEnabled,
+		"isDisabled": lo.IsDisabled,
+		"isVisible":  lo.IsVisible,
+		"isHidden":   lo.IsHidden,
+		"fill":       lo.Fill,
+		"focus":      lo.Focus,
+		"getAttribute": func(name string, opts goja.Value) (any, error) {
+			v, ok, err := lo.GetAttribute(name, opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			if !ok {
+				return nil, nil
+			}
+			return v, nil
+		},
+		"innerHTML": lo.InnerHTML,
+		"innerText": lo.InnerText,
 		"textContent": func(opts goja.Value) (any, error) {
 			v, ok, err := lo.TextContent(opts)
 			if err != nil {

--- a/browser/sync_mapping.go
+++ b/browser/sync_mapping.go
@@ -1,0 +1,26 @@
+package browser
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+
+	k6common "go.k6.io/k6/js/common"
+)
+
+// syncMapBrowserToGoja maps the browser API to the JS module as a
+// synchronous version.
+func syncMapBrowserToGoja(vu moduleVU) *goja.Object {
+	var (
+		rt  = vu.Runtime()
+		obj = rt.NewObject()
+	)
+	for k, v := range syncMapBrowser(vu) {
+		err := obj.Set(k, rt.ToValue(v))
+		if err != nil {
+			k6common.Throw(rt, fmt.Errorf("mapping: %w", err))
+		}
+	}
+
+	return obj
+}

--- a/browser/sync_page_mapping.go
+++ b/browser/sync_page_mapping.go
@@ -168,7 +168,16 @@ func syncMapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return nil, p.Tap(selector, popts) //nolint:wrapcheck
 			}), nil
 		},
-		"textContent":     p.TextContent,
+		"textContent": func(selector string, opts goja.Value) (any, error) {
+			v, ok, err := p.TextContent(selector, opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			if !ok {
+				return nil, nil //nolint:nilnil
+			}
+			return v, nil
+		},
 		"throttleCPU":     p.ThrottleCPU,
 		"throttleNetwork": p.ThrottleNetwork,
 		"title":           p.Title,

--- a/browser/sync_page_mapping.go
+++ b/browser/sync_page_mapping.go
@@ -1,10 +1,253 @@
 package browser
 
 import (
+	"fmt"
+
+	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/k6ext"
 )
 
 // syncMapPage is like mapPage but returns synchronous functions.
-func syncMapPage(_ moduleVU, _ *common.Page) mapping {
-	return nil
+func syncMapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop,funlen
+	rt := vu.Runtime()
+	maps := mapping{
+		"bringToFront": p.BringToFront,
+		"check":        p.Check,
+		"click": func(selector string, opts goja.Value) (*goja.Promise, error) {
+			popts, err := parseFrameClickOptions(vu.Context(), opts, p.Timeout())
+			if err != nil {
+				return nil, err
+			}
+
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				err := p.Click(selector, popts)
+				return nil, err //nolint:wrapcheck
+			}), nil
+		},
+		"close": func(opts goja.Value) error {
+			vu.taskQueueRegistry.close(p.TargetID())
+
+			return p.Close(opts) //nolint:wrapcheck
+		},
+		"content":  p.Content,
+		"context":  p.Context,
+		"dblclick": p.Dblclick,
+		"dispatchEvent": func(selector, typ string, eventInit, opts goja.Value) error {
+			popts := common.NewFrameDispatchEventOptions(p.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return fmt.Errorf("parsing page dispatch event options: %w", err)
+			}
+			return p.DispatchEvent(selector, typ, exportArg(eventInit), popts) //nolint:wrapcheck
+		},
+		"emulateMedia":            p.EmulateMedia,
+		"emulateVisionDeficiency": p.EmulateVisionDeficiency,
+		"evaluate": func(pageFunction goja.Value, gargs ...goja.Value) (any, error) {
+			return p.Evaluate(pageFunction.String(), exportArgs(gargs)...) //nolint:wrapcheck
+		},
+		"evaluateHandle": func(pageFunc goja.Value, gargs ...goja.Value) (mapping, error) {
+			jsh, err := p.EvaluateHandle(pageFunc.String(), exportArgs(gargs)...)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return syncMapJSHandle(vu, jsh), nil
+		},
+		"fill":  p.Fill,
+		"focus": p.Focus,
+		"frames": func() *goja.Object {
+			var (
+				mfrs []mapping
+				frs  = p.Frames()
+			)
+			for _, fr := range frs {
+				mfrs = append(mfrs, syncMapFrame(vu, fr))
+			}
+			return rt.ToValue(mfrs).ToObject(rt)
+		},
+		"getAttribute": p.GetAttribute,
+		"goto": func(url string, opts goja.Value) (*goja.Promise, error) {
+			gopts := common.NewFrameGotoOptions(
+				p.Referrer(),
+				p.NavigationTimeout(),
+			)
+			if err := gopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing page navigation options to %q: %w", url, err)
+			}
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				resp, err := p.Goto(url, gopts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+
+				return syncMapResponse(vu, resp), nil
+			}), nil
+		},
+		"hover":      p.Hover,
+		"innerHTML":  p.InnerHTML,
+		"innerText":  p.InnerText,
+		"inputValue": p.InputValue,
+		"isChecked":  p.IsChecked,
+		"isClosed":   p.IsClosed,
+		"isDisabled": p.IsDisabled,
+		"isEditable": p.IsEditable,
+		"isEnabled":  p.IsEnabled,
+		"isHidden":   p.IsHidden,
+		"isVisible":  p.IsVisible,
+		"keyboard":   rt.ToValue(p.GetKeyboard()).ToObject(rt),
+		"locator": func(selector string, opts goja.Value) *goja.Object {
+			ml := syncMapLocator(vu, p.Locator(selector, opts))
+			return rt.ToValue(ml).ToObject(rt)
+		},
+		"mainFrame": func() *goja.Object {
+			mf := syncMapFrame(vu, p.MainFrame())
+			return rt.ToValue(mf).ToObject(rt)
+		},
+		"mouse": rt.ToValue(p.GetMouse()).ToObject(rt),
+		"on": func(event string, handler goja.Callable) error {
+			tq := vu.taskQueueRegistry.get(p.TargetID())
+
+			mapMsgAndHandleEvent := func(m *common.ConsoleMessage) error {
+				mapping := syncMapConsoleMessage(vu, m)
+				_, err := handler(goja.Undefined(), vu.Runtime().ToValue(mapping))
+				return err
+			}
+			runInTaskQueue := func(m *common.ConsoleMessage) {
+				tq.Queue(func() error {
+					if err := mapMsgAndHandleEvent(m); err != nil {
+						return fmt.Errorf("executing page.on handler: %w", err)
+					}
+					return nil
+				})
+			}
+
+			return p.On(event, runInTaskQueue) //nolint:wrapcheck
+		},
+		"opener": p.Opener,
+		"press":  p.Press,
+		"reload": func(opts goja.Value) (*goja.Object, error) {
+			resp, err := p.Reload(opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+
+			r := syncMapResponse(vu, resp)
+
+			return rt.ToValue(r).ToObject(rt), nil
+		},
+		"screenshot": func(opts goja.Value) (*goja.ArrayBuffer, error) {
+			ctx := vu.Context()
+
+			popts := common.NewPageScreenshotOptions()
+			if err := popts.Parse(ctx, opts); err != nil {
+				return nil, fmt.Errorf("parsing page screenshot options: %w", err)
+			}
+
+			bb, err := p.Screenshot(popts, vu.filePersister)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+
+			ab := rt.NewArrayBuffer(bb)
+
+			return &ab, nil
+		},
+		"selectOption":                p.SelectOption,
+		"setContent":                  p.SetContent,
+		"setDefaultNavigationTimeout": p.SetDefaultNavigationTimeout,
+		"setDefaultTimeout":           p.SetDefaultTimeout,
+		"setExtraHTTPHeaders":         p.SetExtraHTTPHeaders,
+		"setInputFiles":               p.SetInputFiles,
+		"setViewportSize":             p.SetViewportSize,
+		"tap": func(selector string, opts goja.Value) (*goja.Promise, error) {
+			popts := common.NewFrameTapOptions(p.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing page tap options: %w", err)
+			}
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				return nil, p.Tap(selector, popts) //nolint:wrapcheck
+			}), nil
+		},
+		"textContent":     p.TextContent,
+		"throttleCPU":     p.ThrottleCPU,
+		"throttleNetwork": p.ThrottleNetwork,
+		"title":           p.Title,
+		"touchscreen":     syncMapTouchscreen(vu, p.GetTouchscreen()),
+		"type":            p.Type,
+		"uncheck":         p.Uncheck,
+		"url":             p.URL,
+		"viewportSize":    p.ViewportSize,
+		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) (*goja.Promise, error) {
+			js, popts, pargs, err := parseWaitForFunctionArgs(
+				vu.Context(), p.Timeout(), pageFunc, opts, args...,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("page waitForFunction: %w", err)
+			}
+
+			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
+				return p.WaitForFunction(js, popts, pargs...) //nolint:wrapcheck
+			}), nil
+		},
+		"waitForLoadState": p.WaitForLoadState,
+		"waitForNavigation": func(opts goja.Value) (*goja.Promise, error) {
+			popts := common.NewFrameWaitForNavigationOptions(p.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing page wait for navigation options: %w", err)
+			}
+
+			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
+				resp, err := p.WaitForNavigation(popts)
+				if err != nil {
+					return nil, err //nolint:wrapcheck
+				}
+				return syncMapResponse(vu, resp), nil
+			}), nil
+		},
+		"waitForSelector": func(selector string, opts goja.Value) (mapping, error) {
+			eh, err := p.WaitForSelector(selector, opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			return syncMapElementHandle(vu, eh), nil
+		},
+		"waitForTimeout": p.WaitForTimeout,
+		"workers": func() *goja.Object {
+			var mws []mapping
+			for _, w := range p.Workers() {
+				mw := syncMapWorker(vu, w)
+				mws = append(mws, mw)
+			}
+			return rt.ToValue(mws).ToObject(rt)
+		},
+	}
+	maps["$"] = func(selector string) (mapping, error) {
+		eh, err := p.Query(selector)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+		// ElementHandle can be null when the selector does not match any elements.
+		// We do not want to map nil elementHandles since the expectation is a
+		// null result in the test script for this case.
+		if eh == nil {
+			return nil, nil //nolint:nilnil
+		}
+		ehm := syncMapElementHandle(vu, eh)
+
+		return ehm, nil
+	}
+	maps["$$"] = func(selector string) ([]mapping, error) {
+		ehs, err := p.QueryAll(selector)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+		var mehs []mapping
+		for _, eh := range ehs {
+			ehm := syncMapElementHandle(vu, eh)
+			mehs = append(mehs, ehm)
+		}
+		return mehs, nil
+	}
+
+	return maps
 }

--- a/browser/sync_page_mapping.go
+++ b/browser/sync_page_mapping.go
@@ -65,7 +65,16 @@ func syncMapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			}
 			return rt.ToValue(mfrs).ToObject(rt)
 		},
-		"getAttribute": p.GetAttribute,
+		"getAttribute": func(selector string, name string, opts goja.Value) (any, error) {
+			v, ok, err := p.GetAttribute(selector, name, opts)
+			if err != nil {
+				return nil, err //nolint:wrapcheck
+			}
+			if !ok {
+				return nil, nil //nolint:nilnil
+			}
+			return v, nil
+		},
 		"goto": func(url string, opts goja.Value) (*goja.Promise, error) {
 			gopts := common.NewFrameGotoOptions(
 				p.Referrer(),

--- a/browser/sync_page_mapping.go
+++ b/browser/sync_page_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// syncMapPage is like mapPage but returns synchronous functions.
+func syncMapPage(_ moduleVU, _ *common.Page) mapping {
+	return nil
+}

--- a/browser/sync_request_mapping.go
+++ b/browser/sync_request_mapping.go
@@ -5,6 +5,23 @@ import (
 )
 
 // syncMapRequest is like mapRequest but returns synchronous functions.
-func syncMapRequest(_ moduleVU, _ *common.Request) mapping {
-	return nil
+func syncMapRequest(vu moduleVU, r *common.Request) mapping {
+	maps := mapping{
+		"allHeaders":          r.AllHeaders,
+		"frame":               func() mapping { return syncMapFrame(vu, r.Frame()) },
+		"headerValue":         r.HeaderValue,
+		"headers":             r.Headers,
+		"headersArray":        r.HeadersArray,
+		"isNavigationRequest": r.IsNavigationRequest,
+		"method":              r.Method,
+		"postData":            r.PostData,
+		"postDataBuffer":      r.PostDataBuffer,
+		"resourceType":        r.ResourceType,
+		"response":            func() mapping { return syncMapResponse(vu, r.Response()) },
+		"size":                r.Size,
+		"timing":              r.Timing,
+		"url":                 r.URL,
+	}
+
+	return maps
 }

--- a/browser/sync_request_mapping.go
+++ b/browser/sync_request_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// syncMapRequest is like mapRequest but returns synchronous functions.
+func syncMapRequest(_ moduleVU, _ *common.Request) mapping {
+	return nil
+}

--- a/browser/sync_response_mapping.go
+++ b/browser/sync_response_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// syncMapResponse is like mapResponse but returns synchronous functions.
+func syncMapResponse(_ moduleVU, _ *common.Response) mapping {
+	return nil
+}

--- a/browser/sync_response_mapping.go
+++ b/browser/sync_response_mapping.go
@@ -5,6 +5,28 @@ import (
 )
 
 // syncMapResponse is like mapResponse but returns synchronous functions.
-func syncMapResponse(_ moduleVU, _ *common.Response) mapping {
-	return nil
+func syncMapResponse(vu moduleVU, r *common.Response) mapping {
+	if r == nil {
+		return nil
+	}
+	maps := mapping{
+		"allHeaders":      r.AllHeaders,
+		"body":            r.Body,
+		"frame":           func() mapping { return syncMapFrame(vu, r.Frame()) },
+		"headerValue":     r.HeaderValue,
+		"headerValues":    r.HeaderValues,
+		"headers":         r.Headers,
+		"headersArray":    r.HeadersArray,
+		"json":            r.JSON,
+		"ok":              r.Ok,
+		"request":         func() mapping { return syncMapRequest(vu, r.Request()) },
+		"securityDetails": r.SecurityDetails,
+		"serverAddr":      r.ServerAddr,
+		"size":            r.Size,
+		"status":          r.Status,
+		"statusText":      r.StatusText,
+		"url":             r.URL,
+	}
+
+	return maps
 }

--- a/browser/sync_touchscreen_mapping.go
+++ b/browser/sync_touchscreen_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// syncMapTouchscreen is like mapTouchscreen but returns synchronous functions.
+func syncMapTouchscreen(_ moduleVU, _ *common.Touchscreen) mapping {
+	return nil
+}

--- a/browser/sync_touchscreen_mapping.go
+++ b/browser/sync_touchscreen_mapping.go
@@ -1,10 +1,19 @@
 package browser
 
 import (
+	"github.com/dop251/goja"
+
 	"github.com/grafana/xk6-browser/common"
+	"github.com/grafana/xk6-browser/k6ext"
 )
 
 // syncMapTouchscreen is like mapTouchscreen but returns synchronous functions.
-func syncMapTouchscreen(_ moduleVU, _ *common.Touchscreen) mapping {
-	return nil
+func syncMapTouchscreen(vu moduleVU, ts *common.Touchscreen) mapping {
+	return mapping{
+		"tap": func(x float64, y float64) *goja.Promise {
+			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
+				return nil, ts.Tap(x, y) //nolint:wrapcheck
+			})
+		},
+	}
 }

--- a/browser/sync_worker_mapping.go
+++ b/browser/sync_worker_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// syncMapWorker is like mapWorker but returns synchronous functions.
+func syncMapWorker(_ moduleVU, _ *common.Worker) mapping {
+	return nil
+}

--- a/browser/sync_worker_mapping.go
+++ b/browser/sync_worker_mapping.go
@@ -5,6 +5,8 @@ import (
 )
 
 // syncMapWorker is like mapWorker but returns synchronous functions.
-func syncMapWorker(_ moduleVU, _ *common.Worker) mapping {
-	return nil
+func syncMapWorker(_ moduleVU, w *common.Worker) mapping {
+	return mapping{
+		"url": w.URL(),
+	}
 }

--- a/examples/colorscheme.js
+++ b/examples/colorscheme.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/cookies.js
+++ b/examples/cookies.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/device_emulation.js
+++ b/examples/device_emulation.js
@@ -1,5 +1,5 @@
 import { check, sleep } from 'k6';
-import { browser, devices } from 'k6/x/browser';
+import { browser, devices } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/dispatch.js
+++ b/examples/dispatch.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/elementstate.js
+++ b/examples/elementstate.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/evaluate.js
+++ b/examples/evaluate.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/fillform.js
+++ b/examples/fillform.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/getattribute.js
+++ b/examples/getattribute.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/grant_permission.js
+++ b/examples/grant_permission.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/hosts.js
+++ b/examples/hosts.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/keyboard.js
+++ b/examples/keyboard.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/locator.js
+++ b/examples/locator.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/locator_pom.js
+++ b/examples/locator_pom.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/mouse.js
+++ b/examples/mouse.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/multiple-scenario.js
+++ b/examples/multiple-scenario.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/pageon.js
+++ b/examples/pageon.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 import { check } from 'k6';
 
 export const options = {

--- a/examples/querying.js
+++ b/examples/querying.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/screenshot.js
+++ b/examples/screenshot.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/shadowdom.js
+++ b/examples/shadowdom.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/throttle.js
+++ b/examples/throttle.js
@@ -1,4 +1,4 @@
-import { browser, networkProfiles } from 'k6/x/browser';
+import { browser, networkProfiles } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/touchscreen.js
+++ b/examples/touchscreen.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/waitForEvent.js
+++ b/examples/waitForEvent.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/examples/waitforfunction.js
+++ b/examples/waitforfunction.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/x/browser';
+import { browser } from 'k6/x/browser/async';
 
 export const options = {
   scenarios: {

--- a/sync-examples/sync_colorscheme.js
+++ b/sync-examples/sync_colorscheme.js
@@ -1,0 +1,45 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const preferredColorScheme = 'dark';
+
+  const context = browser.newContext({
+    // valid values are "light", "dark" or "no-preference"
+    colorScheme: preferredColorScheme,
+  });
+  const page = context.newPage();
+
+  try {
+    await page.goto(
+      'https://googlechromelabs.github.io/dark-mode-toggle/demo/',
+      { waitUntil: 'load' },
+    )
+    const colorScheme = page.evaluate(() => {
+      return {
+        isDarkColorScheme: window.matchMedia('(prefers-color-scheme: dark)').matches
+      };
+    });
+    check(colorScheme, {
+      'isDarkColorScheme': cs => cs.isDarkColorScheme
+    });
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_cookies.js
+++ b/sync-examples/sync_cookies.js
@@ -1,0 +1,127 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+};
+
+export default async function () {
+  const page = browser.newPage();
+  const context = page.context();
+
+  try {
+    // get cookies from the browser context
+    check(context.cookies().length, {
+        'initial number of cookies should be zero': n => n === 0,
+    });
+
+    // add some cookies to the browser context
+    const unixTimeSinceEpoch = Math.round(new Date() / 1000);
+    const day = 60*60*24;
+    const dayAfter = unixTimeSinceEpoch+day;
+    const dayBefore = unixTimeSinceEpoch-day;
+    context.addCookies([
+      // this cookie expires at the end of the session
+      {
+        name: 'testcookie',
+        value: '1',
+        sameSite: 'Strict',
+        domain: '127.0.0.1',
+        path: '/',
+        httpOnly: true,
+        secure: true,
+      },
+      // this cookie expires in a day
+      {
+        name: 'testcookie2', 
+        value: '2', 
+        sameSite: 'Lax', 
+        domain: '127.0.0.1', 
+        path: '/', 
+        expires: dayAfter,
+      },
+      // this cookie expires in the past, so it will be removed.
+      {
+        name: 'testcookie3',
+        value: '3',
+        sameSite: 'Lax',
+        domain: '127.0.0.1',
+        path: '/',
+        expires: dayBefore
+      }
+    ]);
+    let cookies = context.cookies();
+    check(cookies.length, {
+      'number of cookies should be 2': n => n === 2,
+    });
+    check(cookies[0], {
+      'cookie 1 name should be testcookie': c => c.name === 'testcookie',
+      'cookie 1 value should be 1': c => c.value === '1',
+      'cookie 1 should be session cookie': c => c.expires === -1,
+      'cookie 1 should have domain': c => c.domain === '127.0.0.1',
+      'cookie 1 should have path': c => c.path === '/',
+      'cookie 1 should have sameSite': c => c.sameSite == 'Strict',
+      'cookie 1 should be httpOnly': c => c.httpOnly === true,
+      'cookie 1 should be secure': c => c.secure === true,
+    });
+    check(cookies[1], {
+      'cookie 2 name should be testcookie2': c => c.name === 'testcookie2',
+      'cookie 2 value should be 2': c => c.value === '2',
+    });
+
+    // let's add more cookies to filter by urls.
+    context.addCookies([
+      {
+        name: 'foo',
+        value: '42',
+        sameSite: 'Strict',
+        url: 'http://foo.com'
+      },
+      {
+        name: 'bar',
+        value: '43',
+        sameSite: 'Lax',
+        url: 'https://bar.com'
+      },
+      {
+        name: 'baz',
+        value: '44',
+        sameSite: 'Lax',
+        url: 'https://baz.com'
+      }
+    ]);
+    cookies = context.cookies('http://foo.com', 'https://baz.com');
+    check(cookies.length, {
+      'number of filtered cookies should be 2': n => n === 2,
+    });
+    check(cookies[0], {
+      'the first filtered cookie name should be foo': c => c.name === 'foo',
+      'the first filtered cookie value should be 42': c => c.value === '42',
+    });
+    check(cookies[1], {
+      'the second filtered cookie name should be baz': c => c.name === 'baz',
+      'the second filtered cookie value should be 44': c => c.value === '44',
+    });
+
+    // clear cookies
+    context.clearCookies();
+    cookies = context.cookies();
+    check(cookies.length, {
+      'number of cookies should be zero': n => n === 0,
+    });
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_device_emulation.js
+++ b/sync-examples/sync_device_emulation.js
@@ -1,0 +1,51 @@
+import { check, sleep } from 'k6';
+import { browser, devices } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const device = devices['iPhone X'];
+  // The spread operator is currently unsupported by k6's Babel, so use
+  // Object.assign instead to merge browser context and device options.
+  // See https://github.com/grafana/k6/issues/2296
+  const options = Object.assign({ locale: 'es-ES' }, device);
+  const context = browser.newContext(options);
+  const page = context.newPage();
+
+  try {
+    await page.goto('https://k6.io/', { waitUntil: 'networkidle' });
+    const dimensions = page.evaluate(() => {
+      return {
+        width: document.documentElement.clientWidth,
+        height: document.documentElement.clientHeight,
+        deviceScaleFactor: window.devicePixelRatio
+      };
+    });
+
+    check(dimensions, {
+      'width': d => d.width === device.viewport.width,
+      'height': d => d.height === device.viewport.height,
+      'scale': d => d.deviceScaleFactor === device.deviceScaleFactor,
+    });
+
+    if (!__ENV.K6_BROWSER_HEADLESS) {
+      sleep(10);
+    }
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_dispatch.js
+++ b/sync-examples/sync_dispatch.js
@@ -1,0 +1,36 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+
+    page.locator('a[href="/contacts.php"]')
+        .dispatchEvent("click");
+
+    check(page, {
+      header: (p) => p.locator("h3").textContent() == "Contact us",
+    });
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_elementstate.js
+++ b/sync-examples/sync_elementstate.js
@@ -1,0 +1,47 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default function() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  // Inject page content
+  page.setContent(`
+    <div class="visible">Hello world</div>
+    <div style="display:none" class="hidden"></div>
+    <div class="editable" editable>Edit me</div>
+    <input type="checkbox" enabled class="enabled">
+    <input type="checkbox" disabled class="disabled">
+    <input type="checkbox" checked class="checked">
+    <input type="checkbox" class="unchecked">
+  `);
+
+  // Check state
+  check(page, {
+    'visible': p => p.$('.visible').isVisible(),
+    'hidden': p => p.$('.hidden').isHidden(),
+    'editable': p => p.$('.editable').isEditable(),
+    'enabled': p => p.$('.enabled').isEnabled(),
+    'disabled': p => p.$('.disabled').isDisabled(),
+    'checked': p => p.$('.checked').isChecked(),
+    'unchecked': p => p.$('.unchecked').isChecked() === false,
+  });
+
+  page.close();
+}

--- a/sync-examples/sync_evaluate.js
+++ b/sync-examples/sync_evaluate.js
@@ -1,0 +1,46 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    await page.goto("https://test.k6.io/", { waitUntil: "load" });
+
+    // calling evaluate without arguments
+    let result = page.evaluate(() => {
+        return Promise.resolve(5 * 42);
+    });
+    check(result, {
+      "result should be 210": (result) => result == 210,
+    });
+
+    // calling evaluate with arguments
+    result = page.evaluate(([x, y]) => {
+        return Promise.resolve(x * y);
+      }, [5, 5]
+    );
+    check(result, {
+      "result should be 25": (result) => result == 25,
+    });
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_fillform.js
+++ b/sync-examples/sync_fillform.js
@@ -1,0 +1,55 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    // Goto front page, find login link and click it
+    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator('a[href="/my_messages.php"]').click(),
+    ]);
+    // Enter login credentials and login
+    page.locator('input[name="login"]').type('admin');
+    page.locator('input[name="password"]').type('123');
+    // We expect the form submission to trigger a navigation, so to prevent a
+    // race condition, setup a waiter concurrently while waiting for the click
+    // to resolve.
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator('input[type="submit"]').click(),
+    ]);
+    check(page, {
+      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
+    });
+
+    // Check whether we receive cookies from the logged site.
+    check(context.cookies(), {
+      'session cookie is set': cookies => {
+        const sessionID = cookies.find(c => c.name == 'sid')
+        return typeof sessionID !== 'undefined'
+      }
+    })
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_getattribute.js
+++ b/sync-examples/sync_getattribute.js
@@ -1,0 +1,35 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    await page.goto('https://googlechromelabs.github.io/dark-mode-toggle/demo/', {
+      waitUntil: 'load',
+    });
+    let el = page.$('#dark-mode-toggle-3')
+    check(el, {
+      "GetAttribute('mode')": e => e.getAttribute('mode') == 'light',
+    });
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_grant_permission.js
+++ b/sync-examples/sync_grant_permission.js
@@ -1,0 +1,35 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  // grant camera and microphone permissions to the
+  // new browser context.
+  const context = browser.newContext({
+    permissions: ["camera", "microphone"],
+  });
+
+  const page = context.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/');
+    page.screenshot({ path: `example-chromium.png` });
+    context.clearPermissions();
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_hosts.js
+++ b/sync-examples/sync_hosts.js
@@ -1,0 +1,33 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  hosts: { 'test.k6.io': '127.0.0.254' },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+};
+
+export default async function() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    const res = await page.goto('http://test.k6.io/', { waitUntil: 'load' });
+    check(res, {
+      'null response': r => r === null,
+    });
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_keyboard.js
+++ b/sync-examples/sync_keyboard.js
@@ -1,0 +1,32 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  }
+}
+
+export default async function () {
+  const page = browser.newPage();
+
+  await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
+    
+  const userInput = page.locator('input[name="login"]');
+  await userInput.click();
+  page.keyboard.type('admin');
+    
+  const pwdInput = page.locator('input[name="password"]');
+  await pwdInput.click();
+  page.keyboard.type('123');
+
+  page.keyboard.press('Enter'); // submit
+    
+  await page.close();
+}

--- a/sync-examples/sync_locator.js
+++ b/sync-examples/sync_locator.js
@@ -1,0 +1,74 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const context = browser.newContext();
+  const page = context.newPage();
+  
+  try {
+    await page.goto("https://test.k6.io/flip_coin.php", {
+      waitUntil: "networkidle",
+    })
+
+    /*
+    In this example, we will use two locators, matching a
+    different betting button on the page. If you were to query
+    the buttons once and save them as below, you would see an
+    error after the initial navigation. Try it!
+  
+      const heads = page.$("input[value='Bet on heads!']");
+      const tails = page.$("input[value='Bet on tails!']");
+  
+    The Locator API allows you to get a fresh element handle each
+    time you use one of the locator methods. And, you can carry a
+    locator across frame navigations. Let's create two locators;
+    each locates a button on the page.
+    */
+    const heads = page.locator("input[value='Bet on heads!']");
+    const tails = page.locator("input[value='Bet on tails!']");
+
+    const currentBet = page.locator("//p[starts-with(text(),'Your bet: ')]");
+
+    // In the following Promise.all the tails locator clicks
+    // on the tails button by using the locator's selector.
+    // Since clicking on each button causes page navigation,
+    // waitForNavigation is needed -- this is because the page
+    // won't be ready until the navigation completes.
+    // Setting up the waitForNavigation first before the click
+    // is important to avoid race conditions.
+    await Promise.all([
+      page.waitForNavigation(),
+      tails.click(),
+    ]);
+    console.log(currentBet.innerText());
+    // the heads locator clicks on the heads button
+    // by using the locator's selector.
+    await Promise.all([
+      page.waitForNavigation(),
+      heads.click(),
+    ]);
+    console.log(currentBet.innerText());
+    await Promise.all([
+      page.waitForNavigation(),
+      tails.click(),
+    ]);
+    console.log(currentBet.innerText());
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_locator_pom.js
+++ b/sync-examples/sync_locator_pom.js
@@ -1,0 +1,77 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+/*
+Page Object Model is a well-known pattern to abstract a web page.
+
+The Locator API enables using the Page Object Model pattern to organize
+and simplify test code.
+
+Note: For comparison, you can see another example that does not use
+the Page Object Model pattern in locator.js.
+*/
+export class Bet {
+  constructor(page) {
+    this.page = page;
+    this.headsButton = page.locator("input[value='Bet on heads!']");
+    this.tailsButton = page.locator("input[value='Bet on tails!']");
+    this.currentBet = page.locator("//p[starts-with(text(),'Your bet: ')]");
+  }
+
+  goto() {
+    return this.page.goto("https://test.k6.io/flip_coin.php", { waitUntil: "networkidle" });
+  }
+
+  heads() {
+    return Promise.all([
+      this.page.waitForNavigation(),
+      this.headsButton.click(),
+    ]);
+  }
+
+  tails() {
+    return Promise.all([
+      this.page.waitForNavigation(),
+      this.tailsButton.click(),
+    ]);
+  }
+
+  current() {
+    return this.currentBet.innerText();
+  }
+}
+
+export default async function() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  const bet = new Bet(page);
+  try {
+    await bet.goto()
+    await bet.tails();
+    console.log("Current bet:", bet.current());
+    await bet.heads();
+    console.log("Current bet:", bet.current());
+    await bet.tails();
+    console.log("Current bet:", bet.current());
+    await bet.heads();
+    console.log("Current bet:", bet.current());
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_mouse.js
+++ b/sync-examples/sync_mouse.js
@@ -1,0 +1,27 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  }
+}
+
+export default async function () {
+  const page = browser.newPage();
+
+  await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+
+  // Obtain ElementHandle for news link and navigate to it
+  // by clicking in the 'a' element's bounding box
+  const newsLinkBox = page.$('a[href="/news.php"]').boundingBox();
+  await page.mouse.click(newsLinkBox.x + newsLinkBox.width / 2, newsLinkBox.y);
+
+  await page.close();
+}

--- a/sync-examples/sync_multiple-scenario.js
+++ b/sync-examples/sync_multiple-scenario.js
@@ -1,0 +1,53 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    messages: {
+      executor: 'constant-vus',
+      exec: 'messages',
+      vus: 2,
+      duration: '2s',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+    news: {
+      executor: 'per-vu-iterations',
+      exec: 'news',
+      vus: 2,
+      iterations: 4,
+      maxDuration: '5s',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    browser_web_vital_fcp: ['max < 5000'],
+    checks: ["rate==1.0"]
+  }
+}
+
+export async function messages() {
+  const page = browser.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
+  } finally {
+    page.close();
+  }
+}
+
+export async function news() {
+  const page = browser.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/news.php', { waitUntil: 'networkidle' });
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_pageon.js
+++ b/sync-examples/sync_pageon.js
@@ -1,0 +1,39 @@
+import { browser } from 'k6/x/browser';
+import { check } from 'k6';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const page = browser.newPage();
+  
+  try {
+    await page.goto('https://test.k6.io/');
+
+    page.on('console', msg => {
+        check(msg, {
+            'assertConsoleMessageType': msg => msg.type() == 'log',
+            'assertConsoleMessageText': msg => msg.text() == 'this is a console.log message 42',
+            'assertConsoleMessageArgs0': msg => msg.args()[0].jsonValue() == 'this is a console.log message',
+            'assertConsoleMessageArgs1': msg => msg.args()[1].jsonValue() == 42,
+        });
+    });
+
+    page.evaluate(() => console.log('this is a console.log message', 42));
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_querying.js
+++ b/sync-examples/sync_querying.js
@@ -1,0 +1,35 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/');
+    check(page, {
+      'Title with CSS selector':
+        p => p.$('header h1.title').textContent() == 'test.k6.io',
+      'Title with XPath selector':
+        p => p.$(`//header//h1[@class="title"]`).textContent() == 'test.k6.io',
+    });
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_screenshot.js
+++ b/sync-examples/sync_screenshot.js
@@ -1,0 +1,31 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const context = browser.newContext();
+  const page = context.newPage();
+  
+  try {
+    await page.goto('https://test.k6.io/');
+    page.screenshot({ path: 'screenshot.png' });
+    // TODO: Assert this somehow. Upload as CI artifact or just an external `ls`?
+    // Maybe even do a fuzzy image comparison against a preset known good screenshot?
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_shadowdom.js
+++ b/sync-examples/sync_shadowdom.js
@@ -1,0 +1,36 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const page = browser.newPage();
+  page.setContent("<html><head><style></style></head><body>hello!</body></html>")
+  await page.evaluate(() => {
+    const shadowRoot = document.createElement('div');
+    shadowRoot.id = 'shadow-root';
+    shadowRoot.attachShadow({mode: 'open'});
+    shadowRoot.shadowRoot.innerHTML = '<p id="find">Shadow DOM</p>';
+    document.body.appendChild(shadowRoot);
+  });
+  const shadowEl = page.locator("#find");
+  check(shadowEl, {
+    "shadow element exists": (e) => e !== null,
+    "shadow element text is correct": (e) => e.innerText() === "Shadow DOM",
+  });
+  page.close();
+}

--- a/sync-examples/sync_throttle.js
+++ b/sync-examples/sync_throttle.js
@@ -1,0 +1,76 @@
+import { browser, networkProfiles } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    normal: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+      exec: 'normal',
+    },
+    networkThrottled: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+      exec: 'networkThrottled',
+    },
+    cpuThrottled: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+      exec: 'cpuThrottled',
+    },
+  },
+  thresholds: {
+    'browser_http_req_duration{scenario:normal}': ['p(99)<500'],
+    'browser_http_req_duration{scenario:networkThrottled}': ['p(99)<3000'],
+    'iteration_duration{scenario:normal}': ['p(99)<4000'],
+    'iteration_duration{scenario:cpuThrottled}': ['p(99)<10000'],
+  },
+}
+
+export async function normal() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+  } finally {
+    page.close();
+  }
+}
+
+export async function networkThrottled() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    page.throttleNetwork(networkProfiles['Slow 3G']);
+
+    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+  } finally {
+    page.close();
+  }
+}
+
+export async function cpuThrottled() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    page.throttleCPU({ rate: 4 });
+
+    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+  } finally {
+    page.close();
+  }
+}

--- a/sync-examples/sync_touchscreen.js
+++ b/sync-examples/sync_touchscreen.js
@@ -1,0 +1,32 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  }
+}
+
+export default async function () {
+  const page = browser.newPage();
+
+  await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+
+  // Obtain ElementHandle for news link and navigate to it
+  // by tapping in the 'a' element's bounding box
+  const newsLinkBox = page.$('a[href="/news.php"]').boundingBox();
+  await page.touchscreen.tap(newsLinkBox.x + newsLinkBox.width / 2, newsLinkBox.y);
+
+  // Wait until the navigation is done before closing the page.
+  // Otherwise, there will be a race condition between the page closing
+  // and the navigation.
+  await page.waitForNavigation({ waitUntil: 'networkidle' });
+
+  page.close();
+}

--- a/sync-examples/sync_waitForEvent.js
+++ b/sync-examples/sync_waitForEvent.js
@@ -1,0 +1,39 @@
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    browser: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+}
+
+export default async function() {
+  const context = browser.newContext()
+
+  // We want to wait for two page creations before carrying on.
+  var counter = 0
+  const promise = context.waitForEvent("page", { predicate: page => {
+    if (++counter == 2) {
+      return true
+    }
+    return false
+  } })
+  
+  // Now we create two pages.
+  const page = context.newPage()
+  const page2 = context.newPage()
+
+  // We await for the page creation events to be processed and the predicate
+  // to pass.
+  await promise
+  console.log('predicate passed')
+
+  page.close()
+  page2.close()
+};

--- a/sync-examples/sync_waitforfunction.js
+++ b/sync-examples/sync_waitforfunction.js
@@ -1,0 +1,41 @@
+import { check } from 'k6';
+import { browser } from 'k6/x/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    page.evaluate(() => {
+      setTimeout(() => {
+        const el = document.createElement('h1');
+        el.innerHTML = 'Hello';
+        document.body.appendChild(el);
+      }, 1000);
+    });
+
+    const ok = await page.waitForFunction("document.querySelector('h1')", {
+      polling: 'mutation',
+      timeout: 2000,
+    });
+    check(ok, { 'waitForFunction successfully resolved': ok.innerHTML() == 'Hello' });
+  } finally {
+    page.close();
+  }
+}

--- a/sync_register.go
+++ b/sync_register.go
@@ -1,3 +1,4 @@
+// Package browser provides an entry point to the browser extension.
 package browser
 
 import (
@@ -7,5 +8,5 @@ import (
 )
 
 func init() {
-	k6modules.Register("k6/x/browser/async", browser.New())
+	k6modules.Register("k6/x/browser", browser.NewSync())
 }


### PR DESCRIPTION
## What?

Provides sync and async APIs within the same module.

* `k6/x/browser` -> maps to sync JS API
* `k6/x/browser/async` -> maps to async JS API

## Why?

* To give headroom to users to easily switch to the new async API
* To graduate from the non-experimental module

## Plan
* We'll remove the sync API after ~two cycles.
* We'll also register these from the k6-core side.
 
I'll create issues for this.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#1117 #428