### PR TITLE
Reduce logging noise produced by the browser module as a default

### DIFF
--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -644,11 +644,11 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 		WithField("source", "browser").
 		WithField("browser_source", "console-api")
 
-		/* accessing the state Group while not on the eventloop is racy
-		if s := fs.vu.State(); s.Group.Path != "" {
-			l = l.WithField("group", s.Group.Path)
-		}
-		*/
+	/* accessing the state Group while not on the eventloop is racy
+	if s := fs.vu.State(); s.Group.Path != "" {
+		l = l.WithField("group", s.Group.Path)
+	}
+	*/
 
 	parsedObjects := make([]string, 0, len(event.Args))
 	for _, robj := range event.Args {
@@ -661,18 +661,9 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 
 	msg := strings.Join(parsedObjects, " ")
 
-	switch event.Type {
-	case "log", "info":
-		l.Info(msg)
-	case "warning":
-		l.Warn(msg)
-	case "error":
-		l.Error(msg)
-	default:
-		// this is where debug & other console.* apis will default to (such as
-		// console.table).
-		l.Debug(msg)
-	}
+	// this is where debug & other console.* apis will default to (such as
+	// console.table).
+	l.Debug(msg)
 }
 
 func (fs *FrameSession) onExceptionThrown(event *cdpruntime.EventExceptionThrown) {

--- a/common/frame_session.go
+++ b/common/frame_session.go
@@ -885,21 +885,14 @@ func (fs *FrameSession) onLogEntryAdded(event *cdplog.EventEntryAdded) {
 		WithField("url", event.Entry.URL).
 		WithField("browser_source", event.Entry.Source.String()).
 		WithField("line_number", event.Entry.LineNumber)
-		/* accessing the state Group while not on the eventloop is racy
-		if s := fs.vu.State(); s.Group.Path != "" {
-			l = l.WithField("group", s.Group.Path)
-		}
-		*/
-	switch event.Entry.Level {
-	case "info":
-		l.Info(event.Entry.Text)
-	case "warning":
-		l.Warn(event.Entry.Text)
-	case "error":
-		l.WithField("stacktrace", event.Entry.StackTrace).Error(event.Entry.Text)
-	default:
-		l.Debug(event.Entry.Text)
+
+	/* accessing the state Group while not on the eventloop is racy
+	if s := fs.vu.State(); s.Group.Path != "" {
+		l = l.WithField("group", s.Group.Path)
 	}
+	*/
+
+	l.Debug(event.Entry.Text)
 }
 
 func (fs *FrameSession) onPageLifecycle(event *cdppage.EventLifecycleEvent) {

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -187,7 +187,7 @@ func valueFromRemoteObject(_ context.Context, robj *cdpruntime.RemoteObject) (an
 func parseConsoleRemoteObjectPreview(logger *log.Logger, op *cdpruntime.ObjectPreview) (string, error) {
 	obj := make(map[string]string)
 	if op.Overflow {
-		logger.Infof("parseConsoleRemoteObjectPreview", "object is too large and will be parsed partially")
+		logger.Debugf("parseConsoleRemoteObjectPreview", "object is too large and will be parsed partially")
 	}
 
 	for _, p := range op.Properties {

--- a/common/remote_object.go
+++ b/common/remote_object.go
@@ -209,7 +209,7 @@ func parseConsoleRemoteObjectPreview(logger *log.Logger, op *cdpruntime.ObjectPr
 func parseConsoleRemoteArrayPreview(logger *log.Logger, op *cdpruntime.ObjectPreview) (string, error) {
 	arr := make([]any, 0, len(op.Properties))
 	if op.Overflow {
-		logger.Infof("parseConsoleRemoteArrayPreview", "array is too large and will be parsed partially")
+		logger.Debugf("parseConsoleRemoteArrayPreview", "array is too large and will be parsed partially")
 	}
 
 	for _, p := range op.Properties {


### PR DESCRIPTION
## What

This pull request is aiming at bringing improvements to how the browser module handles logging. Generally we have made most of the relevant logging of the browser use the `debug` level, assuming users still can set the `K6_BROWSER_LOG` env variable to set it to `debug` and keep seeing all the logs.

We believe more could be done on improvements to the logging: such as having a way to subscribe to the various log sources the browser is exposed to such as chromium, or improve the error reporting to not follow the stacktrace-like format it currently follows. 

However we suggest to move those designs/problems to separate issues. Furthermore, we suggest to mark #1483 as closed when this PR is merged, in favor of new more focused issues on the above.

👇 copilot generated

This pull request includes changes to the logging levels and the handling of console API calls in the `common` package. The most important changes include modifying the logging levels from `Info` to `Debug` for certain messages and simplifying the handling of console API calls and log entries.

### Changes to logging levels:

* [`common/remote_object.go`](diffhunk://#diff-09698b39a87137740726f95d9889a0b19d6901434a46ea1afa4d611326210f21L190-R190): Changed logging level from `Info` to `Debug` for messages indicating that an object or array is too large and will be parsed partially. [[1]](diffhunk://#diff-09698b39a87137740726f95d9889a0b19d6901434a46ea1afa4d611326210f21L190-R190) [[2]](diffhunk://#diff-09698b39a87137740726f95d9889a0b19d6901434a46ea1afa4d611326210f21L212-R212)

### Simplification of console API calls and log entries:

* [`common/frame_session.go`](diffhunk://#diff-2a8b700bc15b2ce068271ee5df1e3f848a5d2e8dcfdf3cc1958dc0694249db08L664-L676): Simplified the `onConsoleAPICalled` method by removing the switch statement for different log levels, defaulting to `Debug` for all console API calls.
* [`common/frame_session.go`](diffhunk://#diff-2a8b700bc15b2ce068271ee5df1e3f848a5d2e8dcfdf3cc1958dc0694249db08R888-L912): Simplified the `onLogEntryAdded` method by removing the switch statement for different log levels, defaulting to `Debug` for all log entries.## What?

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [X] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

closes #1483 
