### PR TITLE
Streamline the addition and running of new `page.on` events

### DIFF
--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -449,17 +449,11 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 				<-done
 			}
 		}
-		_ = queueHandler
 
 		onEventPageConsoleAPICalled := func(event common.PageOnEvent) {
-			tq.Queue(func() error {
-				mapping := mapConsoleMessage(vu, event)
-				_, err := handleEvent(sobek.Undefined(), rt.ToValue(mapping))
-				if err != nil {
-					return fmt.Errorf("executing page.on handler: %w", err)
-				}
-				return nil
-			})
+			mapp = mapConsoleMessage
+			wait = false
+			queueHandler(event)
 		}
 
 		onEventPageMetricCalled := func(event common.PageOnEvent) {

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -434,6 +434,9 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 		},
 		common.EventPageMetricCalled: {
 			mapp: mapMetricEvent,
+			prep: func() error {
+				return prepK6BrowserRegExChecker(rt)
+			},
 			wait: true,
 		},
 	}

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -488,19 +488,7 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 			}
 		}
 
-		var mapHandler func(common.PageOnEvent)
-		switch eventName {
-		case common.EventPageConsoleAPICalled:
-			mapHandler = func(event common.PageOnEvent) {
-				queueHandler(event)
-			}
-		case common.EventPageMetricCalled:
-			mapHandler = func(event common.PageOnEvent) {
-				queueHandler(event)
-			}
-		}
-
-		return p.On(eventName, mapHandler) //nolint:wrapcheck
+		return p.On(eventName, queueHandler) //nolint:wrapcheck
 	}
 }
 

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -457,23 +457,9 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 		}
 
 		onEventPageMetricCalled := func(event common.PageOnEvent) {
-			// The function on the taskqueue runs in its own goroutine
-			// so we need to use a channel to wait for it to complete
-			// since we're waiting for updates from the handler which
-			// will be written to the ExportedMetric.
-			done := make(chan struct{})
-			tq.Queue(func() error {
-				defer close(done)
-
-				mapping := mapMetricEvent(vu, event)
-				_, err := handleEvent(sobek.Undefined(), rt.ToValue(mapping))
-				if err != nil {
-					return fmt.Errorf("executing page.on('metric') handler: %w", err)
-				}
-
-				return nil
-			})
-			<-done
+			mapp = mapMetricEvent
+			wait = true
+			queueHandler(event)
 		}
 
 		var mapHandler func(common.PageOnEvent)

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -450,12 +450,6 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 			}
 		}
 
-		onEventPageMetricCalled := func(event common.PageOnEvent) {
-			mapp = mapMetricEvent
-			wait = true
-			queueHandler(event)
-		}
-
 		var mapHandler func(common.PageOnEvent)
 		switch eventName {
 		case common.EventPageConsoleAPICalled:
@@ -465,7 +459,11 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 				queueHandler(event)
 			}
 		case common.EventPageMetricCalled:
-			mapHandler = onEventPageMetricCalled
+			mapHandler = func(event common.PageOnEvent) {
+				mapp = mapMetricEvent
+				wait = true
+				queueHandler(event)
+			}
 		default:
 			return fmt.Errorf("unknown page event: %q", eventName)
 		}

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -450,12 +450,6 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 			}
 		}
 
-		onEventPageConsoleAPICalled := func(event common.PageOnEvent) {
-			mapp = mapConsoleMessage
-			wait = false
-			queueHandler(event)
-		}
-
 		onEventPageMetricCalled := func(event common.PageOnEvent) {
 			mapp = mapMetricEvent
 			wait = true
@@ -465,7 +459,11 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 		var mapHandler func(common.PageOnEvent)
 		switch eventName {
 		case common.EventPageConsoleAPICalled:
-			mapHandler = onEventPageConsoleAPICalled
+			mapHandler = func(event common.PageOnEvent) {
+				mapp = mapConsoleMessage
+				wait = false
+				queueHandler(event)
+			}
 		case common.EventPageMetricCalled:
 			mapHandler = onEventPageMetricCalled
 		default:

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -425,6 +425,7 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 
 	pageOnEvents := map[common.PageOnEventName]struct {
 		mapp func(vu moduleVU, event common.PageOnEvent) mapping
+		prep func() error
 		wait bool // should we wait for the handler to complete?
 	}{
 		common.EventPageConsoleAPICalled: {

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -447,9 +447,9 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 			return fmt.Errorf("unknown page on event: %q", eventName)
 		}
 
-		if eventName == common.EventPageMetricCalled {
-			if err := prepK6BrowserRegExChecker(rt); err != nil {
-				return err
+		if pageOnEvent.prep != nil {
+			if err := pageOnEvent.prep(); err != nil {
+				return fmt.Errorf("initiating page.on('%s'): %w", eventName, err)
 			}
 		}
 

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -490,11 +490,7 @@ func prepK6BrowserRegExChecker(rt *sobek.Runtime) func() error {
 	return func() error {
 		_, err := rt.RunString(`
 			function _k6BrowserCheckRegEx(pattern, url) {
-				let r = pattern;
-				if (typeof pattern === 'string') {
-					r = new RegExp(pattern);
-				}
-				return r.test(url);
+				return pattern.test(url);
 			}
 		`)
 		if err != nil {

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -456,12 +456,12 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 		// Wait for the handler to complete if necessary.
 		tq := vu.taskQueueRegistry.get(vu.Context(), p.TargetID())
 		queueHandler := func(event common.PageOnEvent) {
+			mapping := pageOnEvent.mapp(vu, event)
+
 			done := make(chan struct{})
 
 			tq.Queue(func() error {
 				defer close(done)
-
-				mapping := pageOnEvent.mapp(vu, event)
 
 				_, err := handleEvent(
 					sobek.Undefined(),

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -445,14 +445,16 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 			return fmt.Errorf("unknown page on event: %q", eventName)
 		}
 
+		// Prepare the environment for the page.on event handler if necessary.
 		if pageOnEvent.prep != nil {
 			if err := pageOnEvent.prep(); err != nil {
 				return fmt.Errorf("initiating page.on('%s'): %w", eventName, err)
 			}
 		}
 
+		// Queue the event handler in the task queue.
+		// Wait for the handler to complete if necessary.
 		tq := vu.taskQueueRegistry.get(vu.Context(), p.TargetID())
-
 		queueHandler := func(event common.PageOnEvent) {
 			done := make(chan struct{})
 

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -488,6 +488,8 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 			}
 		}
 
+		// Run the the event handler in the task queue to ensure that
+		// the handler is executed in the event loop.
 		return p.On(eventName, queueHandler) //nolint:wrapcheck
 	}
 }


### PR DESCRIPTION
## What?

Generalize `page.on` events.

## Why?

To streamline the addition and running of additional `page.on` events.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates: #1227