### PR TITLE
Update sync examples with `check` to async `check`

### DIFF
--- a/examples/colorscheme.js
+++ b/examples/colorscheme.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -18,26 +18,20 @@ export const options = {
 }
 
 export default async function() {
-  const preferredColorScheme = 'dark';
-
   const context = await browser.newContext({
     // valid values are "light", "dark" or "no-preference"
-    colorScheme: preferredColorScheme,
+    colorScheme: 'dark',
   });
   const page = await context.newPage();
 
   try {
     await page.goto(
-      'https://googlechromelabs.github.io/dark-mode-toggle/demo/',
+      'https://test.k6.io',
       { waitUntil: 'load' },
     )
-    const colorScheme = await page.evaluate(() => {
-      return {
-        isDarkColorScheme: window.matchMedia('(prefers-color-scheme: dark)').matches
-      };
-    });
-    check(colorScheme, {
-      'isDarkColorScheme': cs => cs.isDarkColorScheme
+    await check(page, {
+      'isDarkColorScheme':
+        p => p.evaluate(() => window.matchMedia('(prefers-color-scheme: dark)').matches)
     });
   } finally {
     await page.close();

--- a/examples/cookies.js
+++ b/examples/cookies.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -23,8 +23,8 @@ export default async function () {
 
   try {
     // get cookies from the browser context
-    check((await context.cookies()).length, {
-        'initial number of cookies should be zero': n => n === 0,
+    await check(await context.cookies(), {
+        'initial number of cookies should be zero': c => c.length === 0,
     });
 
     // add some cookies to the browser context
@@ -63,10 +63,10 @@ export default async function () {
       }
     ]);
     let cookies = await context.cookies();
-    check(cookies.length, {
+    await check(cookies.length, {
       'number of cookies should be 2': n => n === 2,
     });
-    check(cookies[0], {
+    await check(cookies[0], {
       'cookie 1 name should be testcookie': c => c.name === 'testcookie',
       'cookie 1 value should be 1': c => c.value === '1',
       'cookie 1 should be session cookie': c => c.expires === -1,
@@ -76,7 +76,7 @@ export default async function () {
       'cookie 1 should be httpOnly': c => c.httpOnly === true,
       'cookie 1 should be secure': c => c.secure === true,
     });
-    check(cookies[1], {
+    await check(cookies[1], {
       'cookie 2 name should be testcookie2': c => c.name === 'testcookie2',
       'cookie 2 value should be 2': c => c.value === '2',
     });
@@ -103,23 +103,22 @@ export default async function () {
       },
     ]);
     cookies = await context.cookies("http://foo.com", "https://baz.com");
-    check(cookies.length, {
+    await check(cookies.length, {
       'number of filtered cookies should be 2': n => n === 2,
     });
-    check(cookies[0], {
+    await check(cookies[0], {
       'the first filtered cookie name should be foo': c => c.name === 'foo',
       'the first filtered cookie value should be 42': c => c.value === '42',
     });
-    check(cookies[1], {
+    await check(cookies[1], {
       'the second filtered cookie name should be baz': c => c.name === 'baz',
       'the second filtered cookie value should be 44': c => c.value === '44',
     });
 
     // clear cookies
     await context.clearCookies();
-    cookies = await context.cookies();
-    check(cookies.length, {
-      'number of cookies should be zero': n => n === 0,
+    await check(await context.cookies(), {
+      'number of cookies should be zero': c => c.length === 0,
     });
   } finally {
     await page.close();

--- a/examples/device_emulation.js
+++ b/examples/device_emulation.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser, devices } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -27,7 +27,7 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto('https://k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
     const dimensions = await page.evaluate(() => {
       return {
         width: document.documentElement.clientWidth,
@@ -36,7 +36,7 @@ export default async function() {
       };
     });
 
-    check(dimensions, {
+    await check(dimensions, {
       'width': d => d.width === device.viewport.width,
       'height': d => d.height === device.viewport.height,
       'scale': d => d.deviceScaleFactor === device.deviceScaleFactor,

--- a/examples/dispatch.js
+++ b/examples/dispatch.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -27,9 +27,10 @@ export default async function() {
     const contacts = page.locator('a[href="/contacts.php"]');
     await contacts.dispatchEvent("click");
 
-    const h3 = page.locator("h3");
-    const ok = await h3.textContent() == "Contact us";
-    check(ok, { "header": ok });
+    await check(page.locator('h3'), {
+      'header': async lo => lo.textContent()
+        .then(text => text == 'Contact us')
+    });
   } finally {
     await page.close();
   }

--- a/examples/dispatch.js
+++ b/examples/dispatch.js
@@ -28,8 +28,10 @@ export default async function() {
     await contacts.dispatchEvent("click");
 
     await check(page.locator('h3'), {
-      'header': async lo => lo.textContent()
-        .then(text => text == 'Contact us')
+      'header': async lo => {
+        const text = await lo.textContent();
+        return text == 'Contact us';
+      }
     });
   } finally {
     await page.close();

--- a/examples/elementstate.js
+++ b/examples/elementstate.js
@@ -34,36 +34,48 @@ export default async function() {
 
   // Check state
   await check(page, {
-    'is visible':
-      async p => p.$('.visible').then(e => e.isVisible()),
-    'is hidden':
-      async p => p.$('.hidden').then(e => e.isHidden()),
-    'is editable':
-      async p => p.$('.editable').then(e => e.isEditable()),
-    'is enabled':
-      async p => p.$('.enabled').then(e => e.isEnabled()),
-    'is disabled':
-      async p => p.$('.disabled').then(e => e.isDisabled()),
-    'is checked':
-      async p => p.$('.checked').then(e => e.isChecked()),
-    'is unchecked':
-      async p => p.$('.unchecked')
-        .then(async e => await e.isChecked() === false),
+    'is visible': async p => {
+      const e = await p.$('.visible');
+      return await e.isVisible();
+    },
+    'is hidden': async p => {
+      const e = await p.$('.hidden');
+      return await e.isHidden()
+    },
+    'is editable': async p => {
+      const e = await p.$('.editable');
+      return await e.isEditable();
+    },
+    'is enabled': async p => {
+      const e = await p.$('.enabled');
+      return await e.isEnabled();
+    },
+    'is disabled': async p => {
+      const e = await p.$('.disabled');
+      return await e.isDisabled();
+    },
+    'is checked': async p => {
+      const e = await p.$('.checked');
+      return await e.isChecked();
+    },
+    'is unchecked': async p => {
+      const e = await p.$('.unchecked');
+      return !await e.isChecked();
+    }
   });
 
   // Change state and check again
   await check(page, {
-    'is unchecked checked':
-      async p => p.$(".unchecked")
-        .then(e => e.setChecked(true))
-        .then(() => p.$(".unchecked"))
-        .then(e => e.isChecked()),
-    'is checked unchecked':
-      async p => p.$(".checked")
-        .then(e => e.setChecked(false))
-        .then(() => p.$(".checked"))
-        .then(e => e.isChecked())
-        .then(checked => !checked),
+    'is unchecked checked': async p => {
+      const e = await p.$(".unchecked");
+      await e.setChecked(true);
+      return e.isChecked();
+    },
+    'is checked unchecked': async p => {
+      const e = await p.$(".checked");
+      await e.setChecked(false);
+      return !await e.isChecked();
+    }
   });
 
   await page.close();

--- a/examples/elementstate.js
+++ b/examples/elementstate.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -33,34 +33,37 @@ export default async function() {
   `);
 
   // Check state
-  let isVisible = await page.$('.visible').then(e => e.isVisible());
-  let isHidden = await page.$('.hidden').then(e => e.isHidden());
-  let isEditable = await page.$('.editable').then(e => e.isEditable());
-  let isEnabled = await page.$('.enabled').then(e => e.isEnabled());
-  let isDisabled = await page.$('.disabled').then(e => e.isDisabled());
-  let isChecked = await page.$('.checked').then(e => e.isChecked());
-  let isUnchecked = !await page.$('.unchecked').then(e => e.isChecked());
-
-  check(page, {
-    'visible': isVisible,
-    'hidden': isHidden,
-    'editable': isEditable,
-    'enabled': isEnabled,
-    'disabled': isDisabled,
-    'checked': isChecked,
-    'unchecked': isUnchecked,
+  await check(page, {
+    'is visible':
+      async p => p.$('.visible').then(e => e.isVisible()),
+    'is hidden':
+      async p => p.$('.hidden').then(e => e.isHidden()),
+    'is editable':
+      async p => p.$('.editable').then(e => e.isEditable()),
+    'is enabled':
+      async p => p.$('.enabled').then(e => e.isEnabled()),
+    'is disabled':
+      async p => p.$('.disabled').then(e => e.isDisabled()),
+    'is checked':
+      async p => p.$('.checked').then(e => e.isChecked()),
+    'is unchecked':
+      async p => p.$('.unchecked')
+        .then(async e => await e.isChecked() === false),
   });
 
   // Change state and check again
-  await page.$(".unchecked").then(e => e.setChecked(true))
-  await page.$(".checked").then(e => e.setChecked(false))
-
-  let isUncheckedChecked = await page.$(".unchecked").then((e) => e.isChecked());
-  let isCheckedUnchecked = !await page.$(".checked").then((e) => e.isChecked());
-
-  check(page, {
-    isUncheckedChecked: isUncheckedChecked,
-    isCheckedUnchecked: isCheckedUnchecked,
+  await check(page, {
+    'is unchecked checked':
+      async p => p.$(".unchecked")
+        .then(e => e.setChecked(true))
+        .then(() => p.$(".unchecked"))
+        .then(e => e.isChecked()),
+    'is checked unchecked':
+      async p => p.$(".checked")
+        .then(e => e.setChecked(false))
+        .then(() => p.$(".checked"))
+        .then(e => e.isChecked())
+        .then(checked => !checked),
   });
 
   await page.close();

--- a/examples/evaluate.js
+++ b/examples/evaluate.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -25,20 +25,21 @@ export default async function() {
     await page.goto("https://test.k6.io/", { waitUntil: "load" });
 
     // calling evaluate without arguments
-    let result = await page.evaluate(() => {
-        return Promise.resolve(5 * 42);
-    });
-    check(result, {
-      "result should be 210": (result) => result == 210,
-    });
+    await check(page, {
+      'result should be 210':
+        async p => p.evaluate(
+          () => 5 * 42
+        )
+        .then(r => r == 210)
+  });
 
     // calling evaluate with arguments
-    result = await page.evaluate(([x, y]) => {
-        return Promise.resolve(x * y);
-      }, [5, 5]
-    );
-    check(result, {
-      "result should be 25": (result) => result == 25,
+    await check(page, {
+      'result should be 25':
+        async p => p.evaluate(
+          ([x, y]) => x * y, [5, 5],
+        )
+        .then(r => r == 25),
     });
   } finally {
     await page.close();

--- a/examples/evaluate.js
+++ b/examples/evaluate.js
@@ -26,20 +26,18 @@ export default async function() {
 
     // calling evaluate without arguments
     await check(page, {
-      'result should be 210':
-        async p => p.evaluate(
-          () => 5 * 42
-        )
-        .then(r => r == 210)
-  });
+      'result should be 210': async p => {
+        const n = await p.evaluate(() => 5 * 42);
+        return n == 210;
+      }
+    });
 
     // calling evaluate with arguments
     await check(page, {
-      'result should be 25':
-        async p => p.evaluate(
-          ([x, y]) => x * y, [5, 5],
-        )
-        .then(r => r == 25),
+      'result should be 25': async p => {
+        const n = await p.evaluate((x, y) => x * y, 5, 5);
+        return n == 25;
+      }
     });
   } finally {
     await page.close();

--- a/examples/fillform.js
+++ b/examples/fillform.js
@@ -42,15 +42,17 @@ export default async function() {
     ]);
 
     await check(page.locator('h2'), {
-      'header': async lo => lo.textContent()
-        .then(t => t == 'Welcome, admin!')
+      'header': async lo => {
+        return await lo.textContent() == 'Welcome, admin!'
+      }
     });
 
     // Check whether we receive cookies from the logged site.
     await check(context, {
-      'session cookie is set': async ctx => ctx.cookies()
-        .then(cookies => cookies.find(c => c.name == 'sid'))
-        .then(sessionID => typeof sessionID !== 'undefined')
+      'session cookie is set': async ctx => {
+        const cookies = await ctx.cookies();
+        return cookies.find(c => c.name == 'sid') !== undefined;
+      }
     });
   } finally {
     await page.close();

--- a/examples/fillform.js
+++ b/examples/fillform.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -41,17 +41,17 @@ export default async function() {
       page.locator('input[type="submit"]').click(),
     ]);
 
-    const h2 = page.locator('h2');
-    const headerOK = await h2.textContent() == 'Welcome, admin!';
-    check(headerOK, { 'header': headerOK });
+    await check(page.locator('h2'), {
+      'header': async lo => lo.textContent()
+        .then(t => t == 'Welcome, admin!')
+    });
 
     // Check whether we receive cookies from the logged site.
-    check(await context.cookies(), {
-      'session cookie is set': cookies => {
-        const sessionID = cookies.find(c => c.name == 'sid')
-        return typeof sessionID !== 'undefined'
-      }
-    })
+    await check(context, {
+      'session cookie is set': async ctx => ctx.cookies()
+        .then(cookies => cookies.find(c => c.name == 'sid'))
+        .then(sessionID => typeof sessionID !== 'undefined')
+    });
   } finally {
     await page.close();
   }

--- a/examples/getattribute.js
+++ b/examples/getattribute.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -25,10 +25,11 @@ export default async function() {
     await page.goto('https://googlechromelabs.github.io/dark-mode-toggle/demo/', {
       waitUntil: 'load',
     });
-    let el = await page.$('#dark-mode-toggle-3');
-    const mode = await el.getAttribute('mode');
-    check(mode, {
-      "GetAttribute('mode')": mode === 'light',
+    await check(page, {
+      "GetAttribute('mode')":
+        async p => p.$('#dark-mode-toggle-3')
+          .then(e => e.getAttribute('mode'))
+          .then(m => m === 'light'),
     });
   } finally {
     await page.close();

--- a/examples/getattribute.js
+++ b/examples/getattribute.js
@@ -26,10 +26,10 @@ export default async function() {
       waitUntil: 'load',
     });
     await check(page, {
-      "GetAttribute('mode')":
-        async p => p.$('#dark-mode-toggle-3')
-          .then(e => e.getAttribute('mode'))
-          .then(m => m === 'light'),
+      "GetAttribute('mode')": async p => {
+        const e = await p.$('#dark-mode-toggle-3');
+        return await e.getAttribute('mode') === 'light';
+      }
     });
   } finally {
     await page.close();

--- a/examples/hosts.js
+++ b/examples/hosts.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -23,8 +23,10 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    const res = await page.goto('http://test.k6.io/', { waitUntil: 'load' });
-    check(res, {
+    const res = await page.goto('http://test.k6.io/', {
+      waitUntil: 'load'
+    });
+    await check(res, {
       'null response': r => r === null,
     });
   } finally {

--- a/examples/pageon.js
+++ b/examples/pageon.js
@@ -24,16 +24,18 @@ export default async function() {
     await page.goto('https://test.k6.io/');
 
     page.on('console', async msg => check(msg, {
-      'assert console message type':
-        msg => msg.type() == 'log',
-      'assert console message text':
-        msg => msg.text() == 'this is a console.log message 42',
-      'assert console message first argument':
-        msg => msg.args()[0].jsonValue()
-          .then(arg1 => arg1 == 'this is a console.log message'),
-      'assert console message second argument':
-        msg => msg.args()[1].jsonValue()
-          .then(arg2 => arg2 == 42)
+      'assert console message type': msg =>
+        msg.type() == 'log',
+      'assert console message text': msg =>
+        msg.text() == 'this is a console.log message 42',
+      'assert console message first argument': async msg => {
+        const arg1 = await msg.args()[0].jsonValue();
+        return arg1 == 'this is a console.log message';
+      },
+      'assert console message second argument': async msg => {
+        const arg2 = await msg.args()[1].jsonValue();
+        return arg2 == 42;
+      }
     }));
 
     await page.evaluate(() => console.log('this is a console.log message', 42));

--- a/examples/querying.js
+++ b/examples/querying.js
@@ -25,14 +25,14 @@ export default async function() {
     await page.goto('https://test.k6.io/');
 
     await check(page, {
-      'Title with CSS selector':
-        p => p.$('header h1.title')
-          .then(e => e.textContent())
-          .then(title => title == 'test.k6.io'),
-      'Title with XPath selector':
-        p => p.$(`//header//h1[@class="title"]`)
-          .then(e => e.textContent())
-          .then(title => title == 'test.k6.io'),
+      'Title with CSS selector': async p => {
+        const e = await p.$('header h1.title');
+        return await e.textContent() === 'test.k6.io';
+      },
+      'Title with XPath selector': async p => {
+        const e = await p.$('//header//h1[@class="title"]');
+        return await e.textContent() === 'test.k6.io';
+      }
     });
   } finally {
     await page.close();

--- a/examples/querying.js
+++ b/examples/querying.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -24,12 +24,15 @@ export default async function() {
   try {
     await page.goto('https://test.k6.io/');
 
-    const titleWithCSS = await page.$('header h1.title').then(e => e.textContent());
-    const titleWithXPath = await page.$(`//header//h1[@class="title"]`).then(e => e.textContent());
-
-    check(page, {
-      'Title with CSS selector': titleWithCSS == 'test.k6.io',
-      'Title with XPath selector': titleWithXPath == 'test.k6.io',
+    await check(page, {
+      'Title with CSS selector':
+        p => p.$('header h1.title')
+          .then(e => e.textContent())
+          .then(title => title == 'test.k6.io'),
+      'Title with XPath selector':
+        p => p.$(`//header//h1[@class="title"]`)
+          .then(e => e.textContent())
+          .then(title => title == 'test.k6.io'),
     });
   } finally {
     await page.close();

--- a/examples/shadowdom.js
+++ b/examples/shadowdom.js
@@ -30,13 +30,11 @@ export default async function() {
     document.body.appendChild(shadowRoot);
   });
 
-  await check(
-    page.locator('#shadow-dom'), {
-    'shadow element exists':
-      e => e !== null,
-    'shadow element text is correct':
-      async e => e.innerText()
-        .then(text => text === 'Shadow DOM'),
+  await check(page.locator('#shadow-dom'), {
+    'shadow element exists': e => e !== null,
+    'shadow element text is correct': async e => {
+      return await e.innerText() === 'Shadow DOM';
+    }
   });
 
   await page.close();

--- a/examples/shadowdom.js
+++ b/examples/shadowdom.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -26,15 +26,17 @@ export default async function() {
     const shadowRoot = document.createElement('div');
     shadowRoot.id = 'shadow-root';
     shadowRoot.attachShadow({mode: 'open'});
-    shadowRoot.shadowRoot.innerHTML = '<p id="find">Shadow DOM</p>';
+    shadowRoot.shadowRoot.innerHTML = '<p id="shadow-dom">Shadow DOM</p>';
     document.body.appendChild(shadowRoot);
   });
 
-  const shadowEl = page.locator("#find");
-  const ok = await shadowEl.innerText() === "Shadow DOM";
-  check(shadowEl, {
-    "shadow element exists": (e) => e !== null,
-    "shadow element text is correct": () => ok,
+  await check(
+    page.locator('#shadow-dom'), {
+    'shadow element exists':
+      e => e !== null,
+    'shadow element text is correct':
+      async e => e.innerText()
+        .then(text => text === 'Shadow DOM'),
   });
 
   await page.close();

--- a/examples/waitforfunction.js
+++ b/examples/waitforfunction.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -30,11 +30,16 @@ export default async function() {
       }, 1000);
     });
 
-    const ok = await page.waitForFunction("document.querySelector('h1')", {
-      polling: 'mutation',
-      timeout: 2000,
+    await check(page, {
+      'waitForFunction successfully resolved':
+        p => p.waitForFunction(
+          "document.querySelector('h1')", {
+            polling: 'mutation',
+            timeout: 2000
+          })
+          .then(e => e.innerHTML())
+          .then(text => text == 'Hello')
     });
-    check(ok, { 'waitForFunction successfully resolved': ok.innerHTML() == 'Hello' });
   } finally {
     await page.close();
   }

--- a/examples/waitforfunction.js
+++ b/examples/waitforfunction.js
@@ -30,15 +30,16 @@ export default async function() {
       }, 1000);
     });
 
-    await check(page, {
-      'waitForFunction successfully resolved':
-        p => p.waitForFunction(
-          "document.querySelector('h1')", {
-            polling: 'mutation',
-            timeout: 2000
-          })
-          .then(e => e.innerHTML())
-          .then(text => text == 'Hello')
+    const e = await page.waitForFunction(
+      "document.querySelector('h1')", {
+        polling: 'mutation',
+        timeout: 2000
+      }
+    );
+    await check(e, {
+      'waitForFunction successfully resolved': async e => {
+        return await e.innerHTML() === 'Hello';
+      }
     });
   } finally {
     await page.close();


### PR DESCRIPTION
## What?

Updates sync examples with `check` to async `check`.

Some of the examples don't require an async check, but it's better to use async `check` in them for consistency.

## Why?

The sync k6 `check` is cumbersome when working with async functions.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

grafana/k6-docs#1725