### PR TITLE
Add error return value from `page.on` handlers

### DIFF
--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -457,7 +457,7 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 		// Run the the event handler in the task queue to
 		// ensure that the handler is executed on the event loop.
 		tq := vu.taskQueueRegistry.get(ctx, p.TargetID())
-		eventHandler := func(event common.PageOnEvent) {
+		eventHandler := func(event common.PageOnEvent) error {
 			mapping := pageOnEvent.mapp(vu, event)
 
 			done := make(chan struct{})
@@ -482,6 +482,8 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 				case <-ctx.Done():
 				}
 			}
+
+			return nil
 		}
 
 		return p.On(eventName, eventHandler) //nolint:wrapcheck

--- a/browser/page_mapping.go
+++ b/browser/page_mapping.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -480,6 +481,7 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 				select {
 				case <-done:
 				case <-ctx.Done():
+					return errors.New("iteration ended before page.on handler completed executing")
 				}
 			}
 

--- a/browser/sync_page_mapping.go
+++ b/browser/sync_page_mapping.go
@@ -121,13 +121,15 @@ func syncMapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				_, err := handler(sobek.Undefined(), vu.Runtime().ToValue(mapping))
 				return err
 			}
-			runInTaskQueue := func(a common.PageOnEvent) {
+			runInTaskQueue := func(a common.PageOnEvent) error {
 				tq.Queue(func() error {
 					if err := mapMsgAndHandleEvent(a.ConsoleMessage); err != nil {
 						return fmt.Errorf("executing page.on handler: %w", err)
 					}
 					return nil
 				})
+
+				return nil
 			}
 
 			return p.On(event, runInTaskQueue) //nolint:wrapcheck

--- a/common/page.go
+++ b/common/page.go
@@ -207,7 +207,7 @@ type ConsoleMessage struct {
 	Type string
 }
 
-type PageOnHandler func(PageOnEvent)
+type PageOnHandler func(PageOnEvent) error
 
 // Page stores Page/tab related context.
 type Page struct {

--- a/common/page.go
+++ b/common/page.go
@@ -527,9 +527,13 @@ func (p *Page) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICalled) {
 	p.eventHandlersMu.RLock()
 	defer p.eventHandlersMu.RUnlock()
 	for _, h := range p.eventHandlers[EventPageConsoleAPICalled] {
-		h(PageOnEvent{
+		err := h(PageOnEvent{
 			ConsoleMessage: m,
 		})
+		if err != nil {
+			p.logger.Debugf("onConsoleAPICalled", "handler returned an error: %v", err)
+			return
+		}
 	}
 }
 

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -1251,14 +1251,16 @@ func TestPageOn(t *testing.T) {
 			)
 
 			// Console Messages should be multiplexed for every registered handler
-			eventHandlerOne := func(event common.PageOnEvent) {
+			eventHandlerOne := func(event common.PageOnEvent) error {
 				defer close(done1)
 				tc.assertFn(t, event.ConsoleMessage)
+				return nil
 			}
 
-			eventHandlerTwo := func(event common.PageOnEvent) {
+			eventHandlerTwo := func(event common.PageOnEvent) error {
 				defer close(done2)
 				tc.assertFn(t, event.ConsoleMessage)
+				return nil
 			}
 
 			// eventHandlerOne and eventHandlerTwo will be called from a

--- a/tests/remote_obj_test.go
+++ b/tests/remote_obj_test.go
@@ -81,9 +81,10 @@ func TestConsoleLogParse(t *testing.T) {
 
 			done := make(chan bool)
 
-			eventHandler := func(event common.PageOnEvent) {
+			eventHandler := func(event common.PageOnEvent) error {
 				defer close(done)
 				assert.Equal(t, tt.want, event.ConsoleMessage.Text)
+				return nil
 			}
 
 			// eventHandler will be called from a separate goroutine from within


### PR DESCRIPTION
## What?

This adds an error return value from the `page.on` handlers.

## Why?

It's being more defensive to ensure that when an error occurs (due to the iteration ending) we exit early and don't try to process any other handlers, and to ensure that we don't use incorrect url name values when a `page,.on(metric)` handler returns early.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Relates to: https://github.com/grafana/xk6-browser/pull/1493#discussion_r1806534456