### PR TITLE
Remove `Headless` from user agent

### DIFF
--- a/common/browser.go
+++ b/common/browser.go
@@ -691,6 +691,19 @@ func (b *Browser) fetchVersion() (browserVersion, error) {
 		return browserVersion{}, fmt.Errorf("getting browser version information: %w", err)
 	}
 
+	// Adjust the user agent to remove the headless part.
+	//
+	// Including Headless might cause issues with some websites that treat headless
+	// browsers differently. Later on, [BrowserContext] will set the user agent to
+	// this user agent if not set by the user. This will force [FrameSession] to
+	// set the user agent to the browser's user agent.
+	//
+	// Doing this here provides a consistent user agent across all browser contexts.
+	// Also, it makes it consistent to query the user agent from the browser.
+	if b.browserOpts.Headless {
+		bv.userAgent = strings.ReplaceAll(bv.userAgent, "Headless", "")
+	}
+
 	return bv, nil
 }
 

--- a/common/browser_context.go
+++ b/common/browser_context.go
@@ -118,6 +118,11 @@ func NewBrowserContext(
 	if opts == nil {
 		opts = DefaultBrowserContextOptions()
 	}
+	// Always use the [Browser]'s user agent if it's not set by the user.
+	// Setting this forces [FrameSession] to set Chromium's user agent.
+	if strings.TrimSpace(opts.UserAgent) == "" {
+		opts.UserAgent = browser.UserAgent()
+	}
 
 	b := BrowserContext{
 		BaseEventEmitter: NewBaseEventEmitter(ctx),

--- a/examples/useragent.js
+++ b/examples/useragent.js
@@ -1,0 +1,49 @@
+import { browser } from 'k6/x/browser/async';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  let context = await browser.newContext({
+    userAgent: 'k6 test user agent',
+  })
+  let page = await context.newPage();
+  await check(page, {
+    'user agent is set': async p => {
+        const userAgent = await p.evaluate(() => navigator.userAgent);
+        return userAgent.includes('k6 test user agent');
+    }
+  });
+  await page.close();
+  await context.close();
+
+  context = await browser.newContext();
+  check(context.browser(), {
+    'user agent does not contain headless': b => {
+        return b.userAgent().includes('Headless') === false;
+    }
+  });
+
+  page = await context.newPage();
+  await check(page, {
+    'chromium user agent does not contain headless': async p => {
+        const userAgent = await p.evaluate(() => navigator.userAgent);
+        return userAgent.includes('Headless') === false;
+    }
+  });
+  await page.close();
+}

--- a/tests/browser_test.go
+++ b/tests/browser_test.go
@@ -220,13 +220,12 @@ func TestBrowserUserAgent(t *testing.T) {
 
 	b := newTestBrowser(t)
 
-	// testBrowserVersion() tests the version already
-	// just look for "Headless" in UserAgent
 	ua := b.UserAgent()
 	if prefix := "Mozilla/5.0"; !strings.HasPrefix(ua, prefix) {
 		t.Errorf("UserAgent should start with %q, but got: %q", prefix, ua)
 	}
-	assert.Contains(t, ua, "Headless")
+	// We default to removing the "Headless" part of the user agent string.
+	assert.NotContains(t, ua, "Headless")
 }
 
 func TestBrowserCrashErr(t *testing.T) {


### PR DESCRIPTION
## What?

Sets up `Browser.UserAgent` to return a user agent without `Headless`.

## Why?

See #1497.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Updates #1497.