### PR TITLE
Desobekify `BrowserContext` geolocation

### DIFF
--- a/browser/browser_context_mapping.go
+++ b/browser/browser_context_mapping.go
@@ -87,12 +87,12 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 		"setDefaultNavigationTimeout": bc.SetDefaultNavigationTimeout,
 		"setDefaultTimeout":           bc.SetDefaultTimeout,
 		"setGeolocation": func(geolocation sobek.Value) (*sobek.Promise, error) {
-			gl := common.NewGeolocation()
-			if err := gl.Parse(vu.Context(), geolocation); err != nil {
+			gl, err := exportTo[common.Geolocation](vu.Runtime(), geolocation)
+			if err != nil {
 				return nil, fmt.Errorf("parsing geo location: %w", err)
 			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, bc.SetGeolocation(gl)
+				return nil, bc.SetGeolocation(&gl)
 			}), nil
 		},
 		"setHTTPCredentials": func(httpCredentials sobek.Value) (*sobek.Promise, error) {

--- a/browser/browser_mapping.go
+++ b/browser/browser_mapping.go
@@ -144,11 +144,11 @@ func parseBrowserContextOptions(ctx context.Context, opts sobek.Value) (*common.
 				b.ExtraHTTPHeaders[k] = headers.Get(k).String()
 			}
 		case "geolocation":
-			geolocation := common.NewGeolocation()
-			if err := geolocation.Parse(ctx, o.Get(k).ToObject(rt)); err != nil {
+			gl, err := exportTo[*common.Geolocation](rt, o.Get(k))
+			if err != nil {
 				return nil, fmt.Errorf("parsing geolocation options: %w", err)
 			}
-			b.Geolocation = geolocation
+			b.Geolocation = gl
 		case "hasTouch":
 			b.HasTouch = o.Get(k).ToBoolean()
 		case "httpCredentials":

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -295,6 +295,10 @@ func (b *BrowserContext) SetDefaultTimeout(timeout int64) {
 func (b *BrowserContext) SetGeolocation(g *Geolocation) error {
 	b.logger.Debugf("BrowserContext:SetGeolocation", "bctxid:%v", b.id)
 
+	if err := g.Validate(); err != nil {
+		return fmt.Errorf("validating geo location: %w", err)
+	}
+
 	b.opts.Geolocation = g
 	for _, p := range b.browser.getPages() {
 		if err := p.updateGeolocation(); err != nil {

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -21,6 +21,20 @@ func NewGeolocation() *Geolocation {
 	return &Geolocation{}
 }
 
+// Validate validates the [Geolocation].
+func (g *Geolocation) Validate() error {
+	if g.Longitude < -180 || g.Longitude > 180 {
+		return fmt.Errorf(`invalid longitude "%.2f": precondition -180 <= LONGITUDE <= 180 failed`, g.Longitude)
+	}
+	if g.Latitude < -90 || g.Latitude > 90 {
+		return fmt.Errorf(`invalid latitude "%.2f": precondition -90 <= LATITUDE <= 90 failed`, g.Latitude)
+	}
+	if g.Accuracy < 0 {
+		return fmt.Errorf(`invalid accuracy "%.2f": precondition 0 <= ACCURACY failed`, g.Accuracy)
+	}
+	return nil
+}
+
 // Parse parses the geolocation options.
 func (g *Geolocation) Parse(ctx context.Context, sopts sobek.Value) error { //nolint:cyclop
 	var newgl Geolocation
@@ -39,16 +53,6 @@ func (g *Geolocation) Parse(ctx context.Context, sopts sobek.Value) error { //no
 		case "longitude":
 			newgl.Longitude = opts.Get(k).ToFloat()
 		}
-	}
-
-	if newgl.Longitude < -180 || newgl.Longitude > 180 {
-		return fmt.Errorf(`invalid longitude "%.2f": precondition -180 <= LONGITUDE <= 180 failed`, newgl.Longitude)
-	}
-	if newgl.Latitude < -90 || newgl.Latitude > 90 {
-		return fmt.Errorf(`invalid latitude "%.2f": precondition -90 <= LATITUDE <= 90 failed`, newgl.Latitude)
-	}
-	if newgl.Accuracy < 0 {
-		return fmt.Errorf(`invalid accuracy "%.2f": precondition 0 <= ACCURACY failed`, newgl.Accuracy)
 	}
 
 	*g = newgl


### PR DESCRIPTION
## What?

- Desobekify `BrowserContext` geolocation.
- Use Sobek translation directly instead of manual parsing.

## Why?

See "Desobekifying Sobek transformation" in https://github.com/grafana/xk6-browser/issues/1064.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

- #1270