### PR TITLE
Refactor `page.on` mapping names

### DIFF
--- a/browser/console_message_mapping.go
+++ b/browser/console_message_mapping.go
@@ -7,13 +7,13 @@ import (
 )
 
 // mapConsoleMessage to the JS module.
-func mapConsoleMessage(vu moduleVU, cm *common.ConsoleMessage) mapping {
+func mapConsoleMessage(vu moduleVU, event common.PageOnEvent) mapping {
 	rt := vu.Runtime()
 	return mapping{
 		"args": func() *sobek.Object {
 			var (
 				margs []mapping
-				args  = cm.Args
+				args  = event.ConsoleMessage.Args
 			)
 			for _, arg := range args {
 				a := mapJSHandle(vu, arg)
@@ -25,14 +25,14 @@ func mapConsoleMessage(vu moduleVU, cm *common.ConsoleMessage) mapping {
 		// page(), text() and type() are defined as
 		// functions in order to match Playwright's API
 		"page": func() *sobek.Object {
-			mp := mapPage(vu, cm.Page)
+			mp := mapPage(vu, event.ConsoleMessage.Page)
 			return rt.ToValue(mp).ToObject(rt)
 		},
 		"text": func() *sobek.Object {
-			return rt.ToValue(cm.Text).ToObject(rt)
+			return rt.ToValue(event.ConsoleMessage.Text).ToObject(rt)
 		},
 		"type": func() *sobek.Object {
-			return rt.ToValue(cm.Type).ToObject(rt)
+			return rt.ToValue(event.ConsoleMessage.Type).ToObject(rt)
 		},
 	}
 }

--- a/browser/console_message_mapping.go
+++ b/browser/console_message_mapping.go
@@ -1,18 +1,15 @@
 package browser
 
 import (
-	"github.com/grafana/sobek"
-
 	"github.com/grafana/xk6-browser/common"
 )
 
 // mapConsoleMessage to the JS module.
 func mapConsoleMessage(vu moduleVU, event common.PageOnEvent) mapping {
-	rt := vu.Runtime()
 	cm := event.ConsoleMessage
 
 	return mapping{
-		"args": func() *sobek.Object {
+		"args": func() []mapping {
 			var (
 				margs []mapping
 				args  = cm.Args
@@ -22,19 +19,18 @@ func mapConsoleMessage(vu moduleVU, event common.PageOnEvent) mapping {
 				margs = append(margs, a)
 			}
 
-			return rt.ToValue(margs).ToObject(rt)
+			return margs
 		},
 		// page(), text() and type() are defined as
 		// functions in order to match Playwright's API
-		"page": func() *sobek.Object {
-			mp := mapPage(vu, cm.Page)
-			return rt.ToValue(mp).ToObject(rt)
+		"page": func() mapping {
+			return mapPage(vu, cm.Page)
 		},
-		"text": func() *sobek.Object {
-			return rt.ToValue(cm.Text).ToObject(rt)
+		"text": func() string {
+			return cm.Text
 		},
-		"type": func() *sobek.Object {
-			return rt.ToValue(cm.Type).ToObject(rt)
+		"type": func() string {
+			return cm.Type
 		},
 	}
 }

--- a/browser/console_message_mapping.go
+++ b/browser/console_message_mapping.go
@@ -9,11 +9,13 @@ import (
 // mapConsoleMessage to the JS module.
 func mapConsoleMessage(vu moduleVU, event common.PageOnEvent) mapping {
 	rt := vu.Runtime()
+	cm := event.ConsoleMessage
+
 	return mapping{
 		"args": func() *sobek.Object {
 			var (
 				margs []mapping
-				args  = event.ConsoleMessage.Args
+				args  = cm.Args
 			)
 			for _, arg := range args {
 				a := mapJSHandle(vu, arg)
@@ -25,14 +27,14 @@ func mapConsoleMessage(vu moduleVU, event common.PageOnEvent) mapping {
 		// page(), text() and type() are defined as
 		// functions in order to match Playwright's API
 		"page": func() *sobek.Object {
-			mp := mapPage(vu, event.ConsoleMessage.Page)
+			mp := mapPage(vu, cm.Page)
 			return rt.ToValue(mp).ToObject(rt)
 		},
 		"text": func() *sobek.Object {
-			return rt.ToValue(event.ConsoleMessage.Text).ToObject(rt)
+			return rt.ToValue(cm.Text).ToObject(rt)
 		},
 		"type": func() *sobek.Object {
-			return rt.ToValue(event.ConsoleMessage.Type).ToObject(rt)
+			return rt.ToValue(cm.Type).ToObject(rt)
 		},
 	}
 }

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -198,7 +198,9 @@ func TestMappings(t *testing.T) {
 		"mapMetricEvent": {
 			apiInterface: (*metricEventAPI)(nil),
 			mapp: func() mapping {
-				return mapMetricEvent(moduleVU{VU: vu}, &common.MetricEvent{})
+				return mapMetricEvent(moduleVU{VU: vu}, common.PageOnEvent{
+					Metric: &common.MetricEvent{},
+				})
 			},
 		},
 		"mapTouchscreen": {

--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -190,7 +190,9 @@ func TestMappings(t *testing.T) {
 		"mapConsoleMessage": {
 			apiInterface: (*consoleMessageAPI)(nil),
 			mapp: func() mapping {
-				return mapConsoleMessage(moduleVU{VU: vu}, &common.ConsoleMessage{})
+				return mapConsoleMessage(moduleVU{VU: vu}, common.PageOnEvent{
+					ConsoleMessage: &common.ConsoleMessage{},
+				})
 			},
 		},
 		"mapMetricEvent": {

--- a/browser/metric_event_mapping.go
+++ b/browser/metric_event_mapping.go
@@ -9,6 +9,7 @@ import (
 // mapMetricEvent to the JS module.
 func mapMetricEvent(vu moduleVU, event common.PageOnEvent) mapping {
 	rt := vu.Runtime()
+	em := event.Metric
 
 	return mapping{
 		"tag": func(urls common.URLTagPatterns) error {
@@ -23,7 +24,7 @@ func mapMetricEvent(vu moduleVU, event common.PageOnEvent) mapping {
 				return matched.ToBoolean(), nil
 			}
 
-			return event.Metric.Tag(callback, urls) //nolint:wrapcheck
+			return em.Tag(callback, urls) //nolint:wrapcheck
 		},
 	}
 }

--- a/browser/metric_event_mapping.go
+++ b/browser/metric_event_mapping.go
@@ -7,7 +7,7 @@ import (
 )
 
 // mapMetricEvent to the JS module.
-func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) mapping {
+func mapMetricEvent(vu moduleVU, event common.PageOnEvent) mapping {
 	rt := vu.VU.Runtime()
 
 	return mapping{
@@ -23,7 +23,7 @@ func mapMetricEvent(vu moduleVU, cm *common.MetricEvent) mapping {
 				return matched.ToBoolean(), nil
 			}
 
-			return cm.Tag(callback, urls)
+			return event.Metric.Tag(callback, urls) //nolint:wrapcheck
 		},
 	}
 }

--- a/browser/metric_event_mapping.go
+++ b/browser/metric_event_mapping.go
@@ -8,7 +8,7 @@ import (
 
 // mapMetricEvent to the JS module.
 func mapMetricEvent(vu moduleVU, event common.PageOnEvent) mapping {
-	rt := vu.VU.Runtime()
+	rt := vu.Runtime()
 
 	return mapping{
 		"tag": func(urls common.URLTagPatterns) error {

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -428,7 +428,7 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 
 		onEventPageConsoleAPICalled := func(event common.PageOnEvent) {
 			tq.Queue(func() error {
-				mapping := mapConsoleMessage(vu, event.ConsoleMessage)
+				mapping := mapConsoleMessage(vu, event)
 				_, err := handler(sobek.Undefined(), rt.ToValue(mapping))
 				if err != nil {
 					return fmt.Errorf("executing page.on handler: %w", err)

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -429,14 +429,11 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 		var mapHandler func(common.PageOnEvent)
 		switch event {
 		case common.EventPageConsoleAPICalled:
-			mapMsgAndHandleEvent := func(m *common.ConsoleMessage) error {
-				mapping := mapConsoleMessage(vu, m)
-				_, err := handler(sobek.Undefined(), rt.ToValue(mapping))
-				return err
-			}
 			mapHandler = func(event common.PageOnEvent) {
 				tq.Queue(func() error {
-					if err := mapMsgAndHandleEvent(event.ConsoleMessage); err != nil {
+					mapping := mapConsoleMessage(vu, event.ConsoleMessage)
+					_, err := handler(sobek.Undefined(), rt.ToValue(mapping))
+					if err != nil {
 						return fmt.Errorf("executing page.on handler: %w", err)
 					}
 					return nil

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -429,7 +429,7 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 		case common.EventPageConsoleAPICalled:
 			mapMsgAndHandleEvent := func(m *common.ConsoleMessage) error {
 				mapping := mapConsoleMessage(vu, m)
-				_, err := handler(sobek.Undefined(), vu.VU.Runtime().ToValue(mapping))
+				_, err := handler(sobek.Undefined(), vu.Runtime().ToValue(mapping))
 				return err
 			}
 			runInTaskQueue = func(event common.PageOnEvent) {
@@ -451,7 +451,7 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 					defer close(c)
 
 					mapping := mapMetricEvent(vu, event.Metric)
-					if _, err := handler(sobek.Undefined(), vu.VU.Runtime().ToValue(mapping)); err != nil {
+					if _, err := handler(sobek.Undefined(), vu.Runtime().ToValue(mapping)); err != nil {
 						return fmt.Errorf("executing page.on('metric') handler: %w", err)
 					}
 

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -442,9 +442,9 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 			// so we need to use a channel to wait for it to complete
 			// since we're waiting for updates from the handler which
 			// will be written to the ExportedMetric.
-			c := make(chan bool)
+			done := make(chan struct{})
 			tq.Queue(func() error {
-				defer close(c)
+				defer close(done)
 
 				mapping := mapMetricEvent(vu, event)
 				_, err := handler(sobek.Undefined(), rt.ToValue(mapping))
@@ -454,7 +454,7 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 
 				return nil
 			})
-			<-c
+			<-done
 		}
 
 		var mapHandler func(common.PageOnEvent)

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -446,7 +446,7 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 			tq.Queue(func() error {
 				defer close(c)
 
-				mapping := mapMetricEvent(vu, event.Metric)
+				mapping := mapMetricEvent(vu, event)
 				if _, err := handler(sobek.Undefined(), rt.ToValue(mapping)); err != nil {
 					return fmt.Errorf("executing page.on('metric') handler: %w", err)
 				}

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -447,7 +447,8 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 				defer close(c)
 
 				mapping := mapMetricEvent(vu, event)
-				if _, err := handler(sobek.Undefined(), rt.ToValue(mapping)); err != nil {
+				_, err := handler(sobek.Undefined(), rt.ToValue(mapping))
+				if err != nil {
 					return fmt.Errorf("executing page.on('metric') handler: %w", err)
 				}
 

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -423,7 +423,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.Callable) error { //nolint:funlen
 	rt := vu.Runtime()
 
-	return func(event common.PageOnEventName, handler sobek.Callable) error {
+	return func(eventName common.PageOnEventName, handler sobek.Callable) error {
 		tq := vu.taskQueueRegistry.get(vu.Context(), p.TargetID())
 
 		onEventPageConsoleAPICalled := func(event common.PageOnEvent) {
@@ -458,16 +458,16 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 		}
 
 		var mapHandler func(common.PageOnEvent)
-		switch event {
+		switch eventName {
 		case common.EventPageConsoleAPICalled:
 			mapHandler = onEventPageConsoleAPICalled
 		case common.EventPageMetricCalled:
 			mapHandler = onEventPageMetricCalled
 		default:
-			return fmt.Errorf("unknown page event: %q", event)
+			return fmt.Errorf("unknown page event: %q", eventName)
 		}
 
-		if event == common.EventPageMetricCalled {
+		if eventName == common.EventPageMetricCalled {
 			// Register a custom regex function for the metric event
 			// that will be used to check URLs against the patterns.
 			// This is needed because we want to use the JavaScript regex
@@ -486,7 +486,7 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 			}
 		}
 
-		return p.On(event, mapHandler) //nolint:wrapcheck
+		return p.On(eventName, mapHandler) //nolint:wrapcheck
 	}
 }
 

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -423,13 +423,13 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.Callable) error { //nolint:funlen
 	rt := vu.Runtime()
 
-	return func(eventName common.PageOnEventName, handler sobek.Callable) error {
+	return func(eventName common.PageOnEventName, handleEvent sobek.Callable) error {
 		tq := vu.taskQueueRegistry.get(vu.Context(), p.TargetID())
 
 		onEventPageConsoleAPICalled := func(event common.PageOnEvent) {
 			tq.Queue(func() error {
 				mapping := mapConsoleMessage(vu, event)
-				_, err := handler(sobek.Undefined(), rt.ToValue(mapping))
+				_, err := handleEvent(sobek.Undefined(), rt.ToValue(mapping))
 				if err != nil {
 					return fmt.Errorf("executing page.on handler: %w", err)
 				}
@@ -447,7 +447,7 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 				defer close(done)
 
 				mapping := mapMetricEvent(vu, event)
-				_, err := handler(sobek.Undefined(), rt.ToValue(mapping))
+				_, err := handleEvent(sobek.Undefined(), rt.ToValue(mapping))
 				if err != nil {
 					return fmt.Errorf("executing page.on('metric') handler: %w", err)
 				}


### PR DESCRIPTION
## What?

Improves namings in `page.on` mapping.

## Why?

To improve clarity and provide the first step for the `page.on` generalization work.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates: #1227