### PR TITLE
Fix underlying `frame.waitForSelector`

### DIFF
--- a/common/frame.go
+++ b/common/frame.go
@@ -523,15 +523,16 @@ func (f *Frame) waitForSelectorRetry(
 	return nil, err
 }
 
+// waitForSelector will wait for the given selector to reach a defined state in
+// opts.
+//
+// It will auto retry on certain errors until the retryCount is below 0. The
+// retry workaround is needed since the underlying DOM can change when the
+// wait action is performed during a navigation.
 func (f *Frame) waitForSelector(selector string, opts *FrameWaitForSelectorOptions) (_ *ElementHandle, rerr error) {
 	f.log.Debugf("Frame:waitForSelector", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	document, err := f.document()
-	if err != nil {
-		return nil, err
-	}
-
-	handle, err := document.waitForSelector(f.ctx, selector, opts)
+	handle, err := f.waitFor(selector, opts, 20)
 	if err != nil {
 		return nil, err
 	}

--- a/common/frame.go
+++ b/common/frame.go
@@ -564,12 +564,12 @@ func (f *Frame) waitForSelector(selector string, opts *FrameWaitForSelectorOptio
 	return handle, nil
 }
 
-func (f *Frame) waitFor(selector string, opts *FrameWaitForSelectorOptions, retryCount int) error {
+func (f *Frame) waitFor(selector string, opts *FrameWaitForSelectorOptions, retryCount int) (_ *ElementHandle, rerr error) {
 	f.log.Debugf("Frame:waitFor", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
 	retryCount--
 	if retryCount < 0 {
-		return errors.New("waitFor retry threshold reached")
+		return nil, errors.New("waitFor retry threshold reached")
 	}
 
 	document, err := f.document()
@@ -577,10 +577,10 @@ func (f *Frame) waitFor(selector string, opts *FrameWaitForSelectorOptions, retr
 		if strings.Contains(err.Error(), "Cannot find context with specified id") {
 			return f.waitFor(selector, opts, retryCount)
 		}
-		return err
+		return nil, err
 	}
 
-	_, err = document.waitForSelector(f.ctx, selector, opts)
+	handle, err := document.waitForSelector(f.ctx, selector, opts)
 	if err != nil {
 		if strings.Contains(err.Error(), "Inspected target navigated or closed") {
 			return f.waitFor(selector, opts, retryCount)
@@ -593,7 +593,7 @@ func (f *Frame) waitFor(selector string, opts *FrameWaitForSelectorOptions, retr
 		}
 	}
 
-	return err
+	return handle, err
 }
 
 // ChildFrames returns a list of child frames.

--- a/common/locator.go
+++ b/common/locator.go
@@ -621,7 +621,8 @@ func (l *Locator) WaitFor(opts sobek.Value) error {
 
 func (l *Locator) waitFor(opts *FrameWaitForSelectorOptions) error {
 	opts.Strict = true
-	return l.frame.waitFor(l.selector, opts, 20)
+	_, err := l.frame.waitFor(l.selector, opts, 20)
+	return err
 }
 
 // DefaultTimeout returns the default timeout for the locator.


### PR DESCRIPTION
## What?

This fixes an issue with APIs that use the underlying `frame.waitForSelector`. It does this by reusing `frame.waitFor` which contains a [fix](https://github.com/grafana/xk6-browser/pull/1469) to retry on certain errors which can occur when a navigation is taking place while also waiting for the selector.

## Why?

This makes several APIs more robust when called during or after a navigation to a new page. I believe the list covers most of the APIs that this fix applies to:

- `frame.WaitForSelector`
- `locator.IsChecked`
- `locator.DispatchEvent`
- `locator.Fill`
- `locator.Focus`
- `locator.GetAttribute`
- `locator.InnerHTML`
- `locator.InnerText`
- `locator.InputValue`
- `locator.IsEditable`
- `locator.IsEnabled`
- `locator.IsDisabled`
- `locator.Press`
- `locator.SelectOption`
- `frame.SetInputFiles`
- `page.TextContent`
- `locator.Type`
- `locator.Click`
- `locator.Check`
- `locator.SetChecked`
- `locator.Uncheck`
- `locator.DblClick`
- `locator.Hover`
- `locator.Tap`

<details><summary>Tests that works with fix (but not without)</summary>

Test that used to fail on reading the `textContent` of the `h2` header.

```js

import { browser } from 'k6/browser';
import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';

export const options = {
  scenarios: {
    ui: {
      executor: 'shared-iterations',
      options: {
        browser: {
            type: 'chromium',
        },
      },
    },
  },
  thresholds: {
    checks: ["rate==1.0"]
  }
}

export default async function() {
  const context = await browser.newContext();
  const page = await context.newPage();

  try {
    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });

    const wait1 = page.locator('input[name="login"]').waitFor();
    await page.locator('a[href="/my_messages.php"]').click()
    await wait1;

    await page.locator('input[name="login"]').type('admin');
    await page.locator('input[name="password"]').type("123");

    const wait2 = page.locator('h2').waitFor();
    await page.locator('input[type="submit"]').click();
    await wait2;

    await check(page.locator('h2'), {
      'header': async lo => {
        return await lo.textContent() == 'Welcome, admin!'
      }
    });
  } finally {
    await page.close();
  }
}

```

Test that used to fail when working with `waitForSelector`.

```js
import { browser } from 'k6/browser';
import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';

export const options = {
  scenarios: {
    ui: {
      executor: 'shared-iterations',
      options: {
        browser: {
            type: 'chromium',
        },
      },
    },
  },
  thresholds: {
    checks: ["rate==1.0"]
  }
}

export default async function() {
  const context = await browser.newContext();
  const page = await context.newPage();

  try {
    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });

    const wait1 = page.waitForSelector('input[name="login"]');
    await page.locator('a[href="/my_messages.php"]').click()
    await wait1;

    await page.locator('input[name="login"]').type('admin');
    await page.locator('input[name="password"]').type("123");

    const wait2 = page.waitForSelector('h2');
    await page.locator('input[type="submit"]').click();
    await wait2;

    await check(page.locator('h2'), {
      'header': async lo => {
        return await lo.textContent() == 'Welcome, admin!'
      }
    });
  } finally {
    await page.close();
  }
}


```

</details>

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Related: https://github.com/grafana/xk6-browser/pull/1469
Fixes: https://github.com/grafana/k6/issues/4048