### PR TITLE
Fix NPD in getOwnerFrame

### DIFF
--- a/common/page.go
+++ b/common/page.go
@@ -486,6 +486,11 @@ func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) (cdp.Fram
 		return "", nil
 	}
 
+	if node == nil {
+		p.logger.Debugf("Page:getOwnerFrame:node:nil:return", "sid:%v err:%v", p.sessionID(), err)
+		return "", nil
+	}
+
 	frameID := node.FrameID
 	if err := documentElement.Dispose(); err != nil {
 		return "", fmt.Errorf("disposing document element while getting owner frame: %w", err)


### PR DESCRIPTION
## What?

Checking for `nil` after calling `dom.DescribeNode()`.

## Why?

The node from `dom.DescribeNode()` can be `nil`, so checking for `nil` before proceeding.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1416