### PR TITLE
Fix navigation span start

### DIFF
--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -577,6 +577,14 @@ func (m *FrameManager) setMainFrame(f *Frame) {
 	m.mainFrame = f
 }
 
+// MainFrameURL returns the main frame's url.
+func (m *FrameManager) MainFrameURL() string {
+	m.mainFrameMu.RLock()
+	defer m.mainFrameMu.RUnlock()
+
+	return m.mainFrame.URL()
+}
+
 // NavigateFrame will navigate specified frame to specified URL.
 //
 //nolint:funlen,cyclop

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -797,6 +797,11 @@ func (fs *FrameSession) processNavigationSpan(url string, id cdp.FrameID) {
 		return
 	}
 
+	// End the navigation span if it is non-nil
+	if fs.mainFrameSpan != nil {
+		fs.mainFrameSpan.End()
+	}
+
 	_, fs.mainFrameSpan = TraceNavigation(
 		fs.ctx, fs.targetID.String(), trace.WithAttributes(attribute.String("navigation.url", url)),
 	)

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -246,7 +246,7 @@ func (fs *FrameSession) initEvents() {
 				// because at the start of the span we don't know the correct url for
 				// the page we're navigating to. At the end of the span we do have this
 				// information.
-				fs.mainFrameSpan.SetAttributes(attribute.String("navigation.url", fs.manager.MainFrame().URL()))
+				fs.mainFrameSpan.SetAttributes(attribute.String("navigation.url", fs.manager.MainFrameURL()))
 				fs.mainFrameSpan.End()
 				fs.mainFrameSpan = nil
 			}
@@ -821,7 +821,7 @@ func (fs *FrameSession) processNavigationSpan(id cdp.FrameID) {
 		// because at the start of the span we don't know the correct url for
 		// the page we're navigating to. At the end of the span we do have this
 		// information.
-		fs.mainFrameSpan.SetAttributes(attribute.String("navigation.url", fs.manager.MainFrame().URL()))
+		fs.mainFrameSpan.SetAttributes(attribute.String("navigation.url", fs.manager.MainFrameURL()))
 		fs.mainFrameSpan.End()
 	}
 

--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -202,7 +202,7 @@ func TestNavigationSpanCreation(t *testing.T) {
 			js: fmt.Sprintf(`
 				page = await browser.newPage();
 				await page.goto('%s');
-				browser.closeContext();
+				page.close();
 				`, ts.URL),
 			expected: []string{
 				"iteration",
@@ -212,6 +212,7 @@ func TestNavigationSpanCreation(t *testing.T) {
 				"navigation", // created when a new page is created
 				"page.goto",
 				"navigation", // created when a navigation occurs after goto
+				"page.close",
 			},
 		},
 		{
@@ -220,7 +221,7 @@ func TestNavigationSpanCreation(t *testing.T) {
 				page = await browser.newPage();
 				await page.goto('%s');
 				await page.reload();
-				browser.closeContext();
+				page.close();
 				`, ts.URL),
 			expected: []string{
 				"iteration",
@@ -232,6 +233,7 @@ func TestNavigationSpanCreation(t *testing.T) {
 				"navigation", // created when a navigation occurs after goto
 				"page.reload",
 				"navigation", // created when a navigation occurs after reload
+				"page.close",
 			},
 		},
 		{
@@ -240,7 +242,7 @@ func TestNavigationSpanCreation(t *testing.T) {
 				page = await browser.newPage();
 				await page.goto('%s');
 				await page.evaluate(() => window.history.back());
-				browser.closeContext();
+				page.close();
 				`, ts.URL),
 			expected: []string{
 				"iteration",
@@ -251,6 +253,7 @@ func TestNavigationSpanCreation(t *testing.T) {
 				"page.goto",
 				"navigation", // created when a navigation occurs after goto
 				"navigation", // created when going back to the previous page
+				"page.close",
 			},
 		},
 		{
@@ -259,7 +262,7 @@ func TestNavigationSpanCreation(t *testing.T) {
 				page = await browser.newPage();
 				await page.goto('%s');
 				await page.locator('a[id=\"top\"]').click();
-				browser.closeContext();
+				page.close();
 				`, ts.URL),
 			expected: []string{
 				"iteration",
@@ -271,6 +274,7 @@ func TestNavigationSpanCreation(t *testing.T) {
 				"navigation", // created when a navigation occurs after goto
 				"locator.click",
 				"navigation", // created when navigating within the same page
+				"page.close",
 			},
 		},
 	}

--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -298,7 +299,7 @@ func TestNavigationSpanCreation(t *testing.T) {
 
 			assertJSInEventLoop(t, vu, tc.js)
 
-			got := tracer.getOrderedSpan()
+			got := tracer.cloneOrderedSpans()
 			// We can't use assert.Equal since the order of the span creation
 			// changes slightly on every test run. Instead we're going to make
 			// sure that the slice matches but not the order.
@@ -394,12 +395,11 @@ func (m *mockTracer) verifySpans(spanNames ...string) error {
 	return nil
 }
 
-func (m *mockTracer) getOrderedSpan() []string {
+func (m *mockTracer) cloneOrderedSpans() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	c := make([]string, len(m.orderedSpans))
-	copy(c, m.orderedSpans)
+	c := slices.Clone(m.orderedSpans)
 
 	m.orderedSpans = []string{}
 

--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -399,7 +398,8 @@ func (m *mockTracer) cloneOrderedSpans() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	c := slices.Clone(m.orderedSpans)
+	c := make([]string, len(m.orderedSpans))
+	copy(c, m.orderedSpans)
 
 	m.orderedSpans = []string{}
 


### PR DESCRIPTION
## What?

This fixes the navigation span so that the duration is longer than the duration of the child spans. This fix is to start the navigation span earlier in `onFrameStartedLoading`. It also required us to differ adding the url attribute to the navigation span to when it was ended since we don't have knowledge of the new url in `onFrameStartedLoading`.

## Why?

This ensures that the child span values make sense with respect to the parent/navigation span they are part of.

Before the fix:
![image](https://github.com/user-attachments/assets/d2ceb9e7-f08b-4bdd-bf44-4abb18795a0e)

After the fix:
![image](https://github.com/user-attachments/assets/92be3f6a-ad31-442c-b28d-909598965600)

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [X] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1413