### PR TITLE
Desobekify `KeyboardOptions`

### DIFF
--- a/browser/keyboard_mapping.go
+++ b/browser/keyboard_mapping.go
@@ -32,12 +32,11 @@ func mapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
 		},
 		"type": func(text string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				var kbdOpts common.KeyboardOptions
-				if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
+				kbopts, err := exportTo[common.KeyboardOptions](vu.Runtime(), opts)
+				if err != nil {
 					return nil, fmt.Errorf("parsing keyboard options: %w", err)
 				}
-
-				return nil, kb.Type(text, kbdOpts) //nolint:wrapcheck
+				return nil, kb.Type(text, kbopts)
 			})
 		},
 		"insertText": func(text string) *sobek.Promise {

--- a/browser/keyboard_mapping.go
+++ b/browser/keyboard_mapping.go
@@ -23,7 +23,7 @@ func mapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
 		},
 		"press": func(key string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				kbdOpts := common.NewKeyboardOptions()
+				var kbdOpts common.KeyboardOptions
 				if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
 					return nil, fmt.Errorf("parsing keyboard options: %w", err)
 				}
@@ -33,7 +33,7 @@ func mapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
 		},
 		"type": func(text string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				kbdOpts := common.NewKeyboardOptions()
+				var kbdOpts common.KeyboardOptions
 				if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
 					return nil, fmt.Errorf("parsing keyboard options: %w", err)
 				}

--- a/browser/keyboard_mapping.go
+++ b/browser/keyboard_mapping.go
@@ -23,12 +23,11 @@ func mapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
 		},
 		"press": func(key string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				var kbdOpts common.KeyboardOptions
-				if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
+				kbopts, err := exportTo[common.KeyboardOptions](vu.Runtime(), opts)
+				if err != nil {
 					return nil, fmt.Errorf("parsing keyboard options: %w", err)
 				}
-
-				return nil, kb.Press(key, kbdOpts) //nolint:wrapcheck
+				return nil, kb.Press(key, kbopts)
 			})
 		},
 		"type": func(text string, opts sobek.Value) *sobek.Promise {

--- a/browser/sync_keyboard_mapping.go
+++ b/browser/sync_keyboard_mapping.go
@@ -13,12 +13,11 @@ func syncMapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
 		"down": kb.Down,
 		"up":   kb.Up,
 		"press": func(key string, opts sobek.Value) error {
-			var kbdOpts common.KeyboardOptions
-			if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
+			kbopts, err := exportTo[common.KeyboardOptions](vu.Runtime(), opts)
+			if err != nil {
 				return fmt.Errorf("parsing keyboard options: %w", err)
 			}
-
-			return kb.Press(key, kbdOpts) //nolint:wrapcheck
+			return kb.Press(key, kbopts)
 		},
 		"type": func(text string, opts sobek.Value) error {
 			var kbdOpts common.KeyboardOptions

--- a/browser/sync_keyboard_mapping.go
+++ b/browser/sync_keyboard_mapping.go
@@ -20,12 +20,11 @@ func syncMapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
 			return kb.Press(key, kbopts)
 		},
 		"type": func(text string, opts sobek.Value) error {
-			var kbdOpts common.KeyboardOptions
-			if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
+			kbopts, err := exportTo[common.KeyboardOptions](vu.Runtime(), opts)
+			if err != nil {
 				return fmt.Errorf("parsing keyboard options: %w", err)
 			}
-
-			return kb.Type(text, kbdOpts) //nolint:wrapcheck
+			return kb.Type(text, kbopts)
 		},
 		"insertText": kb.InsertText,
 	}

--- a/browser/sync_keyboard_mapping.go
+++ b/browser/sync_keyboard_mapping.go
@@ -13,7 +13,7 @@ func syncMapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
 		"down": kb.Down,
 		"up":   kb.Up,
 		"press": func(key string, opts sobek.Value) error {
-			kbdOpts := common.NewKeyboardOptions()
+			var kbdOpts common.KeyboardOptions
 			if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
 				return fmt.Errorf("parsing keyboard options: %w", err)
 			}
