### PR TITLE
Refactor sobek out of keyboard

### DIFF
--- a/browser/keyboard_mapping.go
+++ b/browser/keyboard_mapping.go
@@ -33,7 +33,12 @@ func mapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
 		},
 		"type": func(text string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, kb.Type(text, opts) //nolint:wrapcheck
+				kbdOpts := common.NewKeyboardOptions()
+				if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
+					return nil, fmt.Errorf("parsing keyboard options: %w", err)
+				}
+
+				return nil, kb.Type(text, kbdOpts) //nolint:wrapcheck
 			})
 		},
 		"insertText": func(text string) *sobek.Promise {

--- a/browser/keyboard_mapping.go
+++ b/browser/keyboard_mapping.go
@@ -1,6 +1,8 @@
 package browser
 
 import (
+	"fmt"
+
 	"github.com/grafana/sobek"
 
 	"github.com/grafana/xk6-browser/common"
@@ -21,7 +23,12 @@ func mapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
 		},
 		"press": func(key string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, kb.Press(key, opts) //nolint:wrapcheck
+				kbdOpts := common.NewKeyboardOptions()
+				if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
+					return nil, fmt.Errorf("parsing keyboard options: %w", err)
+				}
+
+				return nil, kb.Press(key, kbdOpts) //nolint:wrapcheck
 			})
 		},
 		"type": func(text string, opts sobek.Value) *sobek.Promise {

--- a/browser/sync_keyboard_mapping.go
+++ b/browser/sync_keyboard_mapping.go
@@ -1,0 +1,33 @@
+package browser
+
+import (
+	"fmt"
+
+	"github.com/grafana/sobek"
+
+	"github.com/grafana/xk6-browser/common"
+)
+
+func syncMapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
+	return mapping{
+		"down": kb.Down,
+		"up":   kb.Up,
+		"press": func(key string, opts sobek.Value) error {
+			kbdOpts := common.NewKeyboardOptions()
+			if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
+				return fmt.Errorf("parsing keyboard options: %w", err)
+			}
+
+			return kb.Press(key, kbdOpts) //nolint:wrapcheck
+		},
+		"type": func(text string, opts sobek.Value) error {
+			kbdOpts := common.NewKeyboardOptions()
+			if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
+				return fmt.Errorf("parsing keyboard options: %w", err)
+			}
+
+			return kb.Type(text, kbdOpts) //nolint:wrapcheck
+		},
+		"insertText": kb.InsertText,
+	}
+}

--- a/browser/sync_page_mapping.go
+++ b/browser/sync_page_mapping.go
@@ -103,7 +103,7 @@ func syncMapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 		"isEnabled":  p.IsEnabled,
 		"isHidden":   p.IsHidden,
 		"isVisible":  p.IsVisible,
-		"keyboard":   rt.ToValue(p.GetKeyboard()).ToObject(rt),
+		"keyboard":   syncMapKeyboard(vu, p.GetKeyboard()),
 		"locator": func(selector string, opts sobek.Value) *sobek.Object {
 			ml := syncMapLocator(vu, p.Locator(selector, opts))
 			return rt.ToValue(ml).ToObject(rt)

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/input"
-	"github.com/grafana/sobek"
 
 	"github.com/grafana/xk6-browser/keyboardlayout"
 )
@@ -84,11 +83,7 @@ func (k *Keyboard) InsertText(text string) error {
 //
 // It sends an insertText message if a character is not among
 // valid characters in the keyboard's layout.
-func (k *Keyboard) Type(text string, opts sobek.Value) error {
-	kbdOpts := NewKeyboardOptions()
-	if err := kbdOpts.Parse(k.ctx, opts); err != nil {
-		return fmt.Errorf("parsing keyboard options: %w", err)
-	}
+func (k *Keyboard) Type(text string, kbdOpts *KeyboardOptions) error {
 	if err := k.typ(text, kbdOpts); err != nil {
 		return fmt.Errorf("typing text: %w", err)
 	}

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -63,12 +63,7 @@ func (k *Keyboard) Up(key string) error {
 // Press sends a key press message to a session target.
 // It delays the action if `Delay` option is specified.
 // A press message consists of successive key down and up messages.
-func (k *Keyboard) Press(key string, opts sobek.Value) error {
-	kbdOpts := NewKeyboardOptions()
-	if err := kbdOpts.Parse(k.ctx, opts); err != nil {
-		return fmt.Errorf("parsing keyboard options: %w", err)
-	}
-
+func (k *Keyboard) Press(key string, kbdOpts *KeyboardOptions) error {
 	if err := k.comboPress(key, kbdOpts); err != nil {
 		return fmt.Errorf("pressing key: %w", err)
 	}

--- a/common/keyboard_test.go
+++ b/common/keyboard_test.go
@@ -83,7 +83,7 @@ func TestKeyboardPress(t *testing.T) {
 
 		vu := k6test.NewVU(t)
 		k := NewKeyboard(vu.Context(), nil)
-		require.Error(t, k.Press("", nil))
+		require.Error(t, k.Press("", NewKeyboardOptions()))
 	})
 }
 

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -43,7 +43,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("input", nil))
 
-		require.NoError(t, kb.Type("Hello World!", nil))
+		require.NoError(t, kb.Type("Hello World!", common.NewKeyboardOptions()))
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
 		require.Equal(t, "Hello World!", v)
@@ -198,7 +198,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("textarea", nil))
 
-		require.NoError(t, kb.Type("L+m+KeyN", nil))
+		require.NoError(t, kb.Type("L+m+KeyN", common.NewKeyboardOptions()))
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
 		assert.Equal(t, "L+m+KeyN", v)
@@ -249,7 +249,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, p.Focus("textarea", nil))
 
 		require.NoError(t, kb.Down("Shift"))
-		require.NoError(t, kb.Type("oPqR", nil))
+		require.NoError(t, kb.Type("oPqR", common.NewKeyboardOptions()))
 		require.NoError(t, kb.Up("Shift"))
 
 		v, err := el.InputValue(nil)
@@ -270,10 +270,10 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("textarea", nil))
 
