### PR TITLE
Remove deprecated accessibility events

### DIFF
--- a/tests/browser_context_test.go
+++ b/tests/browser_context_test.go
@@ -896,7 +896,6 @@ func TestBrowserContextGrantPermissions(t *testing.T) {
 		{name: "accelerometer", permission: "accelerometer"},
 		{name: "gyroscope", permission: "gyroscope"},
 		{name: "magnetometer", permission: "magnetometer"},
-		{name: "accessibility-events", permission: "accessibility-events"},
 		{name: "clipboard-read", permission: "clipboard-read"},
 		{name: "clipboard-write", permission: "clipboard-write"},
 		{name: "payment-handler", permission: "payment-handler"},


### PR DESCRIPTION
## What?

Removes deprecated accessibility events from tests.

## Why?

This feature [has been deprecated](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/common/permissions/permission_utils.h;l=37;drc=60130be50f68c89220d8ace62c87155025267a2c;bpv=1;bpt=1
) and was causing `TestBrowserContextGrantPermissions` to fail.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

https://github.com/grafana/xk6-browser/actions/runs/11856978357/job/33044367991?pr=1540