@@ -21,7 +21,7 @@ func syncMapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
 			return kb.Press(key, kbdOpts) //nolint:wrapcheck
 		},
 		"type": func(text string, opts sobek.Value) error {
-			kbdOpts := common.NewKeyboardOptions()
+			var kbdOpts common.KeyboardOptions
 			if err := kbdOpts.Parse(vu.Context(), opts); err != nil {
 				return fmt.Errorf("parsing keyboard options: %w", err)
 			}

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -464,7 +464,7 @@ func (h *ElementHandle) scrollRectIntoViewIfNeeded(apiCtx context.Context, rect 
 	return nil
 }
 
-func (h *ElementHandle) press(apiCtx context.Context, key string, opts *KeyboardOptions) error {
+func (h *ElementHandle) press(apiCtx context.Context, key string, opts KeyboardOptions) error {
 	err := h.focus(apiCtx, true)
 	if err != nil {
 		return err
@@ -611,7 +611,7 @@ func (h *ElementHandle) textContent(apiCtx context.Context) (any, error) {
 	return h.eval(apiCtx, opts, js)
 }
 
-func (h *ElementHandle) typ(apiCtx context.Context, text string, opts *KeyboardOptions) error {
+func (h *ElementHandle) typ(apiCtx context.Context, text string, opts KeyboardOptions) error {
 	err := h.focus(apiCtx, true)
 	if err != nil {
 		return err

--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1085,7 +1085,7 @@ func (h *ElementHandle) Press(key string, opts sobek.Value) error {
 	}
 
 	press := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
-		return nil, handle.press(apiCtx, key, NewKeyboardOptions())
+		return nil, handle.press(apiCtx, key, KeyboardOptions{})
 	}
 	pressAction := h.newAction(
 		[]string{}, press, false, popts.NoWaitAfter, popts.Timeout,
@@ -1457,7 +1457,7 @@ func (h *ElementHandle) Type(text string, opts sobek.Value) error {
 	}
 
 	typ := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
-		return nil, handle.typ(apiCtx, text, NewKeyboardOptions())
+		return nil, handle.typ(apiCtx, text, KeyboardOptions{})
 	}
 	typeAction := h.newAction(
 		[]string{}, typ, false, popts.NoWaitAfter, popts.Timeout,

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -459,12 +459,14 @@ func NewFramePressOptions(defaultTimeout time.Duration) *FramePressOptions {
 	}
 }
 
-func (o *FramePressOptions) ToKeyboardOptions() *KeyboardOptions {
+// ToKeyboardOptions converts FramePressOptions to KeyboardOptions.
+func (o *FramePressOptions) ToKeyboardOptions() KeyboardOptions {
 	o2 := NewKeyboardOptions()
 	o2.Delay = o.Delay
 	return o2
 }
 
+// NewFrameSelectOptionOptions creates and returns a new instance of FrameSelectOptionOptions.
 func NewFrameSelectOptionOptions(defaultTimeout time.Duration) *FrameSelectOptionOptions {
 	return &FrameSelectOptionOptions{
 		ElementHandleBaseOptions: *NewElementHandleBaseOptions(defaultTimeout),
@@ -579,7 +581,8 @@ func NewFrameTypeOptions(defaultTimeout time.Duration) *FrameTypeOptions {
 	}
 }
 
-func (o *FrameTypeOptions) ToKeyboardOptions() *KeyboardOptions {
+// ToKeyboardOptions converts FrameTypeOptions to KeyboardOptions.
+func (o *FrameTypeOptions) ToKeyboardOptions() KeyboardOptions {
 	o2 := NewKeyboardOptions()
 	o2.Delay = o.Delay
 	return o2

--- a/common/frame_options.go
+++ b/common/frame_options.go
@@ -461,7 +461,7 @@ func NewFramePressOptions(defaultTimeout time.Duration) *FramePressOptions {
 
 // ToKeyboardOptions converts FramePressOptions to KeyboardOptions.
 func (o *FramePressOptions) ToKeyboardOptions() KeyboardOptions {
-	o2 := NewKeyboardOptions()
+	var o2 KeyboardOptions
 	o2.Delay = o.Delay
 	return o2
 }
@@ -583,7 +583,7 @@ func NewFrameTypeOptions(defaultTimeout time.Duration) *FrameTypeOptions {
 
 // ToKeyboardOptions converts FrameTypeOptions to KeyboardOptions.
 func (o *FrameTypeOptions) ToKeyboardOptions() KeyboardOptions {
-	o2 := NewKeyboardOptions()
+	var o2 KeyboardOptions
 	o2.Delay = o.Delay
 	return o2
 }

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -62,7 +62,7 @@ func (k *Keyboard) Up(key string) error {
 // Press sends a key press message to a session target.
 // It delays the action if `Delay` option is specified.
 // A press message consists of successive key down and up messages.
-func (k *Keyboard) Press(key string, kbdOpts *KeyboardOptions) error {
+func (k *Keyboard) Press(key string, kbdOpts KeyboardOptions) error {
 	if err := k.comboPress(key, kbdOpts); err != nil {
 		return fmt.Errorf("pressing key: %w", err)
 	}
@@ -83,7 +83,7 @@ func (k *Keyboard) InsertText(text string) error {
 //
 // It sends an insertText message if a character is not among
 // valid characters in the keyboard's layout.
-func (k *Keyboard) Type(text string, kbdOpts *KeyboardOptions) error {
+func (k *Keyboard) Type(text string, kbdOpts KeyboardOptions) error {
 	if err := k.typ(text, kbdOpts); err != nil {
 		return fmt.Errorf("typing text: %w", err)
 	}
@@ -245,7 +245,7 @@ func (k *Keyboard) platformSpecificResolution(key string) string {
 	return key
 }
 
-func (k *Keyboard) comboPress(keys string, opts *KeyboardOptions) error {
+func (k *Keyboard) comboPress(keys string, opts KeyboardOptions) error {
 	if opts.Delay > 0 {
 		if err := wait(k.ctx, opts.Delay); err != nil {
 			return err
@@ -291,7 +291,7 @@ func split(keys string) []string {
 	return kk
 }
 
-func (k *Keyboard) press(key string, opts *KeyboardOptions) error {
+func (k *Keyboard) press(key string, opts KeyboardOptions) error {
 	if opts.Delay > 0 {
 		if err := wait(k.ctx, opts.Delay); err != nil {
 			return err
@@ -303,7 +303,7 @@ func (k *Keyboard) press(key string, opts *KeyboardOptions) error {
 	return k.up(key)
 }
 
-func (k *Keyboard) typ(text string, opts *KeyboardOptions) error {
+func (k *Keyboard) typ(text string, opts KeyboardOptions) error {
 	layout := keyboardlayout.GetKeyboardLayout(k.layoutName)
 	for _, c := range text {
 		if opts.Delay > 0 {

--- a/common/keyboard.go
+++ b/common/keyboard.go
@@ -20,6 +20,11 @@ const (
 	ModifierKeyShift
 )
 
+// KeyboardOptions represents the options for the keyboard.
+type KeyboardOptions struct {
+	Delay int64 `json:"delay"`
+}
+
 // Keyboard represents a keyboard input device.
 // Each Page has a publicly accessible Keyboard.
 type Keyboard struct {

--- a/common/keyboard_options.go
+++ b/common/keyboard_options.go
@@ -13,13 +13,6 @@ type KeyboardOptions struct {
 	Delay int64 `json:"delay"`
 }
 
-// NewKeyboardOptions returns a new KeyboardOptions.
-func NewKeyboardOptions() KeyboardOptions {
-	return KeyboardOptions{
-		Delay: 0,
-	}
-}
-
 // Parse parses the keyboard options.
 func (o *KeyboardOptions) Parse(ctx context.Context, opts sobek.Value) error {
 	rt := k6ext.Runtime(ctx)

--- a/common/keyboard_options.go
+++ b/common/keyboard_options.go
@@ -1,6 +1,0 @@
-package common
-
-// KeyboardOptions represents the options for the keyboard.
-type KeyboardOptions struct {
-	Delay int64 `json:"delay"`
-}

--- a/common/keyboard_options.go
+++ b/common/keyboard_options.go
@@ -1,30 +1,6 @@
 package common
 
-import (
-	"context"
-
-	"github.com/grafana/sobek"
-
-	"github.com/grafana/xk6-browser/k6ext"
-)
-
 // KeyboardOptions represents the options for the keyboard.
 type KeyboardOptions struct {
 	Delay int64 `json:"delay"`
-}
-
-// Parse parses the keyboard options.
-func (o *KeyboardOptions) Parse(ctx context.Context, opts sobek.Value) error {
-	rt := k6ext.Runtime(ctx)
-	if opts != nil && !sobek.IsUndefined(opts) && !sobek.IsNull(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "delay":
-				o.Delay = opts.Get(k).ToInteger()
-			}
-		}
-	}
-
-	return nil
 }

--- a/common/keyboard_options.go
+++ b/common/keyboard_options.go
@@ -8,12 +8,14 @@ import (
 	"github.com/grafana/xk6-browser/k6ext"
 )
 
+// KeyboardOptions represents the options for the keyboard.
 type KeyboardOptions struct {
 	Delay int64 `json:"delay"`
 }
 
-func NewKeyboardOptions() *KeyboardOptions {
-	return &KeyboardOptions{
+// NewKeyboardOptions returns a new KeyboardOptions.
+func NewKeyboardOptions() KeyboardOptions {
+	return KeyboardOptions{
 		Delay: 0,
 	}
 }
@@ -30,5 +32,6 @@ func (o *KeyboardOptions) Parse(ctx context.Context, opts sobek.Value) error {
 			}
 		}
 	}
+
 	return nil
 }

--- a/common/keyboard_test.go
+++ b/common/keyboard_test.go
@@ -83,7 +83,7 @@ func TestKeyboardPress(t *testing.T) {
 
 		vu := k6test.NewVU(t)
 		k := NewKeyboard(vu.Context(), nil)
-		require.Error(t, k.Press("", NewKeyboardOptions()))
+		require.Error(t, k.Press("", KeyboardOptions{}))
 	})
 }
 

--- a/tests/keyboard_test.go
+++ b/tests/keyboard_test.go
@@ -26,7 +26,7 @@ func TestKeyboardPress(t *testing.T) {
 		layout := keyboardlayout.GetKeyboardLayout("us")
 
 		for k := range layout.Keys {
-			assert.NoError(t, kb.Press(string(k), common.NewKeyboardOptions()))
+			assert.NoError(t, kb.Press(string(k), common.KeyboardOptions{}))
 		}
 	})
 
@@ -43,12 +43,12 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("input", nil))
 
-		require.NoError(t, kb.Type("Hello World!", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Type("Hello World!", common.KeyboardOptions{}))
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
 		require.Equal(t, "Hello World!", v)
 
-		require.NoError(t, kb.Press("Backspace", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Backspace", common.KeyboardOptions{}))
 		v, err = el.InputValue(nil)
 		require.NoError(t, err)
 		assert.Equal(t, "Hello World", v)
@@ -67,17 +67,17 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("input", nil))
 
-		require.NoError(t, kb.Press("Shift++", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Shift+=", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Shift+@", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Shift+6", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Shift+KeyA", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Shift+b", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Shift+C", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Shift++", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Shift+=", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Shift+@", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Shift+6", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Shift+KeyA", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Shift+b", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Shift+C", common.KeyboardOptions{}))
 
-		require.NoError(t, kb.Press("Control+KeyI", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Control+J", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Control+k", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Control+KeyI", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Control+J", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Control+k", common.KeyboardOptions{}))
 
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
@@ -166,9 +166,9 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("input", nil))
 
-		require.NoError(t, kb.Press("Shift+KeyA", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Shift+b", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Shift+C", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Shift+KeyA", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Shift+b", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Shift+C", common.KeyboardOptions{}))
 
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
@@ -178,8 +178,8 @@ func TestKeyboardPress(t *testing.T) {
 		if runtime.GOOS == "darwin" {
 			metaKey = "Meta"
 		}
-		require.NoError(t, kb.Press(metaKey+"+A", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Delete", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press(metaKey+"+A", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Delete", common.KeyboardOptions{}))
 		v, err = el.InputValue(nil)
 		require.NoError(t, err)
 		assert.Equal(t, "", v)
@@ -198,7 +198,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("textarea", nil))
 
-		require.NoError(t, kb.Type("L+m+KeyN", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Type("L+m+KeyN", common.KeyboardOptions{}))
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
 		assert.Equal(t, "L+m+KeyN", v)
@@ -217,9 +217,9 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("textarea", nil))
 
-		require.NoError(t, kb.Press("C", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("d", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("KeyE", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("C", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("d", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("KeyE", common.KeyboardOptions{}))
 
 		require.NoError(t, kb.Down("Shift"))
 		require.NoError(t, kb.Down("f"))
@@ -249,7 +249,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, p.Focus("textarea", nil))
 
 		require.NoError(t, kb.Down("Shift"))
-		require.NoError(t, kb.Type("oPqR", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Type("oPqR", common.KeyboardOptions{}))
 		require.NoError(t, kb.Up("Shift"))
 
 		v, err := el.InputValue(nil)
@@ -270,10 +270,10 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("textarea", nil))
 
-		require.NoError(t, kb.Type("Hello", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Enter", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Press("Enter", common.NewKeyboardOptions()))
-		require.NoError(t, kb.Type("World!", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Type("Hello", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Enter", common.KeyboardOptions{}))
+		require.NoError(t, kb.Press("Enter", common.KeyboardOptions{}))
+		require.NoError(t, kb.Type("World!", common.KeyboardOptions{}))
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
 		assert.Equal(t, "Hello\n\nWorld!", v)
@@ -293,21 +293,21 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, p.Focus("input", nil))
 
-		require.NoError(t, kb.Type("Hello World!", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Type("Hello World!", common.KeyboardOptions{}))
 		v, err := el.InputValue(nil)
 		require.NoError(t, err)
 		require.Equal(t, "Hello World!", v)
 
-		require.NoError(t, kb.Press("ArrowLeft", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("ArrowLeft", common.KeyboardOptions{}))
 		// Should hold the key until Up() is called.
 		require.NoError(t, kb.Down("Shift"))
 		for i := 0; i < len(" World"); i++ {
-			require.NoError(t, kb.Press("ArrowLeft", common.NewKeyboardOptions()))
+			require.NoError(t, kb.Press("ArrowLeft", common.KeyboardOptions{}))
 		}
 		// Should release the key but the selection should remain active.
 		require.NoError(t, kb.Up("Shift"))
 		// Should delete the selection.
-		require.NoError(t, kb.Press("Backspace", common.NewKeyboardOptions()))
+		require.NoError(t, kb.Press("Backspace", common.KeyboardOptions{}))
 
 		require.NoError(t, err)
 		require.NoError(t, err)


### PR DESCRIPTION
## What?

- Desobekify `KeyboardOptions`.
- Turn `KeyboardOptions` into a value type.

## Why?

See "Desobekifying Sobek transformation" at https://github.com/grafana/xk6-browser/issues/1064.

## Note

The linter warning is a false alarm.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

- #1522
- #1270