### PR TITLE
Remove unused `NetworkManager.ExtraHTTPHeaders` method

### DIFF
--- a/common/network_manager.go
+++ b/common/network_manager.go
@@ -26,7 +26,6 @@ import (
 	"github.com/chromedp/cdproto/emulation"
 	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/cdproto/network"
-	"github.com/grafana/sobek"
 )
 
 // Credentials holds HTTP authentication credentials.
@@ -729,12 +728,6 @@ func (m *NetworkManager) Authenticate(credentials Credentials) error {
 	}
 
 	return nil
-}
-
-// ExtraHTTPHeaders returns the currently set extra HTTP request headers.
-func (m *NetworkManager) ExtraHTTPHeaders() sobek.Value {
-	rt := m.vu.Runtime()
-	return rt.ToValue(m.extraHTTPHeaders)
 }
 
 // SetExtraHTTPHeaders sets extra HTTP request headers to be sent with every request.


### PR DESCRIPTION
## What?

Remove the unused `NetworkManager.ExtraHTTPHeaders` method.

## Why?

Unused.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

- #1282