### PR TITLE
Add `browserContext.downloadsPath`

### DIFF
--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -95,7 +95,7 @@ const artifactsDirectory = "k6browser-artifacts-"
 
 // setDownloadsPath sets the downloads path.
 // If the provided path is empty, a temporary directory with
-// an artifactsDirectory prefix.
+// an artifactsDirectory prefix will be created.
 func (b *BrowserContext) setDownloadsPath(path string) error {
 	path = strings.TrimSpace(path)
 	if path != "" {

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -84,6 +84,9 @@ type BrowserContext struct {
 	vu              k6modules.VU
 
 	evaluateOnNewDocumentSources []string
+
+	// DownloadsPath is the path where downloads will be stored.
+	DownloadsPath string
 }
 
 // NewBrowserContext creates a new browser context.

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -144,6 +144,9 @@ func NewBrowserContext(
 	if err := b.AddInitScript(js.WebVitalInitScript); err != nil {
 		return nil, fmt.Errorf("adding web vital init script to new browser context: %w", err)
 	}
+	if err := b.setDownloadsPath(opts.DownloadsPath); err != nil {
+		return nil, fmt.Errorf("setting downloads path: %w", err)
+	}
 
 	return &b, nil
 }

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -89,6 +89,9 @@ type BrowserContext struct {
 	DownloadsPath string
 }
 
+// artifactsDirectory is the prefix for the temporary directory created for downloads.
+const artifactsDirectory = "k6browser-artifacts-"
+
 // NewBrowserContext creates a new browser context.
 func NewBrowserContext(
 	ctx context.Context, browser *Browser, id cdp.BrowserContextID, opts *BrowserContextOptions, logger *log.Logger,

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -96,7 +96,7 @@ const artifactsDirectory = "k6browser-artifacts-"
 // setDownloadsPath sets the downloads path.
 // If the provided path is empty, a temporary directory with
 // an artifactsDirectory prefix.
-func (b *BrowserContext) setDownloadsPath(path string) error { //nolint:unparam
+func (b *BrowserContext) setDownloadsPath(path string) error {
 	path = strings.TrimSpace(path)
 	if path != "" {
 		b.DownloadsPath = path

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -91,6 +92,24 @@ type BrowserContext struct {
 
 // artifactsDirectory is the prefix for the temporary directory created for downloads.
 const artifactsDirectory = "k6browser-artifacts-"
+
+// setDownloadsPath sets the downloads path.
+// If the provided path is empty, a temporary directory with
+// an artifactsDirectory prefix.
+func (b *BrowserContext) setDownloadsPath(path string) error { //nolint:unparam
+	path = strings.TrimSpace(path)
+	if path != "" {
+		b.DownloadsPath = path
+		return nil
+	}
+	dir, err := os.MkdirTemp(os.TempDir(), artifactsDirectory+"*")
+	if err != nil {
+		return fmt.Errorf("creating temporary directory for downloads: %w", err)
+	}
+	b.DownloadsPath = dir
+
+	return nil
+}
 
 // NewBrowserContext creates a new browser context.
 func NewBrowserContext(

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -112,6 +112,8 @@ func (b *BrowserContextOptions) Parse(ctx context.Context, opts sobek.Value) err
 		switch k {
 		case "acceptDownloads":
 			b.AcceptDownloads = o.Get(k).ToBoolean()
+		case "downloadsPath":
+			b.DownloadsPath = o.Get(k).String()
 		case "bypassCSP":
 			b.BypassCSP = o.Get(k).ToBoolean()
 		case "colorScheme":

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -64,6 +64,7 @@ func (g *Geolocation) Parse(ctx context.Context, opts sobek.Value) error { //nol
 // BrowserContextOptions stores browser context options.
 type BrowserContextOptions struct {
 	AcceptDownloads   bool              `js:"acceptDownloads"`
+	DownloadsPath     string            `js:"downloadsPath"`
 	BypassCSP         bool              `js:"bypassCSP"`
 	ColorScheme       ColorScheme       `js:"colorScheme"`
 	DeviceScaleFactor float64           `js:"deviceScaleFactor"`

--- a/common/browser_context_test.go
+++ b/common/browser_context_test.go
@@ -59,6 +59,14 @@ func TestSetDownloadsPath(t *testing.T) {
 		assert.Contains(t, bc.DownloadsPath, artifactsDirectory)
 		assert.DirExists(t, bc.DownloadsPath)
 	})
+	t.Run("non_empty_path", func(t *testing.T) {
+		t.Parallel()
+
+		var bc BrowserContext
+		path := "/my/directory"
+		require.NoError(t, bc.setDownloadsPath(path))
+		assert.Equal(t, path, bc.DownloadsPath)
+	})
 }
 
 func TestFilterCookies(t *testing.T) {

--- a/common/browser_context_test.go
+++ b/common/browser_context_test.go
@@ -47,6 +47,20 @@ func TestNewBrowserContext(t *testing.T) {
 	})
 }
 
+func TestSetDownloadsPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_path", func(t *testing.T) {
+		t.Parallel()
+
+		var bc BrowserContext
+		require.NoError(t, bc.setDownloadsPath(""))
+		assert.NotEmpty(t, bc.DownloadsPath)
+		assert.Contains(t, bc.DownloadsPath, artifactsDirectory)
+		assert.DirExists(t, bc.DownloadsPath)
+	})
+}
+
 func TestFilterCookies(t *testing.T) {
 	t.Parallel()
 

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -17,6 +17,7 @@ func TestBrowserContextOptionsDefaultValues(t *testing.T) {
 
 	opts := common.NewBrowserContextOptions()
 	assert.False(t, opts.AcceptDownloads)
+	assert.Empty(t, opts.DownloadsPath)
 	assert.False(t, opts.BypassCSP)
 	assert.Equal(t, common.ColorSchemeLight, opts.ColorScheme)
 	assert.Equal(t, 1.0, opts.DeviceScaleFactor)


### PR DESCRIPTION
## What?

Users can set where to download files.

```javascript
const context = await browser.newContext({
    acceptDownloads: true,
    downloadsPath: '/my/directory',
});
```

If `downloadsPath` is unset, we create a temporary directory for each `BrowserContext` with the `k6-browser-artifacts-` prefix. Note that we do this for every call to `NewBrowserContext`.

## Why?

- Finding the downloaded files without `downloadPaths` can be difficult.
- Allow users to download files to a specific directory they want.
- To create a temporary directory to save the downloaded files.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates: #1289