### PR TITLE
Fix frame panic

### DIFF
--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -246,7 +246,19 @@ func (m *FrameManager) frameNavigated(frameID cdp.FrameID, parentFrameID cdp.Fra
 	frame := m.frames[frameID]
 
 	if !isMainFrame && frame == nil {
-		return errors.New("we either navigate top level or have old version of the navigated frame")
+		m.logger.Debugf("FrameManager:frameNavigated:nil frame",
+			"fmid:%d fid:%v pfid:%v docid:%s fname:%s furl:%s initial:%t",
+			m.ID(), frameID, parentFrameID, documentID, name, url, initial)
+
+		// If the frame is nil at this point, then the cause of this is likely
+		// due to chrome not sending a frameAttached event ahead of time. This
+		// isn't a bug in chrome, and seems to be intended behavior. Instead
+		// of worrying about the nil frame and causing the test to fail when
+		// the frame is nil, we can instead return early. The frame will
+		// be initialized when getFrameTree CDP request is made, which will
+		// call onFrameAttached and onFrameNavigated.
+
+		return nil
 	}
 
 	m.logger.Debugf("FrameManager:frameNavigated:removeFrames",


### PR DESCRIPTION
## What?

The change fixes a panic by returning nil instead of erroring.

## Why?

If the frame is nil at this point, then the cause of this is likely due to chrome not sending a frameAttached event ahead of time. This isn't a bug in chrome, and seems to be intended behavior. Instead of worrying about the nil frame and causing the test to fail when the frame is nil, we can instead return early. The frame will be initialized when getFrameTree CDP request is made, which will call onFrameAttached and onFrameNavigated.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
https://github.com/grafana/xk6-browser/issues/1500