### PR TITLE
Fix async reload when it returns a null response

### DIFF
--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -236,6 +236,10 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 					return nil, err //nolint:wrapcheck
 				}
 
+				if resp == nil {
+					return nil, nil
+				}
+
 				r := mapResponse(vu, resp)
 
 				return rt.ToValue(r).ToObject(rt), nil


### PR DESCRIPTION
## What?

Avoid the null exception when reload is called a response is null.

## Why?

Avoids an error that isn't an error. Response can be null.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Linked to: https://github.com/grafana/xk6-browser/pull/1408
Updates: https://github.com/grafana/xk6-browser/issues/1407