### PR TITLE
Refactor runtime out of VU context in tests

### DIFF
--- a/common/browser_context_options_test.go
+++ b/common/browser_context_options_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"testing"
 
+	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/k6ext/k6test"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,8 @@ func TestBrowserContextOptionsPermissions(t *testing.T) {
 	vu := k6test.NewVU(t)
 
 	var opts BrowserContextOptions
-	err := opts.Parse(vu.Context(), vu.ToSobekValue((struct {
+	ctx := k6ext.WithVU(vu.Context(), vu.TestRT.VU)
+	err := opts.Parse(ctx, vu.ToSobekValue((struct {
 		Permissions []any `js:"permissions"`
 	}{
 		Permissions: []any{"camera", "microphone"},

--- a/common/frame_options_test.go
+++ b/common/frame_options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/k6ext/k6test"
 
 	"github.com/stretchr/testify/assert"
@@ -17,12 +18,13 @@ func TestFrameGotoOptionsParse(t *testing.T) {
 		t.Parallel()
 
 		vu := k6test.NewVU(t)
+		vuCtx := k6ext.WithVU(vu.Context(), vu.TestRT.VU)
 		opts := vu.ToSobekValue(map[string]any{
 			"timeout":   "1000",
 			"waitUntil": "networkidle",
 		})
 		gotoOpts := NewFrameGotoOptions("https://example.com/", 0)
-		err := gotoOpts.Parse(vu.Context(), opts)
+		err := gotoOpts.Parse(vuCtx, opts)
 		require.NoError(t, err)
 
 		assert.Equal(t, "https://example.com/", gotoOpts.Referer)
@@ -34,11 +36,12 @@ func TestFrameGotoOptionsParse(t *testing.T) {
 		t.Parallel()
 
 		vu := k6test.NewVU(t)
+		vuCtx := k6ext.WithVU(vu.Context(), vu.TestRT.VU)
 		opts := vu.ToSobekValue(map[string]any{
 			"waitUntil": "none",
 		})
 		navOpts := NewFrameGotoOptions("", 0)
-		err := navOpts.Parse(vu.Context(), opts)
+		err := navOpts.Parse(vuCtx, opts)
 
 		assert.EqualError(t, err,
 			`parsing goto options: `+
@@ -54,11 +57,12 @@ func TestFrameSetContentOptionsParse(t *testing.T) {
 		t.Parallel()
 
 		vu := k6test.NewVU(t)
+		vuCtx := k6ext.WithVU(vu.Context(), vu.TestRT.VU)
 		opts := vu.ToSobekValue(map[string]any{
 			"waitUntil": "networkidle",
 		})
 		scOpts := NewFrameSetContentOptions(30 * time.Second)
-		err := scOpts.Parse(vu.Context(), opts)
+		err := scOpts.Parse(vuCtx, opts)
 		require.NoError(t, err)
 
 		assert.Equal(t, 30*time.Second, scOpts.Timeout)
@@ -69,11 +73,12 @@ func TestFrameSetContentOptionsParse(t *testing.T) {
 		t.Parallel()
 
 		vu := k6test.NewVU(t)
+		vuCtx := k6ext.WithVU(vu.Context(), vu.TestRT.VU)
 		opts := vu.ToSobekValue(map[string]any{
 			"waitUntil": "none",
 		})
 		navOpts := NewFrameSetContentOptions(0)
-		err := navOpts.Parse(vu.Context(), opts)
+		err := navOpts.Parse(vuCtx, opts)
 
 		assert.EqualError(t, err,
 			`parsing setContent options: `+
@@ -89,13 +94,14 @@ func TestFrameWaitForNavigationOptionsParse(t *testing.T) {
 		t.Parallel()
 
 		vu := k6test.NewVU(t)
+		vuCtx := k6ext.WithVU(vu.Context(), vu.TestRT.VU)
 		opts := vu.ToSobekValue(map[string]any{
 			"url":       "https://example.com/",
 			"timeout":   "1000",
 			"waitUntil": "networkidle",
 		})
 		navOpts := NewFrameWaitForNavigationOptions(0)
-		err := navOpts.Parse(vu.Context(), opts)
+		err := navOpts.Parse(vuCtx, opts)
 		require.NoError(t, err)
 
 		assert.Equal(t, "https://example.com/", navOpts.URL)
@@ -107,11 +113,12 @@ func TestFrameWaitForNavigationOptionsParse(t *testing.T) {
 		t.Parallel()
 
 		vu := k6test.NewVU(t)
+		vuCtx := k6ext.WithVU(vu.Context(), vu.TestRT.VU)
 		opts := vu.ToSobekValue(map[string]any{
 			"waitUntil": "none",
 		})
 		navOpts := NewFrameWaitForNavigationOptions(0)
-		err := navOpts.Parse(vu.Context(), opts)
+		err := navOpts.Parse(vuCtx, opts)
 
 		assert.EqualError(t, err,
 			`parsing waitForNavigation options: `+

--- a/common/frame_options_test.go
+++ b/common/frame_options_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/xk6-browser/k6ext"
-	"github.com/grafana/xk6-browser/k6ext/k6test"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/xk6-browser/k6ext"
+	"github.com/grafana/xk6-browser/k6ext/k6test"
 )
 
 func TestFrameGotoOptionsParse(t *testing.T) {

--- a/common/http_test.go
+++ b/common/http_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/k6ext/k6test"
 )
 
@@ -30,7 +31,8 @@ func TestRequest(t *testing.T) {
 		WallTime:  &wt,
 	}
 	vu := k6test.NewVU(t)
-	req, err := NewRequest(vu.Context(), NewRequestParams{
+	vuCtx := k6ext.WithVU(vu.Context(), vu.TestRT.VU)
+	req, err := NewRequest(vuCtx, NewRequestParams{
 		event:          evt,
 		interceptionID: "intercept",
 	})
@@ -99,7 +101,8 @@ func TestResponse(t *testing.T) {
 	req := &Request{
 		offset: 0,
 	}
-	res := NewHTTPResponse(vu.Context(), req, &network.Response{
+	ctx := k6ext.WithVU(vu.Context(), vu.TestRT.VU)
+	res := NewHTTPResponse(ctx, req, &network.Response{
 		URL:     "https://test/post",
 		Headers: network.Headers(headers),
 	}, &ts)

--- a/common/keyboard_test.go
+++ b/common/keyboard_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/k6ext/k6test"
 	"github.com/grafana/xk6-browser/keyboardlayout"
 )
@@ -82,7 +83,8 @@ func TestKeyboardPress(t *testing.T) {
 		t.Parallel()
 
 		vu := k6test.NewVU(t)
-		k := NewKeyboard(vu.Context(), nil)
+		ctx := k6ext.WithVU(vu.Context(), vu.TestRT.VU)
+		k := NewKeyboard(ctx, nil)
 		require.Error(t, k.Press("", nil))
 	})
 }

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -270,12 +270,13 @@ func TestNetworkManagerEmitRequestResponseMetricsTimingSkew(t *testing.T) {
 			k6m := k6ext.RegisterCustomMetrics(registry)
 
 			var (
-				vu = k6test.NewVU(t)
-				nm = &NetworkManager{ctx: vu.Context(), vu: vu, customMetrics: k6m}
+				vu    = k6test.NewVU(t)
+				vuCtx = k6ext.WithVU(vu.Context(), vu.TestRT.VU)
+				nm    = &NetworkManager{ctx: vuCtx, vu: vu, customMetrics: k6m}
 			)
 			vu.ActivateVU()
 
-			req, err := NewRequest(vu.Context(), NewRequestParams{
+			req, err := NewRequest(vuCtx, NewRequestParams{
 				event: &network.EventRequestWillBeSent{
 					Request:   &network.Request{},
 					Timestamp: (*cdp.MonotonicTime)(&tt.req.ts),
@@ -288,7 +289,7 @@ func TestNetworkManagerEmitRequestResponseMetricsTimingSkew(t *testing.T) {
 				assert.Equalf(t, tt.wantReq.wt, s.Time, "timing skew in %s", s.Metric.Name)
 			})
 			assert.Equalf(t, 1, n, "should emit %d request metric", 1)
-			res := NewHTTPResponse(vu.Context(), req,
+			res := NewHTTPResponse(vuCtx, req,
 				&network.Response{Timing: &network.ResourceTiming{}},
 				(*cdp.MonotonicTime)(&tt.res.ts),
 			)

--- a/k6ext/k6test/vu.go
+++ b/k6ext/k6test/vu.go
@@ -11,12 +11,10 @@ import (
 
 	"github.com/grafana/xk6-browser/env"
 
-	"go.k6.io/k6/event"
 	k6event "go.k6.io/k6/event"
 	k6common "go.k6.io/k6/js/common"
 	k6eventloop "go.k6.io/k6/js/eventloop"
 	k6modulestest "go.k6.io/k6/js/modulestest"
-	"go.k6.io/k6/lib"
 	k6lib "go.k6.io/k6/lib"
 	k6executor "go.k6.io/k6/lib/executor"
 	k6testutils "go.k6.io/k6/lib/testutils"
@@ -96,7 +94,7 @@ func (v *VU) EndIteration(tb testing.TB, opts ...any) {
 }
 
 // iterEvent generates an iteration event for the VU.
-func (v *VU) iterEvent(tb testing.TB, eventType event.Type, eventName string, opts ...any) {
+func (v *VU) iterEvent(tb testing.TB, eventType k6event.Type, eventName string, opts ...any) {
 	tb.Helper()
 
 	data := k6event.IterData{
@@ -236,7 +234,7 @@ func NewVU(tb testing.TB, opts ...any) *VU {
 		BufferPool: k6lib.NewBufferPool(),
 		Samples:    samples,
 		Tags: k6lib.NewVUStateTags(
-			testRT.VU.InitEnvField.Registry.RootTagSet().With("group", lib.RootGroupPath),
+			testRT.VU.InitEnvField.Registry.RootTagSet().With("group", k6lib.RootGroupPath),
 		),
 		BuiltinMetrics: k6metrics.RegisterBuiltinMetrics(k6metrics.NewRegistry()),
 		TracerProvider: tracerProvider,

--- a/k6ext/k6test/vu.go
+++ b/k6ext/k6test/vu.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/guregu/null.v3"
 
 	"github.com/grafana/xk6-browser/env"
-	"github.com/grafana/xk6-browser/k6ext"
 
 	"go.k6.io/k6/event"
 	k6event "go.k6.io/k6/event"
@@ -243,7 +242,7 @@ func NewVU(tb testing.TB, opts ...any) *VU {
 		TracerProvider: tracerProvider,
 	}
 
-	ctx := k6ext.WithVU(testRT.VU.CtxField, testRT.VU)
+	ctx := testRT.VU.CtxField
 	ctx = k6lib.WithScenarioState(ctx, &k6lib.ScenarioState{Name: "default"})
 	testRT.VU.CtxField = ctx
 


### PR DESCRIPTION
## What?

Removing the automatic addition of the runtime from the vu context in tests.

## Why?

A recent [change](https://github.com/grafana/k6/pull/3963/commits/1ab4594a770e2c5b4e2dc486a2177a80bc7bc849) was added to k6 engine, and I soon realised that there was something [broken with the vu context in the browser code](https://github.com/grafana/xk6-browser/pull/1432). The vu context doesn't automatically come with the runtime, this is added by us.

I wanted to ensure that we weren't surprised when adding the latest change in the k6 engine in the future, so i've removed the automatic addition of the runtime when the vu context is created for the tests.

This means that if we make a change in the codebase that affects the runtime in the vu context we will find out before any changes are added in the k6 engine.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
