### PR TITLE
Fix panic on iframe attach

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -83,7 +83,7 @@ type FrameSession struct {
 //
 //nolint:funlen
 func NewFrameSession(
-	ctx context.Context, s session, p *Page, parent *FrameSession, tid target.ID, l *log.Logger,
+	ctx context.Context, s session, p *Page, parent *FrameSession, tid target.ID, l *log.Logger, hasUIWindow bool,
 ) (_ *FrameSession, err error) {
 	l.Debugf("NewFrameSession", "sid:%v tid:%v", s.ID(), tid)
 
@@ -997,7 +997,8 @@ func (fs *FrameSession) attachIFrameToTarget(ti *target.Info, sid target.Session
 		fs.ctx,
 		fs.page.browserCtx.getSession(sid),
 		fs.page, fs, ti.TargetID,
-		fs.logger)
+		fs.logger,
+		false)
 	if err != nil {
 		return fmt.Errorf("attaching iframe target ID %v to session ID %v: %w",
 			ti.TargetID, sid, err)

--- a/common/page.go
+++ b/common/page.go
@@ -296,7 +296,7 @@ func NewPage(
 
 	var err error
 	p.frameManager = NewFrameManager(ctx, s, &p, p.timeoutSettings, p.logger)
-	p.mainFrameSession, err = NewFrameSession(ctx, s, &p, nil, tid, p.logger)
+	p.mainFrameSession, err = NewFrameSession(ctx, s, &p, nil, tid, p.logger, true)
 	if err != nil {
 		p.logger.Debugf("Page:NewPage:NewFrameSession:return", "sid:%v tid:%v err:%v",
 			p.sessionID(), tid, err)


### PR DESCRIPTION
## What?

This PR fixes an issue where the browser module would panic when navigating to certain website with iframes on them. The error is `panic: GoError: attaching iframe: attaching iframe target ID 153A0D279584840F49FB1E718A8297AB to session ID DA84F3DFA9B0CA220314557F25BC8B37: getting browser window ID: No web contents for the given target id (-32000)
`

## Why?

The reason for this is when the browser comes to attach an iframe, some iframes do not have any UI elements, which sets a state within [chromium such that no windowID can be returned](https://chromium.googlesource.com/chromium/src/+/665cdea2f5f29e166ad455b5021154456944fcbc/headless/lib/browser/headless_devtools_manager_delegate.cc#633) when one is requested for. This causes a panic [here](https://github.com/grafana/xk6-browser/blob/main/common/frame_session.go#L123). To avoid this issue we have to avoid performing the CDP calls that could cause errors when attaching a new iframe (retrieving a windowID and set the window bounds). PW does the [same](https://github.com/microsoft/playwright/blob/e17d1c498b9dc365fdea47a58c4c35cbad952a5a/packages/playwright-core/src/server/chromium/crPage.ts#L730).

## Test

<details>
  <summary>Test procedure</summary>

You can test against the following page:

```html
<!DOCTYPE html>
<html>
<head>
    <script src="https://js.stripe.com/v3/"></script>
</head>
<body></body>
</html>
```

First we need to replicate the issue, so set the current branch to `main`, and run the following test script (multiple times) until you get the same error as mentioned above:

```js
import { browser } from 'k6/browser';

export const options = {
  scenarios: {
    ui: {
      executor: 'shared-iterations',
      iterations: 1,
      options: {
        browser: {
          type: 'chromium'
        },
      },
    },
  },
}

export default async function () {
  const page = await browser.newPage();

  // You can try against http://2022wfh.ddns.net/static/tmp/panic.html
  await page.goto("URL for test site", {waitUntil:'networkidle'});

  await page.close();
}
```

Now test the same script against the fix branch. The same error shouldn't appear again.

</details>

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1224