### PR TITLE
Handle panic in screenshoter

### DIFF
--- a/common/element_handle.go
+++ b/common/element_handle.go
@@ -1317,7 +1317,7 @@ func (h *ElementHandle) Screenshot(
 
 	span.SetAttributes(attribute.String("screenshot.path", opts.Path))
 
-	s := newScreenshotter(spanCtx, sp)
+	s := newScreenshotter(spanCtx, sp, h.logger)
 	buf, err := s.screenshotElement(h, opts)
 	if err != nil {
 		err := fmt.Errorf("taking screenshot of elementHandle: %w", err)

--- a/common/page.go
+++ b/common/page.go
@@ -1327,7 +1327,7 @@ func (p *Page) Screenshot(opts *PageScreenshotOptions, sp ScreenshotPersister) (
 
 	span.SetAttributes(attribute.String("screenshot.path", opts.Path))
 
-	s := newScreenshotter(spanCtx, sp)
+	s := newScreenshotter(spanCtx, sp, p.logger)
 	buf, err := s.screenshotPage(p, opts)
 	if err != nil {
 		err := fmt.Errorf("taking screenshot of page: %w", err)


### PR DESCRIPTION
## What?

* Migrate screenshoter from [deprecated `visualViewport`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-getLayoutMetrics) to `cssVisualViewport`. 
* Fallback to defaults in the case of `visualViewport` is nil. This is an arguable change since it's partially hiding the issue, on the other side my rational was it's better to make a screenshot with defaults, rather than erroring it. Open to discussion.
* Unfortunately, wasn't able to reproduce that's why no tests

## Why?

Currently, we have an issue with panicing #1502

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code
- [x] I have added tests for my changes
- [x] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

Part of #1502
