### PR TITLE
Refactor sobek out of request type

### DIFF
--- a/browser/request_mapping.go
+++ b/browser/request_mapping.go
@@ -22,7 +22,12 @@ func mapRequest(vu moduleVU, r *common.Request) mapping {
 		},
 		"headerValue": func(name string) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return r.HeaderValue(name), nil
+				v, ok := r.HeaderValue(name)
+				if !ok {
+					return nil, nil
+				}
+
+				return v, nil
 			})
 		},
 		"headers": r.Headers,

--- a/browser/sync_request_mapping.go
+++ b/browser/sync_request_mapping.go
@@ -7,9 +7,16 @@ import (
 // syncMapRequest is like mapRequest but returns synchronous functions.
 func syncMapRequest(vu moduleVU, r *common.Request) mapping {
 	maps := mapping{
-		"allHeaders":          r.AllHeaders,
-		"frame":               func() mapping { return syncMapFrame(vu, r.Frame()) },
-		"headerValue":         r.HeaderValue,
+		"allHeaders": r.AllHeaders,
+		"frame":      func() mapping { return syncMapFrame(vu, r.Frame()) },
+		"headerValue": func(name string) any {
+			v, ok := r.HeaderValue(name)
+			if !ok {
+				return nil
+			}
+
+			return v
+		},
 		"headers":             r.Headers,
 		"headersArray":        r.HeadersArray,
 		"isNavigationRequest": r.IsNavigationRequest,

--- a/common/http.go
+++ b/common/http.go
@@ -179,14 +179,10 @@ func (r *Request) Frame() *Frame {
 }
 
 // HeaderValue returns the value of the given header.
-func (r *Request) HeaderValue(name string) sobek.Value {
-	rt := r.vu.Runtime()
+func (r *Request) HeaderValue(name string) (string, bool) {
 	headers := r.AllHeaders()
 	val, ok := headers[strings.ToLower(name)]
-	if !ok {
-		return sobek.Null()
-	}
-	return rt.ToValue(val)
+	return val, ok
 }
 
 // Headers returns the request headers.

--- a/common/http.go
+++ b/common/http.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
-	"github.com/grafana/sobek"
 
 	"github.com/grafana/xk6-browser/k6ext"
 	"github.com/grafana/xk6-browser/log"
@@ -243,24 +242,24 @@ func (r *Request) Size() HTTPMessageSize {
 	}
 }
 
-// Timing returns the request timing information.
-func (r *Request) Timing() sobek.Value {
-	type resourceTiming struct {
-		StartTime             float64 `js:"startTime"`
-		DomainLookupStart     float64 `js:"domainLookupStart"`
-		DomainLookupEnd       float64 `js:"domainLookupEnd"`
-		ConnectStart          float64 `js:"connectStart"`
-		SecureConnectionStart float64 `js:"secureConnectionStart"`
-		ConnectEnd            float64 `js:"connectEnd"`
-		RequestStart          float64 `js:"requestStart"`
-		ResponseStart         float64 `js:"responseStart"`
-		ResponseEnd           float64 `js:"responseEnd"`
-	}
+// resourceTiming is the type returned from request.timing.
+type resourceTiming struct {
+	StartTime             float64 `js:"startTime"`
+	DomainLookupStart     float64 `js:"domainLookupStart"`
+	DomainLookupEnd       float64 `js:"domainLookupEnd"`
+	ConnectStart          float64 `js:"connectStart"`
+	SecureConnectionStart float64 `js:"secureConnectionStart"`
+	ConnectEnd            float64 `js:"connectEnd"`
+	RequestStart          float64 `js:"requestStart"`
+	ResponseStart         float64 `js:"responseStart"`
+	ResponseEnd           float64 `js:"responseEnd"`
+}
 
-	rt := r.vu.Runtime()
+// Timing returns the request timing information.
+func (r *Request) Timing() *resourceTiming {
 	timing := r.response.timing
 
-	return rt.ToValue(&resourceTiming{
+	return &resourceTiming{
 		StartTime:             (timing.RequestTime - float64(r.timestamp.Unix()) + float64(r.wallTime.Unix())) * 1000,
 		DomainLookupStart:     timing.DNSStart,
 		DomainLookupEnd:       timing.DNSEnd,
@@ -270,7 +269,7 @@ func (r *Request) Timing() sobek.Value {
 		RequestStart:          timing.SendStart,
 		ResponseStart:         timing.ReceiveHeadersEnd,
 		ResponseEnd:           r.responseEndTiming,
-	})
+	}
 }
 
 // URL returns the request URL.

--- a/common/http_test.go
+++ b/common/http_test.go
@@ -73,12 +73,16 @@ func TestRequest(t *testing.T) {
 
 	t.Run("HeaderValue()_key", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "value", req.HeaderValue("key").Export())
+		got, ok := req.HeaderValue("key")
+		assert.True(t, ok)
+		assert.Equal(t, "value", got)
 	})
 
 	t.Run("HeaderValue()_KEY", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "value", req.HeaderValue("KEY").Export())
+		got, ok := req.HeaderValue("KEY")
+		assert.True(t, ok)
+		assert.Equal(t, "value", got)
 	})
 
 	t.Run("Size()", func(t *testing.T) {


### PR DESCRIPTION
## What?

Refactor `sobek` out of `request.headerValue`.

## Why?

Makes the codebase more maintainable where `sobek` code is within the mapping layer and not in the main business logic.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1275