### PR TITLE
Fix `TestKeyboardPress` test panic

### DIFF
--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -138,7 +138,7 @@ func TestKeyboardPress(t *testing.T) {
 				return nil
 			},
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Wait for the new tab to complete loading.
 		assert.NoError(t, newTab.WaitForLoadState("load", nil))


### PR DESCRIPTION
## What?

Fix `TestKeyboardPress` test panic.

## Why?

This only fixes the panic but not the underlying error with `WaitForEvent`. As we can also see in #1506, there is clearly an issue with `WaitForEvent`.

## Note

This fix highlights the fact that we should use `require` instead of `assert` when an error should block the test from continuing.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates #1505