### PR TITLE
Add ControlOrMeta helper key

### DIFF
--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -100,6 +101,8 @@ func (k *Keyboard) Type(text string, opts sobek.Value) error {
 }
 
 func (k *Keyboard) down(key string) error {
+	key = k.platformSpecificResolution(key)
+
 	keyInput := keyboardlayout.KeyInput(key)
 	if _, ok := k.layout.ValidKeys[keyInput]; !ok {
 		return fmt.Errorf("%q is not a valid key for layout %q", key, k.layoutName)
@@ -134,6 +137,8 @@ func (k *Keyboard) down(key string) error {
 }
 
 func (k *Keyboard) up(key string) error {
+	key = k.platformSpecificResolution(key)
+
 	keyInput := keyboardlayout.KeyInput(key)
 	if _, ok := k.layout.ValidKeys[keyInput]; !ok {
 		return fmt.Errorf("'%s' is not a valid key for layout '%s'", key, k.layoutName)
@@ -237,6 +242,17 @@ func (k *Keyboard) modifierBitFromKeyName(key string) int64 {
 		return ModifierKeyShift
 	}
 	return 0
+}
+
+func (k *Keyboard) platformSpecificResolution(key string) string {
+	if key == "ControlOrMeta" {
+		if runtime.GOOS == "darwin" {
+			key = "Meta"
+		} else {
+			key = "Control"
+		}
+	}
+	return key
 }
 
 func (k *Keyboard) comboPress(keys string, opts *KeyboardOptions) error {

--- a/keyboardlayout/us.go
+++ b/keyboardlayout/us.go
@@ -152,6 +152,7 @@ func initUS() {
 		"Clear":              true,
 		"Shift":              true,
 		"Control":            true,
+		"ControlOrMeta":      true,
 		"Alt":                true,
 		"Accept":             true,
 		"ModeChange":         true,

--- a/tests/static/page1.html
+++ b/tests/static/page1.html
@@ -1,0 +1,7 @@
+<html lang="en">
+    <head></head>
+    <body>
+        <h1>Page 1</h1>
+        <a href="page2.html">Click Me</a>
+    </body>
+</html>

--- a/tests/static/page2.html
+++ b/tests/static/page2.html
@@ -1,0 +1,6 @@
+<html lang="en">
+    <head></head>
+    <body>
+        <h1>Page 2</h1>
+    </body>
+</html>


### PR DESCRIPTION
## What?

This will allow us to write the test for all platforms that either work with Control or Meta when performing keyboard actions. E.g. Control+click on windows, and meta+click on mac to open a link in a new window.

## Why?

It allows us to do the following on windows, linux and mac without checking which platform the script is ran on in the test script itself to choose the correct meta key (control or meta):

```js
import { browser } from "k6/browser";

export const options = {
  scenarios: {
    ui: {
      executor: "shared-iterations",
      options: {
        browser: {
          type: "chromium",
        },
      },
    },
  }
};

export default async function () {
  const page = await browser.newPage();

  await page.goto("https://test.k6.io/");
  
  await page.keyboard.down('ControlOrMeta');

  // Open the link in a new tab.
  // Wait for the new page to be created.
  const browserContext = browser.context();
  const [newTab] = await Promise.all([
    browserContext.waitForEvent('page'),
    await page.locator('a[href="/my_messages.php"]').click()
  ]);

  await page.keyboard.up('ControlOrMeta');

  // Wait for the new page (tab) to load.
  await newTab.waitForLoadState('load');

  // Take screenshots of each page.
  await page.screenshot({ path: `screenshot-page.png` });
  await newTab.screenshot({ path: `screenshot-newTab.png` });

  await newTab.close();
  await page.close();
}
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
