### PR TITLE
Fix panic on nil response during page.reload

### DIFF
--- a/browser/sync_page_mapping.go
+++ b/browser/sync_page_mapping.go
@@ -140,6 +140,10 @@ func syncMapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return nil, err //nolint:wrapcheck
 			}
 
+			if resp == nil {
+				return nil, nil //nolint:nilnil
+			}
+
 			r := syncMapResponse(vu, resp)
 
 			return rt.ToValue(r).ToObject(rt), nil


### PR DESCRIPTION
## What?

Returns early from `page.reload` (async API only).

## Why?

Avoids unnecessary panics and aborts since it is expected that response can be nil.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1407
Linked to: https://github.com/grafana/xk6-browser/pull/1387