### PR TITLE
Improve CSS querier for ID and class matching

### DIFF
--- a/common/js/injected_script.js
+++ b/common/js/injected_script.js
@@ -108,6 +108,19 @@ function oneLine(s) {
 
 class CSSQueryEngine {
   queryAll(root, selector) {
+    // Add \\ for each dot the ID selector contains.
+    //
+    // This is for the case when the selector contains an ID selector
+    // that contains a dot (e.g., #my.id). The querier cannot find elements
+    // with a dot in the ID selector (e.g., #my.id) without escaping the dot.
+    //
+    // This is because the dot is interpreted as a class selector.
+    //
+    // Adding \\ before the dot will escape it and allow the querier to find
+    // the element.
+    if (selector.startsWith("#") && selector.includes(".")) {
+      selector = selector.split(".").join("\\.");
+    }
     return root.querySelectorAll(selector);
   }
 }
@@ -984,7 +997,6 @@ class InjectedScript {
 
   waitForSelector(selector, root, strict, state, polling, timeout, ...args) {
     let lastElement;
-    let previewNode = this.previewNode;
     const predicate = () => {
       const elements = this.querySelectorAll(selector, root || document);
       const element = elements[0];

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -558,6 +558,7 @@ func TestPageFill(t *testing.T) {
 	p := newTestBrowser(t).NewPage(nil)
 	err := p.SetContent(`
 		<input id="text" type="text" value="something" />
+		<input id="dotted.id" type="text" value="dotted" />
 		<input id="date" type="date" value="2012-03-12"/>
 		<input id="number" type="number" value="42"/>
 		<input id="unfillable" type="radio" />
@@ -566,6 +567,7 @@ func TestPageFill(t *testing.T) {
 
 	happy := []struct{ name, selector, value string }{
 		{name: "text", selector: "#text", value: "fill me up"},
+		{name: "dotted", selector: "#dotted.id", value: "fill me up"},
 		{name: "date", selector: "#date", value: "2012-03-13"},
 		{name: "number", selector: "#number", value: "42"},
 	}


### PR DESCRIPTION
## What?

Automatically adds `\\` to CSS selectors that contain a dot.

This way, the query engine can distinguish between ID and class selectors.

## Why?

See #1383.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updated #1383