### PR TITLE
Add page.on('metric')

### DIFF
--- a/browser/metric_event_mapping.go
+++ b/browser/metric_event_mapping.go
@@ -25,7 +25,7 @@ func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) (mapping, error) {
 	}
 
 	return mapping{
-		"Tag": func(urls common.URLOverrides) error {
+		"Tag": func(urls common.URLTagPatterns) error {
 			callback := func(pattern, url string) (bool, error) {
 				js := fmt.Sprintf(`_k6BrowserURLGroupingTest(%s, '%s')`, pattern, url)
 

--- a/browser/metric_event_mapping.go
+++ b/browser/metric_event_mapping.go
@@ -13,7 +13,7 @@ func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) (mapping, error) {
 	// We're setting up the function in the Sobek context that will be reused
 	// for this VU.
 	_, err := rt.RunString(`
-	function _k6BrowserURLGroupingTest(pattern, url) {
+	function _k6BrowserCheckRegEx(pattern, url) {
 		let r = pattern;
 		if (typeof pattern === 'string') {
 			r = new RegExp(pattern);
@@ -27,7 +27,7 @@ func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) (mapping, error) {
 	return mapping{
 		"Tag": func(urls common.URLTagPatterns) error {
 			callback := func(pattern, url string) (bool, error) {
-				js := fmt.Sprintf(`_k6BrowserURLGroupingTest(%s, '%s')`, pattern, url)
+				js := fmt.Sprintf(`_k6BrowserCheckRegEx(%s, '%s')`, pattern, url)
 
 				val, err := rt.RunString(js)
 				if err != nil {

--- a/browser/metric_event_mapping.go
+++ b/browser/metric_event_mapping.go
@@ -29,12 +29,12 @@ func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) (mapping, error) {
 			callback := func(pattern, url string) (bool, error) {
 				js := fmt.Sprintf(`_k6BrowserCheckRegEx(%s, '%s')`, pattern, url)
 
-				val, err := rt.RunString(js)
+				matched, err := rt.RunString(js)
 				if err != nil {
 					return false, fmt.Errorf("matching url with regex: %w", err)
 				}
 
-				return val.ToBoolean(), nil
+				return matched.ToBoolean(), nil
 			}
 
 			return cm.Tag(callback, urls)

--- a/browser/metric_event_mapping.go
+++ b/browser/metric_event_mapping.go
@@ -25,7 +25,7 @@ func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) (mapping, error) {
 	}
 
 	return mapping{
-		"Tag": func(urls common.URLGroups) error {
+		"Tag": func(urls common.URLOverrides) error {
 			callback := func(pattern, url string) (bool, error) {
 				js := fmt.Sprintf(`_k6BrowserURLGroupingTest(%s, '%s')`, pattern, url)
 

--- a/browser/metric_event_mapping.go
+++ b/browser/metric_event_mapping.go
@@ -6,8 +6,8 @@ import (
 	"github.com/grafana/xk6-browser/common"
 )
 
-// mapMetric to the JS module.
-func mapMetric(vu moduleVU, cm *common.ExportedMetric) (mapping, error) {
+// mapMetricEvent to the JS module.
+func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) (mapping, error) {
 	rt := vu.VU.Runtime()
 
 	// We're setting up the function in the Sobek context that will be reused
@@ -21,7 +21,7 @@ func mapMetric(vu moduleVU, cm *common.ExportedMetric) (mapping, error) {
 		return r.test(url);
 	}`)
 	if err != nil {
-		return nil, fmt.Errorf("evaluating url grouping: %w", err)
+		return nil, fmt.Errorf("evaluating regex function: %w", err)
 	}
 
 	return mapping{
@@ -31,7 +31,7 @@ func mapMetric(vu moduleVU, cm *common.ExportedMetric) (mapping, error) {
 
 				val, err := rt.RunString(js)
 				if err != nil {
-					return false, fmt.Errorf("evaluating metric tag url grouping: %w", err)
+					return false, fmt.Errorf("matching url with regex: %w", err)
 				}
 
 				return val.ToBoolean(), nil

--- a/browser/metric_mapping.go
+++ b/browser/metric_mapping.go
@@ -1,11 +1,29 @@
 package browser
 
 import (
+	"fmt"
+
 	"github.com/grafana/xk6-browser/common"
 )
 
 // mapMetric to the JS module.
 func mapMetric(vu moduleVU, cm *common.ExportedMetric) (mapping, error) {
+	rt := vu.Runtime()
+
+	// We're setting up the function in the Sobek context that will be reused
+	// for this VU.
+	_, err := rt.RunString(`
+	function _k6BrowserURLGroupingTest(pattern, url) {
+		let r = pattern;
+		if (typeof pattern === 'string') {
+			r = new RegExp(pattern);
+		}
+		return r.test(url);
+	}`)
+	if err != nil {
+		return nil, fmt.Errorf("evaluating url grouping: %w", err)
+	}
+
 	return mapping{
 		"groupURLTag": func(urls common.URLGroups) error {
 			return cm.GroupURLTag(urls)

--- a/browser/metric_mapping.go
+++ b/browser/metric_mapping.go
@@ -1,0 +1,14 @@
+package browser
+
+import (
+	"github.com/grafana/xk6-browser/common"
+)
+
+// mapMetric to the JS module.
+func mapMetric(vu moduleVU, cm *common.ExportedMetric) (mapping, error) {
+	return mapping{
+		"groupURLTag": func(urls common.URLGroups) error {
+			return cm.GroupURLTag(urls)
+		},
+	}, nil
+}

--- a/browser/metric_mapping.go
+++ b/browser/metric_mapping.go
@@ -8,7 +8,7 @@ import (
 
 // mapMetric to the JS module.
 func mapMetric(vu moduleVU, cm *common.ExportedMetric) (mapping, error) {
-	rt := vu.Runtime()
+	rt := vu.VU.Runtime()
 
 	// We're setting up the function in the Sobek context that will be reused
 	// for this VU.

--- a/browser/metric_mapping.go
+++ b/browser/metric_mapping.go
@@ -26,7 +26,18 @@ func mapMetric(vu moduleVU, cm *common.ExportedMetric) (mapping, error) {
 
 	return mapping{
 		"groupURLTag": func(urls common.URLGroups) error {
-			return cm.GroupURLTag(urls)
+			callback := func(pattern, url string) (bool, error) {
+				js := fmt.Sprintf(`_k6BrowserURLGroupingTest(%s, '%s')`, pattern, url)
+
+				val, err := rt.RunString(js)
+				if err != nil {
+					return false, fmt.Errorf("evaluating metric tag url grouping: %w", err)
+				}
+
+				return val.ToBoolean(), nil
+			}
+
+			return cm.GroupURLTag(callback, urls)
 		},
 	}, nil
 }

--- a/browser/metric_mapping.go
+++ b/browser/metric_mapping.go
@@ -25,7 +25,7 @@ func mapMetric(vu moduleVU, cm *common.ExportedMetric) (mapping, error) {
 	}
 
 	return mapping{
-		"groupURLTag": func(urls common.URLGroups) error {
+		"Tag": func(urls common.URLGroups) error {
 			callback := func(pattern, url string) (bool, error) {
 				js := fmt.Sprintf(`_k6BrowserURLGroupingTest(%s, '%s')`, pattern, url)
 
@@ -37,7 +37,7 @@ func mapMetric(vu moduleVU, cm *common.ExportedMetric) (mapping, error) {
 				return val.ToBoolean(), nil
 			}
 
-			return cm.GroupURLTag(callback, urls)
+			return cm.Tag(callback, urls)
 		},
 	}, nil
 }

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -228,6 +228,12 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 						return nil
 					})
 				}
+			case common.EventPageMetricCalled:
+				runInTaskQueue = func(a any) {
+					tq.Queue(func() error {
+						return nil
+					})
+				}
 			default:
 				return fmt.Errorf("unknown page event: %q", event)
 			}

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -238,12 +238,12 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 					tq.Queue(func() error {
 						defer close(c)
 
-						m, ok := a.(*common.ExportedMetric)
+						m, ok := a.(*common.MetricEvent)
 						if !ok {
 							return errors.New("incorrect metric message")
 						}
 
-						mapping, err := mapMetric(vu, m)
+						mapping, err := mapMetricEvent(vu, m)
 						if err != nil {
 							return fmt.Errorf("mapping the metric: %w", err)
 						}

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -228,6 +228,8 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 						return nil
 					})
 				}
+			default:
+				return fmt.Errorf("unknown page event: %q", event)
 			}
 
 			return p.On(event, runInTaskQueue) //nolint:wrapcheck

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -212,7 +212,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			case common.EventPageConsoleAPICalled:
 				mapMsgAndHandleEvent := func(m *common.ConsoleMessage) error {
 					mapping := mapConsoleMessage(vu, m)
-					_, err := handler(sobek.Undefined(), vu.Runtime().ToValue(mapping))
+					_, err := handler(sobek.Undefined(), vu.VU.Runtime().ToValue(mapping))
 					return err
 				}
 				runInTaskQueue = func(a any) {
@@ -234,7 +234,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 					if err != nil {
 						return err
 					}
-					_, err = handler(sobek.Undefined(), vu.Runtime().ToValue(mapping))
+					_, err = handler(sobek.Undefined(), vu.VU.Runtime().ToValue(mapping))
 					return err
 				}
 				runInTaskQueue = func(a any) {

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -231,6 +231,10 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			case common.EventPageMetricCalled:
 				runInTaskQueue = func(a any) {
 					tq.Queue(func() error {
+						_, ok := a.(*common.ExportedMetric)
+						if !ok {
+							return errors.New("incorrect metric message")
+						}
 						return nil
 					})
 				}

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -211,8 +212,13 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				_, err := handler(sobek.Undefined(), vu.Runtime().ToValue(mapping))
 				return err
 			}
-			runInTaskQueue := func(m *common.ConsoleMessage) {
+			runInTaskQueue := func(a any) {
 				tq.Queue(func() error {
+					m, ok := a.(*common.ConsoleMessage)
+					if !ok {
+						return errors.New("incorrect message")
+					}
+
 					if err := mapMsgAndHandleEvent(m); err != nil {
 						return fmt.Errorf("executing page.on handler: %w", err)
 					}

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -243,6 +243,12 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 						if !ok {
 							return errors.New("incorrect metric message")
 						}
+						// page.on('metric') needs to be synchronized so that
+						// the name can be returned back to the caller of the
+						// handler. Once the handler has complete we call
+						// Completed so that the caller knows that the handler
+						// has complete and to work with the new metric.
+						defer m.Completed()
 
 						if err := mapMsgAndHandleEvent(m); err != nil {
 							return fmt.Errorf("executing page.on handler: %w", err)

--- a/browser/sync_page_mapping.go
+++ b/browser/sync_page_mapping.go
@@ -1,6 +1,7 @@
 package browser
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/grafana/sobek"
@@ -121,8 +122,13 @@ func syncMapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				_, err := handler(sobek.Undefined(), vu.Runtime().ToValue(mapping))
 				return err
 			}
-			runInTaskQueue := func(m *common.ConsoleMessage) {
+			runInTaskQueue := func(a any) {
 				tq.Queue(func() error {
+					m, ok := a.(*common.ConsoleMessage)
+					if !ok {
+						return errors.New("incorrect message")
+					}
+
 					if err := mapMsgAndHandleEvent(m); err != nil {
 						return fmt.Errorf("executing page.on handler: %w", err)
 					}

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -355,13 +355,7 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 	state := fs.vu.State()
 	tags := state.Tags.GetCurrentValues().Tags
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		if name, ok := fs.page.urlGroupingName(fs.ctx, wv.URL); ok {
-			tags = tags.With("url", name)
-			tags = tags.With("name", name)
-		} else {
-			tags = tags.With("url", wv.URL)
-			tags = tags.With("name", wv.URL)
-		}
+		tags = handleURLTag(fs.ctx, fs.page, wv.URL, tags)
 	}
 
 	tags = tags.With("rating", wv.Rating)

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -355,7 +355,7 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 	state := fs.vu.State()
 	tags := state.Tags.GetCurrentValues().Tags
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		if name, ok := fs.page.URLGroupingName(fs.ctx, wv.URL); ok {
+		if name, ok := fs.page.urlGroupingName(fs.ctx, wv.URL); ok {
 			tags = tags.With("url", name)
 			tags = tags.With("name", name)
 		} else {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -121,7 +121,7 @@ func NewFrameSession(
 	if fs.parent != nil {
 		parentNM = fs.parent.networkManager
 	}
-	fs.networkManager, err = NewNetworkManager(ctx, k6Metrics, s, fs.manager, parentNM)
+	fs.networkManager, err = NewNetworkManager(ctx, k6Metrics, s, fs.manager, parentNM, fs.manager.page)
 	if err != nil {
 		l.Debugf("NewFrameSession:NewNetworkManager", "sid:%v tid:%v err:%v",
 			s.ID(), tid, err)

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -355,7 +355,13 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 	state := fs.vu.State()
 	tags := state.Tags.GetCurrentValues().Tags
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		tags = tags.With("url", wv.URL)
+		if name, ok := fs.page.URLGroupingName(fs.ctx, wv.URL); ok {
+			tags = tags.With("url", name)
+			tags = tags.With("name", name)
+		} else {
+			tags = tags.With("url", wv.URL)
+			tags = tags.With("name", wv.URL)
+		}
 	}
 
 	tags = tags.With("rating", wv.Rating)

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -181,7 +181,13 @@ func (m *NetworkManager) emitRequestMetrics(req *Request) {
 		tags = tags.With("method", req.method)
 	}
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		tags = tags.With("url", req.URL())
+		if name, ok := m.frameManager.page.URLGroupingName(m.vu.Context(), req.URL()); ok {
+			tags = tags.With("url", name)
+			tags = tags.With("name", name)
+		} else {
+			tags = tags.With("url", req.URL())
+			tags = tags.With("name", req.URL())
+		}
 	}
 
 	k6metrics.PushIfNotDone(m.vu.Context(), state.Samples, k6metrics.ConnectedSamples{
@@ -234,7 +240,13 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 		tags = tags.With("method", req.method)
 	}
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		tags = tags.With("url", url)
+		if name, ok := m.frameManager.page.URLGroupingName(m.vu.Context(), url); ok {
+			tags = tags.With("url", name)
+			tags = tags.With("name", name)
+		} else {
+			tags = tags.With("url", url)
+			tags = tags.With("name", url)
+		}
 	}
 	if state.Options.SystemTags.Has(k6metrics.TagIP) {
 		tags = tags.With("ip", ipAddress)

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -58,7 +58,7 @@ func (c *Credentials) Parse(ctx context.Context, credentials sobek.Value) error 
 }
 
 type metricInterceptor interface {
-	URLGroupingName(ctx context.Context, urlTag string) (string, bool)
+	urlGroupingName(ctx context.Context, urlTag string) (string, bool)
 }
 
 // NetworkManager manages all frames in HTML document.
@@ -188,7 +188,7 @@ func (m *NetworkManager) emitRequestMetrics(req *Request) {
 		tags = tags.With("method", req.method)
 	}
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		if name, ok := m.mi.URLGroupingName(m.vu.Context(), req.URL()); ok {
+		if name, ok := m.mi.urlGroupingName(m.vu.Context(), req.URL()); ok {
 			tags = tags.With("url", name)
 			tags = tags.With("name", name)
 		} else {
@@ -247,7 +247,7 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 		tags = tags.With("method", req.method)
 	}
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		if name, ok := m.mi.URLGroupingName(m.vu.Context(), url); ok {
+		if name, ok := m.mi.urlGroupingName(m.vu.Context(), url); ok {
 			tags = tags.With("url", name)
 			tags = tags.With("name", name)
 		} else {

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -93,7 +93,11 @@ type NetworkManager struct {
 
 // NewNetworkManager creates a new network manager.
 func NewNetworkManager(
-	ctx context.Context, customMetrics *k6ext.CustomMetrics, s session, fm *FrameManager, parent *NetworkManager,
+	ctx context.Context,
+	customMetrics *k6ext.CustomMetrics,
+	s session,
+	fm *FrameManager,
+	parent *NetworkManager,
 	mi metricInterceptor,
 ) (*NetworkManager, error) {
 	vu := k6ext.GetVU(ctx)

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -289,9 +289,9 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 // against user supplied regex. If there's a match a user supplied name will
 // be used instead of the url for the url tag, otherwise the url will be used.
 func handleURLTag(ctx context.Context, mi metricInterceptor, url string, tags *k6metrics.TagSet) *k6metrics.TagSet {
-	if name, ok := mi.urlTagName(ctx, url); ok {
-		tags = tags.With("url", name)
-		tags = tags.With("name", name)
+	if newTagName, urlMatched := mi.urlTagName(ctx, url); urlMatched {
+		tags = tags.With("url", newTagName)
+		tags = tags.With("name", newTagName)
 		return tags
 	}
 

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -58,7 +58,7 @@ func (c *Credentials) Parse(ctx context.Context, credentials sobek.Value) error 
 }
 
 type metricInterceptor interface {
-	urlGroupingName(ctx context.Context, urlTag string) (string, bool)
+	urlTagName(ctx context.Context, urlTag string) (string, bool)
 }
 
 // NetworkManager manages all frames in HTML document.
@@ -289,7 +289,7 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 // against user supplied regex. If there's a match a user supplied name will
 // be used instead of the url for the url tag, otherwise the url will be used.
 func handleURLTag(ctx context.Context, mi metricInterceptor, url string, tags *k6metrics.TagSet) *k6metrics.TagSet {
-	if name, ok := mi.urlGroupingName(ctx, url); ok {
+	if name, ok := mi.urlTagName(ctx, url); ok {
 		tags = tags.With("url", name)
 		tags = tags.With("name", name)
 		return tags

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -211,7 +211,7 @@ func TestOnRequestPausedBlockedIPs(t *testing.T) {
 
 type MetricInterceptorMock struct{}
 
-func (m *MetricInterceptorMock) urlGroupingName(ctx context.Context, urlTag string) (string, bool) {
+func (m *MetricInterceptorMock) urlTagName(ctx context.Context, urlTag string) (string, bool) {
 	return "", false
 }
 

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -211,7 +211,7 @@ func TestOnRequestPausedBlockedIPs(t *testing.T) {
 
 type MetricInterceptorMock struct{}
 
-func (m *MetricInterceptorMock) URLGroupingName(ctx context.Context, urlTag string) (string, bool) {
+func (m *MetricInterceptorMock) urlGroupingName(ctx context.Context, urlTag string) (string, bool) {
 	return "", false
 }
 

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -209,6 +209,12 @@ func TestOnRequestPausedBlockedIPs(t *testing.T) {
 	}
 }
 
+type MetricInterceptorMock struct{}
+
+func (m *MetricInterceptorMock) URLGroupingName(ctx context.Context, urlTag string) (string, bool) {
+	return "", false
+}
+
 func TestNetworkManagerEmitRequestResponseMetricsTimingSkew(t *testing.T) {
 	t.Parallel()
 
@@ -271,7 +277,7 @@ func TestNetworkManagerEmitRequestResponseMetricsTimingSkew(t *testing.T) {
 
 			var (
 				vu = k6test.NewVU(t)
-				nm = &NetworkManager{ctx: vu.Context(), vu: vu, customMetrics: k6m}
+				nm = &NetworkManager{ctx: vu.Context(), vu: vu, customMetrics: k6m, mi: &MetricInterceptorMock{}}
 			)
 			vu.ActivateVU()
 

--- a/common/page.go
+++ b/common/page.go
@@ -366,6 +366,9 @@ func (p *Page) initEvents() {
 // ExportedMetric is the type that is exported to JS. It is currently only used to
 // match on the urlTag and return a name when a match is found.
 type ExportedMetric struct {
+	// The url value from the metric's url tag. It will be used to match
+	// against the url grouping regexs.
+	urlTag string
 }
 
 // URLGroups will contain all the url groupings.
@@ -383,6 +386,23 @@ type URLGroup struct {
 }
 
 func (e *ExportedMetric) GroupURLTag(callBack func(pattern, url string) (bool, error), groups URLGroups) error {
+	for _, g := range groups.Groups {
+		if g.Name == "" {
+			return fmt.Errorf("name %q is invalid", g.Name)
+		}
+
+		// callback is a function that will perform the regex test in the Sobek
+		// runtime.
+		val, err := callBack(g.URL, e.urlTag)
+		if err != nil {
+			return err
+		}
+
+		if val {
+			return nil
+		}
+	}
+
 	return nil
 }
 

--- a/common/page.go
+++ b/common/page.go
@@ -389,7 +389,7 @@ func (p *Page) urlTagName(ctx context.Context, urlTag string) (string, bool) {
 		// the reason to unlock the mutex before calling the handler.
 		p.eventHandlersMu.RUnlock()
 
-		em := &ExportedMetric{
+		em := &MetricEvent{
 			urlTag: urlTag,
 		}
 
@@ -411,9 +411,9 @@ func (p *Page) urlTagName(ctx context.Context, urlTag string) (string, bool) {
 	return name, nameChanged
 }
 
-// ExportedMetric is the type that is exported to JS. It is currently only used to
+// MetricEvent is the type that is exported to JS. It is currently only used to
 // match on the urlTag and return a name when a match is found.
-type ExportedMetric struct {
+type MetricEvent struct {
 	// The URL value from the metric's url tag. It will be used to match
 	// against the URL grouping regexs.
 	urlTag string
@@ -440,7 +440,7 @@ type regexCallback func(pattern, url string) (bool, error)
 
 // Tag will find the first match given the URLGroups and the URL from
 // the metric tag and update the name field.
-func (e *ExportedMetric) Tag(callBack regexCallback, groups URLGroups) error {
+func (e *MetricEvent) Tag(callBack regexCallback, groups URLGroups) error {
 	for _, g := range groups.URLs {
 		name := strings.TrimSpace(g.Name)
 		if name == "" {

--- a/common/page.go
+++ b/common/page.go
@@ -426,18 +426,18 @@ func (p *Page) urlGroupingName(ctx context.Context, urlTag string) (string, bool
 type ExportedMetric struct {
 	ctx context.Context
 
-	// The url value from the metric's url tag. It will be used to match
-	// against the url grouping regexs.
+	// The URL value from the metric's url tag. It will be used to match
+	// against the URL grouping regexs.
 	urlTag string
 
 	// nameCh is used to return the url tag metric name when a match is found.
 	// It is also used to help sync the call to the handler and the caller.
 	// We need to wait for the handler to complete before proceeding to return
-	// the name of the url grouping.
+	// the name of the URL grouping.
 	nameCh chan<- string
 }
 
-// URLGroups will contain all the url groupings.
+// URLGroups will contain all the URL groupings.
 type URLGroups struct {
 	Groups []URLGroup
 }

--- a/common/page.go
+++ b/common/page.go
@@ -368,7 +368,21 @@ func (p *Page) initEvents() {
 type ExportedMetric struct {
 }
 
-func (e *ExportedMetric) GroupURLTag() error {
+// URLGroups will contain all the url groupings.
+type URLGroups struct {
+	Groups []URLGroup
+}
+
+// URLGroup contains the single url regex and the name to give to the metric
+// if a match is found.
+type URLGroup struct {
+	// This is a regex.
+	URL string
+	// The name to send back to the caller of the handler.
+	Name string
+}
+
+func (e *ExportedMetric) GroupURLTag(groups URLGroups) error {
 	return nil
 }
 

--- a/common/page.go
+++ b/common/page.go
@@ -433,9 +433,9 @@ type URLTagPatterns struct {
 // if a match is found.
 type URLTagPattern struct {
 	// This is a regex that will be compared against the existing url tag.
-	URLRegEx string `js:"urlRegEx"`
+	URLRegEx string `js:"url"`
 	// The name to send back to the caller of the handler.
-	TagName string `js:"tagName"`
+	TagName string `js:"name"`
 }
 
 type k6BrowserCheckRegEx func(pattern, url string) (bool, error)

--- a/common/page.go
+++ b/common/page.go
@@ -424,7 +424,7 @@ type ExportedMetric struct {
 
 // URLGroups will contain all the URL groupings.
 type URLGroups struct {
-	Groups []URLGroup
+	URLs []URLGroup `js:"urls"`
 }
 
 // URLGroup contains the single url regex and the name to give to the metric
@@ -439,7 +439,7 @@ type URLGroup struct {
 // GroupURLTag will find the first match given the URLGroups and the URL from
 // the metric tag and update the name field.
 func (e *ExportedMetric) GroupURLTag(callBack func(pattern, url string) (bool, error), groups URLGroups) error {
-	for _, g := range groups.Groups {
+	for _, g := range groups.URLs {
 		name := strings.TrimSpace(g.Name)
 		if name == "" {
 			return fmt.Errorf("name %q is invalid", g.Name)

--- a/common/page.go
+++ b/common/page.go
@@ -363,7 +363,7 @@ func (p *Page) initEvents() {
 	}()
 }
 
-func (p *Page) URLGroupingName(ctx context.Context, urlTag string) (string, bool) {
+func (p *Page) urlGroupingName(ctx context.Context, urlTag string) (string, bool) {
 	p.eventHandlersMu.RLock()
 
 	// If there are no handlers for EventConsoleAPICalled.

--- a/common/page.go
+++ b/common/page.go
@@ -436,9 +436,11 @@ type URLGroup struct {
 	Name string
 }
 
+type regexCallback func(pattern, url string) (bool, error)
+
 // GroupURLTag will find the first match given the URLGroups and the URL from
 // the metric tag and update the name field.
-func (e *ExportedMetric) GroupURLTag(callBack func(pattern, url string) (bool, error), groups URLGroups) error {
+func (e *ExportedMetric) GroupURLTag(callBack regexCallback, groups URLGroups) error {
 	for _, g := range groups.URLs {
 		name := strings.TrimSpace(g.Name)
 		if name == "" {

--- a/common/page.go
+++ b/common/page.go
@@ -435,11 +435,11 @@ type URLTagPattern struct {
 	TagName string `js:"tagName"`
 }
 
-type regexCallback func(pattern, url string) (bool, error)
+type k6BrowserCheckRegEx func(pattern, url string) (bool, error)
 
 // Tag will find the first match given the URLTagPatterns and the URL from
 // the metric tag and update the name field.
-func (e *MetricEvent) Tag(callBack regexCallback, overrides URLTagPatterns) error {
+func (e *MetricEvent) Tag(callBack k6BrowserCheckRegEx, overrides URLTagPatterns) error {
 	for _, o := range overrides.URLs {
 		name := strings.TrimSpace(o.TagName)
 		if name == "" {

--- a/common/page.go
+++ b/common/page.go
@@ -400,8 +400,8 @@ func (p *Page) urlTagName(ctx context.Context, url string) (string, bool) {
 	p.eventHandlersMu.RUnlock()
 
 	// If a match was found then the name field in em will have been updated.
-	if em.name != nil {
-		newTagName = *em.name
+	if em.userProvidedTagName != nil {
+		newTagName = *em.userProvidedTagName
 		urlMatched = true
 	}
 
@@ -417,8 +417,8 @@ type MetricEvent struct {
 	// against the URL grouping regexs.
 	url string
 
-	// When a match is found this name field should be updated.
-	name *string
+	// When a match is found this userProvidedTagName field should be updated.
+	userProvidedTagName *string
 }
 
 // URLTagPatterns will contain all the URL groupings.
@@ -454,7 +454,7 @@ func (e *MetricEvent) Tag(matchesRegex k6BrowserCheckRegEx, overrides URLTagPatt
 		}
 
 		if val {
-			e.name = &name
+			e.userProvidedTagName = &name
 			return nil
 		}
 	}

--- a/common/page.go
+++ b/common/page.go
@@ -421,34 +421,34 @@ type MetricEvent struct {
 	name *string
 }
 
-// URLOverrides will contain all the URL groupings.
-type URLOverrides struct {
-	URLs []URLOverride `js:"urls"`
+// URLTagPatterns will contain all the URL groupings.
+type URLTagPatterns struct {
+	URLs []URLTagPattern `js:"urls"`
 }
 
-// URLOverride contains the single url regex and the name to give to the metric
+// URLTagPattern contains the single url regex and the name to give to the metric
 // if a match is found.
-type URLOverride struct {
-	// This is a regex.
-	URL string
+type URLTagPattern struct {
+	// This is a regex that will be compared against the existing url tag.
+	URLRegEx string `js:"urlRegEx"`
 	// The name to send back to the caller of the handler.
-	Name string
+	TagName string `js:"tagName"`
 }
 
 type regexCallback func(pattern, url string) (bool, error)
 
-// Tag will find the first match given the URLOverrides and the URL from
+// Tag will find the first match given the URLTagPatterns and the URL from
 // the metric tag and update the name field.
-func (e *MetricEvent) Tag(callBack regexCallback, overrides URLOverrides) error {
+func (e *MetricEvent) Tag(callBack regexCallback, overrides URLTagPatterns) error {
 	for _, o := range overrides.URLs {
-		name := strings.TrimSpace(o.Name)
+		name := strings.TrimSpace(o.TagName)
 		if name == "" {
-			return fmt.Errorf("name %q is invalid", o.Name)
+			return fmt.Errorf("name %q is invalid", o.TagName)
 		}
 
 		// callback is a function that will perform the regex test in the Sobek
 		// runtime.
-		val, err := callBack(o.URL, e.urlTag)
+		val, err := callBack(o.URLRegEx, e.urlTag)
 		if err != nil {
 			return err
 		}

--- a/common/page.go
+++ b/common/page.go
@@ -363,6 +363,14 @@ func (p *Page) initEvents() {
 	}()
 }
 
+// urlGroupingName is used to check the incoming metric url tag against user
+// defined url regexes. When a match is found a user defined name, which is to
+// be used in the urls place in the url metric tag, is returned.
+//
+// The check is done by calling the handlers that were registered with
+// `page.on('metric')`. The user will need to use `GroupURLTag` to supply the
+// url regexes and the matching is done from within there. If a match is found,
+// the supplied name is returned back upstream to the caller of urlGroupingName.
 func (p *Page) urlGroupingName(ctx context.Context, urlTag string) (string, bool) {
 	p.eventHandlersMu.RLock()
 

--- a/common/page.go
+++ b/common/page.go
@@ -381,8 +381,8 @@ func (p *Page) urlTagName(ctx context.Context, urlTag string) (string, bool) {
 		return "", false
 	}
 
-	var name string
-	var nameChanged bool
+	var newTagName string
+	var urlMatched bool
 	em := &MetricEvent{
 		urlTag: urlTag,
 	}
@@ -401,13 +401,13 @@ func (p *Page) urlTagName(ctx context.Context, urlTag string) (string, bool) {
 
 	// If a match was found then the name field in em will have been updated.
 	if em.name != nil {
-		name = *em.name
-		nameChanged = true
+		newTagName = *em.name
+		urlMatched = true
 	}
 
-	p.logger.Debugf("urlTagName", "name: %q nameChanged: %v", name, nameChanged)
+	p.logger.Debugf("urlTagName", "name: %q nameChanged: %v", newTagName, urlMatched)
 
-	return name, nameChanged
+	return newTagName, urlMatched
 }
 
 // MetricEvent is the type that is exported to JS. It is currently only used to

--- a/common/page.go
+++ b/common/page.go
@@ -368,7 +368,7 @@ func (p *Page) initEvents() {
 // be used in the urls place in the url metric tag, is returned.
 //
 // The check is done by calling the handlers that were registered with
-// `page.on('metric')`. The user will need to use `GroupURLTag` to supply the
+// `page.on('metric')`. The user will need to use `Tag` to supply the
 // url regexes and the matching is done from within there. If a match is found,
 // the supplied name is returned back upstream to the caller of urlGroupingName.
 func (p *Page) urlGroupingName(ctx context.Context, urlTag string) (string, bool) {
@@ -438,9 +438,9 @@ type URLGroup struct {
 
 type regexCallback func(pattern, url string) (bool, error)
 
-// GroupURLTag will find the first match given the URLGroups and the URL from
+// Tag will find the first match given the URLGroups and the URL from
 // the metric tag and update the name field.
-func (e *ExportedMetric) GroupURLTag(callBack regexCallback, groups URLGroups) error {
+func (e *ExportedMetric) Tag(callBack regexCallback, groups URLGroups) error {
 	for _, g := range groups.URLs {
 		name := strings.TrimSpace(g.Name)
 		if name == "" {

--- a/common/page.go
+++ b/common/page.go
@@ -363,15 +363,15 @@ func (p *Page) initEvents() {
 	}()
 }
 
-// urlGroupingName is used to check the incoming metric url tag against user
+// urlTagName is used to check the incoming metric url tag against user
 // defined url regexes. When a match is found a user defined name, which is to
 // be used in the urls place in the url metric tag, is returned.
 //
 // The check is done by calling the handlers that were registered with
 // `page.on('metric')`. The user will need to use `Tag` to supply the
 // url regexes and the matching is done from within there. If a match is found,
-// the supplied name is returned back upstream to the caller of urlGroupingName.
-func (p *Page) urlGroupingName(ctx context.Context, urlTag string) (string, bool) {
+// the supplied name is returned back upstream to the caller of urlTagName.
+func (p *Page) urlTagName(ctx context.Context, urlTag string) (string, bool) {
 	p.eventHandlersMu.RLock()
 
 	// If there are no handlers for EventConsoleAPICalled.
@@ -406,7 +406,7 @@ func (p *Page) urlGroupingName(ctx context.Context, urlTag string) (string, bool
 	}
 	p.eventHandlersMu.RUnlock()
 
-	p.logger.Debugf("URLGroupingName", "name: %q nameChanged: %v", name, nameChanged)
+	p.logger.Debugf("urlTagName", "name: %q nameChanged: %v", name, nameChanged)
 
 	return name, nameChanged
 }

--- a/common/page.go
+++ b/common/page.go
@@ -363,6 +363,15 @@ func (p *Page) initEvents() {
 	}()
 }
 
+// ExportedMetric is the type that is exported to JS. It is currently only used to
+// match on the urlTag and return a name when a match is found.
+type ExportedMetric struct {
+}
+
+func (e *ExportedMetric) GroupURLTag() error {
+	return nil
+}
+
 func (p *Page) closeWorker(sessionID target.SessionID) {
 	p.logger.Debugf("Page:closeWorker", "sid:%v", sessionID)
 

--- a/common/page.go
+++ b/common/page.go
@@ -36,6 +36,7 @@ const (
 	webVitalBinding = "k6browserSendWebVitalMetric"
 
 	EventPageConsoleAPICalled = "console"
+	EventPageMetricCalled     = "metric"
 )
 
 // MediaType represents the type of media to emulate.
@@ -991,8 +992,9 @@ func (p *Page) NavigationTimeout() time.Duration {
 func (p *Page) On(event string, handler func(any)) error {
 	switch event {
 	case EventPageConsoleAPICalled:
+	case EventPageMetricCalled:
 	default:
-		return fmt.Errorf("unknown page event: %q, must be %q", event, EventPageConsoleAPICalled)
+		return fmt.Errorf("unknown page event: %q", event)
 	}
 
 	p.eventHandlersMu.Lock()

--- a/common/page.go
+++ b/common/page.go
@@ -382,7 +382,7 @@ type URLGroup struct {
 	Name string
 }
 
-func (e *ExportedMetric) GroupURLTag(groups URLGroups) error {
+func (e *ExportedMetric) GroupURLTag(callBack func(pattern, url string) (bool, error), groups URLGroups) error {
 	return nil
 }
 

--- a/common/page.go
+++ b/common/page.go
@@ -35,7 +35,7 @@ const BlankPage = "about:blank"
 const (
 	webVitalBinding = "k6browserSendWebVitalMetric"
 
-	eventPageConsoleAPICalled = "console"
+	EventPageConsoleAPICalled = "console"
 )
 
 // MediaType represents the type of media to emulate.
@@ -990,9 +990,9 @@ func (p *Page) NavigationTimeout() time.Duration {
 // The only accepted event value is 'console'.
 func (p *Page) On(event string, handler func(any)) error {
 	switch event {
-	case eventPageConsoleAPICalled:
+	case EventPageConsoleAPICalled:
 	default:
-		return fmt.Errorf("unknown page event: %q, must be %q", event, eventPageConsoleAPICalled)
+		return fmt.Errorf("unknown page event: %q, must be %q", event, EventPageConsoleAPICalled)
 	}
 
 	p.eventHandlersMu.Lock()
@@ -1382,7 +1382,7 @@ func (p *Page) TargetID() string {
 func (p *Page) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICalled) {
 	// If there are no handlers for EventConsoleAPICalled, return
 	p.eventHandlersMu.RLock()
-	if _, ok := p.eventHandlers[eventPageConsoleAPICalled]; !ok {
+	if _, ok := p.eventHandlers[EventPageConsoleAPICalled]; !ok {
 		p.eventHandlersMu.RUnlock()
 		return
 	}
@@ -1396,7 +1396,7 @@ func (p *Page) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICalled) {
 
 	p.eventHandlersMu.RLock()
 	defer p.eventHandlersMu.RUnlock()
-	for _, h := range p.eventHandlers[eventPageConsoleAPICalled] {
+	for _, h := range p.eventHandlers[EventPageConsoleAPICalled] {
 		h := h
 		h(m)
 	}

--- a/common/page.go
+++ b/common/page.go
@@ -461,7 +461,8 @@ func (e *ExportedMetric) Completed() {
 // tag and send the name via a channel back to the caller of the handler.
 func (e *ExportedMetric) GroupURLTag(callBack func(pattern, url string) (bool, error), groups URLGroups) error {
 	for _, g := range groups.Groups {
-		if g.Name == "" {
+		name := strings.TrimSpace(g.Name)
+		if name == "" {
 			return fmt.Errorf("name %q is invalid", g.Name)
 		}
 
@@ -474,7 +475,7 @@ func (e *ExportedMetric) GroupURLTag(callBack func(pattern, url string) (bool, e
 
 		if val {
 			select {
-			case e.nameCh <- g.Name:
+			case e.nameCh <- name:
 			case <-e.ctx.Done():
 			}
 			return nil

--- a/common/page.go
+++ b/common/page.go
@@ -383,28 +383,27 @@ func (p *Page) urlTagName(ctx context.Context, urlTag string) (string, bool) {
 
 	var name string
 	var nameChanged bool
+	em := &MetricEvent{
+		urlTag: urlTag,
+	}
 
 	for _, h := range p.eventHandlers[EventPageMetricCalled] {
 		// A handler can register another handler from within itself. This is
 		// the reason to unlock the mutex before calling the handler.
 		p.eventHandlersMu.RUnlock()
 
-		em := &MetricEvent{
-			urlTag: urlTag,
-		}
-
 		// Call and wait for the handler to complete.
 		h(em)
-
-		// If a match was found then the name field in em will have been updated.
-		if em.name != nil {
-			name = *em.name
-			nameChanged = true
-		}
 
 		p.eventHandlersMu.RLock()
 	}
 	p.eventHandlersMu.RUnlock()
+
+	// If a match was found then the name field in em will have been updated.
+	if em.name != nil {
+		name = *em.name
+		nameChanged = true
+	}
 
 	p.logger.Debugf("urlTagName", "name: %q nameChanged: %v", name, nameChanged)
 

--- a/common/page.go
+++ b/common/page.go
@@ -421,14 +421,14 @@ type MetricEvent struct {
 	name *string
 }
 
-// URLGroups will contain all the URL groupings.
-type URLGroups struct {
-	URLs []URLGroup `js:"urls"`
+// URLOverrides will contain all the URL groupings.
+type URLOverrides struct {
+	URLs []URLOverride `js:"urls"`
 }
 
-// URLGroup contains the single url regex and the name to give to the metric
+// URLOverride contains the single url regex and the name to give to the metric
 // if a match is found.
-type URLGroup struct {
+type URLOverride struct {
 	// This is a regex.
 	URL string
 	// The name to send back to the caller of the handler.
@@ -437,18 +437,18 @@ type URLGroup struct {
 
 type regexCallback func(pattern, url string) (bool, error)
 
-// Tag will find the first match given the URLGroups and the URL from
+// Tag will find the first match given the URLOverrides and the URL from
 // the metric tag and update the name field.
-func (e *MetricEvent) Tag(callBack regexCallback, groups URLGroups) error {
-	for _, g := range groups.URLs {
-		name := strings.TrimSpace(g.Name)
+func (e *MetricEvent) Tag(callBack regexCallback, overrides URLOverrides) error {
+	for _, o := range overrides.URLs {
+		name := strings.TrimSpace(o.Name)
 		if name == "" {
-			return fmt.Errorf("name %q is invalid", g.Name)
+			return fmt.Errorf("name %q is invalid", o.Name)
 		}
 
 		// callback is a function that will perform the regex test in the Sobek
 		// runtime.
-		val, err := callBack(g.URL, e.urlTag)
+		val, err := callBack(o.URL, e.urlTag)
 		if err != nil {
 			return err
 		}

--- a/common/page.go
+++ b/common/page.go
@@ -380,12 +380,9 @@ func (p *Page) urlGroupingName(ctx context.Context, urlTag string) (string, bool
 
 		return "", false
 	}
-	p.eventHandlersMu.RUnlock()
 
 	var name string
 	var nameChanged bool
-
-	p.eventHandlersMu.RLock()
 
 	for _, h := range p.eventHandlers[EventPageMetricCalled] {
 		// A handler can register another handler from within itself. This is

--- a/common/page.go
+++ b/common/page.go
@@ -400,8 +400,8 @@ func (p *Page) urlTagName(ctx context.Context, url string) (string, bool) {
 	p.eventHandlersMu.RUnlock()
 
 	// If a match was found then the name field in em will have been updated.
-	if em.userProvidedTagName != nil {
-		newTagName = *em.userProvidedTagName
+	if em.isUserURLTagNameExist {
+		newTagName = em.userProvidedTagName
 		urlMatched = true
 	}
 
@@ -418,7 +418,10 @@ type MetricEvent struct {
 	url string
 
 	// When a match is found this userProvidedTagName field should be updated.
-	userProvidedTagName *string
+	userProvidedTagName string
+
+	// When a match is found this is set to true.
+	isUserURLTagNameExist bool
 }
 
 // URLTagPatterns will contain all the URL groupings.
@@ -448,13 +451,14 @@ func (e *MetricEvent) Tag(matchesRegex k6BrowserCheckRegEx, overrides URLTagPatt
 
 		// matchesRegex is a function that will perform the regex test in the Sobek
 		// runtime.
-		val, err := matchesRegex(o.URLRegEx, e.url)
+		matched, err := matchesRegex(o.URLRegEx, e.url)
 		if err != nil {
 			return err
 		}
 
-		if val {
-			e.userProvidedTagName = &name
+		if matched {
+			e.isUserURLTagNameExist = true
+			e.userProvidedTagName = name
 			return nil
 		}
 	}

--- a/common/page.go
+++ b/common/page.go
@@ -989,17 +989,19 @@ func (p *Page) NavigationTimeout() time.Duration {
 // passing in the ConsoleMessage associated with the event.
 // The only accepted event value is 'console'.
 func (p *Page) On(event string, handler func(any)) error {
-	if event != eventPageConsoleAPICalled {
+	switch event {
+	case eventPageConsoleAPICalled:
+	default:
 		return fmt.Errorf("unknown page event: %q, must be %q", event, eventPageConsoleAPICalled)
 	}
 
 	p.eventHandlersMu.Lock()
 	defer p.eventHandlersMu.Unlock()
 
-	if _, ok := p.eventHandlers[eventPageConsoleAPICalled]; !ok {
-		p.eventHandlers[eventPageConsoleAPICalled] = make([]func(any), 0, 1)
+	if _, ok := p.eventHandlers[event]; !ok {
+		p.eventHandlers[event] = make([]func(any), 0, 1)
 	}
-	p.eventHandlers[eventPageConsoleAPICalled] = append(p.eventHandlers[eventPageConsoleAPICalled], handler)
+	p.eventHandlers[event] = append(p.eventHandlers[event], handler)
 
 	return nil
 }

--- a/examples/pageon-metric.js
+++ b/examples/pageon-metric.js
@@ -1,0 +1,33 @@
+import { browser } from 'k6/x/browser/async';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+}
+
+export default async function() {
+  const page = await browser.newPage();
+
+  page.on('metric', (msg) => {
+    msg.groupURLTag({
+      groups: [
+        {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, name:'test'},
+      ]
+    });
+  });
+
+  try {
+    await page.goto('https://test.k6.io/?q=abc123');
+    await page.goto('https://test.k6.io/?q=def456');
+  } finally {
+    await page.close();
+  }
+}

--- a/examples/pageon-metric.js
+++ b/examples/pageon-metric.js
@@ -19,7 +19,7 @@ export default async function() {
   page.on('metric', (metric) => {
     metric.Tag({
       urls: [
-        {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, name:'test'},
+        {urlRegEx: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, tagName:'test'},
       ]
     });
   });

--- a/examples/pageon-metric.js
+++ b/examples/pageon-metric.js
@@ -17,7 +17,7 @@ export default async function() {
   const page = await browser.newPage();
 
   page.on('metric', (msg) => {
-    msg.groupURLTag({
+    msg.Tag({
       urls: [
         {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, name:'test'},
       ]

--- a/examples/pageon-metric.js
+++ b/examples/pageon-metric.js
@@ -19,7 +19,7 @@ export default async function() {
   page.on('metric', (metric) => {
     metric.Tag({
       urls: [
-        {urlRegEx: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, tagName:'test'},
+        {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, name:'test'},
       ]
     });
   });

--- a/examples/pageon-metric.js
+++ b/examples/pageon-metric.js
@@ -16,8 +16,8 @@ export const options = {
 export default async function() {
   const page = await browser.newPage();
 
-  page.on('metric', (msg) => {
-    msg.Tag({
+  page.on('metric', (metric) => {
+    metric.Tag({
       urls: [
         {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, name:'test'},
       ]

--- a/examples/pageon-metric.js
+++ b/examples/pageon-metric.js
@@ -18,7 +18,7 @@ export default async function() {
 
   page.on('metric', (msg) => {
     msg.groupURLTag({
-      groups: [
+      urls: [
         {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, name:'test'},
       ]
     });

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1910,7 +1910,7 @@ func TestPageOnMetric(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	ignoreURLs := map[string]interface{}{
+	ignoreURLs := map[string]any{
 		tb.url("/home"):        nil,
 		tb.url("/favicon.ico"): nil,
 	}

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1924,7 +1924,7 @@ func TestPageOnMetric(t *testing.T) {
 			// Just a single page.on.
 			name: "single_page.on",
 			fun: `page.on('metric', (msg) => {
-				msg.groupURLTag({
+				msg.Tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
@@ -1933,15 +1933,15 @@ func TestPageOnMetric(t *testing.T) {
 			want: "ping-1",
 		},
 		{
-			// A single page.on but with multiple calls to groupURLTag.
-			name: "multi_groupURLTag",
+			// A single page.on but with multiple calls to Tag.
+			name: "multi_tag",
 			fun: `page.on('metric', (msg) => {
-				msg.groupURLTag({
+				msg.Tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
-				msg.groupURLTag({
+				msg.Tag({
 					urls: [
 						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
 					  ]
@@ -1950,22 +1950,22 @@ func TestPageOnMetric(t *testing.T) {
 			want: "ping-2",
 		},
 		{
-			// Two page.on and in one of them multiple calls to groupURLTag.
-			name: "multi_groupURLTag_page.on",
+			// Two page.on and in one of them multiple calls to Tag.
+			name: "multi_tag_page.on",
 			fun: `page.on('metric', (msg) => {
-				msg.groupURLTag({
+				msg.Tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
-				msg.groupURLTag({
+				msg.Tag({
 					urls: [
 						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
 					  ]
 				  });
 			});
 			page.on('metric', (msg) => {
-				msg.groupURLTag({
+				msg.Tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-3'},
 					]
@@ -1977,13 +1977,13 @@ func TestPageOnMetric(t *testing.T) {
 			// A single page.on but within it another page.on.
 			name: "multi_page.on_call",
 			fun: `page.on('metric', (msg) => {
-				msg.groupURLTag({
+				msg.Tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
 				page.on('metric', (msg) => {
-					msg.groupURLTag({
+					msg.Tag({
 						urls: [
 							{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-4'},
 						]
@@ -2026,7 +2026,7 @@ func TestPageOnMetric(t *testing.T) {
 						}
 
 						// Url shouldn't contain any of the hash values, and should
-						// instead take the name that was supplied in the groupURLTag
+						// instead take the name that was supplied in the Tag
 						// function on metric in page.on.
 						assert.Equal(t, tt.want, u)
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1926,7 +1926,7 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.Tag({
 				  urls: [
-						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
+						{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-1'},
 					]
 				});
 			});`,
@@ -1938,12 +1938,12 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.Tag({
 				  urls: [
-						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
+						{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-1'},
 					]
 				});
 				metric.Tag({
 					urls: [
-						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
+						  {urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-2'},
 					  ]
 				  });
 			});`,
@@ -1955,19 +1955,19 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.Tag({
 				  urls: [
-						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
+						{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-1'},
 					]
 				});
 				metric.Tag({
 					urls: [
-						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
+						  {urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-2'},
 					  ]
 				  });
 			});
 			page.on('metric', (metric) => {
 				metric.Tag({
 				  urls: [
-						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-3'},
+						{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-3'},
 					]
 				});
 			});`,
@@ -1979,13 +1979,13 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.Tag({
 				  urls: [
-						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
+						{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-1'},
 					]
 				});
 				page.on('metric', (metric) => {
 					metric.Tag({
 						urls: [
-							{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-4'},
+							{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-4'},
 						]
 					});
 				});

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1970,6 +1970,24 @@ func TestPageOnMetric(t *testing.T) {
 			});`,
 			want: "ping-3",
 		},
+		{
+			name: "multi_page.on_call",
+			fun: `page.on('metric', (msg) => {
+				msg.groupURLTag({
+				  groups: [
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
+					]
+				});
+				page.on('metric', (msg) => {
+					msg.groupURLTag({
+						groups: [
+							{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-4'},
+						]
+					});
+				});
+			});`,
+			want: "ping-4",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1925,7 +1925,7 @@ func TestPageOnMetric(t *testing.T) {
 			name: "single_page.on",
 			fun: `page.on('metric', (msg) => {
 				msg.groupURLTag({
-				  groups: [
+				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
@@ -1937,12 +1937,12 @@ func TestPageOnMetric(t *testing.T) {
 			name: "multi_groupURLTag",
 			fun: `page.on('metric', (msg) => {
 				msg.groupURLTag({
-				  groups: [
+				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
 				msg.groupURLTag({
-					groups: [
+					urls: [
 						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
 					  ]
 				  });
@@ -1954,19 +1954,19 @@ func TestPageOnMetric(t *testing.T) {
 			name: "multi_groupURLTag_page.on",
 			fun: `page.on('metric', (msg) => {
 				msg.groupURLTag({
-				  groups: [
+				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
 				msg.groupURLTag({
-					groups: [
+					urls: [
 						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
 					  ]
 				  });
 			});
 			page.on('metric', (msg) => {
 				msg.groupURLTag({
-				  groups: [
+				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-3'},
 					]
 				});
@@ -1978,13 +1978,13 @@ func TestPageOnMetric(t *testing.T) {
 			name: "multi_page.on_call",
 			fun: `page.on('metric', (msg) => {
 				msg.groupURLTag({
-				  groups: [
+				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
 				page.on('metric', (msg) => {
 					msg.groupURLTag({
-						groups: [
+						urls: [
 							{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-4'},
 						]
 					});

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1248,12 +1248,18 @@ func TestPageOn(t *testing.T) {
 			)
 
 			// Console Messages should be multiplexed for every registered handler
-			eventHandlerOne := func(cm *common.ConsoleMessage) {
+			eventHandlerOne := func(a any) {
+				cm, ok := a.(*common.ConsoleMessage)
+				assert.True(t, ok)
+
 				defer close(done1)
 				tc.assertFn(t, cm)
 			}
 
-			eventHandlerTwo := func(cm *common.ConsoleMessage) {
+			eventHandlerTwo := func(a any) {
+				cm, ok := a.(*common.ConsoleMessage)
+				assert.True(t, ok)
+
 				defer close(done2)
 				tc.assertFn(t, cm)
 			}

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1997,6 +1997,8 @@ func TestPageOnMetric(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var foundAmended atomic.Int32
 			var foundUnamended atomic.Int32
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1926,7 +1926,7 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.Tag({
 				  urls: [
-						{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-1'},
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
 			});`,
@@ -1938,12 +1938,12 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.Tag({
 				  urls: [
-						{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-1'},
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
 				metric.Tag({
 					urls: [
-						  {urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-2'},
+						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
 					  ]
 				  });
 			});`,
@@ -1955,19 +1955,19 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.Tag({
 				  urls: [
-						{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-1'},
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
 				metric.Tag({
 					urls: [
-						  {urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-2'},
+						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
 					  ]
 				  });
 			});
 			page.on('metric', (metric) => {
 				metric.Tag({
 				  urls: [
-						{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-3'},
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-3'},
 					]
 				});
 			});`,
@@ -1979,13 +1979,13 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.Tag({
 				  urls: [
-						{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-1'},
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
 				page.on('metric', (metric) => {
 					metric.Tag({
 						urls: [
-							{urlRegEx: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, tagName:'ping-4'},
+							{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-4'},
 						]
 					});
 				});

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1921,6 +1921,7 @@ func TestPageOnMetric(t *testing.T) {
 		want string
 	}{
 		{
+			// Just a single page.on.
 			name: "single_page.on",
 			fun: `page.on('metric', (msg) => {
 				msg.groupURLTag({
@@ -1932,6 +1933,7 @@ func TestPageOnMetric(t *testing.T) {
 			want: "ping-1",
 		},
 		{
+			// A single page.on but with multiple calls to groupURLTag.
 			name: "multi_groupURLTag",
 			fun: `page.on('metric', (msg) => {
 				msg.groupURLTag({
@@ -1948,6 +1950,7 @@ func TestPageOnMetric(t *testing.T) {
 			want: "ping-2",
 		},
 		{
+			// Two page.on and in one of them multiple calls to groupURLTag.
 			name: "multi_groupURLTag_page.on",
 			fun: `page.on('metric', (msg) => {
 				msg.groupURLTag({
@@ -1971,6 +1974,7 @@ func TestPageOnMetric(t *testing.T) {
 			want: "ping-3",
 		},
 		{
+			// A single page.on but within it another page.on.
 			name: "multi_page.on_call",
 			fun: `page.on('metric', (msg) => {
 				msg.groupURLTag({

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1923,8 +1923,8 @@ func TestPageOnMetric(t *testing.T) {
 		{
 			// Just a single page.on.
 			name: "single_page.on",
-			fun: `page.on('metric', (msg) => {
-				msg.Tag({
+			fun: `page.on('metric', (metric) => {
+				metric.Tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
@@ -1935,13 +1935,13 @@ func TestPageOnMetric(t *testing.T) {
 		{
 			// A single page.on but with multiple calls to Tag.
 			name: "multi_tag",
-			fun: `page.on('metric', (msg) => {
-				msg.Tag({
+			fun: `page.on('metric', (metric) => {
+				metric.Tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
-				msg.Tag({
+				metric.Tag({
 					urls: [
 						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
 					  ]
@@ -1952,20 +1952,20 @@ func TestPageOnMetric(t *testing.T) {
 		{
 			// Two page.on and in one of them multiple calls to Tag.
 			name: "multi_tag_page.on",
-			fun: `page.on('metric', (msg) => {
-				msg.Tag({
+			fun: `page.on('metric', (metric) => {
+				metric.Tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
-				msg.Tag({
+				metric.Tag({
 					urls: [
 						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
 					  ]
 				  });
 			});
-			page.on('metric', (msg) => {
-				msg.Tag({
+			page.on('metric', (metric) => {
+				metric.Tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-3'},
 					]
@@ -1976,14 +1976,14 @@ func TestPageOnMetric(t *testing.T) {
 		{
 			// A single page.on but within it another page.on.
 			name: "multi_page.on_call",
-			fun: `page.on('metric', (msg) => {
-				msg.Tag({
+			fun: `page.on('metric', (metric) => {
+				metric.Tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
-				page.on('metric', (msg) => {
-					msg.Tag({
+				page.on('metric', (metric) => {
+					metric.Tag({
 						urls: [
 							{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-4'},
 						]

--- a/tests/remote_obj_test.go
+++ b/tests/remote_obj_test.go
@@ -81,7 +81,10 @@ func TestConsoleLogParse(t *testing.T) {
 
 			done := make(chan bool)
 
-			eventHandler := func(cm *common.ConsoleMessage) {
+			eventHandler := func(a any) {
+				cm, ok := a.(*common.ConsoleMessage)
+				assert.True(t, ok)
+
 				defer close(done)
 				assert.Equal(t, tt.want, cm.Text)
 			}


### PR DESCRIPTION
## What?

This adds the functionality to group url tags by intercepting all metrics that the **browser module** emits, compare and match with the supplied regex(s), and then set the `name` and `url` tags with the new name supplied by the user in the script.

## Why?

A lot of websites will perform requests that contain dynamic parts in the request url, which could be ids that are generated on every new session, account ids, or for cache busting purposes.

This will help in two ways:
1. Avoids high cardinality issues where tests work with websites with a lot of these dynamic urls.
2. It becomes trivial to correlate urls which are for the same page but contain dynamic parts in the url (ids/cache busting/etc).

## How

The user first needs to register an event handler:

```mermaid
sequenceDiagram
  box main goroutine
  participant page.on('metric')
  participant p.eventHandlers
  end
  
  page.on('metric') ->> p.eventHandlers: add metric handler
```

This is a high level overview of what happens when a [http request is started and a metric is about to be emitted](https://github.com/grafana/xk6-browser/blob/d6a878e7f6f9b454bb7089996238ffd15b883ae5/common/network_manager.go#L183):

```mermaid
sequenceDiagram
    box CDP handler goroutine
    participant emitRequestMetrics
    participant handleURLTag
    participant page.urlTagName
    end
    box taskqueue goroutine
    participant handler
    participant MetricEvent.Tag
    end
    box sobek context
    participant _k6BrowserURLGroupingTest
    end

    emitRequestMetrics ->> handleURLTag: url, tags
    handleURLTag ->> page.urlTagName: url
    page.urlTagName ->> page.urlTagName: create MetricEvent{url}
    loop each p.eventHandler
    page.urlTagName ->> handler: MetricEvent{url}
    Note right of handler: Regex supplied by user in handler in URLOverrides{}
    handler ->> MetricEvent.Tag: URLTagPatterns{}
    loop each URLTagPatterns
    MetricEvent.Tag ->> _k6BrowserURLGroupingTest: URLTagPattern.urlRegEx, url
    Note right of _k6BrowserURLGroupingTest: if match found, return true, else false
    _k6BrowserURLGroupingTest ->> MetricEvent.Tag: return true|false
    end
    Note left of MetricEvent.Tag: assign user defined name to MetricEvent.name if match found.
    MetricEvent.Tag ->> handler: return
    handler ->> page.urlTagName: return
    end
    Note left of page.urlTagName: read MetricEvent.name when it's not nil and set urlMatched.
    page.urlTagName ->> handleURLTag: return newTagName, urlMatched
    Note left of handleURLTag: set tags.url and tags.name as newTagName if urlMatched is true
    handleURLTag ->> emitRequestMetrics: return tags
```

The same happens when we're about to emit [response](https://github.com/grafana/xk6-browser/blob/d6a878e7f6f9b454bb7089996238ffd15b883ae5/common/network_manager.go#L205) and [web vital](https://github.com/grafana/xk6-browser/blob/7274e17b078ed1274d0075aa7bc65671b0ba91b3/common/frame_session.go#L326) metrics.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/371