### PR TITLE
Add method field on Match object for `page.on('metric')`

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"runtime"
 	"strings"
 	"sync"
@@ -355,7 +356,7 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 	state := fs.vu.State()
 	tags := state.Tags.GetCurrentValues().Tags
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		tags = handleURLTag(fs.page, wv.URL, tags)
+		tags = handleURLTag(fs.page, wv.URL, http.MethodGet, tags)
 	}
 
 	tags = tags.With("rating", wv.Rating)

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -192,7 +192,7 @@ func (m *NetworkManager) emitRequestMetrics(req *Request) {
 		tags = tags.With("method", req.method)
 	}
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		tags = handleURLTag(m.mi, req.URL(), tags)
+		tags = handleURLTag(m.mi, req.URL(), req.method, tags)
 	}
 
 	k6metrics.PushIfNotDone(m.vu.Context(), state.Samples, k6metrics.ConnectedSamples{
@@ -245,7 +245,7 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 		tags = tags.With("method", req.method)
 	}
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		tags = handleURLTag(m.mi, url, tags)
+		tags = handleURLTag(m.mi, url, req.method, tags)
 	}
 	if state.Options.SystemTags.Has(k6metrics.TagIP) {
 		tags = tags.With("ip", ipAddress)
@@ -292,7 +292,7 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 // handleURLTag will check if the url tag needs to be grouped by testing
 // against user supplied regex. If there's a match a user supplied name will
 // be used instead of the url for the url tag, otherwise the url will be used.
-func handleURLTag(mi metricInterceptor, url string, tags *k6metrics.TagSet) *k6metrics.TagSet {
+func handleURLTag(mi metricInterceptor, url string, method string, tags *k6metrics.TagSet) *k6metrics.TagSet {
 	if newTagName, urlMatched := mi.urlTagName(url); urlMatched {
 		tags = tags.With("url", newTagName)
 		tags = tags.With("name", newTagName)

--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -58,7 +58,7 @@ func (c *Credentials) Parse(ctx context.Context, credentials sobek.Value) error 
 }
 
 type metricInterceptor interface {
-	urlTagName(urlTag string) (string, bool)
+	urlTagName(urlTag string, method string) (string, bool)
 }
 
 // NetworkManager manages all frames in HTML document.
@@ -293,7 +293,7 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 // against user supplied regex. If there's a match a user supplied name will
 // be used instead of the url for the url tag, otherwise the url will be used.
 func handleURLTag(mi metricInterceptor, url string, method string, tags *k6metrics.TagSet) *k6metrics.TagSet {
-	if newTagName, urlMatched := mi.urlTagName(url); urlMatched {
+	if newTagName, urlMatched := mi.urlTagName(url, method); urlMatched {
 		tags = tags.With("url", newTagName)
 		tags = tags.With("name", newTagName)
 		return tags

--- a/common/network_manager_test.go
+++ b/common/network_manager_test.go
@@ -211,7 +211,7 @@ func TestOnRequestPausedBlockedIPs(t *testing.T) {
 
 type MetricInterceptorMock struct{}
 
-func (m *MetricInterceptorMock) urlTagName(_ string) (string, bool) {
+func (m *MetricInterceptorMock) urlTagName(_ string, _ string) (string, bool) {
 	return "", false
 }
 

--- a/common/page.go
+++ b/common/page.go
@@ -436,6 +436,10 @@ func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, matches TagMatches) 
 			default:
 				return fmt.Errorf("method %q is invalid", m.Method)
 			}
+
+			if method != e.method {
+				continue
+			}
 		}
 
 		// matchesRegex is a function that will perform the regex test in the Sobek

--- a/common/page.go
+++ b/common/page.go
@@ -447,7 +447,7 @@ func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, matches TagMatches) 
 // `page.on('metric')`. The user will need to use `Tag` to supply the
 // url regexes and the matching is done from within there. If a match is found,
 // the supplied name is returned back upstream to the caller of urlTagName.
-func (p *Page) urlTagName(url string) (string, bool) {
+func (p *Page) urlTagName(url string, method string) (string, bool) {
 	if !hasPageOnHandler(p, EventPageMetricCalled) {
 		return "", false
 	}

--- a/common/page.go
+++ b/common/page.go
@@ -384,6 +384,8 @@ type MetricEvent struct {
 	// The URL value from the metric's url tag. It will be used to match
 	// against the URL grouping regexs.
 	url string
+	// The method of the request made to the URL.
+	method string
 
 	// When a match is found this userProvidedURLTagName field should be updated.
 	userProvidedURLTagName string
@@ -455,7 +457,8 @@ func (p *Page) urlTagName(url string, method string) (string, bool) {
 	var newTagName string
 	var urlMatched bool
 	em := &MetricEvent{
-		url: url,
+		url:    url,
+		method: method,
 	}
 
 	p.eventHandlersMu.RLock()

--- a/common/page.go
+++ b/common/page.go
@@ -408,6 +408,8 @@ type TagMatches struct {
 type Match struct {
 	// This is a regex that will be compared against the existing url tag.
 	URLRegEx string `js:"url"`
+	// This is the request method to match on.
+	Method string `js:"method"`
 }
 
 // K6BrowserCheckRegEx is a function that will be used to check the URL tag

--- a/common/page.go
+++ b/common/page.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -425,6 +426,18 @@ func (e *MetricEvent) Tag(matchesRegex K6BrowserCheckRegEx, matches TagMatches) 
 	}
 
 	for _, m := range matches.Matches {
+		// Validate the request method type if it has been assigned in a Match.
+		method := strings.TrimSpace(m.Method)
+		if method != "" {
+			method = strings.ToUpper(method)
+			switch method {
+			case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch,
+				http.MethodHead, http.MethodOptions, http.MethodConnect, http.MethodTrace:
+			default:
+				return fmt.Errorf("method %q is invalid", m.Method)
+			}
+		}
+
 		// matchesRegex is a function that will perform the regex test in the Sobek
 		// runtime.
 		matched, err := matchesRegex(m.URLRegEx, e.url)

--- a/examples/pageon-metric.js
+++ b/examples/pageon-metric.js
@@ -20,7 +20,7 @@ export default async function() {
     metric.tag({
       name:'test',
       matches: [
-        {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/},
+        {url: /^https:\/\/test\.k6\.io\/\?q=[0-9a-z]+$/, method: 'GET'},
       ]
     });
   });

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1994,6 +1994,19 @@ func TestPageOnMetric(t *testing.T) {
 			});`,
 			want: "ping-4",
 		},
+		{
+			// With method field GET, which is the correct method for the request.
+			name: "with_method",
+			fun: `page.on('metric', (metric) => {
+				metric.tag({
+					name:'ping-1',
+					matches: [
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, method: 'GET'},
+					]
+				});
+			});`,
+			want: "ping-1",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -2010,6 +2010,20 @@ func TestPageOnMetric(t *testing.T) {
 			want: "ping-1",
 		},
 		{
+			// With method field " get ", which is to ensure it is internally
+			// converted to "GET" before comparing.
+			name: "lowercase_needs_trimming",
+			fun: `page.on('metric', (metric) => {
+				metric.tag({
+					name:'ping-1',
+					matches: [
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, method: ' get '},
+					]
+				});
+			});`,
+			want: "ping-1",
+		},
+		{
 			// When supplying the wrong request method (POST) when it should be GET.
 			// In this case the URLs aren't grouped.
 			name: "wrong_method_should_skip_method_comparison",

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -2037,6 +2037,20 @@ func TestPageOnMetric(t *testing.T) {
 			wantRegex: `http://127\.0\.0\.1:[0-9]+/ping\?h=[0-9a-z]+`,
 			wantErr:   `name "  " is invalid`,
 		},
+		{
+			// We should get an error back when the method is invalid.
+			name: "with_invalid_name",
+			fun: `page.on('metric', (metric) => {
+				metric.tag({
+					name:'ping-1',
+					matches: [
+						{url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, method: 'foo'},
+					]
+				});
+			});`,
+			wantRegex: `http://127\.0\.0\.1:[0-9]+/ping\?h=[0-9a-z]+`,
+			wantErr:   `method "foo" is invalid`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What?

This change adds a new field to the `Match` object in `page.on('metric')`. It allows the user to add the request method to it so that the tagging can be fine tuned to group requests with the same url and method. `method` is an optional field, and if it's not defined then the grouping will be done for all urls that match regardless of the request method.

```js
page.on('metric', (metric) => {
  metric.tag({
    name:'ping-1',
    matches: [
      {url: /^http:\/\/127\.0\.0\.1\:[0-9]+\/ping\?h=[0-9a-z]+$/, method: 'GET'},
    ]
  });
});
```

## Why?

The use case for this is when requests are made against the same URL but with different request methods. A simple example is a `PUT` to `/cart/123` to add an item to the cart, and a `GET` to `/cart/123` to retrieve the cart.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1450