### PR TITLE
WIP: Experiment working with VU Context to control the iteration lifecycle

### DIFF
--- a/browser/registry.go
+++ b/browser/registry.go
@@ -185,13 +185,13 @@ type browserRegistry struct {
 	stopped atomic.Bool // testing purposes
 }
 
-type browserBuildFunc func(ctx context.Context) (*common.Browser, error)
+type browserBuildFunc func(ctx, k6Ctx context.Context) (*common.Browser, error)
 
 func newBrowserRegistry(
 	backgroundCtx context.Context, vu k6modules.VU, remote *remoteRegistry, pids *pidRegistry, tracesMetadata map[string]string,
 ) *browserRegistry {
 	bt := chromium.NewBrowserType(vu)
-	builder := func(backgroundCtx context.Context) (*common.Browser, error) {
+	builder := func(backgroundCtx, k6Ctx context.Context) (*common.Browser, error) {
 		var (
 			err                    error
 			b                      *common.Browser
@@ -199,13 +199,13 @@ func newBrowserRegistry(
 		)
 
 		if isRemoteBrowser {
-			b, err = bt.Connect(backgroundCtx, wsURL)
+			b, err = bt.Connect(backgroundCtx, k6Ctx, wsURL)
 			if err != nil {
 				return nil, err //nolint:wrapcheck
 			}
 		} else {
 			var pid int
-			b, pid, err = bt.Launch(backgroundCtx)
+			b, pid, err = bt.Launch(backgroundCtx, k6Ctx)
 			if err != nil {
 				return nil, err //nolint:wrapcheck
 			}
@@ -287,11 +287,11 @@ func (r *browserRegistry) handleIterEvents( //nolint:funlen
 
 			// Wrap the tracer into the browser context to make it accessible for the other
 			// components that inherit the context so these can use it to trace their actions.
-			ctx := backgroundCtx
+			ctx := r.vu.Context()
 			tracerCtx := common.WithTracer(ctx, r.tr.tracer)
 			tracedCtx := r.tr.startIterationTrace(tracerCtx, data)
 
-			b, err := r.buildFn(tracedCtx)
+			b, err := r.buildFn(backgroundCtx, tracedCtx)
 			if err != nil {
 				e.Done()
 				k6ext.Abort(vuCtx, "error building browser on IterStart: %v", err)

--- a/browser/registry.go
+++ b/browser/registry.go
@@ -188,10 +188,10 @@ type browserRegistry struct {
 type browserBuildFunc func(ctx context.Context) (*common.Browser, error)
 
 func newBrowserRegistry(
-	ctx context.Context, vu k6modules.VU, remote *remoteRegistry, pids *pidRegistry, tracesMetadata map[string]string,
+	backgroundCtx context.Context, vu k6modules.VU, remote *remoteRegistry, pids *pidRegistry, tracesMetadata map[string]string,
 ) *browserRegistry {
 	bt := chromium.NewBrowserType(vu)
-	builder := func(ctx context.Context) (*common.Browser, error) {
+	builder := func(backgroundCtx context.Context) (*common.Browser, error) {
 		var (
 			err                    error
 			b                      *common.Browser
@@ -199,13 +199,13 @@ func newBrowserRegistry(
 		)
 
 		if isRemoteBrowser {
-			b, err = bt.Connect(ctx, wsURL)
+			b, err = bt.Connect(backgroundCtx, wsURL)
 			if err != nil {
 				return nil, err //nolint:wrapcheck
 			}
 		} else {
 			var pid int
-			b, pid, err = bt.Launch(ctx)
+			b, pid, err = bt.Launch(backgroundCtx)
 			if err != nil {
 				return nil, err //nolint:wrapcheck
 			}
@@ -235,13 +235,13 @@ func newBrowserRegistry(
 	}
 
 	go r.handleExitEvent(exitCh, unsubscribe)
-	go r.handleIterEvents(ctx, eventsCh, unsubscribe)
+	go r.handleIterEvents(backgroundCtx, eventsCh, unsubscribe)
 
 	return r
 }
 
 func (r *browserRegistry) handleIterEvents( //nolint:funlen
-	ctx context.Context, eventsCh <-chan *k6event.Event, unsubscribeFn func(),
+	backgroundCtx context.Context, eventsCh <-chan *k6event.Event, unsubscribeFn func(),
 ) {
 	var (
 		ok   bool
@@ -287,6 +287,7 @@ func (r *browserRegistry) handleIterEvents( //nolint:funlen
 
 			// Wrap the tracer into the browser context to make it accessible for the other
 			// components that inherit the context so these can use it to trace their actions.
+			ctx := backgroundCtx
 			tracerCtx := common.WithTracer(ctx, r.tr.tracer)
 			tracedCtx := r.tr.startIterationTrace(tracerCtx, data)
 

--- a/common/browser.go
+++ b/common/browser.go
@@ -29,6 +29,7 @@ const (
 // Browser stores a Browser context.
 type Browser struct {
 	backgroundCtx context.Context
+	k6Ctx         context.Context
 	cancelFn      context.CancelFunc
 
 	state int64
@@ -54,6 +55,7 @@ type Browser struct {
 	defaultContext *BrowserContext
 
 	// Cancel function to stop event listening
+	// TODO: Remove as we're not using this.
 	evCancelFn context.CancelFunc
 
 	// Needed as the targets map will be accessed from multiple Go routines,
@@ -86,13 +88,13 @@ type browserVersion struct {
 
 // NewBrowser creates a new browser, connects to it, then returns it.
 func NewBrowser(
-	backgroundCtx context.Context,
+	backgroundCtx, k6Ctx context.Context,
 	cancel context.CancelFunc,
 	browserProc *BrowserProcess,
 	browserOpts *BrowserOptions,
 	logger *log.Logger,
 ) (*Browser, error) {
-	b := newBrowser(backgroundCtx, cancel, browserProc, browserOpts, logger)
+	b := newBrowser(backgroundCtx, k6Ctx, cancel, browserProc, browserOpts, logger)
 	if err := b.connect(); err != nil {
 		return nil, err
 	}
@@ -108,7 +110,7 @@ func NewBrowser(
 
 // newBrowser returns a ready to use Browser without connecting to an actual browser.
 func newBrowser(
-	backgroundCtx context.Context,
+	backgroundCtx, k6Ctx context.Context,
 	cancelFn context.CancelFunc,
 	browserProc *BrowserProcess,
 	browserOpts *BrowserOptions,
@@ -116,6 +118,7 @@ func newBrowser(
 ) *Browser {
 	return &Browser{
 		backgroundCtx:       backgroundCtx,
+		k6Ctx:               k6Ctx,
 		cancelFn:            cancelFn,
 		state:               int64(BrowserStateOpen),
 		browserProc:         browserProc,
@@ -146,7 +149,7 @@ func (b *Browser) connect() error {
 	}
 
 	// We don't need to lock this because `connect()` is called only in NewBrowser
-	b.defaultContext, err = NewBrowserContext(b.backgroundCtx, b, "", NewBrowserContextOptions(), b.logger)
+	b.defaultContext, err = NewBrowserContext(b.k6Ctx, b, "", NewBrowserContextOptions(), b.logger)
 	if err != nil {
 		return fmt.Errorf("browser connect: %w", err)
 	}
@@ -158,7 +161,7 @@ func (b *Browser) disposeContext(id cdp.BrowserContextID) error {
 	b.logger.Debugf("Browser:disposeContext", "bctxid:%v", id)
 
 	action := target.DisposeBrowserContext(id)
-	if err := action.Do(cdp.WithExecutor(b.backgroundCtx, b.conn)); err != nil {
+	if err := action.Do(cdp.WithExecutor(b.k6Ctx, b.conn)); err != nil {
 		return fmt.Errorf("disposing browser context ID %s: %w", id, err)
 	}
 
@@ -192,6 +195,9 @@ func (b *Browser) getPages() []*Page {
 
 func (b *Browser) initEvents() error { //nolint:cyclop
 	var cancelCtx context.Context
+	// Should use backgroundCtx otherwise when the iteration ends the
+	// browserProc is closed and connection is closed and therefore chromium closes.
+	// Preferably this Browser type shouldn't be coupled to the connection and the chromium subprocess.
 	cancelCtx, b.evCancelFn = context.WithCancel(b.backgroundCtx)
 	chHandler := make(chan Event)
 
@@ -217,7 +223,7 @@ func (b *Browser) initEvents() error { //nolint:cyclop
 				if ev, ok := event.data.(*target.EventAttachedToTarget); ok {
 					b.logger.Debugf("Browser:initEvents:onAttachedToTarget", "sid:%v tid:%v", ev.SessionID, ev.TargetInfo.TargetID)
 					if err := b.onAttachedToTarget(ev); err != nil {
-						k6ext.Panic(b.backgroundCtx, "browser is attaching to target: %w", err)
+						k6ext.Panic(b.k6Ctx, "browser is attaching to target: %w", err)
 					}
 				} else if ev, ok := event.data.(*target.EventDetachedFromTarget); ok {
 					b.logger.Debugf("Browser:initEvents:onDetachedFromTarget", "sid:%v", ev.SessionID)
@@ -231,7 +237,7 @@ func (b *Browser) initEvents() error { //nolint:cyclop
 	}()
 
 	action := target.SetAutoAttach(true, true).WithFlatten(true)
-	if err := action.Do(cdp.WithExecutor(b.backgroundCtx, b.conn)); err != nil {
+	if err := action.Do(cdp.WithExecutor(b.k6Ctx, b.conn)); err != nil {
 		return fmt.Errorf("internal error while auto-attaching to browser pages: %w", err)
 	}
 
@@ -239,7 +245,7 @@ func (b *Browser) initEvents() error { //nolint:cyclop
 	// However making a dummy call afterwards fixes this.
 	// This can be removed after https://chromium-review.googlesource.com/c/chromium/src/+/2885888 lands in stable.
 	action2 := target.GetTargetInfo()
-	if _, err := action2.Do(cdp.WithExecutor(b.backgroundCtx, b.conn)); err != nil {
+	if _, err := action2.Do(cdp.WithExecutor(b.k6Ctx, b.conn)); err != nil {
 		return fmt.Errorf("internal error while getting browser target info: %w", err)
 	}
 
@@ -299,7 +305,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) error {
 		}
 		b.pagesMu.RUnlock()
 	}
-	p, err := NewPage(b.backgroundCtx, session, browserCtx, targetPage.TargetID, opener, isPage, b.logger)
+	p, err := NewPage(b.k6Ctx, session, browserCtx, targetPage.TargetID, opener, isPage, b.logger)
 	if err != nil && b.isPageAttachmentErrorIgnorable(ev, session, err) {
 		return nil // Ignore this page.
 	}
@@ -388,10 +394,10 @@ func (b *Browser) isPageAttachmentErrorIgnorable(ev *target.EventAttachedToTarge
 	}
 	// No need to register the page if the test run is over.
 	select {
-	case <-b.backgroundCtx.Done():
+	case <-b.k6Ctx.Done():
 		b.logger.Debugf("Browser:isPageAttachmentErrorIgnorable:return:<-ctx.Done",
 			"sid:%v tid:%v pageType:%s err:%v",
-			ev.SessionID, targetPage.TargetID, targetPage.Type, b.backgroundCtx.Err())
+			ev.SessionID, targetPage.TargetID, targetPage.Type, b.k6Ctx.Err())
 		return true
 	default:
 	}
@@ -439,7 +445,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 		return nil, fmt.Errorf("missing browser context %s, current context is %s", id, b.context.id)
 	}
 
-	ctx, cancel := context.WithTimeout(b.backgroundCtx, b.browserOpts.Timeout)
+	ctx, cancel := context.WithTimeout(b.k6Ctx, b.browserOpts.Timeout)
 	defer cancel()
 
 	// buffer of one is for sending the target ID whether an event handler
@@ -569,7 +575,7 @@ func (b *Browser) IsConnected() bool {
 
 // NewContext creates a new incognito-like browser context.
 func (b *Browser) NewContext(opts *BrowserContextOptions) (*BrowserContext, error) {
-	_, span := TraceAPICall(b.backgroundCtx, "", "browser.newContext")
+	_, span := TraceAPICall(b.k6Ctx, "", "browser.newContext")
 	defer span.End()
 
 	if b.context != nil {
@@ -579,7 +585,7 @@ func (b *Browser) NewContext(opts *BrowserContextOptions) (*BrowserContext, erro
 	}
 
 	action := target.CreateBrowserContext().WithDisposeOnDetach(true)
-	browserContextID, err := action.Do(cdp.WithExecutor(b.backgroundCtx, b.conn))
+	browserContextID, err := action.Do(cdp.WithExecutor(b.k6Ctx, b.conn))
 	b.logger.Debugf("Browser:NewContext", "bctxid:%v", browserContextID)
 	if err != nil {
 		err := fmt.Errorf("creating browser context ID %s: %w", browserContextID, err)
@@ -587,7 +593,7 @@ func (b *Browser) NewContext(opts *BrowserContextOptions) (*BrowserContext, erro
 		return nil, err
 	}
 
-	browserCtx, err := NewBrowserContext(b.backgroundCtx, b, browserContextID, opts, b.logger)
+	browserCtx, err := NewBrowserContext(b.k6Ctx, b, browserContextID, opts, b.logger)
 	if err != nil {
 		err := fmt.Errorf("new context: %w", err)
 		spanRecordError(span, err)
@@ -603,7 +609,7 @@ func (b *Browser) NewContext(opts *BrowserContextOptions) (*BrowserContext, erro
 
 // NewPage creates a new tab in the browser window.
 func (b *Browser) NewPage(opts *BrowserContextOptions) (*Page, error) {
-	_, span := TraceAPICall(b.backgroundCtx, "", "browser.newPage")
+	_, span := TraceAPICall(b.k6Ctx, "", "browser.newPage")
 	defer span.End()
 
 	browserCtx, err := b.NewContext(opts)
@@ -632,8 +638,8 @@ func (b *Browser) On(event string) (bool, error) {
 	select {
 	case <-b.browserProc.lostConnection:
 		return true, nil
-	case <-b.backgroundCtx.Done():
-		return false, fmt.Errorf("browser.on promise rejected: %w", b.backgroundCtx.Err())
+	case <-b.k6Ctx.Done():
+		return false, fmt.Errorf("browser.on promise rejected: %w", b.k6Ctx.Err())
 	}
 }
 
@@ -660,7 +666,7 @@ func (b *Browser) fetchVersion() (browserVersion, error) {
 	)
 	bv.protocolVersion, bv.product, bv.revision, bv.userAgent, bv.jsVersion, err = cdpbrowser.
 		GetVersion().
-		Do(cdp.WithExecutor(b.backgroundCtx, b.conn))
+		Do(cdp.WithExecutor(b.k6Ctx, b.conn))
 	if err != nil {
 		return browserVersion{}, fmt.Errorf("getting browser version information: %w", err)
 	}

--- a/common/browser.go
+++ b/common/browser.go
@@ -28,8 +28,8 @@ const (
 
 // Browser stores a Browser context.
 type Browser struct {
-	ctx      context.Context
-	cancelFn context.CancelFunc
+	backgroundCtx context.Context
+	cancelFn      context.CancelFunc
 
 	state int64
 
@@ -86,13 +86,13 @@ type browserVersion struct {
 
 // NewBrowser creates a new browser, connects to it, then returns it.
 func NewBrowser(
-	ctx context.Context,
+	backgroundCtx context.Context,
 	cancel context.CancelFunc,
 	browserProc *BrowserProcess,
 	browserOpts *BrowserOptions,
 	logger *log.Logger,
 ) (*Browser, error) {
-	b := newBrowser(ctx, cancel, browserProc, browserOpts, logger)
+	b := newBrowser(backgroundCtx, cancel, browserProc, browserOpts, logger)
 	if err := b.connect(); err != nil {
 		return nil, err
 	}
@@ -108,21 +108,21 @@ func NewBrowser(
 
 // newBrowser returns a ready to use Browser without connecting to an actual browser.
 func newBrowser(
-	ctx context.Context,
+	backgroundCtx context.Context,
 	cancelFn context.CancelFunc,
 	browserProc *BrowserProcess,
 	browserOpts *BrowserOptions,
 	logger *log.Logger,
 ) *Browser {
 	return &Browser{
-		ctx:                 ctx,
+		backgroundCtx:       backgroundCtx,
 		cancelFn:            cancelFn,
 		state:               int64(BrowserStateOpen),
 		browserProc:         browserProc,
 		browserOpts:         browserOpts,
 		pages:               make(map[target.ID]*Page),
 		sessionIDtoTargetID: make(map[target.SessionID]target.ID),
-		vu:                  k6ext.GetVU(ctx),
+		vu:                  k6ext.GetVU(backgroundCtx),
 		logger:              logger,
 	}
 }
@@ -136,7 +136,7 @@ func (b *Browser) connect() error {
 	// from doing unnecessary work.
 	var err error
 	b.conn, err = NewConnection(
-		b.ctx,
+		b.backgroundCtx,
 		b.browserProc.WsURL(),
 		b.logger,
 		b.connectionOnAttachedToTarget,
@@ -146,7 +146,7 @@ func (b *Browser) connect() error {
 	}
 
 	// We don't need to lock this because `connect()` is called only in NewBrowser
-	b.defaultContext, err = NewBrowserContext(b.ctx, b, "", NewBrowserContextOptions(), b.logger)
+	b.defaultContext, err = NewBrowserContext(b.backgroundCtx, b, "", NewBrowserContextOptions(), b.logger)
 	if err != nil {
 		return fmt.Errorf("browser connect: %w", err)
 	}
@@ -158,7 +158,7 @@ func (b *Browser) disposeContext(id cdp.BrowserContextID) error {
 	b.logger.Debugf("Browser:disposeContext", "bctxid:%v", id)
 
 	action := target.DisposeBrowserContext(id)
-	if err := action.Do(cdp.WithExecutor(b.ctx, b.conn)); err != nil {
+	if err := action.Do(cdp.WithExecutor(b.backgroundCtx, b.conn)); err != nil {
 		return fmt.Errorf("disposing browser context ID %s: %w", id, err)
 	}
 
@@ -192,7 +192,7 @@ func (b *Browser) getPages() []*Page {
 
 func (b *Browser) initEvents() error { //nolint:cyclop
 	var cancelCtx context.Context
-	cancelCtx, b.evCancelFn = context.WithCancel(b.ctx)
+	cancelCtx, b.evCancelFn = context.WithCancel(b.backgroundCtx)
 	chHandler := make(chan Event)
 
 	b.conn.on(cancelCtx, []string{
@@ -217,7 +217,7 @@ func (b *Browser) initEvents() error { //nolint:cyclop
 				if ev, ok := event.data.(*target.EventAttachedToTarget); ok {
 					b.logger.Debugf("Browser:initEvents:onAttachedToTarget", "sid:%v tid:%v", ev.SessionID, ev.TargetInfo.TargetID)
 					if err := b.onAttachedToTarget(ev); err != nil {
-						k6ext.Panic(b.ctx, "browser is attaching to target: %w", err)
+						k6ext.Panic(b.backgroundCtx, "browser is attaching to target: %w", err)
 					}
 				} else if ev, ok := event.data.(*target.EventDetachedFromTarget); ok {
 					b.logger.Debugf("Browser:initEvents:onDetachedFromTarget", "sid:%v", ev.SessionID)
@@ -231,7 +231,7 @@ func (b *Browser) initEvents() error { //nolint:cyclop
 	}()
 
 	action := target.SetAutoAttach(true, true).WithFlatten(true)
-	if err := action.Do(cdp.WithExecutor(b.ctx, b.conn)); err != nil {
+	if err := action.Do(cdp.WithExecutor(b.backgroundCtx, b.conn)); err != nil {
 		return fmt.Errorf("internal error while auto-attaching to browser pages: %w", err)
 	}
 
@@ -239,7 +239,7 @@ func (b *Browser) initEvents() error { //nolint:cyclop
 	// However making a dummy call afterwards fixes this.
 	// This can be removed after https://chromium-review.googlesource.com/c/chromium/src/+/2885888 lands in stable.
 	action2 := target.GetTargetInfo()
-	if _, err := action2.Do(cdp.WithExecutor(b.ctx, b.conn)); err != nil {
+	if _, err := action2.Do(cdp.WithExecutor(b.backgroundCtx, b.conn)); err != nil {
 		return fmt.Errorf("internal error while getting browser target info: %w", err)
 	}
 
@@ -299,7 +299,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) error {
 		}
 		b.pagesMu.RUnlock()
 	}
-	p, err := NewPage(b.ctx, session, browserCtx, targetPage.TargetID, opener, isPage, b.logger)
+	p, err := NewPage(b.backgroundCtx, session, browserCtx, targetPage.TargetID, opener, isPage, b.logger)
 	if err != nil && b.isPageAttachmentErrorIgnorable(ev, session, err) {
 		return nil // Ignore this page.
 	}
@@ -388,10 +388,10 @@ func (b *Browser) isPageAttachmentErrorIgnorable(ev *target.EventAttachedToTarge
 	}
 	// No need to register the page if the test run is over.
 	select {
-	case <-b.ctx.Done():
+	case <-b.backgroundCtx.Done():
 		b.logger.Debugf("Browser:isPageAttachmentErrorIgnorable:return:<-ctx.Done",
 			"sid:%v tid:%v pageType:%s err:%v",
-			ev.SessionID, targetPage.TargetID, targetPage.Type, b.ctx.Err())
+			ev.SessionID, targetPage.TargetID, targetPage.Type, b.backgroundCtx.Err())
 		return true
 	default:
 	}
@@ -439,7 +439,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 		return nil, fmt.Errorf("missing browser context %s, current context is %s", id, b.context.id)
 	}
 
-	ctx, cancel := context.WithTimeout(b.ctx, b.browserOpts.Timeout)
+	ctx, cancel := context.WithTimeout(b.backgroundCtx, b.browserOpts.Timeout)
 	defer cancel()
 
 	// buffer of one is for sending the target ID whether an event handler
@@ -519,7 +519,7 @@ func (b *Browser) Close() {
 	// command, which triggers the browser process to exit.
 	if !b.browserOpts.isRemoteBrowser {
 		var closeErr *websocket.CloseError
-		err := cdpbrowser.Close().Do(cdp.WithExecutor(b.ctx, b.conn))
+		err := cdpbrowser.Close().Do(cdp.WithExecutor(b.backgroundCtx, b.conn))
 		if err != nil && !errors.As(err, &closeErr) {
 			b.logger.Errorf("Browser:Close", "closing the browser: %v", err)
 		}
@@ -569,7 +569,7 @@ func (b *Browser) IsConnected() bool {
 
 // NewContext creates a new incognito-like browser context.
 func (b *Browser) NewContext(opts *BrowserContextOptions) (*BrowserContext, error) {
-	_, span := TraceAPICall(b.ctx, "", "browser.newContext")
+	_, span := TraceAPICall(b.backgroundCtx, "", "browser.newContext")
 	defer span.End()
 
 	if b.context != nil {
@@ -579,7 +579,7 @@ func (b *Browser) NewContext(opts *BrowserContextOptions) (*BrowserContext, erro
 	}
 
 	action := target.CreateBrowserContext().WithDisposeOnDetach(true)
-	browserContextID, err := action.Do(cdp.WithExecutor(b.ctx, b.conn))
+	browserContextID, err := action.Do(cdp.WithExecutor(b.backgroundCtx, b.conn))
 	b.logger.Debugf("Browser:NewContext", "bctxid:%v", browserContextID)
 	if err != nil {
 		err := fmt.Errorf("creating browser context ID %s: %w", browserContextID, err)
@@ -587,7 +587,7 @@ func (b *Browser) NewContext(opts *BrowserContextOptions) (*BrowserContext, erro
 		return nil, err
 	}
 
-	browserCtx, err := NewBrowserContext(b.ctx, b, browserContextID, opts, b.logger)
+	browserCtx, err := NewBrowserContext(b.backgroundCtx, b, browserContextID, opts, b.logger)
 	if err != nil {
 		err := fmt.Errorf("new context: %w", err)
 		spanRecordError(span, err)
@@ -603,7 +603,7 @@ func (b *Browser) NewContext(opts *BrowserContextOptions) (*BrowserContext, erro
 
 // NewPage creates a new tab in the browser window.
 func (b *Browser) NewPage(opts *BrowserContextOptions) (*Page, error) {
-	_, span := TraceAPICall(b.ctx, "", "browser.newPage")
+	_, span := TraceAPICall(b.backgroundCtx, "", "browser.newPage")
 	defer span.End()
 
 	browserCtx, err := b.NewContext(opts)
@@ -632,8 +632,8 @@ func (b *Browser) On(event string) (bool, error) {
 	select {
 	case <-b.browserProc.lostConnection:
 		return true, nil
-	case <-b.ctx.Done():
-		return false, fmt.Errorf("browser.on promise rejected: %w", b.ctx.Err())
+	case <-b.backgroundCtx.Done():
+		return false, fmt.Errorf("browser.on promise rejected: %w", b.backgroundCtx.Err())
 	}
 }
 
@@ -660,7 +660,7 @@ func (b *Browser) fetchVersion() (browserVersion, error) {
 	)
 	bv.protocolVersion, bv.product, bv.revision, bv.userAgent, bv.jsVersion, err = cdpbrowser.
 		GetVersion().
-		Do(cdp.WithExecutor(b.ctx, b.conn))
+		Do(cdp.WithExecutor(b.backgroundCtx, b.conn))
 	if err != nil {
 		return browserVersion{}, fmt.Errorf("getting browser version information: %w", err)
 	}

--- a/common/browser_context_test.go
+++ b/common/browser_context_test.go
@@ -21,7 +21,7 @@ func TestNewBrowserContext(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		logger := log.NewNullLogger()
-		b := newBrowser(ctx, cancel, nil, NewLocalBrowserOptions(), logger)
+		b := newBrowser(ctx, ctx, cancel, nil, NewLocalBrowserOptions(), logger)
 
 		vu := k6test.NewVU(t)
 		ctx = k6ext.WithVU(ctx, vu)

--- a/common/browser_test.go
+++ b/common/browser_test.go
@@ -26,7 +26,7 @@ func TestBrowserNewPageInContext(t *testing.T) {
 	newTestCase := func(id cdp.BrowserContextID) *testCase {
 		ctx, cancel := context.WithCancel(context.Background())
 		logger := log.NewNullLogger()
-		b := newBrowser(ctx, cancel, nil, NewLocalBrowserOptions(), logger)
+		b := newBrowser(ctx, ctx, cancel, nil, NewLocalBrowserOptions(), logger)
 		// set a new browser context in the browser with `id`, so that newPageInContext can find it.
 		var err error
 		vu := k6test.NewVU(t)
@@ -171,7 +171,7 @@ func TestBrowserNewPageInContext(t *testing.T) {
 		}
 
 		var cancel func()
-		tc.b.ctx, cancel = context.WithCancel(tc.b.ctx)
+		tc.b.backgroundCtx, cancel = context.WithCancel(tc.b.backgroundCtx)
 		// let newPageInContext return a context cancelation error by canceling the context before
 		// running the method.
 		cancel()

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -326,14 +326,14 @@ func TestMultiConnectToSingleBrowser(t *testing.T) {
 
 	ctx := context.Background()
 
-	b1, err := tb.browserType.Connect(ctx, tb.wsURL)
+	b1, err := tb.browserType.Connect(ctx, ctx, tb.wsURL)
 	require.NoError(t, err)
 	bctx1, err := b1.NewContext(nil)
 	require.NoError(t, err)
 	p1, err := bctx1.NewPage()
 	require.NoError(t, err, "failed to create page #1")
 
-	b2, err := tb.browserType.Connect(ctx, tb.wsURL)
+	b2, err := tb.browserType.Connect(ctx, ctx, tb.wsURL)
 	require.NoError(t, err)
 	bctx2, err := b2.NewContext(nil)
 	require.NoError(t, err)
@@ -379,7 +379,7 @@ func TestIsolateBrowserContexts(t *testing.T) {
 	tb := newTestBrowser(t)
 
 	b1 := tb.Browser
-	b2, err := tb.browserType.Connect(tb.context(), tb.wsURL)
+	b2, err := tb.browserType.Connect(tb.context(), tb.context(), tb.wsURL)
 	require.NoError(t, err)
 	t.Cleanup(b2.Close)
 

--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -22,7 +22,7 @@ func TestBrowserTypeConnect(t *testing.T) {
 	bt := chromium.NewBrowserType(vu)
 	vu.ActivateVU()
 
-	b, err := bt.Connect(context.Background(), tb.wsURL)
+	b, err := bt.Connect(context.Background(), context.Background(), tb.wsURL)
 	require.NoError(t, err)
 	_, err = b.NewPage(nil)
 	require.NoError(t, err)

--- a/tests/test_browser.go
+++ b/tests/test_browser.go
@@ -80,7 +80,7 @@ func newTestBrowser(tb testing.TB, opts ...func(*testBrowser)) *testBrowser {
 	tbr.isBrowserTypeInitialized = true // some option require the browser type to be initialized.
 	tbr.applyOptions(opts...)           // apply post-init stage options.
 
-	b, pid, err := tbr.browserType.Launch(tbr.vu.Context())
+	b, pid, err := tbr.browserType.Launch(tbr.vu.Context(), tbr.vu.Context())
 	if err != nil {
 		tb.Fatalf("testBrowser: %v", err)
 	}


### PR DESCRIPTION
## What?

**This is WIP**

Experiment working with VU Context to control the iteration lifecycle. This change doesn't affect the browser lifecycle which should still be handled by the event system. This avoids working with a new abort event.

## Why?

The VU context is easier to work with then a potential new abort event since it was designed to to specifically control the lifecycle of the iteration.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1410