### PR TITLE
Desobekify `Screen`

### DIFF
--- a/browser/browser_mapping.go
+++ b/browser/browser_mapping.go
@@ -181,11 +181,11 @@ func parseBrowserContextOptions(ctx context.Context, opts sobek.Value) (*common.
 				b.ReducedMotion = common.ReducedMotionNoPreference
 			}
 		case "screen":
-			var screen common.Screen
-			if err := screen.Parse(ctx, o.Get(k).ToObject(rt)); err != nil {
+			var err error
+			b.Screen, err = exportTo[common.Screen](rt, o.Get(k))
+			if err != nil {
 				return nil, fmt.Errorf("parsing screen options: %w", err)
 			}
-			b.Screen = screen
 		case "timezoneID":
 			b.TimezoneID = o.Get(k).String()
 		case "userAgent":

--- a/browser/browser_mapping.go
+++ b/browser/browser_mapping.go
@@ -185,7 +185,7 @@ func parseBrowserContextOptions(ctx context.Context, opts sobek.Value) (*common.
 			if err := screen.Parse(ctx, o.Get(k).ToObject(rt)); err != nil {
 				return nil, fmt.Errorf("parsing screen options: %w", err)
 			}
-			b.Screen = &screen
+			b.Screen = screen
 		case "timezoneID":
 			b.TimezoneID = o.Get(k).String()
 		case "userAgent":

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -78,7 +78,7 @@ type BrowserContextOptions struct {
 	Offline           bool              `js:"offline"`
 	Permissions       []string          `js:"permissions"`
 	ReducedMotion     ReducedMotion     `js:"reducedMotion"`
-	Screen            *Screen           `js:"screen"`
+	Screen            Screen            `js:"screen"`
 	TimezoneID        string            `js:"timezoneID"`
 	UserAgent         string            `js:"userAgent"`
 	VideosPath        string            `js:"videosPath"`
@@ -95,7 +95,7 @@ func NewBrowserContextOptions() *BrowserContextOptions {
 		Locale:            DefaultLocale,
 		Permissions:       []string{},
 		ReducedMotion:     ReducedMotionNoPreference,
-		Screen:            &Screen{Width: DefaultScreenWidth, Height: DefaultScreenHeight},
+		Screen:            Screen{Width: DefaultScreenWidth, Height: DefaultScreenHeight},
 		Viewport:          &Viewport{Width: DefaultScreenWidth, Height: DefaultScreenHeight},
 	}
 }

--- a/common/page.go
+++ b/common/page.go
@@ -106,29 +106,6 @@ type Screen struct {
 	Height int64 `js:"height"`
 }
 
-const (
-	screenWidth  = "width"
-	screenHeight = "height"
-)
-
-// Parse parses the given screen options.
-func (s *Screen) Parse(ctx context.Context, screen sobek.Value) error {
-	rt := k6ext.Runtime(ctx)
-	if screen != nil && !sobek.IsUndefined(screen) && !sobek.IsNull(screen) {
-		screen := screen.ToObject(rt)
-		for _, k := range screen.Keys() {
-			switch k {
-			case screenWidth:
-				s.Width = screen.Get(k).ToInteger()
-			case screenHeight:
-				s.Height = screen.Get(k).ToInteger()
-			}
-		}
-	}
-
-	return nil
-}
-
 // ColorScheme represents a browser color scheme.
 type ColorScheme string
 

--- a/common/page.go
+++ b/common/page.go
@@ -178,11 +178,11 @@ func (c *ColorScheme) UnmarshalJSON(b []byte) error {
 // EmulatedSize represents the emulated viewport and screen sizes.
 type EmulatedSize struct {
 	Viewport *Viewport
-	Screen   *Screen
+	Screen   Screen
 }
 
 // NewEmulatedSize creates and returns a new EmulatedSize.
-func NewEmulatedSize(viewport *Viewport, screen *Screen) *EmulatedSize {
+func NewEmulatedSize(viewport *Viewport, screen Screen) *EmulatedSize {
 	return &EmulatedSize{
 		Viewport: viewport,
 		Screen:   screen,
@@ -743,7 +743,7 @@ func (p *Page) setViewportSize(viewportSize *Size) error {
 		Width:  int64(viewportSize.Width),
 		Height: int64(viewportSize.Height),
 	}
-	screen := &Screen{
+	screen := Screen{
 		Width:  int64(viewportSize.Width),
 		Height: int64(viewportSize.Height),
 	}

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -32,7 +32,7 @@ func TestBrowserContextOptionsDefaultValues(t *testing.T) {
 	assert.False(t, opts.Offline)
 	assert.Empty(t, opts.Permissions)
 	assert.Equal(t, common.ReducedMotionNoPreference, opts.ReducedMotion)
-	assert.Equal(t, &common.Screen{Width: common.DefaultScreenWidth, Height: common.DefaultScreenHeight}, opts.Screen)
+	assert.Equal(t, common.Screen{Width: common.DefaultScreenWidth, Height: common.DefaultScreenHeight}, opts.Screen)
 	assert.Equal(t, "", opts.TimezoneID)
 	assert.Equal(t, "", opts.UserAgent)
 	assert.Equal(t, &common.Viewport{Width: common.DefaultScreenWidth, Height: common.DefaultScreenHeight}, opts.Viewport)


### PR DESCRIPTION
## What?

- Desobekify `Screen`.
- Turn `Screen` into a value type.

## Why?

See "Desobekifying Sobek transformation" at https://github.com/grafana/xk6-browser/issues/1064.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

- #1270