### PR TITLE
Fix waitForEvent when taskqueue closed before the task is executed

### DIFF
--- a/browser/browser_context_mapping.go
+++ b/browser/browser_context_mapping.go
@@ -1,6 +1,7 @@
 package browser
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -126,7 +127,12 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 							close(c)
 							return nil
 						})
-						<-c
+
+						select {
+						case <-c:
+						case <-ctx.Done():
+							err = errors.New("iteration ended before waitForEvent completed")
+						}
 
 						return rtn, err //nolint:wrapcheck
 					}


### PR DESCRIPTION
## What?

Adding a `context.Done()` check so that when the context is closed we can carry on with shutting down of the iteration and not wait for the task to run (which will not happen since the taskqueue will have also been shutdown either from [here](https://github.com/grafana/xk6-browser/blob/f757283a54096ce3868d6fec13eebc4b6f1fd6ff/browser/page_mapping.go#L45), or [here](https://github.com/grafana/xk6-browser/blob/8fce16a75360a2317dfe2ff4c8ac4e5a2c292b5b/browser/registry.go#L549-L555)).

## Why?

If the taskqueue is closed before all the tasks are read from the queue, the remaining tasks on the queue will not be read and executed and so the done channel will not be closed causing the goroutine to wait forever.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Related: https://github.com/grafana/xk6-browser/pull/1493