### PR TITLE
Fix panic in onFrameRequestedNavigation

### DIFF
--- a/common/frame_manager.go
+++ b/common/frame_manager.go
@@ -389,7 +389,10 @@ func (m *FrameManager) frameRequestedNavigation(frameID cdp.FrameID, url string,
 		m.logger.Debugf("FrameManager:frameRequestedNavigation:nilFrame:return",
 			"fmid:%d fid:%v url:%s docid:%s", m.ID(), frameID, url, documentID)
 
-		return fmt.Errorf("no frame exists with ID %s", frameID)
+		// If a frame doesn't exist then the call to this method (which
+		// originates from a EventFrameRequestedNavigation CDP event) is on a
+		// stale frame that no longer exists in memory.
+		return nil
 	}
 
 	m.barriersMu.RLock()


### PR DESCRIPTION
## What?

Don't return an error from `frameRequestedNavigation` when a `frame` is not found (`nil`).

## Why?

This panic is unnecessary since the event is associated to a stale frame that no longer exists in memory.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Related: https://github.com/grafana/xk6-browser/issues/1546