### PR TITLE
Add warning to readme on archive intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> Starting from k6 version v0.56, this codebase has been merged and is now part of the [main k6 repository](https://github.com/grafana/k6). Please contribute and [open issues there](https://github.com/grafana/k6/issues). This repository is no longer maintained.
+
 <h3 align="center">Browser automation and end-to-end web testing for k6</h3>
 <p align="center">A module for k6 adding browser-level APIs with rough Playwright compatibility.</p>
 


### PR DESCRIPTION
## What?

Adding a warning to the readme to point users to the main k6 repo to add contributions and issues for the browser module which is now part of k6.

## Why?

The code from xk6-browser has been merged into k6.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
