### PR TITLE
Update example to work with page.waitForTimeout

### DIFF
--- a/examples/device_emulation.js
+++ b/examples/device_emulation.js
@@ -1,4 +1,4 @@
-import { check, sleep } from 'k6';
+import { check } from 'k6';
 import { browser, devices } from 'k6/x/browser/async';
 
 export const options = {
@@ -43,7 +43,7 @@ export default async function() {
     });
 
     if (!__ENV.K6_BROWSER_HEADLESS) {
-      sleep(10);
+      await page.waitForTimeout(10000);
     }
   } finally {
     await page.close();


### PR DESCRIPTION
This is recommended when working with the browser APIs.

## What?

Update example to work with `page.waitForTimeout`.

## Why?

It's recommended that we work with `page.waitForTimeout` over `sleep` due to the async nature of the browser API and the synchronous `sleep` that blocks the event loop.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/k6-docs/issues/1719