### PR TITLE
Refactor sobek out of connection.Close

### DIFF
--- a/common/connection.go
+++ b/common/connection.go
@@ -17,7 +17,6 @@ import (
 	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 	"github.com/gorilla/websocket"
-	"github.com/grafana/sobek"
 	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jlexer"
 	"github.com/mailru/easyjson/jwriter"
@@ -51,7 +50,7 @@ type executorEmitter interface {
 
 type connection interface {
 	executorEmitter
-	Close(...sobek.Value)
+	Close(...int)
 	IgnoreIOErrors()
 	getSession(target.SessionID) *Session
 }
@@ -566,10 +565,12 @@ func (c *Connection) sendLoop() {
 
 // Close cleanly closes the WebSocket connection.
 // It returns an error if sending the Close control frame fails.
-func (c *Connection) Close(args ...sobek.Value) {
-	code := websocket.CloseGoingAway
+//
+// Optional code to override default websocket.CloseGoingAway (1001).
+func (c *Connection) Close(args ...int) {
+	code := websocket.CloseNormalClosure
 	if len(args) > 0 {
-		code = int(args[0].ToInteger())
+		code = int(args[0])
 	}
 	c.logger.Debugf("connection:Close", "wsURL:%q code:%d", c.wsURL, code)
 	_ = c.close(code)

--- a/common/connection.go
+++ b/common/connection.go
@@ -50,7 +50,7 @@ type executorEmitter interface {
 
 type connection interface {
 	executorEmitter
-	Close(...int)
+	Close()
 	IgnoreIOErrors()
 	getSession(target.SessionID) *Session
 }
@@ -567,11 +567,8 @@ func (c *Connection) sendLoop() {
 // It returns an error if sending the Close control frame fails.
 //
 // Optional code to override default websocket.CloseGoingAway (1001).
-func (c *Connection) Close(args ...int) {
+func (c *Connection) Close() {
 	code := websocket.CloseNormalClosure
-	if len(args) > 0 {
-		code = int(args[0])
-	}
 	c.logger.Debugf("connection:Close", "wsURL:%q code:%d", c.wsURL, code)
 	_ = c.close(code)
 }


### PR DESCRIPTION
## What?

Remove sobek from `connection.Close`.

## Why?

It's not needed. Keeps things more maintainable.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1281