-		require.NoError(t, kb.Type("Hello", nil))
+		require.NoError(t, kb.Type("Hello", common.NewKeyboardOptions()))
 		require.NoError(t, kb.Press("Enter", common.NewKeyboardOptions()))
 		require.NoError(t, kb.Press("Enter", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Type("World!", nil))
+		require.NoError(t, kb.Type("World!", common.NewKeyboardOptions()))
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
 		assert.Equal(t, "Hello\n\nWorld!", v)
@@ -293,7 +293,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("input", nil))
 
-		require.NoError(t, kb.Type("Hello World!", nil))
+		require.NoError(t, kb.Type("Hello World!", common.NewKeyboardOptions()))
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
 		require.Equal(t, "Hello World!", v)

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -26,7 +26,7 @@ func TestKeyboardPress(t *testing.T) {
 		layout := keyboardlayout.GetKeyboardLayout("us")
 
 		for k := range layout.Keys {
-			assert.NoError(t, kb.Press(string(k), nil))
+			assert.NoError(t, kb.Press(string(k), common.NewKeyboardOptions()))
 		}
 	})
 
@@ -48,7 +48,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "Hello World!", v)
 
-		require.NoError(t, kb.Press("Backspace", nil))
+		require.NoError(t, kb.Press("Backspace", common.NewKeyboardOptions()))
 		v, err = el.InputValue(nil)
 		require.NoError(t, err)
 		assert.Equal(t, "Hello World", v)
@@ -67,17 +67,17 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("input", nil))
 
-		require.NoError(t, kb.Press("Shift++", nil))
-		require.NoError(t, kb.Press("Shift+=", nil))
-		require.NoError(t, kb.Press("Shift+@", nil))
-		require.NoError(t, kb.Press("Shift+6", nil))
-		require.NoError(t, kb.Press("Shift+KeyA", nil))
-		require.NoError(t, kb.Press("Shift+b", nil))
-		require.NoError(t, kb.Press("Shift+C", nil))
+		require.NoError(t, kb.Press("Shift++", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Shift+=", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Shift+@", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Shift+6", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Shift+KeyA", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Shift+b", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Shift+C", common.NewKeyboardOptions()))
 
-		require.NoError(t, kb.Press("Control+KeyI", nil))
-		require.NoError(t, kb.Press("Control+J", nil))
-		require.NoError(t, kb.Press("Control+k", nil))
+		require.NoError(t, kb.Press("Control+KeyI", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Control+J", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Control+k", common.NewKeyboardOptions()))
 
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
@@ -166,9 +166,9 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("input", nil))
 
-		require.NoError(t, kb.Press("Shift+KeyA", nil))
-		require.NoError(t, kb.Press("Shift+b", nil))
-		require.NoError(t, kb.Press("Shift+C", nil))
+		require.NoError(t, kb.Press("Shift+KeyA", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Shift+b", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Shift+C", common.NewKeyboardOptions()))
 
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
@@ -178,8 +178,8 @@ func TestKeyboardPress(t *testing.T) {
 		if runtime.GOOS == "darwin" {
 			metaKey = "Meta"
 		}
-		require.NoError(t, kb.Press(metaKey+"+A", nil))
-		require.NoError(t, kb.Press("Delete", nil))
+		require.NoError(t, kb.Press(metaKey+"+A", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Delete", common.NewKeyboardOptions()))
 		v, err = el.InputValue(nil)
 		require.NoError(t, err)
 		assert.Equal(t, "", v)
@@ -217,9 +217,9 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("textarea", nil))
 
-		require.NoError(t, kb.Press("C", nil))
-		require.NoError(t, kb.Press("d", nil))
-		require.NoError(t, kb.Press("KeyE", nil))
+		require.NoError(t, kb.Press("C", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("d", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("KeyE", common.NewKeyboardOptions()))
 
 		require.NoError(t, kb.Down("Shift"))
 		require.NoError(t, kb.Down("f"))
@@ -271,8 +271,8 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, p.Focus("textarea", nil))
 
 		require.NoError(t, kb.Type("Hello", nil))
-		require.NoError(t, kb.Press("Enter", nil))
-		require.NoError(t, kb.Press("Enter", nil))
+		require.NoError(t, kb.Press("Enter", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Enter", common.NewKeyboardOptions()))
 		require.NoError(t, kb.Type("World!", nil))
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
@@ -298,16 +298,16 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "Hello World!", v)
 
-		require.NoError(t, kb.Press("ArrowLeft", nil))
+		require.NoError(t, kb.Press("ArrowLeft", common.NewKeyboardOptions()))
 		// Should hold the key until Up() is called.
 		require.NoError(t, kb.Down("Shift"))
 		for i := 0; i < len(" World"); i++ {
-			require.NoError(t, kb.Press("ArrowLeft", nil))
+			require.NoError(t, kb.Press("ArrowLeft", common.NewKeyboardOptions()))
 		}
 		// Should release the key but the selection should remain active.
 		require.NoError(t, kb.Up("Shift"))
 		// Should delete the selection.
-		require.NoError(t, kb.Press("Backspace", nil))
+		require.NoError(t, kb.Press("Backspace", common.NewKeyboardOptions()))
 
 		require.NoError(t, err)
 		require.NoError(t, err)


### PR DESCRIPTION
## What?

Remove Sobek from the keyboard type.

## Why?

Keeps things more maintainable.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1277