### PR TITLE
Fix the team issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/team_issues.yaml
+++ b/.github/ISSUE_TEMPLATE/team_issues.yaml
@@ -17,7 +17,7 @@ body:
   - type: textarea
     attributes:
       label: How?
-      Description: Do you have any suggestions/solutions for solving the issue?
+      description: Do you have any suggestions/solutions for solving the issue?
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
`Description` should be `description` as Github says:

> Property Description is not allowed.yaml-schema: textarea attributes

Somehow, the team template doesn't appear while creating an issue. This might be the reason.