### PR TITLE
Remove the CI schedule

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    # At 06:00 AM UTC from Monday through Friday
-    - cron:  '0 6 * * 1-5'
 
 defaults:
   run:

--- a/.github/workflows/sync_e2e.yml
+++ b/.github/workflows/sync_e2e.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    # At 06:00 AM UTC from Monday through Friday
-    - cron:  '0 6 * * 1-5'
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    # At 06:00 AM UTC from Monday through Friday
-    - cron:  '0 6 * * 1-5'
 
 defaults:
   run:


### PR DESCRIPTION
## What?

Stop the scheduled CI test runs.

## Why?

This was placed here to keep track of k6 breaking changes. Now that the xk6-browser codebase has been merged into k6 this isn't needed.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code
- [ ] I have added tests for my changes
- [ ] I have commented on my code, particularly in hard-to-understand areas

## Related PR(s)/Issue(s)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
