### PR TITLE
Fix/jshandle evaluate

### DIFF
--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -124,6 +124,7 @@ func (h *BaseJSHandle) dispose() error {
 
 // Evaluate will evaluate provided page function within an execution context.
 func (h *BaseJSHandle) Evaluate(pageFunc string, args ...any) (any, error) {
+	args = append([]any{h}, args...)
 	res, err := h.execCtx.Eval(h.ctx, pageFunc, args...)
 	if err != nil {
 		return nil, fmt.Errorf("evaluating element: %w", err)

--- a/common/js_handle.go
+++ b/common/js_handle.go
@@ -135,6 +135,7 @@ func (h *BaseJSHandle) Evaluate(pageFunc string, args ...any) (any, error) {
 
 // EvaluateHandle will evaluate provided page function within an execution context.
 func (h *BaseJSHandle) EvaluateHandle(pageFunc string, args ...any) (JSHandleAPI, error) {
+	args = append([]any{h}, args...)
 	eh, err := h.execCtx.EvalHandle(h.ctx, pageFunc, args...)
 	if err != nil {
 		return nil, fmt.Errorf("evaluating handle for element: %w", err)

--- a/tests/js_handle_test.go
+++ b/tests/js_handle_test.go
@@ -49,7 +49,7 @@ func TestJSHandleEvaluate(t *testing.T) {
 			require.NotNil(t, result)
 
 			got, err := result.Evaluate(tt.pageFunc, tt.args...)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, got)
 		})
 	}
@@ -98,11 +98,11 @@ func TestJSHandleEvaluateHandle(t *testing.T) {
 			require.NotNil(t, result)
 
 			got, err := result.EvaluateHandle(tt.pageFunc, tt.args...)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, got)
 
 			j, err := got.JSONValue()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, j)
 		})
 	}

--- a/tests/js_handle_test.go
+++ b/tests/js_handle_test.go
@@ -54,3 +54,56 @@ func TestJSHandleEvaluate(t *testing.T) {
 		})
 	}
 }
+
+func TestJSHandleEvaluateHandle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		pageFunc string
+		args     []any
+		expected string
+	}{
+		{
+			name: "no_args",
+			pageFunc: `handle => {
+				return {"innerText": handle.innerText};
+			}`,
+			args:     nil,
+			expected: `{"innerText":"Some title"}`,
+		},
+		{
+			name: "with_args",
+			pageFunc: `(handle, a, b) => {
+				return {"innerText": handle.innerText, "sum": a + b};
+			}`,
+			args:     []any{1, 2},
+			expected: `{"innerText":"Some title","sum":3}`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tb := newTestBrowser(t)
+			p := tb.NewPage(nil)
+
+			err := p.SetContent(`<html><head><title>Some title</title></head></html>`, nil)
+			require.NoError(t, err)
+
+			result, err := p.EvaluateHandle(`() => document.head`)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			got, err := result.EvaluateHandle(tt.pageFunc, tt.args...)
+			assert.NoError(t, err)
+			assert.NotNil(t, got)
+
+			j, err := got.JSONValue()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, j)
+		})
+	}
+}

--- a/tests/js_handle_test.go
+++ b/tests/js_handle_test.go
@@ -1,0 +1,56 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSHandleEvaluate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		pageFunc string
+		args     []any
+		expected string
+	}{
+		{
+			name:     "no_args",
+			pageFunc: `handle => handle.innerText`,
+			args:     nil,
+			expected: "Some title",
+		},
+		{
+			name: "with_args",
+			pageFunc: `(handle, a, b) => {
+				const c = a + b;
+				return handle.innerText + " " + c
+			}`,
+			args:     []any{1, 2},
+			expected: "Some title 3",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tb := newTestBrowser(t)
+			p := tb.NewPage(nil)
+
+			err := p.SetContent(`<html><head><title>Some title</title></head></html>`, nil)
+			require.NoError(t, err)
+
+			result, err := p.EvaluateHandle(`() => document.head`)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			got, err := result.Evaluate(tt.pageFunc, tt.args...)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## What?

This ensures that `jshandle.evaluate` and `jshandle.evaluateHandle` both set themselves as the first argument.

## Why?

It's the expected behaviour which matches Playwright: https://playwright.dev/docs/api/class-jshandle#js-handle-evaluate

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
https://github.com/grafana/xk6-browser/issues/1379