### PR TITLE
Move the name field on the `page.on('metric') API

### DIFF
--- a/browser/mapping_test.go
+++ b/browser/mapping_test.go
@@ -378,7 +378,7 @@ type consoleMessageAPI interface {
 
 // metricEventAPI is the interface of a metric event.
 type metricEventAPI interface {
-	Tag(matchesRegex common.K6BrowserCheckRegEx, patterns common.URLTagPatterns) error
+	Tag(matchesRegex common.K6BrowserCheckRegEx, patterns common.TagMatches) error
 }
 
 // frameAPI is the interface of a CDP target frame.

--- a/browser/metric_event_mapping.go
+++ b/browser/metric_event_mapping.go
@@ -12,7 +12,7 @@ func mapMetricEvent(vu moduleVU, event common.PageOnEvent) mapping {
 	em := event.Metric
 
 	return mapping{
-		"tag": func(urls common.URLTagPatterns) error {
+		"tag": func(urls common.TagMatches) error {
 			callback := func(pattern, url string) (bool, error) {
 				js := fmt.Sprintf(`_k6BrowserCheckRegEx(%s, '%s')`, pattern, url)
 

--- a/common/page.go
+++ b/common/page.go
@@ -385,8 +385,8 @@ type MetricEvent struct {
 	// against the URL grouping regexs.
 	url string
 
-	// When a match is found this userProvidedTagName field should be updated.
-	userProvidedTagName string
+	// When a match is found this userProvidedURLTagName field should be updated.
+	userProvidedURLTagName string
 
 	// When a match is found this is set to true.
 	isUserURLTagNameExist bool
@@ -430,7 +430,7 @@ func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, matches TagMatches) 
 
 		if matched {
 			e.isUserURLTagNameExist = true
-			e.userProvidedTagName = name
+			e.userProvidedURLTagName = name
 			return nil
 		}
 	}
@@ -476,7 +476,7 @@ func (p *Page) urlTagName(url string) (string, bool) {
 
 	// If a match was found then the name field in em will have been updated.
 	if em.isUserURLTagNameExist {
-		newTagName = em.userProvidedTagName
+		newTagName = em.userProvidedURLTagName
 		urlMatched = true
 	}
 

--- a/common/page.go
+++ b/common/page.go
@@ -414,16 +414,16 @@ type K6BrowserCheckRegEx func(pattern, url string) (bool, error)
 
 // Tag will find the first match given the URLTagPatterns and the URL from
 // the metric tag and update the name field.
-func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, patterns TagMatches) error {
-	for _, o := range patterns.Matches {
-		name := strings.TrimSpace(patterns.TagName)
+func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, matches TagMatches) error {
+	for _, m := range matches.Matches {
+		name := strings.TrimSpace(matches.TagName)
 		if name == "" {
-			return fmt.Errorf("name %q is invalid", patterns.TagName)
+			return fmt.Errorf("name %q is invalid", matches.TagName)
 		}
 
 		// matchesRegex is a function that will perform the regex test in the Sobek
 		// runtime.
-		matched, err := matchesRegex(o.URLRegEx, e.url)
+		matched, err := matchesRegex(m.URLRegEx, e.url)
 		if err != nil {
 			return err
 		}

--- a/common/page.go
+++ b/common/page.go
@@ -392,17 +392,18 @@ type MetricEvent struct {
 	isUserURLTagNameExist bool
 }
 
-// URLTagPatterns will contain all the URL groupings.
-type URLTagPatterns struct {
+// TagMatches contains the name tag and matches used to match against existing
+// metric tags that are about to be emitted.
+type TagMatches struct {
 	// The name to send back to the caller of the handler.
 	TagName string `js:"name"`
-	// The request patterns to match against.
-	URLs []URLTagPattern `js:"urls"`
+	// The patterns to match against.
+	Matches []Match `js:"matches"`
 }
 
-// URLTagPattern contains the fields that will be used to match against
-// metric tags that are about to be emitted.
-type URLTagPattern struct {
+// Match contains the fields that will be used to match against metric tags
+// that are about to be emitted.
+type Match struct {
 	// This is a regex that will be compared against the existing url tag.
 	URLRegEx string `js:"url"`
 }
@@ -413,8 +414,8 @@ type K6BrowserCheckRegEx func(pattern, url string) (bool, error)
 
 // Tag will find the first match given the URLTagPatterns and the URL from
 // the metric tag and update the name field.
-func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, patterns URLTagPatterns) error {
-	for _, o := range patterns.URLs {
+func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, patterns TagMatches) error {
+	for _, o := range patterns.Matches {
 		name := strings.TrimSpace(patterns.TagName)
 		if name == "" {
 			return fmt.Errorf("name %q is invalid", patterns.TagName)

--- a/common/page.go
+++ b/common/page.go
@@ -394,16 +394,17 @@ type MetricEvent struct {
 
 // URLTagPatterns will contain all the URL groupings.
 type URLTagPatterns struct {
+	// The name to send back to the caller of the handler.
+	TagName string `js:"name"`
+	// The request patterns to match against.
 	URLs []URLTagPattern `js:"urls"`
 }
 
-// URLTagPattern contains the single url regex and the name to give to the metric
-// if a match is found.
+// URLTagPattern contains the fields that will be used to match against
+// metric tags that are about to be emitted.
 type URLTagPattern struct {
 	// This is a regex that will be compared against the existing url tag.
 	URLRegEx string `js:"url"`
-	// The name to send back to the caller of the handler.
-	TagName string `js:"name"`
 }
 
 // K6BrowserCheckRegEx is a function that will be used to check the URL tag
@@ -414,9 +415,9 @@ type K6BrowserCheckRegEx func(pattern, url string) (bool, error)
 // the metric tag and update the name field.
 func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, patterns URLTagPatterns) error {
 	for _, o := range patterns.URLs {
-		name := strings.TrimSpace(o.TagName)
+		name := strings.TrimSpace(patterns.TagName)
 		if name == "" {
-			return fmt.Errorf("name %q is invalid", o.TagName)
+			return fmt.Errorf("name %q is invalid", patterns.TagName)
 		}
 
 		// matchesRegex is a function that will perform the regex test in the Sobek

--- a/common/page.go
+++ b/common/page.go
@@ -438,9 +438,10 @@ func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, patterns TagMatches)
 	return nil
 }
 
-// urlTagName is used to check the incoming metric url tag against user
-// defined url regexes. When a match is found a user defined name, which is to
-// be used in the urls place in the url metric tag, is returned.
+// urlTagName is used to match the given url with the matches defined by the
+// user. Currently matches only contains url. When a match is found a user
+// defined name, which is to be used in the urls place in the url metric tag,
+// is returned.
 //
 // The check is done by calling the handlers that were registered with
 // `page.on('metric')`. The user will need to use `Tag` to supply the

--- a/common/page.go
+++ b/common/page.go
@@ -415,12 +415,12 @@ type K6BrowserCheckRegEx func(pattern, url string) (bool, error)
 // Tag will find the first match given the URLTagPatterns and the URL from
 // the metric tag and update the name field.
 func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, matches TagMatches) error {
-	for _, m := range matches.Matches {
-		name := strings.TrimSpace(matches.TagName)
-		if name == "" {
-			return fmt.Errorf("name %q is invalid", matches.TagName)
-		}
+	name := strings.TrimSpace(matches.TagName)
+	if name == "" {
+		return fmt.Errorf("name %q is invalid", matches.TagName)
+	}
 
+	for _, m := range matches.Matches {
 		// matchesRegex is a function that will perform the regex test in the Sobek
 		// runtime.
 		matched, err := matchesRegex(m.URLRegEx, e.url)

--- a/examples/pageon-metric.js
+++ b/examples/pageon-metric.js
@@ -18,8 +18,9 @@ export default async function() {
 
   page.on('metric', (metric) => {
     metric.tag({
+      name:'test',
       urls: [
-        {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, name:'test'},
+        {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/},
       ]
     });
   });

--- a/examples/pageon-metric.js
+++ b/examples/pageon-metric.js
@@ -19,7 +19,7 @@ export default async function() {
   page.on('metric', (metric) => {
     metric.tag({
       name:'test',
-      urls: [
+      matches: [
         {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/},
       ]
     });

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1920,7 +1920,7 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.tag({
 				  	name:'ping-1',
-					urls: [
+					matches: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					]
 				});
@@ -1933,13 +1933,13 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.tag({
 					name:'ping-1',
-					urls: [
+					matches: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					]
 				});
 				metric.tag({
 					name:'ping-2',
-					urls: [
+					matches: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					]
 				  });
@@ -1952,13 +1952,13 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.tag({
 					name:'ping-1',
-					urls: [
+					matches: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					]
 				});
 				metric.tag({
 					name:'ping-2',
-					urls: [
+					matches: [
 						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					  ]
 				  });
@@ -1966,7 +1966,7 @@ func TestPageOnMetric(t *testing.T) {
 			page.on('metric', (metric) => {
 				metric.tag({
 					name:'ping-3',
-					urls: [
+					matches: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					]
 				});
@@ -1979,14 +1979,14 @@ func TestPageOnMetric(t *testing.T) {
 			fun: `page.on('metric', (metric) => {
 				metric.tag({
 					name:'ping-1',
-					urls: [
+					matches: [
 						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					]
 				});
 				page.on('metric', (metric) => {
 					metric.tag({
 						name:'ping-4',
-						urls: [
+						matches: [
 							{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 						]
 					});

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1919,8 +1919,9 @@ func TestPageOnMetric(t *testing.T) {
 			name: "single_page.on",
 			fun: `page.on('metric', (metric) => {
 				metric.tag({
-				  urls: [
-						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
+				  	name:'ping-1',
+					urls: [
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					]
 				});
 			});`,
@@ -1931,14 +1932,16 @@ func TestPageOnMetric(t *testing.T) {
 			name: "multi_tag",
 			fun: `page.on('metric', (metric) => {
 				metric.tag({
-				  urls: [
-						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
+					name:'ping-1',
+					urls: [
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					]
 				});
 				metric.tag({
+					name:'ping-2',
 					urls: [
-						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
-					  ]
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
+					]
 				  });
 			});`,
 			want: "ping-2",
@@ -1948,20 +1951,23 @@ func TestPageOnMetric(t *testing.T) {
 			name: "multi_tag_page.on",
 			fun: `page.on('metric', (metric) => {
 				metric.tag({
-				  urls: [
-						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
+					name:'ping-1',
+					urls: [
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					]
 				});
 				metric.tag({
+					name:'ping-2',
 					urls: [
-						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-2'},
+						  {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					  ]
 				  });
 			});
 			page.on('metric', (metric) => {
 				metric.tag({
-				  urls: [
-						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-3'},
+					name:'ping-3',
+					urls: [
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					]
 				});
 			});`,
@@ -1972,14 +1978,16 @@ func TestPageOnMetric(t *testing.T) {
 			name: "multi_page.on_call",
 			fun: `page.on('metric', (metric) => {
 				metric.tag({
-				  urls: [
-						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-1'},
+					name:'ping-1',
+					urls: [
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 					]
 				});
 				page.on('metric', (metric) => {
 					metric.tag({
+						name:'ping-4',
 						urls: [
-							{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, name:'ping-4'},
+							{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/},
 						]
 					});
 				});


### PR DESCRIPTION
## What?

This change does two things:
1. Moves the `name` field to the level above.
2. Rename the `urls` field to `matches`.

So from:

```js
  page.on('metric', (metric) => {
    metric.tag({
      urls: [
        {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, name:'test'},
      ]
    });
  });
```

to:

```js
  page.on('metric', (metric) => {
    metric.tag({
      name:'test',
      matches: [
        {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/},
      ]
    });
  });
```

## Why?

It was unclear what `name` was doing when it was part of the "`match`" object and it made it difficult to add other fields to the object to match against.

`urls` doesn't lend itself to extending with more fields to match against. It also doesn't represent what it is doing, whereas `matches` is a helpful verb that makes it clearer to the user/reader of the API what its impact is.

By moving the `name` field one level up, and renaming `urls` to `matches`, we can now read this API:

```js
    metric.tag({
      name:'test',
      matches: [
        {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/},
      ]
    });
```

as:

1. tag metric;
2. with this name;
3. that matches.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1487