### PR TITLE
Fix frame.title

### DIFF
--- a/browser/frame_mapping.go
+++ b/browser/frame_mapping.go
@@ -230,7 +230,7 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping { //nolint:gocognit,cyclop
 		},
 		"title": func() *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return f.Title(), nil
+				return f.Title()
 			})
 		},
 		"type": func(selector, text string, opts sobek.Value) *sobek.Promise {

--- a/common/frame.go
+++ b/common/frame.go
@@ -1738,15 +1738,20 @@ func (f *Frame) Timeout() time.Duration {
 }
 
 // Title returns the title of the frame.
-func (f *Frame) Title() string {
+func (f *Frame) Title() (string, error) {
 	f.log.Debugf("Frame:Title", "fid:%s furl:%q", f.ID(), f.URL())
 
-	script := `() => document.title`
+	js := `() => document.title`
+	v, err := f.Evaluate(js)
+	if err != nil {
+		return "", fmt.Errorf("getting frame title: %w", err)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("getting frame title: expected string, got %T", v)
+	}
 
-	// TODO: return error
-
-	v, _ := f.Evaluate(script)
-	return v.(string) //nolint:forcetypeassert
+	return s, nil
 }
 
 // Type text on the first element found matches the selector.

--- a/tests/frame_test.go
+++ b/tests/frame_test.go
@@ -168,7 +168,10 @@ func TestFrameTitle(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "Some title", p.MainFrame().Title())
+
+	title, err := p.MainFrame().Title()
+	assert.NoError(t, err)
+	assert.Equal(t, "Some title", title)
 }
 
 func TestFrameGetAttribute(t *testing.T) {


### PR DESCRIPTION
## What?

The fixes involves casting the value from evaluate to a string, and if that doesn't cast to a string we should return an error. The cast was missing from the earlier implementation.

## Why?

Calling `frame.title` causes an error since the value returned from evaluate is an `interface{}` and not a string.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [X] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
