### PR TITLE
Desobekify `BrowserContext` wait for event options

### DIFF
--- a/browser/browser_context_mapping.go
+++ b/browser/browser_context_mapping.go
@@ -199,8 +199,8 @@ type waitForEventOptions struct {
 // callable predicate function and a timeout.
 func parseWaitForEventOptions(
 	rt *sobek.Runtime, optsOrPredicate sobek.Value, defaultTime time.Duration,
-) (*common.WaitForEventOptions, error) {
-	w := &common.WaitForEventOptions{
+) (*waitForEventOptions, error) {
+	w := &waitForEventOptions{
 		Timeout: defaultTime,
 	}
 

--- a/browser/browser_context_mapping.go
+++ b/browser/browser_context_mapping.go
@@ -110,14 +110,12 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 			})
 		},
 		"waitForEvent": func(event string, optsOrPredicate sobek.Value) (*sobek.Promise, error) {
-			ctx := vu.Context()
-			popts := common.NewWaitForEventOptions(
-				bc.Timeout(),
-			)
-			if err := popts.Parse(ctx, optsOrPredicate); err != nil {
-				return nil, fmt.Errorf("parsing waitForEvent options: %w", err)
+			popts, err := parseWaitForEventOptions(vu.Runtime(), optsOrPredicate, bc.Timeout())
+			if err != nil {
+				return nil, fmt.Errorf("parsing wait for event options: %w", err)
 			}
 
+			ctx := vu.Context()
 			return k6ext.Promise(ctx, func() (result any, reason error) {
 				var runInTaskQueue func(p *common.Page) (bool, error)
 				if popts.PredicateFn != nil {

--- a/browser/browser_context_mapping.go
+++ b/browser/browser_context_mapping.go
@@ -186,6 +186,12 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 	}
 }
 
+// waitForEventOptions are the options used by the browserContext.waitForEvent API.
+type waitForEventOptions struct {
+	Timeout     time.Duration
+	PredicateFn sobek.Callable
+}
+
 // parseWaitForEventOptions parses optsOrPredicate into a WaitForEventOptions.
 // It returns a WaitForEventOptions with the default timeout if optsOrPredicate is nil,
 // or not a callable predicate function.

--- a/browser/sync_browser_context_mapping.go
+++ b/browser/sync_browser_context_mapping.go
@@ -61,14 +61,12 @@ func syncMapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //n
 		"setHTTPCredentials":          bc.SetHTTPCredentials, //nolint:staticcheck
 		"setOffline":                  bc.SetOffline,
 		"waitForEvent": func(event string, optsOrPredicate sobek.Value) (*sobek.Promise, error) {
-			ctx := vu.Context()
-			popts := common.NewWaitForEventOptions(
-				bc.Timeout(),
-			)
-			if err := popts.Parse(ctx, optsOrPredicate); err != nil {
-				return nil, fmt.Errorf("parsing waitForEvent options: %w", err)
+			popts, err := parseWaitForEventOptions(vu.Runtime(), optsOrPredicate, bc.Timeout())
+			if err != nil {
+				return nil, fmt.Errorf("parsing wait for event options: %w", err)
 			}
 
+			ctx := vu.Context()
 			return k6ext.Promise(ctx, func() (result any, reason error) {
 				var runInTaskQueue func(p *common.Page) (bool, error)
 				if popts.PredicateFn != nil {

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -102,48 +101,6 @@ func NewBrowserContextOptions() *BrowserContextOptions {
 type WaitForEventOptions struct {
 	Timeout     time.Duration
 	PredicateFn sobek.Callable
-}
-
-// NewWaitForEventOptions created a new instance of WaitForEventOptions with a
-// default timeout.
-func NewWaitForEventOptions(defaultTimeout time.Duration) *WaitForEventOptions {
-	return &WaitForEventOptions{
-		Timeout: defaultTimeout,
-	}
-}
-
-// Parse will parse the options or a callable predicate function. It can parse
-// only a callable predicate function or an object which contains a callable
-// predicate function and a timeout.
-func (w *WaitForEventOptions) Parse(ctx context.Context, optsOrPredicate sobek.Value) error {
-	if !sobekValueExists(optsOrPredicate) {
-		return nil
-	}
-
-	var (
-		isCallable bool
-		rt         = k6ext.Runtime(ctx)
-	)
-
-	w.PredicateFn, isCallable = sobek.AssertFunction(optsOrPredicate)
-	if isCallable {
-		return nil
-	}
-
-	opts := optsOrPredicate.ToObject(rt)
-	for _, k := range opts.Keys() {
-		switch k {
-		case "predicate":
-			w.PredicateFn, isCallable = sobek.AssertFunction(opts.Get(k))
-			if !isCallable {
-				return errors.New("predicate function is not callable")
-			}
-		case "timeout": //nolint:goconst
-			w.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
-		}
-	}
-
-	return nil
 }
 
 // GrantPermissionsOptions is used by BrowserContext.GrantPermissions.

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/grafana/sobek"
 
@@ -95,12 +94,6 @@ func NewBrowserContextOptions() *BrowserContextOptions {
 		Screen:            &Screen{Width: DefaultScreenWidth, Height: DefaultScreenHeight},
 		Viewport:          &Viewport{Width: DefaultScreenWidth, Height: DefaultScreenHeight},
 	}
-}
-
-// WaitForEventOptions are the options used by the browserContext.waitForEvent API.
-type WaitForEventOptions struct {
-	Timeout     time.Duration
-	PredicateFn sobek.Callable
 }
 
 // GrantPermissionsOptions is used by BrowserContext.GrantPermissions.


### PR DESCRIPTION
## What?

- Moves `BrowserContext` waitForEvent Sobek-option parsing into the mapping layer.
- Removes `common.WaitForEventOptions` as it's only used in the mapping.

## Why?

See "Desobekifying Sobek transformation" in #1064.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

#1270