### PR TITLE
Add workaround to retry `waitFor` until it is success or retry count is 0

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -564,13 +564,18 @@ func (f *Frame) waitForSelector(selector string, opts *FrameWaitForSelectorOptio
 	return handle, nil
 }
 
-func (f *Frame) waitFor(selector string, opts *FrameWaitForSelectorOptions) error {
+func (f *Frame) waitFor(selector string, opts *FrameWaitForSelectorOptions, retryCount int) error {
 	f.log.Debugf("Frame:waitFor", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
+
+	retryCount--
+	if retryCount < 0 {
+		return errors.New("waitFor retry threshold reached")
+	}
 
 	document, err := f.document()
 	if err != nil {
 		if strings.Contains(err.Error(), "Cannot find context with specified id") {
-			return f.waitFor(selector, opts)
+			return f.waitFor(selector, opts, retryCount)
 		}
 		return err
 	}
@@ -578,13 +583,13 @@ func (f *Frame) waitFor(selector string, opts *FrameWaitForSelectorOptions) erro
 	_, err = document.waitForSelector(f.ctx, selector, opts)
 	if err != nil {
 		if strings.Contains(err.Error(), "Inspected target navigated or closed") {
-			return f.waitFor(selector, opts)
+			return f.waitFor(selector, opts, retryCount)
 		}
 		if strings.Contains(err.Error(), "Cannot find context with specified id") {
-			return f.waitFor(selector, opts)
+			return f.waitFor(selector, opts, retryCount)
 		}
 		if strings.Contains(err.Error(), "Execution context was destroyed") {
-			return f.waitFor(selector, opts)
+			return f.waitFor(selector, opts, retryCount)
 		}
 	}
 

--- a/common/frame.go
+++ b/common/frame.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -568,10 +569,25 @@ func (f *Frame) waitFor(selector string, opts *FrameWaitForSelectorOptions) erro
 
 	document, err := f.document()
 	if err != nil {
+		if strings.Contains(err.Error(), "Cannot find context with specified id") {
+			return f.waitFor(selector, opts)
+		}
 		return err
 	}
 
 	_, err = document.waitForSelector(f.ctx, selector, opts)
+	if err != nil {
+		if strings.Contains(err.Error(), "Inspected target navigated or closed") {
+			return f.waitFor(selector, opts)
+		}
+		if strings.Contains(err.Error(), "Cannot find context with specified id") {
+			return f.waitFor(selector, opts)
+		}
+		if strings.Contains(err.Error(), "Execution context was destroyed") {
+			return f.waitFor(selector, opts)
+		}
+	}
+
 	return err
 }
 

--- a/common/locator.go
+++ b/common/locator.go
@@ -621,7 +621,7 @@ func (l *Locator) WaitFor(opts sobek.Value) error {
 
 func (l *Locator) waitFor(opts *FrameWaitForSelectorOptions) error {
 	opts.Strict = true
-	return l.frame.waitFor(l.selector, opts)
+	return l.frame.waitFor(l.selector, opts, 20)
 }
 
 // DefaultTimeout returns the default timeout for the locator.


### PR DESCRIPTION
## What?

We're allowing retries on `waitFor` when the following errors occur when `waitFor` is waiting:

- "Inspected target navigated or closed"
- "Cannot find context with specified id"
- "Execution context was destroyed"

To prevent a stack overflow, it will retry for a maximum of 20 times before failing. In my tests i've seen the retry count drop from 20 to 12 at most. I feel 20 is a safe number that shouldn't be reached in normal SSO login flows. I want to avoid using a larger retry count to force us to fix this permanently asap.

## Why?

This PR fixes an issue where `waitFor` fails to wait while the underlying page it is waiting on is navigating. A common scenario where we might see this is during a login/logout flow using SSO. The initial page will be redirected multiple times until we get to the desired page/state.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Updates: https://github.com/grafana/xk6-browser/issues/1472