### PR TITLE
Tiny refactoring for file uploading code

### DIFF
--- a/storage/file_persister_test.go
+++ b/storage/file_persister_test.go
@@ -158,7 +158,7 @@ func TestRemoteFilePersister(t *testing.T) {
 			},
 			wantPresignedURLMethod:  http.MethodPost,
 			getPresignedURLResponse: http.StatusTooManyRequests,
-			wantError:               "getting presigned url: server returned 429 (too many requests)",
+			wantError:               "requesting presigned url: server returned 429 (too many requests)",
 		},
 		{
 			name:         "get_presigned_fails",
@@ -175,7 +175,7 @@ func TestRemoteFilePersister(t *testing.T) {
 			},
 			wantPresignedURLMethod:  http.MethodPost,
 			getPresignedURLResponse: http.StatusInternalServerError,
-			wantError:               "getting presigned url: server returned 500 (internal server error)",
+			wantError:               "requesting presigned url: server returned 500 (internal server error)",
 		},
 		{
 			name:         "upload_rate_limited",


### PR DESCRIPTION
## What?

Improve file persister naming.

- Move checkStatus utility to the bottom to reduce noise while reading
- pre-signed to presigned and preSigned to presigned for consistency
- getPresignedURL to requestPresignedURL for saying it's a request
- newUploadRequest to newFileUploadRequest for specificity
- readResponseBody generic naming to specific readPresignedURLResponse
- preSignedURLGetterURL to presignedURLRequestURL for consistency

## Why?

For consistency and readability (hopefully).

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates grafana/k6-cloud#2539