### PR TITLE
Refactor `parseBrowserContextOptions` to Sobek

### DIFF
--- a/browser/browser_context_options_test.go
+++ b/browser/browser_context_options_test.go
@@ -12,7 +12,7 @@ import (
 func TestBrowserContextOptionsPermissions(t *testing.T) {
 	vu := k6test.NewVU(t)
 
-	opts, err := parseBrowserContextOptions(vu.Context(), vu.ToSobekValue((struct {
+	opts, err := parseBrowserContextOptions(vu.Runtime(), vu.ToSobekValue((struct {
 		Permissions []any `js:"permissions"`
 	}{
 		Permissions: []any{"camera", "microphone"},
@@ -25,7 +25,7 @@ func TestBrowserContextOptionsPermissions(t *testing.T) {
 func TestBrowserContextSetGeolocation(t *testing.T) {
 	vu := k6test.NewVU(t)
 
-	opts, err := parseBrowserContextOptions(vu.Context(), vu.ToSobekValue((struct {
+	opts, err := parseBrowserContextOptions(vu.Runtime(), vu.ToSobekValue((struct {
 		GeoLocation *common.Geolocation `js:"geolocation"`
 	}{
 		GeoLocation: &common.Geolocation{

--- a/browser/browser_context_options_test.go
+++ b/browser/browser_context_options_test.go
@@ -45,7 +45,7 @@ func TestBrowserContextSetGeolocation(t *testing.T) {
 func TestBrowserContextDefaultOptions(t *testing.T) {
 	vu := k6test.NewVU(t)
 
-	defaults := common.NewBrowserContextOptions()
+	defaults := common.DefaultBrowserContextOptions()
 
 	// gets the default options by default
 	opts, err := parseBrowserContextOptions(vu.Runtime(), nil)

--- a/browser/browser_context_options_test.go
+++ b/browser/browser_context_options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/xk6-browser/common"
 	"github.com/grafana/xk6-browser/k6ext/k6test"
@@ -39,4 +40,25 @@ func TestBrowserContextSetGeolocation(t *testing.T) {
 	assert.Equal(t, 1.0, opts.Geolocation.Latitude)
 	assert.Equal(t, 2.0, opts.Geolocation.Longitude)
 	assert.Equal(t, 3.0, opts.Geolocation.Accuracy)
+}
+
+func TestBrowserContextDefaultOptions(t *testing.T) {
+	vu := k6test.NewVU(t)
+
+	defaults := common.NewBrowserContextOptions()
+
+	// gets the default options by default
+	opts, err := parseBrowserContextOptions(vu.Runtime(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, defaults, opts)
+
+	// merges with the default options
+	opts, err = parseBrowserContextOptions(vu.Runtime(), vu.ToSobekValue((struct {
+		DeviceScaleFactor float64 `js:"deviceScaleFactor"` // just to test a different field
+	}{
+		DeviceScaleFactor: defaults.DeviceScaleFactor + 1,
+	})))
+	require.NoError(t, err)
+	assert.NotEqual(t, defaults.DeviceScaleFactor, opts.DeviceScaleFactor)
+	assert.Equal(t, defaults.Locale, opts.Locale) // should remain as default
 }

--- a/browser/browser_mapping.go
+++ b/browser/browser_mapping.go
@@ -110,94 +110,13 @@ func initBrowserContext(bctx *common.BrowserContext, testRunID string) error {
 }
 
 // parseBrowserContextOptions parses the [common.BrowserContext] options from a Sobek value.
-func parseBrowserContextOptions(ctx context.Context, opts sobek.Value) (*common.BrowserContextOptions, error) { //nolint:cyclop,funlen,gocognit,lll
+func parseBrowserContextOptions(ctx context.Context, opts sobek.Value) (*common.BrowserContextOptions, error) {
 	if !sobekValueExists(opts) {
 		return nil, nil //nolint:nilnil
 	}
-
 	b := common.NewBrowserContextOptions()
-
-	rt := k6ext.Runtime(ctx)
-	o := opts.ToObject(rt)
-	for _, k := range o.Keys() {
-		switch k {
-		case "acceptDownloads":
-			b.AcceptDownloads = o.Get(k).ToBoolean()
-		case "downloadsPath":
-			b.DownloadsPath = o.Get(k).String()
-		case "bypassCSP":
-			b.BypassCSP = o.Get(k).ToBoolean()
-		case "colorScheme":
-			switch common.ColorScheme(o.Get(k).String()) { //nolint:exhaustive
-			case "light":
-				b.ColorScheme = common.ColorSchemeLight
-			case "dark":
-				b.ColorScheme = common.ColorSchemeDark
-			default:
-				b.ColorScheme = common.ColorSchemeNoPreference
-			}
-		case "deviceScaleFactor":
-			b.DeviceScaleFactor = o.Get(k).ToFloat()
-		case "extraHTTPHeaders":
-			headers := o.Get(k).ToObject(rt)
-			for _, k := range headers.Keys() {
-				b.ExtraHTTPHeaders[k] = headers.Get(k).String()
-			}
-		case "geolocation":
-			gl, err := exportTo[*common.Geolocation](rt, o.Get(k))
-			if err != nil {
-				return nil, fmt.Errorf("parsing geolocation options: %w", err)
-			}
-			b.Geolocation = gl
-		case "hasTouch":
-			b.HasTouch = o.Get(k).ToBoolean()
-		case "httpCredentials":
-			var err error
-			b.HTTPCredentials, err = exportTo[common.Credentials](rt, o.Get(k))
-			if err != nil {
-				return nil, fmt.Errorf("parsing HTTP credential options: %w", err)
-			}
-		case "ignoreHTTPSErrors":
-			b.IgnoreHTTPSErrors = o.Get(k).ToBoolean()
-		case "isMobile":
-			b.IsMobile = o.Get(k).ToBoolean()
-		case "javaScriptEnabled":
-			b.JavaScriptEnabled = o.Get(k).ToBoolean()
-		case "locale":
-			b.Locale = o.Get(k).String()
-		case "offline":
-			b.Offline = o.Get(k).ToBoolean()
-		case "permissions":
-			var err error
-			b.Permissions, err = exportTo[[]string](rt, o.Get(k))
-			if err != nil {
-				return nil, fmt.Errorf("parsing permissions options: %w", err)
-			}
-		case "reducedMotion":
-			switch common.ReducedMotion(o.Get(k).String()) { //nolint:exhaustive
-			case "reduce":
-				b.ReducedMotion = common.ReducedMotionReduce
-			default:
-				b.ReducedMotion = common.ReducedMotionNoPreference
-			}
-		case "screen":
-			var err error
-			b.Screen, err = exportTo[common.Screen](rt, o.Get(k))
-			if err != nil {
-				return nil, fmt.Errorf("parsing screen options: %w", err)
-			}
-		case "timezoneID":
-			b.TimezoneID = o.Get(k).String()
-		case "userAgent":
-			b.UserAgent = o.Get(k).String()
-		case "viewport":
-			var err error
-			b.Viewport, err = exportTo[common.Viewport](rt, o.Get(k))
-			if err != nil {
-				return nil, fmt.Errorf("parsing viewport options: %w", err)
-			}
-		}
+	if err := k6ext.Runtime(ctx).ExportTo(opts, &b); err != nil {
+		return nil, err //nolint:wrapcheck
 	}
-
 	return b, nil
 }

--- a/browser/browser_mapping.go
+++ b/browser/browser_mapping.go
@@ -110,7 +110,7 @@ func initBrowserContext(bctx *common.BrowserContext, testRunID string) error {
 
 // parseBrowserContextOptions parses the [common.BrowserContext] options from a Sobek value.
 func parseBrowserContextOptions(rt *sobek.Runtime, opts sobek.Value) (*common.BrowserContextOptions, error) {
-	b := common.NewBrowserContextOptions()
+	b := common.DefaultBrowserContextOptions()
 	if err := mergeWith(rt, b, opts); err != nil {
 		return nil, err
 	}

--- a/browser/browser_mapping.go
+++ b/browser/browser_mapping.go
@@ -1,7 +1,6 @@
 package browser
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/grafana/sobek"
@@ -37,7 +36,7 @@ func mapBrowser(vu moduleVU) mapping { //nolint:funlen,cyclop,gocognit
 			return b.IsConnected(), nil
 		},
 		"newContext": func(opts sobek.Value) (*sobek.Promise, error) {
-			popts, err := parseBrowserContextOptions(vu.Context(), opts)
+			popts, err := parseBrowserContextOptions(vu.Runtime(), opts)
 			if err != nil {
 				return nil, fmt.Errorf("parsing browser.newContext options: %w", err)
 			}
@@ -72,7 +71,7 @@ func mapBrowser(vu moduleVU) mapping { //nolint:funlen,cyclop,gocognit
 			return b.Version(), nil
 		},
 		"newPage": func(opts sobek.Value) (*sobek.Promise, error) {
-			popts, err := parseBrowserContextOptions(vu.Context(), opts)
+			popts, err := parseBrowserContextOptions(vu.Runtime(), opts)
 			if err != nil {
 				return nil, fmt.Errorf("parsing browser.newPage options: %w", err)
 			}
@@ -110,12 +109,12 @@ func initBrowserContext(bctx *common.BrowserContext, testRunID string) error {
 }
 
 // parseBrowserContextOptions parses the [common.BrowserContext] options from a Sobek value.
-func parseBrowserContextOptions(ctx context.Context, opts sobek.Value) (*common.BrowserContextOptions, error) {
+func parseBrowserContextOptions(rt *sobek.Runtime, opts sobek.Value) (*common.BrowserContextOptions, error) {
 	if !sobekValueExists(opts) {
 		return nil, nil //nolint:nilnil
 	}
 	b := common.NewBrowserContextOptions()
-	if err := k6ext.Runtime(ctx).ExportTo(opts, &b); err != nil {
+	if err := rt.ExportTo(opts, &b); err != nil {
 		return nil, err //nolint:wrapcheck
 	}
 	return b, nil

--- a/browser/browser_mapping.go
+++ b/browser/browser_mapping.go
@@ -110,12 +110,9 @@ func initBrowserContext(bctx *common.BrowserContext, testRunID string) error {
 
 // parseBrowserContextOptions parses the [common.BrowserContext] options from a Sobek value.
 func parseBrowserContextOptions(rt *sobek.Runtime, opts sobek.Value) (*common.BrowserContextOptions, error) {
-	if !sobekValueExists(opts) {
-		return nil, nil //nolint:nilnil
-	}
 	b := common.NewBrowserContextOptions()
-	if err := rt.ExportTo(opts, &b); err != nil {
-		return nil, err //nolint:wrapcheck
+	if err := mergeWith(rt, b, opts); err != nil {
+		return nil, err
 	}
 	return b, nil
 }

--- a/browser/helpers.go
+++ b/browser/helpers.go
@@ -16,6 +16,14 @@ func panicIfFatalError(ctx context.Context, err error) {
 	}
 }
 
+// mergeWith merges the Sobek value with the existing Go value.
+func mergeWith[T any](rt *sobek.Runtime, src T, v sobek.Value) error {
+	if !sobekValueExists(v) {
+		return nil
+	}
+	return rt.ExportTo(v, &src) //nolint:wrapcheck
+}
+
 // exportTo exports the Sobek value to a Go value.
 // It returns the zero value of T if obj does not exist in the Sobek runtime.
 // It's caller's responsibility to check for nilness.

--- a/browser/sync_browser_mapping.go
+++ b/browser/sync_browser_mapping.go
@@ -32,7 +32,7 @@ func syncMapBrowser(vu moduleVU) mapping { //nolint:funlen,cyclop
 			return b.IsConnected(), nil
 		},
 		"newContext": func(opts sobek.Value) (*sobek.Object, error) {
-			popts, err := parseBrowserContextOptions(vu.Context(), opts)
+			popts, err := parseBrowserContextOptions(vu.Runtime(), opts)
 			if err != nil {
 				return nil, fmt.Errorf("parsing browser.newContext options: %w", err)
 			}
@@ -69,7 +69,7 @@ func syncMapBrowser(vu moduleVU) mapping { //nolint:funlen,cyclop
 			return b.Version(), nil
 		},
 		"newPage": func(opts sobek.Value) (mapping, error) {
-			popts, err := parseBrowserContextOptions(vu.Context(), opts)
+			popts, err := parseBrowserContextOptions(vu.Runtime(), opts)
 			if err != nil {
 				return nil, fmt.Errorf("parsing browser.newPage options: %w", err)
 			}

--- a/common/browser.go
+++ b/common/browser.go
@@ -157,7 +157,7 @@ func (b *Browser) connect() error {
 	}
 
 	// We don't need to lock this because `connect()` is called only in NewBrowser
-	b.defaultContext, err = NewBrowserContext(b.vuCtx, b, "", NewBrowserContextOptions(), b.logger)
+	b.defaultContext, err = NewBrowserContext(b.vuCtx, b, "", DefaultBrowserContextOptions(), b.logger)
 	if err != nil {
 		return fmt.Errorf("browser connect: %w", err)
 	}

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -116,7 +116,7 @@ func NewBrowserContext(
 ) (*BrowserContext, error) {
 	// set the default options if none provided.
 	if opts == nil {
-		opts = NewBrowserContextOptions()
+		opts = DefaultBrowserContextOptions()
 	}
 
 	b := BrowserContext{

--- a/common/browser_context_options.go
+++ b/common/browser_context_options.go
@@ -55,8 +55,8 @@ type BrowserContextOptions struct {
 	Viewport          Viewport          `js:"viewport"`
 }
 
-// NewBrowserContextOptions creates a default set of browser context options.
-func NewBrowserContextOptions() *BrowserContextOptions {
+// DefaultBrowserContextOptions returns the default browser context options.
+func DefaultBrowserContextOptions() *BrowserContextOptions {
 	return &BrowserContextOptions{
 		ColorScheme:       ColorSchemeLight,
 		DeviceScaleFactor: 1.0,

--- a/tests/browser_context_options_test.go
+++ b/tests/browser_context_options_test.go
@@ -15,7 +15,7 @@ import (
 func TestBrowserContextOptionsDefaultValues(t *testing.T) {
 	t.Parallel()
 
-	opts := common.NewBrowserContextOptions()
+	opts := common.DefaultBrowserContextOptions()
 	assert.False(t, opts.AcceptDownloads)
 	assert.Empty(t, opts.DownloadsPath)
 	assert.False(t, opts.BypassCSP)
@@ -52,7 +52,7 @@ func TestBrowserContextOptionsSetViewport(t *testing.T) {
 	t.Parallel()
 
 	tb := newTestBrowser(t)
-	opts := common.NewBrowserContextOptions()
+	opts := common.DefaultBrowserContextOptions()
 	opts.Viewport = common.Viewport{
 		Width:  800,
 		Height: 600,
@@ -77,7 +77,7 @@ func TestBrowserContextOptionsExtraHTTPHeaders(t *testing.T) {
 
 	tb := newTestBrowser(t, withHTTPServer())
 
-	opts := common.NewBrowserContextOptions()
+	opts := common.DefaultBrowserContextOptions()
 	opts.ExtraHTTPHeaders = map[string]string{
 		"Some-Header": "Some-Value",
 	}

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -182,7 +182,7 @@ func TestElementHandleClickConcealedLink(t *testing.T) {
 
 	tb := newTestBrowser(t, withFileServer())
 
-	bcopts := common.NewBrowserContextOptions()
+	bcopts := common.DefaultBrowserContextOptions()
 	bcopts.Viewport = common.Viewport{
 		Width:  500,
 		Height: 240,

--- a/tests/network_manager_test.go
+++ b/tests/network_manager_test.go
@@ -113,7 +113,7 @@ func TestBasicAuth(t *testing.T) {
 
 		browser := newTestBrowser(t, withHTTPServer())
 
-		bcopts := common.NewBrowserContextOptions()
+		bcopts := common.DefaultBrowserContextOptions()
 		bcopts.HTTPCredentials = common.Credentials{
 			Username: validUser,
 			Password: validPassword,


### PR DESCRIPTION
## What?

Refactor `parseBrowserContextOptions` to use direct Sobek transformation.

## Why?

After the refactorings we made in #1270, it's now possible to let Sobek perform this transformation alone.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes (locally tested it—see the script)
- [x] I have commented on my code, particularly in hard-to-understand areas

## Script

I also used the script to test it using my old friend `Printf` in `Browser.NewContext` etc..

```javascript
export default async function() {
  const context = await browser.newContext({
    acceptDownloads: true,
    downloadsPath: "/tmp",
    bypassCSP: true,
    colorScheme: "dark",
    deviceScaleFactor: 1,
    extraHTTPHeaders: {
        "X-Header": "value",
    },
    geolocation: { latitude: 51.509865, longitude: -0.118092 },
    hasTouch: true,
    httpCredentials: { username: "admin", password: "password" },
    ignoreHTTPSErrors: true,
    isMobile: true,
    javaScriptEnabled: true,
    locale: "fr-FR",
    offline: true,
    permissions: ["camera", "microphone"],
    reducedMotion: true,
    screen: { width: 800, height: 600 },
    timezoneID: "Europe/Paris",
    userAgent: "my agent",
    viewport: { width: 800, height: 600 },
  });
}
```

## Related PR(s)/Issue(s)

- #1270