### PR TITLE
Fix write channel to exit when ctx is done

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1558,9 +1558,15 @@ func (h *ElementHandle) newAction(
 
 	return func(apiCtx context.Context, resultCh chan any, errCh chan error) {
 		if res, err := actionFn(apiCtx); err != nil {
-			errCh <- err
+			select {
+			case <-apiCtx.Done():
+			case errCh <- err:
+			}
 		} else {
-			resultCh <- res
+			select {
+			case <-apiCtx.Done():
+			case resultCh <- res:
+			}
 		}
 	}
 }
@@ -1646,9 +1652,15 @@ func (h *ElementHandle) newPointerAction(
 
 	return func(apiCtx context.Context, resultCh chan any, errCh chan error) {
 		if res, err := retryPointerAction(apiCtx, pointerFn, opts); err != nil {
-			errCh <- err
+			select {
+			case <-apiCtx.Done():
+			case errCh <- err:
+			}
 		} else {
-			resultCh <- res
+			select {
+			case <-apiCtx.Done():
+			case resultCh <- res:
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What?

Ensuring that the goroutine can exit early if the context is closed.

## Why?

There's a chance that the goroutine [reading](https://github.com/grafana/xk6-browser/blob/29f6ef3049fe1ce603fcd90f9dbfe1827ee5dbb9/common/helpers.go#L105-L113) off the `resultCh` has or is exiting due to the context being closed. We don't want [this goroutine](https://github.com/grafana/xk6-browser/blob/4350722189cf533a31228ff0c032b88f14ae394b/common/element_handle.go#L1648-L1652) to be hanging around waiting since nothing will read off the `resultCh` or `errCh`.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1437