### PR TITLE
Fix memory leak caused by taskqueue closing before all tasks are executed

### DIFF
--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -452,9 +452,11 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 			}
 		}
 
+		ctx := vu.Context()
+
 		// Run the the event handler in the task queue to
 		// ensure that the handler is executed on the event loop.
-		tq := vu.taskQueueRegistry.get(vu.Context(), p.TargetID())
+		tq := vu.taskQueueRegistry.get(ctx, p.TargetID())
 		eventHandler := func(event common.PageOnEvent) {
 			mapping := pageOnEvent.mapp(vu, event)
 
@@ -475,7 +477,10 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 			})
 
 			if pageOnEvent.wait {
-				<-done
+				select {
+				case <-done:
+				case <-ctx.Done():
+				}
 			}
 		}
 


### PR DESCRIPTION
## What?

Adding a `context.Done()` check so that when the context is closed we can carry on with shutting down of the iteration and not wait for the task to run (which will not happen since the taskqueue will have also been shutdown either from [here](https://github.com/grafana/xk6-browser/blob/f757283a54096ce3868d6fec13eebc4b6f1fd6ff/browser/page_mapping.go#L45), or [here](https://github.com/grafana/xk6-browser/blob/8fce16a75360a2317dfe2ff4c8ac4e5a2c292b5b/browser/registry.go#L549-L555)).

## Why?

If the taskqueue is closed before all the tasks are read from the queue, the remaining tasks on the queue will not be read and executed and so the done channel will not be closed causing the goroutine to wait forever.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Updates: https://github.com/grafana/xk6-browser/issues/1480