### PR TITLE
Fix empty `newDocument` on `page.reload`

### DIFF
--- a/common/page.go
+++ b/common/page.go
@@ -1100,7 +1100,11 @@ func (p *Page) Reload(opts sobek.Value) (*Response, error) { //nolint:funlen,cyc
 	}
 
 	var resp *Response
-	if req := navigationEvent.newDocument.request; req != nil {
+
+	// Sometimes the new document is not yet available when the navigation event is emitted.
+	newDocument := navigationEvent.newDocument
+	if newDocument != nil && newDocument.request != nil {
+		req := newDocument.request
 		req.responseMu.RLock()
 		resp = req.response
 		req.responseMu.RUnlock()

--- a/common/page.go
+++ b/common/page.go
@@ -1085,6 +1085,7 @@ func (p *Page) Reload(opts sobek.Value) (*Response, error) { //nolint:funlen,cyc
 	)
 	select {
 	case <-p.ctx.Done():
+		err = fmt.Errorf("reloading page: %w", p.ctx.Err())
 	case <-timeoutCtx.Done():
 		err = wrapTimeoutError(timeoutCtx.Err())
 	case event := <-waitForFrameNavigation:


### PR DESCRIPTION
## What?

Fixes an NPE when the new document or request is missing.

## Why?

To fix this error.

```go
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x14bee2c]

goroutine 111 [running]:
github.com/dop251/goja.(*Runtime).runWrapped.func1()
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/runtime.go:2442 +0xe5
panic({0x18327c0?, 0x2db2e80?})
runtime/panic.go:770 +0x132
github.com/dop251/goja.(*vm).handleThrow(0xc002ea0900, {0x18327c0, 0x2db2e80})
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/vm.go:788 +0x405
github.com/dop251/goja.(*vm).try.func1()
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/vm.go:807 +0x3f
panic({0x18327c0?, 0x2db2e80?})
runtime/panic.go:770 +0x132
github.com/dop251/goja.(*vm).handleThrow(0xc002ea0900, {0x18327c0, 0x2db2e80})
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/vm.go:788 +0x405
github.com/dop251/goja.(*vm).runTryInner.func1()
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/vm.go:830 +0x3f
panic({0x18327c0?, 0x2db2e80?})
runtime/panic.go:770 +0x132
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
go.opentelemetry.io/otel/sdk@v1.24.0/trace/span.go:405 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0031e3680, {0x0, 0x0, 0xc00411e778?})
go.opentelemetry.io/otel/sdk@v1.24.0/trace/span.go:443 +0xa82
panic({0x18327c0?, 0x2db2e80?})
runtime/panic.go:770 +0x132
github.com/grafana/xk6-browser/common.(*Page).Reload(0xc001e9e000, {0x0, 0x0})
github.com/grafana/xk6-browser@v1.5.2-0.20240607140836-ffcc1f5169ad/common/page.go:1102 +0x84c
github.com/grafana/xk6-browser/browser.syncMapPage.func12({0x0?, 0x0?})
github.com/grafana/xk6-browser@v1.5.2-0.20240607140836-ffcc1f5169ad/browser/sync_page_mapping.go:138 +0x3c
reflect.Value.call({0x17f3ea0?, 0xc000c05980?, 0x18?}, {0x1a94a74, 0x4}, {0xc00996fc50, 0x1, 0xc00996fc50?})
reflect/value.go:596 +0xca6
reflect.Value.Call({0x17f3ea0?, 0xc000c05980?, 0x13?}, {0xc00996fc50?, 0xc000c05980?, 0x2e00000000?})
reflect/value.go:380 +0xb9
github.com/dop251/goja.(*Runtime).newWrappedFunc.(*Runtime).wrapReflectFunc.func1({{0x1eddcf8, 0xc0029a1a10}, {0xc002280760, 0x0, 0x8}})
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/runtime.go:1982 +0x3bd
github.com/dop251/goja.(*nativeFuncObject).vmCall(0xc000d98b40, 0xc002ea0900, 0x0)
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/func.go:563 +0x184
github.com/dop251/goja.call.exec(0x6?, 0xc002ea0900)
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/vm.go:3377 +0x66
github.com/dop251/goja.(*vm).run(0xc002ea0900)
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/vm.go:582 +0x5b
github.com/dop251/goja.(*vm).runTryInner(0x1?)
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/vm.go:834 +0x65
github.com/dop251/goja.(*generator).step(0xc000371260)
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/func.go:762 +0x2b
github.com/dop251/goja.(*generator).next(0xc000371260, {0x1ede250, 0x2e56620})
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/func.go:800 +0x1b1
github.com/dop251/goja.(*asyncRunner).onFulfilled(0xc000371260, {{0x1ede250, 0x2e56620}, {0xc01177a180, 0x1, 0x1}})
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/func.go:686 +0x105
github.com/dop251/goja.(*Runtime).callJobCallback(0x2e56620?, 0xc00214d580?, {0x1ede250?, 0x2e56620?}, {0xc01177a180?, 0xc007714262?, 0x1ede250?})
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/runtime.go:2878 +0x65
github.com/dop251/goja.(*Promise).fulfill.(*Runtime).triggerPromiseReactions.(*Runtime).newPromiseReactionJob.func1.1()
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/builtin_promise.go:213 +0xaa
github.com/dop251/goja.(*vm).try(0xc002ea0900, 0xc0028e3658)
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/vm.go:811 +0x258
github.com/dop251/goja.(*Promise).fulfill.(*Runtime).triggerPromiseReactions.(*Runtime).newPromiseReactionJob.func1()
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/builtin_promise.go:212 +0xef
github.com/dop251/goja.(*Runtime).leave(0xc000287008)
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/runtime.go:2751 +0xef
github.com/dop251/goja.(*Runtime).runWrapped(0xc000287008, 0xc0028e37a8?)
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/runtime.go:2451 +0x107
github.com/dop251/goja.AssertFunction.func1({0x1eddcf8?, 0xc002ffa7e0?}, {0x2e56620?, 0x41a238?, 0x7f857863d1c0?})
github.com/dop251/goja@v0.0.0-20240516125602-ccbae20bcec2/runtime.go:2401 +0x8c
go.k6.io/k6/js/modules/k6/timers.(*Timers).call(0x1821620?, 0xc00129af48, {0x2e56620, 0x0, 0x0})
go.k6.io/k6/js/modules/k6/timers/timers.go:84 +0x5b
go.k6.io/k6/js/modules/k6/timers.(*Timers).timerInitialization.func1()
go.k6.io/k6/js/modules/k6/timers/timers.go:
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas