### PR TITLE
Add tracing to page.waitForTimeout

### DIFF
--- a/common/page.go
+++ b/common/page.go
@@ -1466,6 +1466,9 @@ func (p *Page) WaitForSelector(selector string, opts sobek.Value) (*ElementHandl
 func (p *Page) WaitForTimeout(timeout int64) {
 	p.logger.Debugf("Page:WaitForTimeout", "sid:%v timeout:%d", p.sessionID(), timeout)
 
+	_, span := TraceAPICall(p.ctx, p.targetID.String(), "page.waitForTimeout")
+	defer span.End()
+
 	p.frameManager.MainFrame().WaitForTimeout(timeout)
 }
 

--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -143,6 +143,13 @@ func TestTracing(t *testing.T) {
 			},
 		},
 		{
+			name: "page.waitForTimeout",
+			js:   "page.waitForTimeout(10);",
+			spans: []string{
+				"page.waitForTimeout",
+			},
+		},
+		{
 			name: "web_vital",
 			js:   "page.close();", // on page.close, web vitals are collected and fired/received.
 			spans: []string{


### PR DESCRIPTION
## What?

This instruments `page.waitForTimeout` with tracing.

## Why?

We do this so that we can identify when a test is waiting/sleeping.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1426