### PR TITLE
Generalize `page.on` event

### DIFF
--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -332,7 +332,7 @@ type pageAPI interface {
 	IsVisible(selector string, opts sobek.Value) (bool, error)
 	Locator(selector string, opts sobek.Value) *common.Locator
 	MainFrame() *common.Frame
-	On(event string, handler func(any) error) error
+	On(event string, handler func(common.PageOnEvent) error) error
 	Opener() pageAPI
 	Press(selector string, key string, opts sobek.Value) error
 	Query(selector string) (*common.ElementHandle, error)

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -214,16 +214,16 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 					_, err := handler(sobek.Undefined(), vu.VU.Runtime().ToValue(mapping))
 					return err
 				}
-				runInTaskQueue = func(a common.PageOnEvent) {
+				runInTaskQueue = func(event common.PageOnEvent) {
 					tq.Queue(func() error {
-						if err := mapMsgAndHandleEvent(a.ConsoleMessage); err != nil {
+						if err := mapMsgAndHandleEvent(event.ConsoleMessage); err != nil {
 							return fmt.Errorf("executing page.on handler: %w", err)
 						}
 						return nil
 					})
 				}
 			case common.EventPageMetricCalled:
-				runInTaskQueue = func(a common.PageOnEvent) {
+				runInTaskQueue = func(event common.PageOnEvent) {
 					// The function on the taskqueue runs in its own goroutine
 					// so we need to use a channel to wait for it to complete
 					// since we're waiting for updates from the handler which
@@ -232,7 +232,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 					tq.Queue(func() error {
 						defer close(c)
 
-						mapping := mapMetricEvent(vu, a.Metric)
+						mapping := mapMetricEvent(vu, event.Metric)
 						if _, err := handler(sobek.Undefined(), vu.VU.Runtime().ToValue(mapping)); err != nil {
 							return fmt.Errorf("executing page.on('metric') handler: %w", err)
 						}

--- a/browser/sync_page_mapping.go
+++ b/browser/sync_page_mapping.go
@@ -1,7 +1,6 @@
 package browser
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/grafana/sobek"
@@ -122,14 +121,9 @@ func syncMapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				_, err := handler(sobek.Undefined(), vu.Runtime().ToValue(mapping))
 				return err
 			}
-			runInTaskQueue := func(a any) {
+			runInTaskQueue := func(a common.PageOnEvent) {
 				tq.Queue(func() error {
-					m, ok := a.(*common.ConsoleMessage)
-					if !ok {
-						return errors.New("incorrect message")
-					}
-
-					if err := mapMsgAndHandleEvent(m); err != nil {
+					if err := mapMsgAndHandleEvent(a.ConsoleMessage); err != nil {
 						return fmt.Errorf("executing page.on handler: %w", err)
 					}
 					return nil

--- a/common/page.go
+++ b/common/page.go
@@ -1091,6 +1091,16 @@ func (p *Page) NavigationTimeout() time.Duration {
 	return p.frameManager.timeoutSettings.navigationTimeout()
 }
 
+// PageOnEvent represents a generic page event.
+// Use one of the fields to get the specific event data.
+type PageOnEvent struct {
+	// ConsoleMessage is the console message event.
+	ConsoleMessage *ConsoleMessage
+
+	// Metric is the metric event event.
+	Metric *MetricEvent
+}
+
 // On subscribes to a page event for which the given handler will be executed
 // passing in the ConsoleMessage associated with the event.
 // The only accepted event value is 'console'.

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1251,20 +1251,14 @@ func TestPageOn(t *testing.T) {
 			)
 
 			// Console Messages should be multiplexed for every registered handler
-			eventHandlerOne := func(a any) {
-				cm, ok := a.(*common.ConsoleMessage)
-				assert.True(t, ok)
-
+			eventHandlerOne := func(a common.PageOnEvent) {
 				defer close(done1)
-				tc.assertFn(t, cm)
+				tc.assertFn(t, a.ConsoleMessage)
 			}
 
-			eventHandlerTwo := func(a any) {
-				cm, ok := a.(*common.ConsoleMessage)
-				assert.True(t, ok)
-
+			eventHandlerTwo := func(a common.PageOnEvent) {
 				defer close(done2)
-				tc.assertFn(t, cm)
+				tc.assertFn(t, a.ConsoleMessage)
 			}
 
 			// eventHandlerOne and eventHandlerTwo will be called from a

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1251,14 +1251,14 @@ func TestPageOn(t *testing.T) {
 			)
 
 			// Console Messages should be multiplexed for every registered handler
-			eventHandlerOne := func(a common.PageOnEvent) {
+			eventHandlerOne := func(event common.PageOnEvent) {
 				defer close(done1)
-				tc.assertFn(t, a.ConsoleMessage)
+				tc.assertFn(t, event.ConsoleMessage)
 			}
 
-			eventHandlerTwo := func(a common.PageOnEvent) {
+			eventHandlerTwo := func(event common.PageOnEvent) {
 				defer close(done2)
-				tc.assertFn(t, a.ConsoleMessage)
+				tc.assertFn(t, event.ConsoleMessage)
 			}
 
 			// eventHandlerOne and eventHandlerTwo will be called from a

--- a/tests/remote_obj_test.go
+++ b/tests/remote_obj_test.go
@@ -81,9 +81,9 @@ func TestConsoleLogParse(t *testing.T) {
 
 			done := make(chan bool)
 
-			eventHandler := func(a common.PageOnEvent) {
+			eventHandler := func(event common.PageOnEvent) {
 				defer close(done)
-				assert.Equal(t, tt.want, a.ConsoleMessage.Text)
+				assert.Equal(t, tt.want, event.ConsoleMessage.Text)
 			}
 
 			// eventHandler will be called from a separate goroutine from within

--- a/tests/remote_obj_test.go
+++ b/tests/remote_obj_test.go
@@ -81,12 +81,9 @@ func TestConsoleLogParse(t *testing.T) {
 
 			done := make(chan bool)
 
-			eventHandler := func(a any) {
-				cm, ok := a.(*common.ConsoleMessage)
-				assert.True(t, ok)
-
+			eventHandler := func(a common.PageOnEvent) {
 				defer close(done)
-				assert.Equal(t, tt.want, cm.Text)
+				assert.Equal(t, tt.want, a.ConsoleMessage.Text)
 			}
 
 			// eventHandler will be called from a separate goroutine from within


### PR DESCRIPTION
## What?

Generalizes `page.on` events.

## Why?

- To provide more type-safety.
- Get rid of runtime type assertions.
- Easy to extend for other `page.on` event types.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates: #1227