### PR TITLE
Refactor to type safe `page.on` event names

### DIFF
--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -332,7 +332,7 @@ type pageAPI interface {
 	IsVisible(selector string, opts sobek.Value) (bool, error)
 	Locator(selector string, opts sobek.Value) *common.Locator
 	MainFrame() *common.Frame
-	On(event string, handler func(common.PageOnEvent) error) error
+	On(event common.PageOnEventName, handler func(common.PageOnEvent) error) error
 	Opener() pageAPI
 	Press(selector string, key string, opts sobek.Value) error
 	Query(selector string) (*common.ElementHandle, error)

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -203,7 +203,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"mouse": mapMouse(vu, p.GetMouse()),
-		"on": func(event string, handler sobek.Callable) error {
+		"on": func(event common.PageOnEventName, handler sobek.Callable) error {
 			tq := vu.taskQueueRegistry.get(vu.Context(), p.TargetID())
 
 			var runInTaskQueue func(common.PageOnEvent)

--- a/browser/sync_page_mapping.go
+++ b/browser/sync_page_mapping.go
@@ -113,7 +113,7 @@ func syncMapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"mouse": rt.ToValue(p.GetMouse()).ToObject(rt),
-		"on": func(event string, handler sobek.Callable) error {
+		"on": func(event common.PageOnEventName, handler sobek.Callable) error {
 			tq := vu.taskQueueRegistry.get(vu.Context(), p.TargetID())
 
 			mapMsgAndHandleEvent := func(m *common.ConsoleMessage) error {

--- a/common/page.go
+++ b/common/page.go
@@ -1113,13 +1113,6 @@ type PageOnEvent struct {
 // passing in the ConsoleMessage associated with the event.
 // The only accepted event value is 'console'.
 func (p *Page) On(event PageOnEventName, handler func(PageOnEvent)) error {
-	switch event {
-	case EventPageConsoleAPICalled:
-	case EventPageMetricCalled:
-	default:
-		return fmt.Errorf("unknown page event: %q", event)
-	}
-
 	p.eventHandlersMu.Lock()
 	defer p.eventHandlersMu.Unlock()
 

--- a/common/page.go
+++ b/common/page.go
@@ -35,11 +35,14 @@ const BlankPage = "about:blank"
 // PageOnEventName represents the name of the page.on event.
 type PageOnEventName string
 
-const (
-	webVitalBinding = "k6browserSendWebVitalMetric"
+const webVitalBinding = "k6browserSendWebVitalMetric"
 
-	EventPageConsoleAPICalled = "console"
-	EventPageMetricCalled     = "metric"
+const (
+	// EventPageConsoleAPICalled represents the page.on('console') event.
+	EventPageConsoleAPICalled PageOnEventName = "console"
+
+	// EventPageMetricCalled represents the page.on('metric') event.
+	EventPageMetricCalled PageOnEventName = "metric"
 )
 
 // MediaType represents the type of media to emulate.
@@ -241,7 +244,7 @@ type Page struct {
 	backgroundPage bool
 
 	eventCh         chan Event
-	eventHandlers   map[string][]func(PageOnEvent)
+	eventHandlers   map[PageOnEventName][]func(PageOnEvent)
 	eventHandlersMu sync.RWMutex
 
 	mainFrameSession *FrameSession
@@ -280,7 +283,7 @@ func NewPage(
 		Keyboard:         NewKeyboard(ctx, s),
 		jsEnabled:        true,
 		eventCh:          make(chan Event),
-		eventHandlers:    make(map[string][]func(PageOnEvent)),
+		eventHandlers:    make(map[PageOnEventName][]func(PageOnEvent)),
 		frameSessions:    make(map[cdp.FrameID]*FrameSession),
 		workers:          make(map[target.SessionID]*Worker),
 		vu:               k6ext.GetVU(ctx),
@@ -1109,7 +1112,7 @@ type PageOnEvent struct {
 // On subscribes to a page event for which the given handler will be executed
 // passing in the ConsoleMessage associated with the event.
 // The only accepted event value is 'console'.
-func (p *Page) On(event string, handler func(PageOnEvent)) error {
+func (p *Page) On(event PageOnEventName, handler func(PageOnEvent)) error {
 	switch event {
 	case EventPageConsoleAPICalled:
 	case EventPageMetricCalled:

--- a/common/page.go
+++ b/common/page.go
@@ -32,6 +32,9 @@ import (
 // BlankPage represents a blank page.
 const BlankPage = "about:blank"
 
+// PageOnEventName represents the name of the page.on event.
+type PageOnEventName string
+
 const (
 	webVitalBinding = "k6browserSendWebVitalMetric"
 


### PR DESCRIPTION
## What?

Add and use `PageOnEventName`.

## Why?

For greater readability, clarity, and type safety at the compile time.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates: #1227