### PR TITLE
Unify `page.on` event mappings

### DIFF
--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -326,7 +326,7 @@ type pageAPI interface {
 	IsVisible(selector string, opts sobek.Value) (bool, error)
 	Locator(selector string, opts sobek.Value) *common.Locator
 	MainFrame() *common.Frame
-	On(event string, handler func(*common.ConsoleMessage) error) error
+	On(event string, handler func(any) error) error
 	Opener() pageAPI
 	Press(selector string, key string, opts sobek.Value) error
 	Query(selector string) (*common.ElementHandle, error)

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -366,6 +366,11 @@ type consoleMessageAPI interface {
 	Type() string
 }
 
+// metricEventAPI is the interface of a metric event.
+type metricEventAPI interface {
+	Tag(matchesRegex common.K6BrowserCheckRegEx, overrides common.URLTagPatterns) error
+}
+
 // frameAPI is the interface of a CDP target frame.
 type frameAPI interface {
 	Check(selector string, opts sobek.Value) error

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -374,7 +374,7 @@ type consoleMessageAPI interface {
 
 // metricEventAPI is the interface of a metric event.
 type metricEventAPI interface {
-	Tag(matchesRegex common.K6BrowserCheckRegEx, overrides common.URLTagPatterns) error
+	Tag(matchesRegex common.K6BrowserCheckRegEx, patterns common.URLTagPatterns) error
 }
 
 // frameAPI is the interface of a CDP target frame.

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -196,8 +196,7 @@ func TestMappings(t *testing.T) {
 		"mapMetricEvent": {
 			apiInterface: (*metricEventAPI)(nil),
 			mapp: func() mapping {
-				m, _ := mapMetricEvent(moduleVU{VU: vu}, &common.MetricEvent{})
-				return m
+				return mapMetricEvent(moduleVU{VU: vu}, &common.MetricEvent{})
 			},
 		},
 		"mapTouchscreen": {

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -193,6 +193,13 @@ func TestMappings(t *testing.T) {
 				return mapConsoleMessage(moduleVU{VU: vu}, &common.ConsoleMessage{})
 			},
 		},
+		"mapMetricEvent": {
+			apiInterface: (*metricEventAPI)(nil),
+			mapp: func() mapping {
+				m, _ := mapMetricEvent(moduleVU{VU: vu}, &common.MetricEvent{})
+				return m
+			},
+		},
 		"mapTouchscreen": {
 			apiInterface: (*touchscreenAPI)(nil),
 			mapp: func() mapping {

--- a/browser/metric_event_mapping.go
+++ b/browser/metric_event_mapping.go
@@ -25,7 +25,7 @@ func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) (mapping, error) {
 	}
 
 	return mapping{
-		"Tag": func(urls common.URLTagPatterns) error {
+		"tag": func(urls common.URLTagPatterns) error {
 			callback := func(pattern, url string) (bool, error) {
 				js := fmt.Sprintf(`_k6BrowserCheckRegEx(%s, '%s')`, pattern, url)
 

--- a/browser/metric_event_mapping.go
+++ b/browser/metric_event_mapping.go
@@ -7,22 +7,8 @@ import (
 )
 
 // mapMetricEvent to the JS module.
-func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) (mapping, error) {
+func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) mapping {
 	rt := vu.VU.Runtime()
-
-	// We're setting up the function in the Sobek context that will be reused
-	// for this VU.
-	_, err := rt.RunString(`
-	function _k6BrowserCheckRegEx(pattern, url) {
-		let r = pattern;
-		if (typeof pattern === 'string') {
-			r = new RegExp(pattern);
-		}
-		return r.test(url);
-	}`)
-	if err != nil {
-		return nil, fmt.Errorf("evaluating regex function: %w", err)
-	}
 
 	return mapping{
 		"tag": func(urls common.URLTagPatterns) error {
@@ -39,5 +25,5 @@ func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) (mapping, error) {
 
 			return cm.Tag(callback, urls)
 		},
-	}, nil
+	}
 }

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -243,20 +243,36 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 							return errors.New("incorrect metric message")
 						}
 
-						mapping, err := mapMetricEvent(vu, m)
-						if err != nil {
-							return fmt.Errorf("mapping the metric: %w", err)
-						}
-
-						if _, err = handler(sobek.Undefined(), vu.VU.Runtime().ToValue(mapping)); err != nil {
+						mapping := mapMetricEvent(vu, m)
+						if _, err := handler(sobek.Undefined(), vu.VU.Runtime().ToValue(mapping)); err != nil {
 							return fmt.Errorf("executing page.on('metric') handler: %w", err)
 						}
+
 						return nil
 					})
 					<-c
 				}
 			default:
 				return fmt.Errorf("unknown page event: %q", event)
+			}
+
+			if event == common.EventPageMetricCalled {
+				// Register a custom regex function for the metric event
+				// that will be used to check URLs against the patterns.
+				// This is needed because we want to use the JavaScript regex
+				// to comply with what users expect when using the `tag` method.
+				_, err := rt.RunString(`
+					function _k6BrowserCheckRegEx(pattern, url) {
+						let r = pattern;
+						if (typeof pattern === 'string') {
+							r = new RegExp(pattern);
+						}
+						return r.test(url);
+					}
+				`)
+				if err != nil {
+					return fmt.Errorf("evaluating regex function: %w", err)
+				}
 			}
 
 			return p.On(event, runInTaskQueue) //nolint:wrapcheck

--- a/common/page.go
+++ b/common/page.go
@@ -439,12 +439,12 @@ type URLTagPattern struct {
 }
 
 // K6BrowserCheckRegEx is a function that will be used to check the URL tag
-// against the user defined regexes in Sobek runtime.
+// against the user defined regexes in the Sobek runtime.
 type K6BrowserCheckRegEx func(pattern, url string) (bool, error)
 
 // Tag will find the first match given the URLTagPatterns and the URL from
 // the metric tag and update the name field.
-func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, overrides URLTagPatterns) error {
+func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, patterns URLTagPatterns) error {
 	for _, o := range overrides.URLs {
 		name := strings.TrimSpace(o.TagName)
 		if name == "" {

--- a/common/page.go
+++ b/common/page.go
@@ -438,11 +438,13 @@ type URLTagPattern struct {
 	TagName string `js:"name"`
 }
 
-type k6BrowserCheckRegEx func(pattern, url string) (bool, error)
+// K6BrowserCheckRegEx is a function that will be used to check the URL tag
+// against the user defined regexes in Sobek runtime.
+type K6BrowserCheckRegEx func(pattern, url string) (bool, error)
 
 // Tag will find the first match given the URLTagPatterns and the URL from
 // the metric tag and update the name field.
-func (e *MetricEvent) Tag(matchesRegex k6BrowserCheckRegEx, overrides URLTagPatterns) error {
+func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, overrides URLTagPatterns) error {
 	for _, o := range overrides.URLs {
 		name := strings.TrimSpace(o.TagName)
 		if name == "" {

--- a/examples/pageon-metric.js
+++ b/examples/pageon-metric.js
@@ -17,7 +17,7 @@ export default async function() {
   const page = await browser.newPage();
 
   page.on('metric', (metric) => {
-    metric.Tag({
+    metric.tag({
       urls: [
         {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, name:'test'},
       ]

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1924,7 +1924,7 @@ func TestPageOnMetric(t *testing.T) {
 			// Just a single page.on.
 			name: "single_page.on",
 			fun: `page.on('metric', (metric) => {
-				metric.Tag({
+				metric.tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
@@ -1936,12 +1936,12 @@ func TestPageOnMetric(t *testing.T) {
 			// A single page.on but with multiple calls to Tag.
 			name: "multi_tag",
 			fun: `page.on('metric', (metric) => {
-				metric.Tag({
+				metric.tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
-				metric.Tag({
+				metric.tag({
 					urls: [
 						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
 					  ]
@@ -1953,19 +1953,19 @@ func TestPageOnMetric(t *testing.T) {
 			// Two page.on and in one of them multiple calls to Tag.
 			name: "multi_tag_page.on",
 			fun: `page.on('metric', (metric) => {
-				metric.Tag({
+				metric.tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
-				metric.Tag({
+				metric.tag({
 					urls: [
 						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
 					  ]
 				  });
 			});
 			page.on('metric', (metric) => {
-				metric.Tag({
+				metric.tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-3'},
 					]
@@ -1977,13 +1977,13 @@ func TestPageOnMetric(t *testing.T) {
 			// A single page.on but within it another page.on.
 			name: "multi_page.on_call",
 			fun: `page.on('metric', (metric) => {
-				metric.Tag({
+				metric.tag({
 				  urls: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
 					]
 				});
 				page.on('metric', (metric) => {
-					metric.Tag({
+					metric.tag({
 						urls: [
 							{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-4'},
 						]


### PR DESCRIPTION
## What?

1. Conforms the `page.on` event mappings to the existing mappers.
2. Adds a test for the metric mapping.

## Why?

This will be needed when generalizing the `page.on` API events. To be generalized, all mappers need to be in the same signature. This is a part of [the suggestions](https://github.com/grafana/xk6-browser/issues/1227#issuecomment-2393348036).

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates: #1227