### PR TITLE
Update to using ubuntu-latest-8-cores

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x]
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest-8-cores]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -42,7 +42,7 @@ jobs:
           K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome K6_BROWSER_HEADLESS=true go test "${args[@]}" -timeout 5m ./...
 
   test-tip:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     continue-on-error: true
     steps:
       - name: Checkout code
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.23.x]
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest-8-cores]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -111,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.23.x]
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest-8-cores]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What?

Temporarily updating the github runners to ubuntu-latest-8-cores for the test workflow.

## Why?

Default runners are failing with `launching browser: open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)` when running the tests workflow.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
